### PR TITLE
Accept trailing chars in GraphQL content-type header

### DIFF
--- a/josh-proxy/src/juniper_hyper.rs
+++ b/josh-proxy/src/juniper_hyper.rs
@@ -62,10 +62,13 @@ async fn parse_req<S: ScalarValue>(
             let content_type = req
                 .headers()
                 .get(header::CONTENT_TYPE)
-                .map(HeaderValue::to_str);
+                .map(|x| HeaderValue::to_str(x).ok())
+                .flatten()
+                .map(|x| x.split(";").next())
+                .flatten();
             match content_type {
-                Some(Ok("application/json")) => parse_post_json_req(req.into_body()).await,
-                Some(Ok("application/graphql")) => parse_post_graphql_req(req.into_body()).await,
+                Some("application/json") => parse_post_json_req(req.into_body()).await,
+                Some("application/graphql") => parse_post_graphql_req(req.into_body()).await,
                 _ => return Err(new_response(StatusCode::BAD_REQUEST)),
             }
         }

--- a/tests/proxy/graphql_path.t
+++ b/tests/proxy/graphql_path.t
@@ -61,4 +61,16 @@
     }
   } (no-eol)
 
+  $ cat ../query | curl -s -X POST -H "content-type: application/json; charset=utf-8" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "dir": {
+          "path": "",
+          "hash": "fcd9aba1ef0c6d812452bdcb04ac155f5d7f42d6"
+        }
+      }
+    }
+  } (no-eol)
+
 $ cat ${TESTTMP}/josh-proxy.out


### PR DESCRIPTION
Some clients append "charset=utf-8" to the content type
header causing the match to fail. This will discard
those trailing chars including the semicolon.