### PR TITLE
Make ref creation help more helpful

### DIFF
--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -96,9 +96,9 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> josh::JoshResult<String> 
             } else {
                 return Err(josh::josh_error(&unindent::unindent(&format!(
                     r###"
-                    Branch {:?} does not exist on remote.
-                    If you want to create it, pass "-o base=<branchname>"
-                    to specify a base branch.
+                    Reference {:?} does not exist on remote.
+                    If you want to create it, pass "-o base=refs/heads/<branchname>"
+                    to specify a base branch/reference.
                     "###,
                     baseref
                 ))));

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -24,9 +24,9 @@
   $ git push origin HEAD:refs/heads/new_branch 2>&1 >/dev/null | sed -e 's/[ ]*$//g'
   remote: josh-proxy
   remote: response from upstream:
-  remote: Branch "refs/heads/new_branch" does not exist on remote.
-  remote: If you want to create it, pass "-o base=<branchname>"
-  remote: to specify a base branch.
+  remote: Reference "refs/heads/new_branch" does not exist on remote.
+  remote: If you want to create it, pass "-o base=refs/heads/<branchname>"
+  remote: to specify a base branch/reference.
   remote:
   remote:
   remote:


### PR DESCRIPTION
It was not obvious that the reference name had to be given
in fully qualified form. Now it should be.