### PR TITLE
Add more optimiser rules for subtract 

### DIFF
--- a/tests/filter/pretty_print.t
+++ b/tests/filter/pretty_print.t
@@ -27,6 +27,15 @@
       :/b
   ]
 
+  $ josh-filter -p :subtract[a=:[::x/,::y/,::z/],b=:[::x/,::y/]]
+  a/z = :/z
+  $ josh-filter -p :subtract[a=:[::x/,::y/,::z/],a=:[::x/,::y/]]
+  a/z = :/z
+  $ josh-filter -p :subtract[a=:[::x/,::y/],a=:[::x/,::y/]]
+  :empty
+  $ josh-filter -p :subtract[a=:[::x/,::y/],b=:[::x/,::y/]]
+  :empty
+
   $ cat > f <<EOF
   > a/b = :/a/b
   > a/j = :/a/j
@@ -71,9 +80,9 @@
   > ]]
   > EOF
   $ josh-filter -p --file f
-  :subtract[
-      ::b/
-      ::c/
+  b = :subtract[
+      :/b
+      :/c
   ]
 
   $ cat > f <<EOF
@@ -173,9 +182,9 @@
   > EOF
 
   $ josh-filter -p --file f
-  :subtract[
-      x/g = :/a/x/g
-      p/au/bs/i1 = :/m/bs/m2/i/tc/i1
+  x/g = :subtract[
+      :/a/x/g
+      :/m/bs/m2/i/tc/i1
   ]
 
   $ cat > f <<EOF

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -17,22 +17,19 @@
   
   nothing to commit (create/copy files and use "git add" to track)
 
-  $ git checkout -b master
-  Switched to a new branch 'master'
+  $ git checkout -q -b master
 
 
   $ echo content1 > file1 1> /dev/null
   $ git add .
   $ git commit -m "initial" 1> /dev/null
 
-  $ git checkout -b new1
-  Switched to a new branch 'new1'
+  $ git checkout -q -b new1
   $ echo content > newfile1 1> /dev/null
   $ git add .
   $ git commit -m "add newfile1" 1> /dev/null
 
-  $ git checkout master 1> /dev/null
-  Switched to branch 'master'
+  $ git checkout -q master 1> /dev/null
   $ echo content > newfile_master 1> /dev/null
   $ git add .
   $ git commit -m "newfile master" 1> /dev/null
@@ -116,25 +113,7 @@
   * add file2
   * add file1
 
-  $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
-  
-  You are in 'detached HEAD' state. You can look around, make experimental
-  changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
-  
-  If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
-  
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
-  
-  HEAD is now at a4b6822 add workspace
+  $ git checkout -q HEAD~1 1> /dev/null
   $ tree
   .
   |-- a
@@ -147,9 +126,7 @@
   
   4 directories, 3 files
 
-  $ git checkout HEAD~1 1> /dev/null
-  Previous HEAD position was a4b6822 add workspace
-  HEAD is now at 2a03ad0 add file2
+  $ git checkout -q HEAD~1 1> /dev/null
   $ tree
   .
   |-- a
@@ -161,9 +138,7 @@
   
   4 directories, 2 files
 
-  $ git checkout master 1> /dev/null
-  Previous HEAD position was 2a03ad0 add file2
-  Switched to branch 'master'
+  $ git checkout -q master 1> /dev/null
 
   $ echo newfile_1_contents > c/subsub/newfile_1
   $ git rm c/subsub/file1
@@ -282,25 +257,7 @@ Note that ws/d/ is now present in the ws
   cat: sub1/subsub/file1: No such file or directory
   [1]
 
-  $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
-  
-  You are in 'detached HEAD' state. You can look around, make experimental
-  changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
-  
-  If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
-  
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
-  
-  HEAD is now at edefd7d add in filter
+  $ git checkout -q HEAD~1 1> /dev/null
   $ git clean -ffdx 1> /dev/null
   $ tree
   .
@@ -321,9 +278,7 @@ Note that ws/d/ is now present in the ws
   
   5 directories, 9 files
 
-  $ git checkout HEAD~1 1> /dev/null
-  Previous HEAD position was edefd7d add in filter
-  HEAD is now at aaec05d mod workspace
+  $ git checkout -q HEAD~1 1> /dev/null
   $ git clean -ffdx 1> /dev/null
   $ tree
   .
@@ -370,13 +325,11 @@ Note that ws/d/ is now present in the ws
   |   |       |   `-- HEAD
   |   |       |-- %3A%2Fws%2Fd
   |   |       |   `-- HEAD
-  |   |       |-- %3Aworkspace=ws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws%3Aprefix=pre%3A%2Fpre
+  |   |       `-- %3Aworkspace=ws
   |   |           `-- HEAD
   |   |-- rewrites
   |   |   `-- real_repo.git
-  |   |       `-- 010e03f34d3497fc1e309e7c8bd06a95e399677b
+  |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
   |   |           |-- r_44edc62d506b9805a3edfc74db15b1cc0bfc6871
   |   |           `-- r_9d72b88b11aed97d3313f0a6d80894ee2ffdf3e9
   |   `-- upstream
@@ -388,6 +341,6 @@ Note that ws/d/ is now present in the ws
   |-- namespaces
   `-- tags
   
-  21 directories, 12 files
+  20 directories, 11 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW


### PR DESCRIPTION
Changing just the prefix part of a mapping in very large
workspaces resulted in very expensive filtering that can be
avoided by applying these additional rules.