### PR TITLE
Prepend refs/heads to base parameter as default

### DIFF
--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -80,7 +80,17 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> josh::JoshResult<String> 
         };
 
         let original_target_ref = if let Some(base) = push_options.get("base") {
-            transaction.refname(base)
+            // Allow user to use just the branchname as the base:
+            let full_path_base_refname = transaction.refname(&format!("refs/heads/{}", base));
+            if transaction
+                .repo()
+                .refname_to_id(&full_path_base_refname)
+                .is_ok()
+            {
+                full_path_base_refname
+            } else {
+                transaction.refname(base)
+            }
         } else {
             transaction.refname(&baseref)
         };
@@ -97,7 +107,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> josh::JoshResult<String> 
                 return Err(josh::josh_error(&unindent::unindent(&format!(
                     r###"
                     Reference {:?} does not exist on remote.
-                    If you want to create it, pass "-o base=refs/heads/<branchname>"
+                    If you want to create it, pass "-o base=<basebranch>" or "-o base=path/to/ref"
                     to specify a base branch/reference.
                     "###,
                     baseref

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -63,7 +63,7 @@ Check the branch pushed
    * [new branch]      new-branch -> origin/new-branch
   $ [ "${SHA1}" = "$(git log --max-count=1 --format='%H' origin/new-branch)" ] || echo "SHA1 differs after push!"
 
-Add one more commit in the workspace
+Add one more commit in the workspace and push using implicit prefix in base
 
   $ cd ${TESTTMP}/sub
   $ echo test > test.txt
@@ -72,7 +72,7 @@ Add one more commit in the workspace
   [new-branch 751ef45] test commit
    1 file changed, 1 insertion(+)
    create mode 100644 test.txt
-  $ git push origin new-branch -o base=refs/heads/master
+  $ git push origin new-branch -o base=master
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -25,7 +25,7 @@
   remote: josh-proxy
   remote: response from upstream:
   remote: Reference "refs/heads/new_branch" does not exist on remote.
-  remote: If you want to create it, pass "-o base=refs/heads/<branchname>"
+  remote: If you want to create it, pass "-o base=<basebranch>" or "-o base=path/to/ref"
   remote: to specify a base branch/reference.
   remote:
   remote:


### PR DESCRIPTION
It falls back to user given input if prepended refname is not found

Closes #616