### PR TITLE
Revert "Fix exclude of compose"

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,7 @@
 use super::*;
 use std::collections::HashMap;
 
-const VERSION: u64 = 7;
+const VERSION: u64 = 6;
 
 lazy_static! {
     static ref DB: std::sync::Mutex<Option<sled::Db>> = std::sync::Mutex::new(None);

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -377,23 +377,18 @@ fn apply_to_commit2(
                     .map(|x| x.tree_id())
                     .unwrap_or(tree::empty_id())
             };
-            let bu = {
+            let bf = {
                 transaction
                     .repo()
                     .find_commit(some_or!(
-                        apply_to_commit2(
-                            &Op::Chain(
-                                to_filter(Op::Paths),
-                                to_filter(Op::Chain(*b, to_filter(Op::Invert))),
-                            ),
-                            commit,
-                            transaction,
-                        )?,
+                        apply_to_commit2(&to_op(*b), commit, transaction)?,
                         { return Ok(None) }
                     ))
-                    .map(|x| x.tree())
-                    .unwrap_or(Ok(tree::empty(repo)))
-            }?;
+                    .map(|x| x.tree_id())
+                    .unwrap_or(tree::empty_id())
+            };
+            let bf = repo.find_tree(bf)?;
+            let bu = unapply(transaction, *b, bf, tree::empty(repo))?;
             let ba = apply(transaction, *a, bu)?;
 
             repo.find_tree(tree::subtract(repo, af, ba.id())?)?
@@ -479,14 +474,8 @@ fn apply2<'a>(
 
         Op::Subtract(a, b) => {
             let af = apply(transaction, *a, tree.clone())?;
-            let bu = apply(
-                transaction,
-                to_filter(Op::Chain(
-                    to_filter(Op::Paths),
-                    to_filter(Op::Chain(*b, to_filter(Op::Invert))),
-                )),
-                tree.clone(),
-            )?;
+            let bf = apply(transaction, *b, tree.clone())?;
+            let bu = unapply(transaction, *b, bf, tree::empty(repo))?;
             let ba = apply(transaction, *a, bu)?;
             Ok(repo.find_tree(tree::subtract(repo, af.id(), ba.id())?)?)
         }

--- a/tests/filter/empty_orphan.t
+++ b/tests/filter/empty_orphan.t
@@ -101,13 +101,9 @@ Empty root commits from unrelated parts of the tree should not be included
   c/file3
 
   $ josh-filter -s c=:exclude[:/sub1] master
-  [4] :INVERT
-  [4] _invert
+  [5] :/sub1
   [5] :exclude[:/sub1]
   [6] :prefix=c
-  [7] :PATHS
-  [9] :/sub1
-  [10] _paths
 
   $ git log FILTERED_HEAD --graph --pretty=%s
   * add some_other_file
@@ -120,13 +116,9 @@ Empty root commits from unrelated parts of the tree should not be included
 
   $ josh-filter -s :prefix=x FILTERED_HEAD
   [3] :prefix=x
-  [4] :INVERT
-  [4] _invert
+  [5] :/sub1
   [5] :exclude[:/sub1]
   [6] :prefix=c
-  [7] :PATHS
-  [9] :/sub1
-  [10] _paths
 
   $ git ls-tree --name-only -r FILTERED_HEAD
   x/c/some_file

--- a/tests/filter/exclude_compose.t
+++ b/tests/filter/exclude_compose.t
@@ -14,53 +14,37 @@
   $ git add sub2
   $ git commit -m "add file2" 1> /dev/null
 
-  $ mkdir sub3
-  $ echo contents1 > sub3/file3
-  $ git add sub3
-  $ git commit -m "add file3" 1> /dev/null
-
-  $ echo contents1 > file4
-  $ git add file4
-  $ git commit -m "add file4" 1> /dev/null
-
   $ josh-filter -s :exclude[:/sub2] master --update refs/heads/hidden
-  [1] :INVERT
-  [1] _invert
+  [1] :exclude[:/sub2]
   [2] :/sub2
-  [3] :exclude[:/sub2]
-  [4] :PATHS
-  [7] _paths
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
   $ tree
   .
-  |-- file4
-  |-- sub1
-  |   `-- file1
-  `-- sub3
-      `-- file3
+  `-- sub1
+      `-- file1
   
-  2 directories, 3 files
+  1 directory, 1 file
   $ git log --graph --pretty=%s
-  * add file4
-  * add file3
   * add file1
 
   $ echo contents3 > sub1/file3
   $ git add sub1/file3
   $ git commit -m "add sub1/file3" 1> /dev/null
 
-  $ josh-filter -s :exclude[:/sub1]:exclude[:/sub2]:exclude[:/sub3] master --update refs/josh/filtered
+  $ josh-filter -s :exclude[:/sub1,:/sub2] master --update refs/josh/filtered
   [1] :/sub1
-  [1] :/sub3
-  [2] :exclude[:/sub3]
-  [3] :/sub2
-  [3] :INVERT
-  [3] _invert
-  [4] :exclude[:/sub1]
-  [6] :exclude[:/sub2]
-  [9] :PATHS
-  [12] _paths
+  [1] :exclude[
+      :/sub1
+      :/sub2
+  ]
+  [1] :exclude[:/sub2]
+  [2] :/sub2
+  [2] :[
+      :/sub1
+      :/sub2
+  ]
+
   $ git checkout refs/josh/filtered
   Note: switching to 'refs/josh/filtered'.
   
@@ -79,38 +63,10 @@
   
   Turn off this advice by setting config variable advice.detachedHead to false
   
-  HEAD is now at e96b01b add file4
+  HEAD is now at bb282e9 add file1
   $ tree
   .
-  `-- file4
+  `-- sub1
+      `-- file1
   
-  0 directories, 1 file
-  $ josh-filter -s :exclude[:/sub1,:/sub2,:/sub3] master --update refs/josh/filtered
-  [1] :/sub1
-  [2] :exclude[
-      :/sub1
-      :/sub2
-      :/sub3
-  ]
-  [2] :exclude[:/sub3]
-  [3] :/sub2
-  [3] :/sub3
-  [3] :[
-      :/sub1
-      :/sub2
-      :/sub3
-  ]
-  [4] :exclude[:/sub1]
-  [5] :INVERT
-  [5] _invert
-  [6] :exclude[:/sub2]
-  [9] :PATHS
-  [12] _paths
-
-  $ git checkout refs/josh/filtered
-  HEAD is now at e96b01b add file4
-  $ tree
-  .
-  `-- file4
-  
-  0 directories, 1 file
+  1 directory, 1 file

--- a/tests/filter/hide_view.t
+++ b/tests/filter/hide_view.t
@@ -36,11 +36,7 @@
   $ josh-filter -s c=:exclude[:/sub1] master --update refs/josh/filter/master
   [1] :prefix=c
   [2] :/sub1
-  [2] :INVERT
   [2] :exclude[:/sub1]
-  [2] _invert
-  [3] :PATHS
-  [6] _paths
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
   * add file3
@@ -57,11 +53,7 @@
   [2] ::sub1/file2
   [2] :exclude[:/sub1]
   [2] :exclude[::sub1/file2]
-  [3] :INVERT
-  [3] :PATHS
   [3] :prefix=c
-  [4] _invert
-  [6] _paths
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
   * add file3
@@ -83,11 +75,7 @@
   [2] :exclude[:/sub1]
   [2] :exclude[::sub1/file2]
   [2] :exclude[::sub2/file3]
-  [3] :PATHS
-  [4] :INVERT
   [4] :prefix=c
-  [6] _invert
-  [6] _paths
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
   * add file2

--- a/tests/filter/permissions.t
+++ b/tests/filter/permissions.t
@@ -185,11 +185,9 @@
   [1] :/a
   [1] :exclude[:/c]
   [1] :prefix=x
-  [3] :INVERT
-  [6] :/c
-  [6] :PATHS
-  [7] _invert
-  [28] _paths
+  [3] :/c
+  [3] :PATHS
+  [16] _paths
 
   $ git log --graph --pretty=%s refs/josh/filtered
   * add dirs
@@ -237,11 +235,11 @@
   [1] :/a
   [1] :exclude[:/c]
   [1] :prefix=x
-  [6] :/c
-  [6] :INVERT
-  [6] :PATHS
-  [19] _invert
-  [28] _paths
+  [3] :/c
+  [3] :INVERT
+  [3] :PATHS
+  [12] _invert
+  [16] _paths
 
   $ git checkout refs/josh/filtered 2> /dev/null
   $ tree
@@ -315,12 +313,12 @@
   [1] :/a
   [1] :exclude[:/c]
   [1] :prefix=x
+  [3] :/c
+  [3] :PATHS
   [3] :workspace=a
-  [6] :/c
-  [6] :PATHS
-  [9] :INVERT
-  [28] _paths
-  [29] _invert
+  [6] :INVERT
+  [16] _paths
+  [22] _invert
 
   $ git checkout refs/josh/filtered 2> /dev/null
   $ tree
@@ -383,13 +381,13 @@
   [1] :/a
   [1] :exclude[:/c]
   [1] :prefix=x
+  [3] :/c
   [3] :FOLD
+  [3] :PATHS
   [3] :workspace=a
-  [6] :/c
-  [6] :PATHS
-  [9] :INVERT
-  [28] _paths
-  [29] _invert
+  [6] :INVERT
+  [16] _paths
+  [22] _invert
 
 
 
@@ -408,13 +406,13 @@
   [1] :/a
   [1] :exclude[:/c]
   [1] :prefix=x
+  [3] :/c
   [3] :FOLD
   [3] :workspace=a
-  [6] :/c
-  [8] :PATHS
-  [9] :INVERT
-  [29] _invert
-  [31] _paths
+  [5] :PATHS
+  [6] :INVERT
+  [19] _paths
+  [22] _invert
 
   $ git log --graph --pretty=%s master
   * add newfile
@@ -538,12 +536,12 @@
   [1] :exclude[:/c]
   [1] :prefix=x
   [3] :workspace=a
+  [4] :/c
+  [5] :PATHS
   [6] :FOLD
-  [7] :/c
-  [8] :PATHS
-  [9] :INVERT
-  [29] _invert
-  [31] _paths
+  [6] :INVERT
+  [19] _paths
+  [22] _invert
 
   $ git log --graph --pretty=%s refs/josh/filtered
   * add file_cd3
@@ -593,13 +591,13 @@
   [1] :/a
   [1] :exclude[:/c]
   [1] :prefix=x
+  [4] :/c
+  [5] :PATHS
   [5] :workspace=a
-  [7] :/c
-  [8] :PATHS
-  [9] :INVERT
+  [6] :INVERT
   [10] :FOLD
-  [29] _invert
-  [31] _paths
+  [19] _paths
+  [22] _invert
 
   $ git log --graph --pretty=%s refs/josh/filtered
   * add newfile

--- a/tests/filter/reverse_hide.t
+++ b/tests/filter/reverse_hide.t
@@ -15,12 +15,8 @@
   $ git commit -m "add file2" 1> /dev/null
 
   $ josh-filter -s :exclude[:/sub2] master --update refs/heads/hidden
-  [1] :INVERT
   [1] :exclude[:/sub2]
-  [1] _invert
   [2] :/sub2
-  [2] :PATHS
-  [4] _paths
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
   $ tree
@@ -37,12 +33,8 @@
   $ git commit -m "add sub1/file3" 1> /dev/null
 
   $ josh-filter -s :exclude[:/sub2] --reverse master --update refs/heads/hidden
-  [1] :INVERT
   [1] :exclude[:/sub2]
-  [1] _invert
   [2] :/sub2
-  [2] :PATHS
-  [4] _paths
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/reverse_merge.t
+++ b/tests/filter/reverse_merge.t
@@ -26,11 +26,7 @@
 
   $ josh-filter -s :exclude[:/sub2] branch1 --update refs/heads/hidden_branch1
   [1] :/sub2
-  [1] :INVERT
-  [1] _invert
-  [2] :PATHS
   [2] :exclude[:/sub2]
-  [4] _paths
   $ git checkout hidden_branch1
   Switched to branch 'hidden_branch1'
   $ tree
@@ -45,11 +41,7 @@
 
   $ josh-filter -s :exclude[:/sub2] master --update refs/heads/hidden_master
   [1] :/sub2
-  [1] :INVERT
-  [1] _invert
-  [3] :PATHS
   [3] :exclude[:/sub2]
-  [6] _paths
   $ git checkout hidden_master
   Switched to branch 'hidden_master'
   $ tree
@@ -87,11 +79,7 @@
 
   $ josh-filter -s :exclude[:/sub2] --reverse master --update refs/heads/hidden_master
   [1] :/sub2
-  [1] :INVERT
-  [1] _invert
-  [3] :PATHS
   [3] :exclude[:/sub2]
-  [6] _paths
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/workspace_exclude.t
+++ b/tests/filter/workspace_exclude.t
@@ -27,8 +27,6 @@
   [1] :/sub1
   [1] :/subsub
   [1] ::file1
-  [1] :INVERT
-  [1] :PATHS
   [1] :exclude[::file1]
   [1] :prefix=a
   [1] :prefix=sub2
@@ -39,8 +37,6 @@
       ::sub2/subsub/
   ]
   [2] :workspace=ws
-  [2] _invert
-  [2] _paths
 
   $ git log --graph --pretty=%s refs/heads/filtered
   * add ws
@@ -69,8 +65,6 @@
   [1] :/sub1
   [1] :/subsub
   [1] ::file1
-  [1] :INVERT
-  [1] :PATHS
   [1] :exclude[::file1]
   [1] :prefix=a
   [1] :prefix=sub2
@@ -81,8 +75,6 @@
       ::sub2/subsub/
   ]
   [2] :workspace=ws
-  [2] _invert
-  [3] _paths
   $ git checkout master
   Switched to branch 'master'
 


### PR DESCRIPTION
The behaviour was correct. The documentation needs to be updated:
Exclude removes the result of applying the exluded filter

This reverts commit 6d7a5388eb6c2efafe511033e7c6ab7f0b9b27bf.