### PR TITLE
Next release on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "josh"
 version = "0.3.0"
-repository = "https://github.com/esrlabs/josh"
-authors = ["Christian Schilling <christian.schilling@esrlabs.com>"]
+repository = "https://github.com/josh-project/josh"
+authors = ["Christian Schilling <initcrash@gmail.com>"]
 license-file = "LICENSE"
 description = "GIT virtualization proxy"
 keywords = ["git", "monorepo", "workflow", "scm"]


### PR DESCRIPTION
The idea would be to push this as a next release on crates.io (0.3.0) so that the links are up to date