### PR TITLE
Introduce tree cache for subtract

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -53,6 +53,7 @@ pub fn print_stats() {
 struct Transaction2 {
     commit_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
     apply_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
+    subtract_map: HashMap<(git2::Oid, git2::Oid), git2::Oid>,
     unapply_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
     sled_trees: HashMap<git2::Oid, sled::Tree>,
     path_tree: sled::Tree,
@@ -114,6 +115,7 @@ impl Transaction {
             t2: std::cell::RefCell::new(Transaction2 {
                 commit_map: HashMap::new(),
                 apply_map: HashMap::new(),
+                subtract_map: HashMap::new(),
                 unapply_map: HashMap::new(),
                 sled_trees: HashMap::new(),
                 path_tree,
@@ -168,6 +170,16 @@ impl Transaction {
             return m.get(&from).cloned();
         }
         None
+    }
+
+    pub fn insert_subtract(&self, from: (git2::Oid, git2::Oid), to: git2::Oid) {
+        let mut t2 = self.t2.borrow_mut();
+        t2.subtract_map.insert(from, to);
+    }
+
+    pub fn get_subtract(&self, from: (git2::Oid, git2::Oid)) -> Option<git2::Oid> {
+        let t2 = self.t2.borrow_mut();
+        return t2.subtract_map.get(&from).cloned();
     }
 
     pub fn insert_unapply(&self, filter: filter::Filter, from: git2::Oid, to: git2::Oid) {

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -399,7 +399,7 @@ fn apply_to_commit2(
             let bf = repo.find_tree(bf)?;
             let bu = unapply(transaction, *b, bf, tree::empty(repo))?;
             let ba = apply(transaction, *a, bu)?.id();
-            repo.find_tree(tree::subtract(repo, af, ba)?)?
+            repo.find_tree(tree::subtract(transaction, af, ba)?)?
         }
         Op::Exclude(b) => {
             let bf = {
@@ -412,7 +412,7 @@ fn apply_to_commit2(
                     .map(|x| x.tree_id())
                     .unwrap_or(tree::empty_id())
             };
-            repo.find_tree(tree::subtract(repo, commit.tree_id(), bf)?)?
+            repo.find_tree(tree::subtract(transaction, commit.tree_id(), bf)?)?
         }
         _ => apply(transaction, filter, commit.tree()?)?,
     };
@@ -498,11 +498,11 @@ fn apply2<'a>(
             let bf = apply(transaction, *b, tree.clone())?;
             let bu = unapply(transaction, *b, bf, tree::empty(repo))?;
             let ba = apply(transaction, *a, bu)?.id();
-            Ok(repo.find_tree(tree::subtract(repo, af.id(), ba)?)?)
+            Ok(repo.find_tree(tree::subtract(transaction, af.id(), ba)?)?)
         }
         Op::Exclude(b) => {
             let bf = apply(transaction, *b, tree.clone())?.id();
-            Ok(repo.find_tree(tree::subtract(repo, tree.id(), bf)?)?)
+            Ok(repo.find_tree(tree::subtract(transaction, tree.id(), bf)?)?)
         }
 
         Op::Paths => tree::pathstree("", tree.id(), transaction),
@@ -644,7 +644,7 @@ fn unapply2<'a>(
                 let reapply = apply(transaction, *other, from_empty.clone())?;
 
                 remaining = transaction.repo().find_tree(tree::subtract(
-                    transaction.repo(),
+                    transaction,
                     remaining.id(),
                     reapply.id(),
                 )?)?;
@@ -668,7 +668,7 @@ fn unapply2<'a>(
         Op::Subtract(_, _) => return Err(josh_error("filter not reversible")),
         Op::Exclude(b) => {
             let subtracted = tree::subtract(
-                transaction.repo(),
+                transaction,
                 tree.id(),
                 unapply(transaction, *b, tree, tree::empty(transaction.repo()))?.id(),
             )?;

--- a/src/filter/tree.rs
+++ b/src/filter/tree.rs
@@ -122,16 +122,21 @@ pub fn remove_pred<'a>(
     Ok(result)
 }
 
-pub fn subtract(
-    repo: &git2::Repository,
+pub fn subtract<'a>(
+    transaction: &'a cache::Transaction,
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> super::JoshResult<git2::Oid> {
+    let repo = transaction.repo();
     if input1 == input2 {
         return Ok(tree::empty_id());
     }
     if input1 == tree::empty_id() {
         return Ok(tree::empty_id());
+    }
+
+    if let Some(cached) = transaction.get_subtract((input1, input2)) {
+        return Ok(cached);
     }
 
     if let (Ok(tree1), Ok(tree2)) = (repo.find_tree(input1), repo.find_tree(input2)) {
@@ -146,15 +151,19 @@ pub fn subtract(
                 result_tree = replace_child(
                     repo,
                     std::path::Path::new(entry.name().ok_or(super::josh_error("no name"))?),
-                    subtract(repo, e.id(), entry.id())?,
+                    subtract(transaction, e.id(), entry.id())?,
                     e.filemode(),
                     &result_tree,
                 )?;
             }
         }
 
+        transaction.insert_subtract((input1, input2), result_tree.id());
+
         return Ok(result_tree.id());
     }
+
+    transaction.insert_subtract((input1, input2), tree::empty_id());
 
     Ok(tree::empty_id())
 }
@@ -805,7 +814,7 @@ pub fn compose<'a>(
         };
         transaction.insert_apply(*f, tid, taken_applied);
 
-        let subtracted = repo.find_tree(subtract(repo, applied.id(), taken_applied)?)?;
+        let subtracted = repo.find_tree(subtract(transaction, applied.id(), taken_applied)?)?;
 
         let aid = applied.id();
         let unapplied = if let Some(cached) = transaction.get_unapply(*f, aid) {


### PR DESCRIPTION
This should help with very slow workspace rebuilt times
for complex workspaces.