### PR TITLE
Implement symref (HEAD) forwarding

### DIFF
--- a/src/housekeeping.rs
+++ b/src/housekeeping.rs
@@ -30,7 +30,7 @@ pub fn default_from_to(
     }
     refs.append(&mut memorize_from_to(
         repo,
-        &crate::to_filtered_ref(upstream_repo, filter_spec),
+        &to_filtered_ref(upstream_repo, filter_spec),
         upstream_repo,
     ));
 
@@ -43,13 +43,10 @@ pub fn memorize_from_to(
     upstream_repo: &str,
 ) -> Vec<(String, String)> {
     let mut refs = vec![];
-    let glob = format!(
-        "refs/josh/upstream/{}/refs/heads/master",
-        &to_ns(upstream_repo)
-    );
+    let glob = format!("refs/josh/upstream/{}/HEAD", &to_ns(upstream_repo));
     for refname in repo.references_glob(&glob).unwrap().names() {
         let refname = refname.unwrap();
-        let to_ref = format!("refs/{}/heads/master", &namespace);
+        let to_ref = format!("refs/{}/HEAD", &namespace);
 
         refs.push((refname.to_owned(), to_ref.clone()));
     }

--- a/tests/filter/ambigous_merge.t
+++ b/tests/filter/ambigous_merge.t
@@ -72,13 +72,7 @@
   * 81a8353 add sub_/fileY
   * 7671c2a add sub1/file1
 
-  $ git merge hidden_branch1 --no-ff
-  Merge made by the 'recursive' strategy.
-   sub1/file3 | 1 +
-   sub1/fileY | 1 +
-   2 files changed, 2 insertions(+)
-   create mode 100644 sub1/file3
-   create mode 100644 sub1/fileY
+  $ git merge -q hidden_branch1 --no-ff
   $ git log --graph --oneline
   *   2fcb6a4 Merge branch 'hidden_branch1' into hidden_master
   |\  

--- a/tests/filter/empty_orphan.t
+++ b/tests/filter/empty_orphan.t
@@ -56,13 +56,7 @@ Empty root commits from unrelated parts of the tree should not be included
 
   $ git checkout master
   Switched to branch 'master'
-  $ git merge other --no-ff --allow-unrelated
-  Merge made by the 'recursive' strategy.
-   some_file       | 1 +
-   some_other_file | 1 +
-   2 files changed, 2 insertions(+)
-   create mode 100644 some_file
-   create mode 100644 some_other_file
+  $ git merge -q other --no-ff --allow-unrelated
 
   $ tree
   .

--- a/tests/filter/empty_reimport.t
+++ b/tests/filter/empty_reimport.t
@@ -26,13 +26,7 @@
   $ git add .
   $ git commit -m "unrelated change on this" 1> /dev/null
 
-  $ git merge other_branch
-  Merge made by the 'recursive' strategy.
-   pre/testfile2 | 1 +
-   pre/testfile4 | 1 +
-   2 files changed, 2 insertions(+)
-   create mode 100644 pre/testfile2
-   create mode 100644 pre/testfile4
+  $ git merge -q other_branch
   $ git log --graph --pretty=%s
   *   Merge branch 'other_branch'
   |\  
@@ -68,13 +62,7 @@
   $ echo content > testfile7
   $ git add .
   $ git commit -m "more unrelated change on this" 1> /dev/null
-  $ git merge other_branch
-  Merge made by the 'recursive' strategy.
-   pre/blafile1 | 1 +
-   pre/blefile2 | 1 +
-   2 files changed, 2 insertions(+)
-   create mode 100644 pre/blafile1
-   create mode 100644 pre/blefile2
+  $ git merge -q other_branch
 
   $ git log --graph --pretty=%s
   *   Merge branch 'other_branch'

--- a/tests/filter/reverse_merge.t
+++ b/tests/filter/reverse_merge.t
@@ -65,11 +65,7 @@
   * add file3
   * add file1
 
-  $ git merge hidden_branch1 --no-ff
-  Merge made by the 'recursive' strategy.
-   sub1/file3 | 1 +
-   1 file changed, 1 insertion(+)
-   create mode 100644 sub1/file3
+  $ git merge -q hidden_branch1 --no-ff
   $ git log --graph --pretty=%s
   *   Merge branch 'hidden_branch1' into hidden_master
   |\  

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -125,13 +125,12 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub3
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               |-- changes
   |               |   `-- 1
@@ -143,4 +142,4 @@
   |-- namespaces
   `-- tags
   
-  17 directories, 5 files
+  15 directories, 6 files

--- a/tests/proxy/authentication.t
+++ b/tests/proxy/authentication.t
@@ -128,17 +128,16 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub1
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  14 directories, 3 files
+  12 directories, 4 files

--- a/tests/proxy/clone_absent_head.t
+++ b/tests/proxy/clone_absent_head.t
@@ -88,13 +88,9 @@
   refs
   |-- heads
   |-- josh
-  |   `-- filtered
-  |       `-- real_repo.git
-  |           `-- %3A
-  |               `-- heads
-  |                   `-- master
   |-- namespaces
   `-- tags
   
-  8 directories, 1 file
+  4 directories, 0 files
 
+$ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/clone_all.t
+++ b/tests/proxy/clone_all.t
@@ -57,18 +57,17 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub1
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  14 directories, 3 files
+  12 directories, 4 files
 

--- a/tests/proxy/clone_invalid_url.t
+++ b/tests/proxy/clone_invalid_url.t
@@ -26,7 +26,7 @@
   $ git clone -q http://localhost:8002/xxx full_repo
   fatal: unable to update url base from redirection:
     asked for: http://localhost:8002/xxx/info/refs?service=git-upload-pack
-     redirect: http://localhost:8002/~/browse/xxx/info/refs@refs/heads/master(:/)/()
+     redirect: http://localhost:8002/~/browse/xxx/info/refs@HEAD(:/)/()
   [128]
 
 

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -77,20 +77,18 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aprefix=pre
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  16 directories, 4 files
+  13 directories, 5 files

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -91,20 +91,18 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub2
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  16 directories, 4 files
+  13 directories, 5 files

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -46,11 +46,22 @@
   To http://localhost:8001/real_repo.git
    * [new branch]      master -> master
 
+  $ git ls-remote --symref
+  From http://localhost:8001/real_repo.git
+  ref: refs/heads/master\tHEAD (esc)
+  ffe8d082c1034053534ea8068f4205ac72a1098e\tHEAD (esc)
+  ffe8d082c1034053534ea8068f4205ac72a1098e\trefs/heads/master (esc)
+
   $ cd ${TESTTMP}
 
   $ git clone -q http://localhost:8002/real_repo.git:/sub1.git sub1
 
   $ cd sub1
+  $ git ls-remote --symref
+  From http://localhost:8002/real_repo.git:/sub1.git
+  ref: refs/heads/master\tHEAD (esc)
+  0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb\tHEAD (esc)
+  0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb\trefs/heads/master (esc)
   $ cat .git/refs/remotes/origin/HEAD
   ref: refs/remotes/origin/master
 
@@ -77,17 +88,16 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub2
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  14 directories, 3 files
+  12 directories, 4 files

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -118,13 +118,12 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub2
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               |-- heads
   |               |   `-- master
@@ -133,5 +132,5 @@
   |-- namespaces
   `-- tags
   
-  15 directories, 4 files
+  13 directories, 5 files
 $ cat ${TESTTMP}/josh-proxy.out | grep TAGS

--- a/tests/proxy/empty_commit.t
+++ b/tests/proxy/empty_commit.t
@@ -87,17 +87,16 @@ should still be included.
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub1
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  14 directories, 3 files
+  12 directories, 4 files

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -302,36 +302,34 @@ Flushed credential cache
   |   |-- filtered
   |   |   |-- real_repo.git
   |   |   |   |-- %3A
-  |   |   |   |   `-- heads
-  |   |   |   |       `-- master
+  |   |   |   |   `-- HEAD
   |   |   |   |-- %3A%2Frepo1
-  |   |   |   |   `-- heads
-  |   |   |   |       `-- master
+  |   |   |   |   `-- HEAD
   |   |   |   `-- %3A%2Frepo2
-  |   |   |       `-- heads
-  |   |   |           `-- master
+  |   |   |       `-- HEAD
   |   |   |-- repo1.git
   |   |   |   `-- %3Aprefix=repo1
-  |   |   |       `-- heads
-  |   |   |           `-- master
+  |   |   |       `-- HEAD
   |   |   `-- repo2.git
   |   |       `-- %3Aprefix=repo2
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       |-- real_repo.git
+  |       |   |-- HEAD
   |       |   `-- refs
   |       |       `-- heads
   |       |           `-- master
   |       |-- repo1.git
+  |       |   |-- HEAD
   |       |   `-- refs
   |       |       `-- heads
   |       |           `-- master
   |       `-- repo2.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  28 directories, 8 files
+  23 directories, 11 files

--- a/tests/proxy/info_api.t
+++ b/tests/proxy/info_api.t
@@ -51,16 +51,15 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub2
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   `-- tags
   
-  13 directories, 3 files
+  11 directories, 4 files

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -66,14 +66,14 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       `-- %3Aprefix=sub1
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  12 directories, 2 files
+  11 directories, 3 files

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -24,11 +24,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
 
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
+  $ git merge -q new1 --no-ff
 
   $ git push 1> /dev/null
   To http://localhost:8001/real_repo.git

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -332,19 +332,16 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fa
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fa%2Fb
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub1
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               |-- heads
   |               |   `-- master
@@ -353,4 +350,4 @@
   |-- namespaces
   `-- tags
   
-  19 directories, 6 files
+  15 directories, 7 files

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -57,18 +57,17 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aprefix=pre
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  14 directories, 3 files
+  12 directories, 4 files
 

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -88,17 +88,17 @@ Make sure all temporary namespace got removed
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       `-- %3A%2Fsub1
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  12 directories, 2 files
+  11 directories, 3 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_review_already_in.t
+++ b/tests/proxy/push_review_already_in.t
@@ -51,15 +51,15 @@ test for that.
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       `-- %3A
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  12 directories, 2 files
+  11 directories, 3 files
 

--- a/tests/proxy/push_review_nop_behind.t
+++ b/tests/proxy/push_review_nop_behind.t
@@ -58,14 +58,14 @@ This is a regression test for that problem.
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       `-- %3A
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  12 directories, 2 files
+  11 directories, 3 files

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -86,17 +86,17 @@ Flushed credential cache
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       `-- %3A%2Fsub1
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  12 directories, 2 files
+  11 directories, 3 files
 
   $ cat ${TESTTMP}/josh-proxy.out | grep graph_descendant_of
   [1]

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -43,17 +43,17 @@ Make sure all temporary namespace got removed
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       `-- %3A%2Fsub1
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  12 directories, 2 files
+  11 directories, 3 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -49,19 +49,18 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub1%3Aprefix=pre
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  14 directories, 3 files
+  12 directories, 4 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -91,10 +91,10 @@ Make sure all temporary namespace got removed
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       `-- %3A%2Fsub1
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   |-- master
@@ -102,6 +102,6 @@ Make sure all temporary namespace got removed
   |-- namespaces
   `-- tags
   
-  12 directories, 3 files
+  11 directories, 4 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -116,23 +116,23 @@ Put a double slash in the URL to see that it also works
   |   |-- filtered
   |   |   |-- real%2Frepo2.git
   |   |   |   `-- %3A%2Fsub1
-  |   |   |       `-- heads
-  |   |   |           `-- master
+  |   |   |       `-- HEAD
   |   |   `-- real_repo.git
   |   |       `-- %3A%2Fsub1
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       |-- real%2Frepo2.git
+  |       |   |-- HEAD
   |       |   `-- refs
   |       |       `-- heads
   |       |           `-- master
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  18 directories, 4 files
+  16 directories, 6 files
 

--- a/tests/proxy/unrelated_leak.t
+++ b/tests/proxy/unrelated_leak.t
@@ -87,13 +87,12 @@ Flushed credential cache
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3A%2Fsub2
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   |-- from_filtered
@@ -101,4 +100,4 @@ Flushed credential cache
   |-- namespaces
   `-- tags
   
-  14 directories, 4 files
+  12 directories, 5 files

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -271,35 +271,30 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub3
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   |-- rewrites
   |   |   `-- real_repo.git
   |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
   |   |           `-- r_fa3b9622c1bcc8363c27d4eb05d1ae8dae15e871
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  25 directories, 8 files
+  19 directories, 9 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -50,11 +50,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
 
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
+  $ git merge -q new1 --no-ff
 
   $ mkdir sub3
   $ echo contents3 > sub3/file3

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -488,26 +488,19 @@ Note that ws/d/ is now present in the ws
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub3
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws%2Fd
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   |-- rewrites
   |   |   `-- real_repo.git
   |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
@@ -516,12 +509,13 @@ Note that ws/d/ is now present in the ws
   |   |           `-- r_60bd0e180735e169b5c853545d8b1272ed0fc319
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  27 directories, 11 files
+  20 directories, 12 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -37,11 +37,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
 
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
+  $ git merge -q new1 --no-ff
 
 
   $ mkdir -p sub1/subsub

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -77,7 +77,6 @@ Flushed credential cache
   HEAD is now at 003a297 add workspace
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
   POST git-receive-pack (440 bytes)
-  remote: warning: ignoring broken ref refs/namespaces/* (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -112,37 +112,30 @@
   |   |-- filtered
   |   |   `-- real%2Frepo2.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub3
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3Aworkspace=ws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws2
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real%2Frepo2.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  26 directories, 9 files
+  18 directories, 10 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -52,11 +52,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
 
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
+  $ git merge -q new1 --no-ff
 
   $ mkdir sub3
   $ echo contents3 > sub3/file3

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -191,26 +191,19 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub3
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub4
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   |-- rewrites
   |   |   `-- real_repo.git
   |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
@@ -218,6 +211,7 @@
   |   |           `-- r_9bd58f891b4f17736c1b51903837de717fce13a5
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               |-- changes
   |               |   `-- 1
@@ -227,4 +221,4 @@
   |-- namespaces
   `-- tags
   
-  29 directories, 11 files
+  22 directories, 12 files

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -45,11 +45,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
 
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
+  $ git merge -q new1 --no-ff
 
   $ mkdir sub3
   $ echo contents3 > sub3/file3

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -218,7 +218,6 @@
   HEAD is now at b3be5ad add ws2
   Pushing to http://localhost:8002/real_repo.git:workspace=ws2.git
   POST git-receive-pack (424 bytes)
-  remote: warning: ignoring broken ref refs/namespaces/request_* (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -45,11 +45,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
 
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
+  $ git merge -q new1 --no-ff
 
   $ mkdir sub3
   $ echo contents3 > sub3/file3

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -275,29 +275,21 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub3
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3Aworkspace=ws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws2
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   |-- rewrites
   |   |   `-- real_repo.git
   |   |       |-- 191ead67feb541c237317e25b2c66c5d8f3e33fa
@@ -307,11 +299,12 @@
   |   |           `-- r_2cbcd105ead63a4fecf486b949db7f44710300e5
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  30 directories, 12 files
+  22 directories, 13 files
 

--- a/tests/proxy/workspace_in_workspace_prefix.t
+++ b/tests/proxy/workspace_in_workspace_prefix.t
@@ -218,7 +218,6 @@
   HEAD is now at b3be5ad add ws2
   Pushing to http://localhost:8002/real_repo.git:workspace=ws2.git
   POST git-receive-pack (424 bytes)
-  remote: warning: ignoring broken ref refs/namespaces/request_* (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        

--- a/tests/proxy/workspace_in_workspace_prefix.t
+++ b/tests/proxy/workspace_in_workspace_prefix.t
@@ -45,11 +45,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
 
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
+  $ git merge -q new1 --no-ff
 
   $ mkdir sub3
   $ echo contents3 > sub3/file3

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -54,7 +54,6 @@ Flushed credential cache
   $ git add .
   $ git commit -m "add workspace" 1> /dev/null
   $ git push origin HEAD:refs/heads/master -o merge 2>&1 >/dev/null | sed -e 's/[ ]*$//g'
-  remote: warning: ignoring broken ref refs/namespaces/* (glob)
   remote: josh-proxy
   remote: response from upstream:
   remote: To http://localhost:8001/real_repo.git

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -191,30 +191,26 @@ Flushed credential cache
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   |-- rewrites
   |   |   `-- real_repo.git
   |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
   |   |           `-- r_c255706f564f629eed1756b789d761048cfe060a
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  23 directories, 7 files
+  18 directories, 8 files

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -495,26 +495,19 @@ Note that ws/d/ is now present in the ws
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub3
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws%2Fd
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   |-- rewrites
   |   |   `-- real_repo.git
   |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
@@ -523,12 +516,13 @@ Note that ws/d/ is now present in the ws
   |   |           `-- r_4a199f3a19a292e6639dede0f8602afc19a82dfc
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  27 directories, 11 files
+  20 directories, 12 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -77,7 +77,6 @@ Flushed credential cache
   HEAD is now at 4a199f3 Merge from :workspace=ws
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
   POST git-receive-pack (439 bytes)
-  remote: warning: ignoring broken ref refs/namespaces/* (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -37,11 +37,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
 
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
+  $ git merge -q new1 --no-ff
 
 
   $ mkdir -p sub1/subsub

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -294,34 +294,28 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub3
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3Aworkspace=ws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws%3A%2Fpre
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  24 directories, 8 files
+  17 directories, 9 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -37,11 +37,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
  
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
+  $ git merge -q new1 --no-ff
  
  
   $ mkdir -p sub1/subsub

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -364,29 +364,21 @@ Note that ws/d/ is now present in the ws
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub3
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws%2Fd
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3Aworkspace=ws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws%3Aprefix=pre%3A%2Fpre
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   |-- rewrites
   |   |   `-- real_repo.git
   |   |       `-- 010e03f34d3497fc1e309e7c8bd06a95e399677b
@@ -394,12 +386,13 @@ Note that ws/d/ is now present in the ws
   |   |           `-- r_9d72b88b11aed97d3313f0a6d80894ee2ffdf3e9
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  29 directories, 11 files
+  21 directories, 12 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -37,12 +37,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
 
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
-
+  $ git merge -q new1 --no-ff
 
   $ mkdir -p sub1/subsub
   $ echo contents1 > sub1/subsub/file1

--- a/tests/proxy/workspace_mv_folder.t
+++ b/tests/proxy/workspace_mv_folder.t
@@ -77,7 +77,6 @@ Flushed credential cache
   HEAD is now at 4a199f3 Merge from :workspace=ws
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
   POST git-receive-pack (439 bytes)
-  remote: warning: ignoring broken ref refs/namespaces/request_*/HEAD         (glob)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        

--- a/tests/proxy/workspace_mv_folder.t
+++ b/tests/proxy/workspace_mv_folder.t
@@ -37,11 +37,7 @@
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
 
-  $ git merge new1 --no-ff
-  Merge made by the 'recursive' strategy.
-   newfile1 | 0
-   1 file changed, 0 insertions(+), 0 deletions(-)
-   create mode 100644 newfile1
+  $ git merge -q new1 --no-ff
 
 
   $ mkdir -p sub1/subsub

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -112,25 +112,22 @@ file was created
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub1
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  18 directories, 5 files
+  14 directories, 6 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -147,26 +147,24 @@
   |   |-- filtered
   |   |   `-- real_repo.git
   |   |       |-- %3A%2Fsub2
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws
-  |   |       |   `-- heads
-  |   |       |       `-- master
+  |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
-  |   |           `-- heads
-  |   |               `-- master
+  |   |           `-- HEAD
   |   |-- rewrites
   |   |   `-- real_repo.git
   |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
   |   |           `-- r_9db51080a4d148b32bd4c4e0b39eae8d0b3df763
   |   `-- upstream
   |       `-- real_repo.git
+  |           |-- HEAD
   |           `-- refs
   |               `-- heads
   |                   `-- master
   |-- namespaces
   `-- tags
   
-  19 directories, 5 files
+  16 directories, 6 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW


### PR DESCRIPTION
Previously it was simply assumed that HEAD always points to
refs/heads/master but as it turns out that is far from true.
Now HEAD is queried per repo from the upstream and forwarded.
Unfortunately it seems that it is not avoidable to to an extra
request to the upstream server for this. (calling ls-remote)