### PR TITLE
Add redirect to support git lfs

### DIFF
--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -438,16 +438,23 @@ async fn call_service(
         }
     };
 
-    let mut headref = parsed_url.headref.trim_start_matches('@').to_owned();
-    if headref.is_empty() {
-        headref = "HEAD".to_string();
-    }
-
     let remote_url = [
         serv.upstream_url.as_str(),
         parsed_url.upstream_repo.as_str(),
     ]
     .join("");
+
+    if parsed_url.pathinfo.starts_with("/info/lfs") {
+        return Ok(Response::builder()
+            .status(307)
+            .header("Location", format!("{}{}", remote_url, parsed_url.pathinfo))
+            .body(hyper::Body::empty())?);
+    }
+
+    let mut headref = parsed_url.headref.trim_start_matches('@').to_owned();
+    if headref.is_empty() {
+        headref = "HEAD".to_string();
+    }
 
     if !josh_proxy::auth::check_auth(&remote_url, &auth, ARGS.is_present("require-auth"))
         .in_current_span()

--- a/tests/proxy/lfs_redirect.t
+++ b/tests/proxy/lfs_redirect.t
@@ -1,0 +1,32 @@
+  $ . ${TESTDIR}/setup_test_env.sh
+  $ cd ${TESTTMP}
+
+  $ git clone -q http://localhost:8001/real_repo.git
+  warning: You appear to have cloned an empty repository.
+
+  $ cd real_repo
+
+  $ git status
+  On branch master
+  
+  No commits yet
+  
+  nothing to commit (create/copy files and use "git add" to track)
+
+  $ curl -is http://localhost:8002/real_repo.git/info/lfs/objects/batch | grep -v "date:"
+  HTTP/1.1 307 Temporary Redirect\r (esc)
+  location: http://localhost:8001/real_repo.git/info/lfs/objects/batch\r (esc)
+  content-length: 0\r (esc)
+  \r (esc)
+
+  $ curl -is http://localhost:8002/real_repo.git/info/lfs | grep -v "date:"
+  HTTP/1.1 307 Temporary Redirect\r (esc)
+  location: http://localhost:8001/real_repo.git/info/lfs\r (esc)
+  content-length: 0\r (esc)
+  \r (esc)
+
+  $ curl -is http://localhost:8002/real_repo.git@refs/heads/master:/sub1.git/info/lfs | grep -v "date:"
+  HTTP/1.1 307 Temporary Redirect\r (esc)
+  location: http://localhost:8001/real_repo.git/info/lfs\r (esc)
+  content-length: 0\r (esc)
+  \r (esc)


### PR DESCRIPTION
Git lfs requests are just redirected to the upstream host.