### PR TITLE
feature: add simple (user, path) based access control

### DIFF
--- a/josh-proxy/src/acl.rs
+++ b/josh-proxy/src/acl.rs
@@ -1,0 +1,47 @@
+use toml;
+use regex::Regex;
+use serde::Deserialize;
+use std::{collections::HashMap, result::Result};
+
+#[derive(Clone)]
+pub struct Validator {
+    rules: HashMap<String, Vec<Regex>>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Error {
+    Toml(toml::de::Error),
+    Regex(regex::Error),
+}
+
+impl Validator {
+
+    pub fn from_toml(src: &str) -> std::result::Result<Validator, Error> {
+        // parse Vec<Entry> from text
+        let parse: Rule = toml::from_str(&src).map_err(Error::Toml)?;
+        // map Vec<Entry> into HashMap<String, Vec<Regex>>
+        let rules = parse.rule
+            .unwrap_or(Vec::new())
+            .into_iter()
+            .map(|u| (u.user, u.repo.into_iter().map(|v| Regex::new(v.as_str()).map_err(Error::Regex)).collect::<Result<Vec<Regex>, Error>>()))
+            .map(|(w, x)| x.map(|y| (w, y)))
+            .collect::<Result<HashMap<String, Vec<Regex>>, Error>>()
+            ?;
+        Ok(Validator{rules})
+    }
+
+    pub fn is_accessible(self: &Validator, user: &str, path: &str) -> bool {
+        self.rules.get(user).map(|x| x.iter().any(|r| r.is_match(path))).unwrap_or(true)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct Rule {
+    pub rule: Option<Vec<Entry>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Entry {
+    pub user: String,
+    pub repo: Vec<String>,
+}

--- a/josh-proxy/src/acl.rs
+++ b/josh-proxy/src/acl.rs
@@ -56,6 +56,7 @@ impl Validator {
             Some(rule) => {
                 // e.g. if "we" want to access "http://localhost:8080/a/b.git:/c/d.git"
                 //      then user = we, repo = a/b, path = c/d
+                let repo = repo.trim_start_matches("/");
                 let repo = repo.trim_end_matches(".git");
                 let path = path.trim_start_matches(":/");
                 rule.get(repo)

--- a/josh-proxy/src/acl.rs
+++ b/josh-proxy/src/acl.rs
@@ -3,9 +3,10 @@ use regex::Regex;
 use serde::Deserialize;
 use std::{collections::HashMap, result::Result};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Validator {
-    rules: HashMap<String, Vec<Regex>>,
+    // note:       repo            user        paths
+    rules: HashMap<String, HashMap<String, Vec<Regex>>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -17,31 +18,59 @@ pub enum Error {
 impl Validator {
 
     pub fn from_toml(src: &str) -> std::result::Result<Validator, Error> {
-        // parse Vec<Entry> from text
-        let parse: Rule = toml::from_str(&src).map_err(Error::Toml)?;
-        // map Vec<Entry> into HashMap<String, Vec<Regex>>
-        let rules = parse.rule
+        // parse Rule from text
+        let raw: Doc = toml::from_str(&src).map_err(Error::Toml)?;
+
+        // map Rule into HashMap<String, HashMap<String, Vec<Regex>>>
+        let dst = |x: Vec<String>| x
+            .into_iter()
+            .map(|v| Regex::new(v.as_str()).map_err(Error::Regex))
+            .collect::<Result<Vec<Regex>, Error>>()
+            ;
+        let dst = |x: Option<Vec<Match>>| x
             .unwrap_or(Vec::new())
             .into_iter()
-            .map(|u| (u.user, u.repo.into_iter().map(|v| Regex::new(v.as_str()).map_err(Error::Regex)).collect::<Result<Vec<Regex>, Error>>()))
-            .map(|(w, x)| x.map(|y| (w, y)))
+            .map(|m| (m.user, dst(m.path)))
+            .map(|(s, r)| r.map(|v| (s, v)))
             .collect::<Result<HashMap<String, Vec<Regex>>, Error>>()
+            ;
+        let dst = raw.repo
+            .unwrap_or(Vec::new())
+            .into_iter()
+            .map(|r| (r.name, dst(r.rule)))
+            .map(|(s, r)| r.map(|v| (s, v)))
+            .collect::<Result<HashMap<String, _>, Error>>()
             ?;
-        Ok(Validator{rules})
+
+        // return value
+        Ok(Validator{rules: dst})
     }
 
-    pub fn is_accessible(self: &Validator, user: &str, path: &str) -> bool {
-        self.rules.get(user).map(|x| x.iter().any(|r| r.is_match(path))).unwrap_or(true)
+    pub fn is_accessible(self: &Validator, user: &str, repo: &str, path: &str) -> bool {
+        // e.g. if "we" want to access "http://localhost:8080/a/b.git:/c/d.git"
+        //      then user = we, repo = a/b, path = c/d
+        let repo = repo.trim_end_matches(".git");
+        let path = path.trim_start_matches(":/");
+        self.rules
+            .get(repo)
+            .and_then(|r| r.get(user).map(|x| x.iter().any(|r| r.is_match(path))))
+            .unwrap_or(false)
     }
 }
 
 #[derive(Debug, Deserialize)]
-struct Rule {
-    pub rule: Option<Vec<Entry>>,
+struct Doc {
+    pub repo: Option<Vec<Repo>>,
 }
 
 #[derive(Debug, Deserialize)]
-struct Entry {
+struct Repo {
+    pub name: String,
+    pub rule: Option<Vec<Match>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Match {
     pub user: String,
-    pub repo: Vec<String>,
+    pub path: Vec<String>,
 }

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -399,7 +399,8 @@ async fn call_service(
         return Ok(builder.body(hyper::Body::empty())?);
     }
 
-    if !serv.validator.is_accessible(&username, &remote_url) {
+    // e.g. "http://localhost:port/a/b.git:/c/d.git" will become "a/b.git" ":/c/d"
+    if !serv.validator.is_accessible(&username, &parsed_url.upstream_repo, &parsed_url.filter) {
         tracing::trace!("acl-validator");
         let builder = Response::builder()
             .header("WWW-Authenticate", "Basic realm=User Visible Realm")

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod acl;
 pub mod auth;
 pub mod juniper_hyper;
 

--- a/run-josh.sh
+++ b/run-josh.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+[ -n "${JOSH_ACL}" ] && acl_arg="--acl ${JOSH_ACL}"
 cd /josh/
-RUST_BACKTRACE=1 josh-proxy --gc --local=/data/git/ --remote="${JOSH_REMOTE}" ${JOSH_EXTRA_OPTS}
+RUST_BACKTRACE=1 josh-proxy --gc --local=/data/git/ --remote="${JOSH_REMOTE}" ${acl_arg} ${JOSH_EXTRA_OPTS}


### PR DESCRIPTION
We needed ACL ability so dveloped a simple ACL feature based on a TOML config file like this:

```toml
[[repo]]
name = "josh-project/josh"
[[repo.rule]]
user = "nexzhu"
path = ["josh-proxy/*", docs/*"] # Can specify multiple regex string to match filter path
[[repo.rule]]
user = "wiryls"
path = [".*"]
```

ACL config file can be specified with `--acl` flag.
