### PR TITLE
Ignore failures of killall in setup_test_env.sh

### DIFF
--- a/tests/proxy/setup_test_env.sh
+++ b/tests/proxy/setup_test_env.sh
@@ -1,6 +1,7 @@
 export TESTTMP=${PWD}
-killall josh-proxy >/dev/null 2>&1
-killall hyper-cgi-test-server >/dev/null 2>&1
+
+killall josh-proxy >/dev/null 2>&1 || true
+killall hyper-cgi-test-server >/dev/null 2>&1 || true
 
 git init --bare ${TESTTMP}/remote/real_repo.git/ 1> /dev/null
 git config -f ${TESTTMP}/remote/real_repo.git/config http.receivepack true


### PR DESCRIPTION
Killall exits with a non-zero code when no matching process is found, making tests fail