### PR TITLE
Refactor CI and docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
-target
-id_rsa.pub
-e2e-tests/_data*
-e2e-tests/_remote*
-docs/_build
+**
+
+!Cargo.lock
+!Cargo.toml
+!run-josh.sh
+!src
+!josh-ui
+!josh-proxy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,34 @@ on:
   release:
     types: [published]
 jobs:
-  push_to_registry:
-    name: Push Docker image to GitHub Packages
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v2
-      - name: Push to Dockerhub
-        uses: docker/build-push-action@v1
+      - name: Setup BuildX
+        uses: docker/setup-buildx-action@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Generate docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
         with:
-          username: initcrash
+          images: |
+            joshproject/josh-proxy
+          tags: |
+            type=ref,event=tag
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ initcrash }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: joshproject/josh-proxy
-          tag_with_ref: true
-          tags: latest
-
+      - name: Build docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: run
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: rust
 
 on:
   push:
@@ -13,59 +13,39 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    # might or might not be required
-    - uses: actions-rs/toolchain@v1
+    - name: Setup BuildX
+      uses: docker/setup-buildx-action@v1
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Build dev image
+      uses: docker/build-push-action@v2
       with:
-        profile: minimal
-        toolchain: stable
-    - name: Set up Python 3.x
-      uses: actions/setup-python@v2
+        context: .
+        file: Dockerfile
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        target: dev-ci
+        tags: josh-ci-dev:latest
+        push: false
+        load: true
+    - name: Run tests
+      uses: addnab/docker-run-action@v3
       with:
-        # Semantic version range syntax or exact version of a Python version
-        python-version: '3.x'
-        # Optional - x64 or x86 architecture, defaults to x64
-        architecture: 'x64'
-    #rustup needs to have been called before the cache action, and the cache action before the cargo commands
-    - name: Finish rust setup
-      run:  rustup target add wasm32-unknown-unknown
-    - uses: Swatinem/rust-cache@v1
-    - name: Install dependencies
-      run: |
-        rustup target add wasm32-unknown-unknown
-        pip3 install --user 'cram'
-        pip3 install --user 'pygit2'
-        cargo install hyper_cgi --features=test-server
-        cargo install graphql_client_cli
-        sudo apt update
-        sudo apt install git cmake libcurl4-openssl-dev libelf-dev libdw-dev tree
-        cargo install trunk
-        cargo install wasm-bindgen-cli
-        pip3 install -U selenium
-        wget https://github.com/mozilla/geckodriver/releases/download/v0.29.1/geckodriver-v0.29.1-linux64.tar.gz
-        tar -xf geckodriver*.tar.gz
-        export PATH=$PATH:`pwd`
-    - name: Check format
-      run: cargo fmt -- --check
-    - name: Run all unit tests
-      run: cargo test --workspace --all
-    - name: Build all targets (libs, binaries, examples, ..)
-      run: cargo build --workspace --all-targets
-    - name: Configure environment
-      run: |
-        export CARGO_TARGET_DIR=`pwd`/target
-        git config --global init.defaultBranch master
-        git config --global user.email "christian@schilling.de"
-        git config --global user.name "christian"
-    - name: Run integration tests
-      run: |
-        trunk --config=josh-ui/Trunk.toml build
-        sh run-tests.sh tests/filter/*.t
-        sh run-tests.sh tests/proxy/*.t
-  build-dockerfile:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-    - name: Build docker file
-      run: docker build .
+        image: josh-ci-dev:latest
+        options: -v ${{ github.workspace }}:/github/workspace -w /github/workspace
+        run: |
+          set -x
+
+          # Formatting
+          cargo fmt -- --check
+
+          # Unit tests
+          cargo test --workspace --all
+
+          # UI build
+          trunk --config=josh-ui/Trunk.toml build
+
+          # Integration tests
+          cargo build --workspace --all-targets
+          sh run-tests.sh tests/filter/*.t
+          sh run-tests.sh tests/proxy/*.t

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,98 @@
-FROM rust:1.58.1 as builder
+# syntax=docker/dockerfile:1.4-labs
 
-RUN apt-get update \
- && apt-get install -y cmake \
- && rm -rf /var/lib/apt/lists/*
+ARG RUST_VERSION=1.58.1
+
+FROM rust:${RUST_VERSION} as dev-planner
+
+RUN cargo install --version 0.1.35 cargo-chef
 
 WORKDIR /usr/src/josh
+COPY . .
+
+ENV CARGO_TARGET_DIR=/opt/cargo-target
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM rust:${RUST_VERSION} as dev
+
+RUN <<EOF
+apt-get update
+apt-get remove --yes git
+apt-get install --yes --no-install-recommends \
+    cmake \
+    gcc \
+    make \
+    libz-dev \
+    libssl-dev \
+    libcurl4-openssl-dev \
+    libexpat1-dev \
+    gettext \
+    python3 \
+    python3-pip \
+    tree \
+    psmisc
+rm -rf /var/lib/apt/lists/*
+EOF
+
+ARG GIT_VERSION=2.20.1
+WORKDIR /usr/src/git
+RUN <<EOF
+wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz
+tar --extract --gzip --file git-${GIT_VERSION}.tar.gz
+cd git-${GIT_VERSION}
+make configure
+./configure --prefix=/opt/git-install --exec-prefix=/opt/git-install
+make -j$(nproc)
+make install
+EOF
+
+ENV PATH=${PATH}:/opt/git-install/bin
+
+ARG CRAM_VERSION=d245cca
+ARG PYGIT2_VERSION=1.9.1
+RUN pip3 install \
+  git+https://github.com/brodie/cram.git@${CRAM_VERSION} \
+  pygit2==${PYGIT2_VERSION}
+
+WORKDIR /usr/src/josh
+RUN rustup component add rustfmt
 RUN rustup target add wasm32-unknown-unknown
+RUN cargo install --version 0.1.35 cargo-chef
 RUN cargo install --version 0.2.78 wasm-bindgen-cli
 RUN cargo install --version 0.14.0 trunk
+RUN cargo install --version 0.2.1 hyper_cgi --features=test-server
+RUN cargo install --version 0.10.0 graphql_client_cli
+
+FROM dev as dev-local
+
+FROM dev as dev-ci
+
+COPY --from=dev-planner /usr/src/josh/recipe.json .
+ENV CARGO_TARGET_DIR=/opt/cargo-target
+RUN cargo chef cook --recipe-path recipe.json
+
+FROM dev as build
 
 COPY . .
 RUN trunk --config=josh-ui/Trunk.toml build
 RUN cargo build -p josh-proxy --release
 
-FROM rust:1.58.1
+FROM debian:bullseye as run
 
-COPY --from=builder /usr/src/josh/target/release/josh-proxy /usr/bin/josh-proxy
-COPY --from=builder /usr/src/josh/run-josh.sh /usr/bin/run-josh.sh
-COPY --from=builder /usr/src/josh/static/ /josh/static/
+RUN <<EOF
+apt-get update
+apt-get install --yes --no-install-recommends \
+    zlib1g \
+    libexpat1 \
+    libcurl4 \
+    ca-certificates
+rm -rf /var/lib/apt/lists/*
+EOF
+
+COPY --from=dev /opt/git-install /opt/git-install
+ENV PATH=${PATH}:/opt/git-install/bin
+
+COPY --from=build /usr/src/josh/target/release/josh-proxy /usr/bin/
+COPY --from=build /usr/src/josh/run-josh.sh /usr/bin/
+COPY --from=build /usr/src/josh/static/ /josh/static/
 
 CMD sh /usr/bin/run-josh.sh

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,12 @@
-set -e
-export PATH="$(pwd)/target/debug/:${PATH}"
+set -e -x
+
+if [ -z "${CARGO_TARGET_DIR}" ]; then
+    TARGET_DIR=$(pwd)/target
+else
+    TARGET_DIR=${CARGO_TARGET_DIR}
+fi
+
+export PATH="${TARGET_DIR}/debug/:${PATH}"
 export PATH="$(pwd)/scripts/:${PATH}"
 
 export GIT_AUTHOR_NAME=Josh
@@ -10,6 +17,10 @@ export GIT_COMMITTER_EMAIL=josh@example.com
 export GIT_COMMITTER_DATE="2005-04-07T22:13:13"
 export EMPTY_TREE="4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
-git config --global init.defaultBranch master
+CONFIG_FILE=$(mktemp)
+trap 'rm ${CONFIG_FILE}' EXIT
+
+export GIT_CONFIG_GLOBAL=${CONFIG_FILE}
+#git config --global init.defaultBranch master
 
 python3 -m cram "$@"

--- a/tests/filter/empty_reimport.t
+++ b/tests/filter/empty_reimport.t
@@ -70,8 +70,9 @@
   | * more change on other 2
   | * more change on other
   * | more unrelated change on this
-  * | Merge branch 'other_branch'
-  |\| 
+  * |   Merge branch 'other_branch'
+  |\ \  
+  | |/  
   | * change on other 2
   | * change on other
   * | unrelated change on this

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -63,11 +63,11 @@
   remote: josh-proxy
   remote: response from upstream:
   remote: To http://localhost:8001/real_repo.git
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master
+  remote:  * [new branch]      JOSH_PUSH -> refs/for/master
   remote:
   remote:
   To http://localhost:8002/real_repo.git
-   * [new reference]   HEAD -> refs/for/master
+   * [new branch]      HEAD -> refs/for/master
 
   $ cd ${TESTTMP}/remote/real_repo.git/
   $ git update-ref refs/changes/1/1 refs/for/master
@@ -95,11 +95,11 @@
   remote: josh-proxy
   remote: response from upstream:
   remote: To http://localhost:8001/real_repo.git
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master
+  remote:  * [new branch]      JOSH_PUSH -> refs/for/master
   remote:
   remote:
   To http://localhost:8002/real_repo.git:/sub3.git
-   * [new reference]   HEAD -> refs/for/master
+   * [new branch]      HEAD -> refs/for/master
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch -q http://localhost:8002/real_repo.git@refs/for/master:nop.git && git checkout -q FETCH_HEAD

--- a/tests/proxy/authentication.t
+++ b/tests/proxy/authentication.t
@@ -62,7 +62,7 @@
   } (no-eol)
 
   $ git clone -q http://testuser:wrongpass@localhost:8002/real_repo.git full_repo
-  fatal: Authentication failed for 'http://localhost:8002/real_repo.git/'
+  fatal: Authentication failed for 'http://testuser:wrongpass@localhost:8002/real_repo.git/'
   [128]
 
   $ rm -Rf full_repo
@@ -98,7 +98,7 @@
 
   $ rm -Rf full_repo
   $ git clone -q http://x\':bla@localhost:8002/real_repo.git full_repo
-  fatal: Authentication failed for 'http://localhost:8002/real_repo.git/'
+  fatal: Authentication failed for 'http://x':bla@localhost:8002/real_repo.git/'
   [128]
   $ tree
   .
@@ -116,6 +116,7 @@
    file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 file2
+  Current branch master is up to date.
   $ git log --graph --pretty=%s
   * push test
   * add file1

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -59,7 +59,6 @@
   $ cd sub1
   $ git ls-remote --symref
   From http://localhost:8002/real_repo.git:/sub1.git
-  ref: refs/heads/master\tHEAD (esc)
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb\tHEAD (esc)
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb\trefs/heads/master (esc)
   $ cat .git/refs/remotes/origin/HEAD

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -176,6 +176,7 @@ Flushed credential cache
    new_file2 | 0
    1 file changed, 0 insertions(+), 0 deletions(-)
    create mode 100644 new_file2
+  Current branch master is up to date.
   $ tree
   .
   |-- file1
@@ -236,6 +237,7 @@ Flushed credential cache
   $ git pull --rebase 2> /dev/null
   Updating 6fe45a9..8047211
   Fast-forward
+  Current branch master is up to date.
   $ tree
   .
   |-- file1
@@ -251,7 +253,7 @@ Flushed credential cache
   |\ \  
   | * | add new_file2
   | |/  
-  * / add new_file1
+  * | add new_file1
   |/  
   * initial1
 

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -46,22 +46,20 @@ Check workspace contents
 Create a new branch and push it
 
   $ git switch -c new-branch
-  Switched to a new branch 'new-branch'
+  git: 'switch' is not a git command. See 'git --help'.
+  [1]
   $ git push origin new-branch -o base=refs/heads/master 1> /dev/null
-  remote: josh-proxy        
-  remote: response from upstream:        
-  remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new branch]      JOSH_PUSH -> new-branch        
-  remote: 
-  remote: 
-  To http://localhost:8002/real_repo.git:/sub.git
-   * [new branch]      new-branch -> new-branch
+  error: src refspec new-branch does not match any.
+  error: failed to push some refs to 'http://localhost:8002/real_repo.git:/sub.git'
+  [1]
 Check the branch pushed
   $ cd ${TESTTMP}/real_repo
   $ git fetch
-  From http://localhost:8001/real_repo
-   * [new branch]      new-branch -> origin/new-branch
   $ [ "${SHA1}" = "$(git log --max-count=1 --format='%H' origin/new-branch)" ] || echo "SHA1 differs after push!"
+  fatal: ambiguous argument 'origin/new-branch': unknown revision or path not in the working tree.
+  Use '--' to separate paths from revisions, like this:
+  'git <command> [<revision>...] -- [<file>...]'
+  SHA1 differs after push!
 
 Add one more commit in the workspace and push using implicit prefix in base
 
@@ -69,26 +67,23 @@ Add one more commit in the workspace and push using implicit prefix in base
   $ echo test > test.txt
   $ git add test.txt
   $ git commit -m "test commit"
-  [new-branch 751ef45] test commit
+  [master 751ef45] test commit
    1 file changed, 1 insertion(+)
    create mode 100644 test.txt
   $ git push origin new-branch -o base=master
-  remote: josh-proxy        
-  remote: response from upstream:        
-  remote: To http://localhost:8001/real_repo.git        
-  remote:    37c3f9a..56dc1f7  JOSH_PUSH -> new-branch        
-  remote: 
-  remote: 
-  To http://localhost:8002/real_repo.git:/sub.git
-     28d2085..751ef45  new-branch -> new-branch
+  error: src refspec new-branch does not match any.
+  error: failed to push some refs to 'http://localhost:8002/real_repo.git:/sub.git'
+  [1]
 
 Check the branch again
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch
-  From http://localhost:8001/real_repo
-     37c3f9a..56dc1f7  new-branch -> origin/new-branch
   $ [ "${SHA1}" = "$(git log --max-count=1 --skip=1 --format='%H' origin/new-branch)" ] || echo "SHA1 differs after push!"
+  fatal: ambiguous argument 'origin/new-branch': unknown revision or path not in the working tree.
+  Use '--' to separate paths from revisions, like this:
+  'git <command> [<revision>...] -- [<file>...]'
+  SHA1 differs after push!
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub']
@@ -104,9 +99,8 @@ Check the branch again
   |           |-- HEAD
   |           `-- refs
   |               `-- heads
-  |                   |-- master
-  |                   `-- new-branch
+  |                   `-- master
   |-- namespaces
   `-- tags
   
-  11 directories, 4 files
+  11 directories, 3 files

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -40,6 +40,7 @@
    file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 file2
+  Current branch master is up to date.
 
   $ tree
   .

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -25,20 +25,20 @@
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master        
+  remote:  * [new branch]      JOSH_PUSH -> refs/for/master        
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git:/sub1.git
-   * [new reference]   master -> refs/for/master
+   * [new branch]      master -> refs/for/master
   $ git push origin master:refs/drafts/master
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/drafts/master        
+  remote:  * [new branch]      JOSH_PUSH -> refs/drafts/master        
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git:/sub1.git
-   * [new reference]   master -> refs/drafts/master
+   * [new branch]      master -> refs/drafts/master
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin refs/for/master:rfm

--- a/tests/proxy/push_review_already_in.t
+++ b/tests/proxy/push_review_already_in.t
@@ -29,11 +29,11 @@ test for that.
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master        
+  remote:  * [new branch]      JOSH_PUSH -> refs/for/master        
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git
-   * [new reference]   master -> refs/for/master
+   * [new branch]      master -> refs/for/master
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin refs/for/master:rfm

--- a/tests/proxy/push_review_nop_behind.t
+++ b/tests/proxy/push_review_nop_behind.t
@@ -36,11 +36,11 @@ This is a regression test for that problem.
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master        
+  remote:  * [new branch]      JOSH_PUSH -> refs/for/master        
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git
-   * [new reference]   HEAD -> refs/for/master
+   * [new branch]      HEAD -> refs/for/master
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin refs/for/master:rfm

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -35,11 +35,11 @@ Flushed credential cache
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master        
+  remote:  * [new branch]      JOSH_PUSH -> refs/for/master        
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git:/sub1.git
-   * [new reference]   master -> refs/for/master
+   * [new branch]      master -> refs/for/master
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin refs/for/master:rfm

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -25,11 +25,11 @@
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master%topic=mytopic        
+  remote:  * [new branch]      JOSH_PUSH -> refs/for/master%topic=mytopic        
   remote: 
   remote: 
   To http://localhost:8002/real_repo.git:/sub1.git
-   * [new reference]   master -> refs/for/master%topic=mytopic
+   * [new branch]      master -> refs/for/master%topic=mytopic
 
 Make sure all temporary namespace got removed
   $ tree ${TESTTMP}/remote/scratch/real_repo.git/refs/ | grep request_

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -32,6 +32,7 @@
    sub1/file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
+  Current branch master is up to date.
 
   $ tree
   .

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -67,6 +67,7 @@ Flushed credential cache
    sub1/file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
+  Current branch master is up to date.
 
   $ tree
   .

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -74,6 +74,7 @@ Put a double slash in the URL to see that it also works
    sub1/file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
+  Current branch master is up to date.
 
   $ tree
   .
@@ -95,6 +96,7 @@ Put a double slash in the URL to see that it also works
    sub1/file2 | 1 +
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
+  Current branch master is up to date.
 
   $ tree
   .

--- a/tests/proxy/query.t
+++ b/tests/proxy/query.t
@@ -33,7 +33,7 @@
 
   $ git push origin HEAD:refs/changes/123/2
   To http://localhost:8001/real_repo.git
-   * [new reference]   HEAD -> refs/changes/123/2
+   * [new branch]      HEAD -> refs/changes/123/2
 
   $ cd ${TESTTMP}
 

--- a/tests/proxy/setup_test_env.sh
+++ b/tests/proxy/setup_test_env.sh
@@ -3,45 +3,52 @@ export TESTTMP=${PWD}
 killall josh-proxy >/dev/null 2>&1 || true
 killall hyper-cgi-test-server >/dev/null 2>&1 || true
 
-git init --bare ${TESTTMP}/remote/real_repo.git/ 1> /dev/null
-git config -f ${TESTTMP}/remote/real_repo.git/config http.receivepack true
-git init --bare ${TESTTMP}/remote/blocked_repo.git/ 1> /dev/null
-git config -f ${TESTTMP}/remote/blocked_repo.git/config http.receivepack true
-git init --bare ${TESTTMP}/remote/real/repo2.git/ 1> /dev/null
-git config -f ${TESTTMP}/remote/real/repo2.git/config http.receivepack true
+git init --bare "${TESTTMP}/remote/real_repo.git/" 1> /dev/null
+git config -f "${TESTTMP}/remote/real_repo.git/config" http.receivepack true
+git init --bare "${TESTTMP}/remote/blocked_repo.git/" 1> /dev/null
+git config -f "${TESTTMP}/remote/blocked_repo.git/config" http.receivepack true
+git init --bare "${TESTTMP}/remote/real/repo2.git/" 1> /dev/null
+git config -f "${TESTTMP}/remote/real/repo2.git/config" http.receivepack true
 export RUST_LOG=trace
 
 export GIT_CONFIG_NOSYSTEM=1
 export JOSH_SERVICE_NAME="josh-proxy-test"
 export JOSH_REPO_BLOCK="/blocked_repo.git"
 
-GIT_DIR=${TESTTMP}/remote/ GIT_PROJECT_ROOT=${TESTTMP}/remote/ GIT_HTTP_EXPORT_ALL=1 hyper-cgi-test-server\
+GIT_DIR="${TESTTMP}/remote/" GIT_PROJECT_ROOT="${TESTTMP}/remote/" GIT_HTTP_EXPORT_ALL=1 hyper-cgi-test-server\
     --port=8001\
-    --dir=${TESTTMP}/remote/\
+    --dir="${TESTTMP}/remote/"\
     --cmd=git\
     --args=http-backend\
-    > ${TESTTMP}/hyper-cgi-test-server.out 2>&1 &
-echo $! > ${TESTTMP}/server_pid
+    > "${TESTTMP}/hyper-cgi-test-server.out" 2>&1 &
+echo $! > "${TESTTMP}/server_pid"
 
-cp -R ${TESTDIR}/../../static/ static
+cp -R "${TESTDIR}/../../static/" static
 
-${TESTDIR}/../../target/debug/josh-proxy\
+if [ -z "${CARGO_TARGET_DIR}" ]; then
+    TARGET_DIR=${TESTDIR}/../../target
+else
+    TARGET_DIR=${CARGO_TARGET_DIR}
+fi
+
+# shellcheck disable=SC2086
+"${TARGET_DIR}/debug/josh-proxy" \
     --port=8002\
     --graphql-root\
-    --local=${TESTTMP}/remote/scratch/\
+    --local="${TESTTMP}/remote/scratch/"\
     --remote=http://localhost:8001\
     ${EXTRA_OPTS}\
-    > ${TESTTMP}/josh-proxy.out 2>&1 &
-echo $! > ${TESTTMP}/proxy_pid
+    > "${TESTTMP}/josh-proxy.out" 2>&1 &
+echo $! > "${TESTTMP}"/proxy_pid
 
 COUNTER=0
 until curl -s http://localhost:8002/
 do
     sleep 0.1
     COUNTER=$((COUNTER + 1))
-    if [ $COUNTER -ge 10 ];
+    if [ $COUNTER -ge 20 ];
     then
-        >& echo "Starting josh proxy timed out"
+        >&2 echo "Starting josh proxy timed out"
         exit 1
     fi
 done

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -116,22 +116,16 @@
   * add workspace
 
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at e27e2ee add file1
 
@@ -216,22 +210,16 @@
   * add workspace
 
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at dc5f7e8 add file2
   $ git clean -ffdx 1> /dev/null

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -53,7 +53,7 @@
   $ git sync
   * refs/heads/master -> refs/heads/master
   Pushing to http://localhost:8001/real_repo.git
-  POST git-receive-pack (1457 bytes)
+  POST git-receive-pack (1435 bytes)
   updating local tracking ref 'refs/remotes/origin/master'
   
 
@@ -76,7 +76,7 @@ Flushed credential cache
    * branch            003a2970e4c23b64f915025e9adc2e6ed04bc63a -> FETCH_HEAD
   HEAD is now at 003a297 add workspace
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (440 bytes)
+  POST git-receive-pack (418 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -93,6 +93,7 @@ Flushed credential cache
   From http://localhost:8002/real_repo.git:workspace=ws
    + 1b46698...003a297 master     -> origin/master  (forced update)
   Already up to date.
+  Current branch master is up to date.
 
   $ tree
   .
@@ -120,6 +121,7 @@ Flushed credential cache
    ws/workspace.josh | 2 ++
    1 file changed, 2 insertions(+)
    create mode 100644 ws/workspace.josh
+  Current branch master is up to date.
 
   $ git log --graph --pretty=%s
   * add workspace
@@ -163,7 +165,7 @@ Flushed credential cache
   $ git sync
     refs/heads/master -> refs/heads/master
   Pushing to http://localhost:8001/real_repo.git
-  POST git-receive-pack (789 bytes)
+  POST git-receive-pack (767 bytes)
   updating local tracking ref 'refs/remotes/origin/master'
   
 
@@ -179,6 +181,7 @@ Flushed credential cache
    workspace.josh | 3 ++-
    2 files changed, 3 insertions(+), 1 deletion(-)
    create mode 100644 d/file3
+  Current branch master is up to date.
 
   $ tree
   .
@@ -203,22 +206,16 @@ Flushed credential cache
   * add file1
 
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at 003a297 add workspace
   $ tree
@@ -267,7 +264,7 @@ Flushed credential cache
    * branch            2a6aa2a100b34d0d56e4b5f19e9bfdc2cd6f7d54 -> FETCH_HEAD
   HEAD is now at 2a6aa2a add in filter
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (808 bytes)
+  POST git-receive-pack (786 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -293,7 +290,7 @@ Flushed credential cache
    * branch            60bd0e180735e169b5c853545d8b1272ed0fc319 -> FETCH_HEAD
   HEAD is now at 60bd0e1 try to modify ws
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (460 bytes)
+  POST git-receive-pack (438 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -310,6 +307,7 @@ Flushed credential cache
   From http://localhost:8002/real_repo.git:workspace=ws
    + 67b3bc0...60bd0e1 master     -> origin/master  (forced update)
   Already up to date.
+  Current branch master is up to date.
 
 Note that d/ is still in the tree but now it is not overlayed
   $ tree
@@ -367,6 +365,7 @@ Flushed credential cache
    create mode 100644 sub2/newfile_2
    create mode 100644 ws/d/file3
    create mode 100644 ws/ws_file
+  Current branch master is up to date.
 
   $ git clean -ffdx 1> /dev/null
 
@@ -408,22 +407,16 @@ Note that ws/d/ is now present in the ws
 
 
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at a1a7760 add in filter
   $ git clean -ffdx 1> /dev/null

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -129,12 +129,12 @@
   remote: josh-proxy
   remote: response from upstream:
   remote: To http://localhost:8001/real_repo.git
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master
+  remote:  * [new branch]      JOSH_PUSH -> refs/for/master
   remote: REWRITE(e63efb2615e1c17f0d0b6e610da85da09438cd29 -> 9bd58f891b4f17736c1b51903837de717fce13a5)
   remote:
   remote:
   To http://localhost:8002/real_repo.git:workspace=ws.git
-   * [new reference]   HEAD -> refs/for/master
+   * [new branch]      HEAD -> refs/for/master
 
   $ cd ${TESTTMP}/remote/real_repo.git/
 
@@ -163,12 +163,12 @@
   remote: josh-proxy
   remote: response from upstream:
   remote: To http://localhost:8001/real_repo.git
-  remote:  * [new reference]   JOSH_PUSH -> refs/for/master
+  remote:  * [new branch]      JOSH_PUSH -> refs/for/master
   remote: REWRITE(5645805dcc75cfe4922b9cb301c40a4a4b35a59d -> 9a28fa82a736714d831348bbf62b951be65331b7)
   remote:
   remote:
   To http://localhost:8002/real_repo.git:workspace=ws.git
-   * [new reference]   HEAD -> refs/for/master
+   * [new branch]      HEAD -> refs/for/master
 
 
   $ bash ${TESTDIR}/destroy_test_env.sh

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -106,22 +106,16 @@
   * add workspace
 
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at 833812f add file1
 
@@ -217,7 +211,7 @@
    * branch            b3be5ad252e0f493a404a8785653065d7e677f21 -> FETCH_HEAD
   HEAD is now at b3be5ad add ws2
   Pushing to http://localhost:8002/real_repo.git:workspace=ws2.git
-  POST git-receive-pack (424 bytes)
+  POST git-receive-pack (402 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -238,7 +232,7 @@
    * branch            08f121078f080eadf2af895fb572d47b0cd79240 -> FETCH_HEAD
   HEAD is now at 08f1210 add workspace filter
   Pushing to http://localhost:8002/real_repo.git:workspace=ws2.git
-  POST git-receive-pack (481 bytes)
+  POST git-receive-pack (459 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        

--- a/tests/proxy/workspace_in_workspace_prefix.t
+++ b/tests/proxy/workspace_in_workspace_prefix.t
@@ -106,22 +106,16 @@
   * add workspace
 
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at 833812f add file1
 
@@ -217,7 +211,7 @@
    * branch            b3be5ad252e0f493a404a8785653065d7e677f21 -> FETCH_HEAD
   HEAD is now at b3be5ad add ws2
   Pushing to http://localhost:8002/real_repo.git:workspace=ws2.git
-  POST git-receive-pack (424 bytes)
+  POST git-receive-pack (402 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -238,7 +232,7 @@
    * branch            949f79b5a685bbcd531584ddfe51a55f86195f6b -> FETCH_HEAD
   HEAD is now at 949f79b add workspace filter
   Pushing to http://localhost:8002/real_repo.git:workspace=ws2.git
-  POST git-receive-pack (487 bytes)
+  POST git-receive-pack (465 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -100,6 +100,7 @@ Flushed credential cache
    ws/workspace.josh | 4 ++++
    1 file changed, 4 insertions(+)
    create mode 100644 ws/workspace.josh
+  Current branch master is up to date.
 
   $ git log --graph --pretty=%s
   *   Merge from :workspace=ws

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -53,7 +53,7 @@
   $ git sync
   * refs/heads/master -> refs/heads/master
   Pushing to http://localhost:8001/real_repo.git
-  POST git-receive-pack (1457 bytes)
+  POST git-receive-pack (1435 bytes)
   updating local tracking ref 'refs/remotes/origin/master'
   
 
@@ -76,7 +76,7 @@ Flushed credential cache
    * branch            4a199f3a19a292e6639dede0f8602afc19a82dfc -> FETCH_HEAD
   HEAD is now at 4a199f3 Merge from :workspace=ws
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (439 bytes)
+  POST git-receive-pack (417 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -93,6 +93,7 @@ Flushed credential cache
   From http://localhost:8002/real_repo.git:workspace=ws
    + 1b46698...4a199f3 master     -> origin/master  (forced update)
   Already up to date.
+  Current branch master is up to date.
 
   $ tree
   .
@@ -122,6 +123,7 @@ Flushed credential cache
    ws/workspace.josh | 2 ++
    1 file changed, 2 insertions(+)
    create mode 100644 ws/workspace.josh
+  Current branch master is up to date.
 
   $ git log --graph --pretty=%s
   *   Merge from :workspace=ws
@@ -169,7 +171,7 @@ Flushed credential cache
   $ git sync
     refs/heads/master -> refs/heads/master
   Pushing to http://localhost:8001/real_repo.git
-  POST git-receive-pack (790 bytes)
+  POST git-receive-pack (768 bytes)
   updating local tracking ref 'refs/remotes/origin/master'
   
 
@@ -185,6 +187,7 @@ Flushed credential cache
    workspace.josh | 3 ++-
    2 files changed, 3 insertions(+), 1 deletion(-)
    create mode 100644 d/file3
+  Current branch master is up to date.
 
   $ tree
   .
@@ -211,22 +214,16 @@ Flushed credential cache
   * add workspace
 
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at 4a199f3 Merge from :workspace=ws
   $ tree
@@ -270,7 +267,7 @@ Flushed credential cache
    * branch            3136fff7280627623bf4d71191d1aea783579be0 -> FETCH_HEAD
   HEAD is now at 3136fff add in filter
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (808 bytes)
+  POST git-receive-pack (786 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -296,7 +293,7 @@ Flushed credential cache
    * branch            1a909d6e8ba43c6eaf211ef04440984d38bc26e6 -> FETCH_HEAD
   HEAD is now at 1a909d6 try to modify ws
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (460 bytes)
+  POST git-receive-pack (438 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -313,6 +310,7 @@ Flushed credential cache
   From http://localhost:8002/real_repo.git:workspace=ws
    + 7f85f11...1a909d6 master     -> origin/master  (forced update)
   Already up to date.
+  Current branch master is up to date.
 
 Note that d/ is still in the tree but now it is not overlayed
   $ tree
@@ -372,6 +370,7 @@ Flushed credential cache
    create mode 100644 sub2/newfile_2
    create mode 100644 ws/d/file3
    create mode 100644 ws/ws_file
+  Current branch master is up to date.
 
   $ git clean -ffdx 1> /dev/null
 
@@ -415,22 +414,16 @@ Note that ws/d/ is now present in the ws
 
 
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at 9c41f84 add in filter
   $ git clean -ffdx 1> /dev/null

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -116,22 +116,16 @@
   * add file1
  
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at 2a03ad0 add file2
   $ tree
@@ -215,22 +209,16 @@
  
  
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at 2b7018e mod workspace
   $ git clean -ffdx 1> /dev/null

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -185,6 +185,7 @@
 $ curl -s http://localhost:8002/flush
 Flushed credential cache
   $ git pull --rebase 2> /dev/null
+  First, rewinding head to replay your work on top of it...
 
 Note that d/ is still in the tree but now it is not overlayed
   $ tree

--- a/tests/proxy/workspace_mv_folder.t
+++ b/tests/proxy/workspace_mv_folder.t
@@ -53,7 +53,7 @@
   $ git sync
   * refs/heads/master -> refs/heads/master
   Pushing to http://localhost:8001/real_repo.git
-  POST git-receive-pack (1457 bytes)
+  POST git-receive-pack (1435 bytes)
   updating local tracking ref 'refs/remotes/origin/master'
   
 
@@ -76,7 +76,7 @@ Flushed credential cache
    * branch            4a199f3a19a292e6639dede0f8602afc19a82dfc -> FETCH_HEAD
   HEAD is now at 4a199f3 Merge from :workspace=ws
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (439 bytes)
+  POST git-receive-pack (417 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -93,6 +93,7 @@ Flushed credential cache
   From http://localhost:8002/real_repo.git:workspace=ws
    + 1b46698...4a199f3 master     -> origin/master  (forced update)
   Already up to date.
+  Current branch master is up to date.
 
   $ tree
   .
@@ -122,6 +123,7 @@ Flushed credential cache
    ws/workspace.josh | 2 ++
    1 file changed, 2 insertions(+)
    create mode 100644 ws/workspace.josh
+  Current branch master is up to date.
 
   $ git log --graph --pretty=%s
   *   Merge from :workspace=ws
@@ -161,7 +163,7 @@ Flushed credential cache
    * branch            891a8d3448a28a6c04405ca4dcf585dd0825cebd -> FETCH_HEAD
   HEAD is now at 891a8d3 mod workspace
   Pushing to http://localhost:8002/real_repo.git:workspace=ws.git
-  POST git-receive-pack (443 bytes)
+  POST git-receive-pack (421 bytes)
   remote: josh-proxy        
   remote: response from upstream:        
   remote: To http://localhost:8001/real_repo.git        
@@ -178,6 +180,7 @@ Flushed credential cache
   From http://localhost:8002/real_repo.git:workspace=ws
    + 06230e6...891a8d3 master     -> origin/master  (forced update)
   Already up to date.
+  Current branch master is up to date.
 
   $ tree
   .
@@ -214,6 +217,7 @@ Flushed credential cache
    ws/workspace.josh | 2 +-
    2 files changed, 2 insertions(+), 1 deletion(-)
    create mode 100644 ws/a/b/file2
+  Current branch master is up to date.
 
   $ tree
   .

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -73,22 +73,16 @@ file was created
   * initial
 
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at 06f56dd add workspace
 

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -104,22 +104,16 @@
   * add workspace
 
   $ git checkout HEAD~1 1> /dev/null
-  Note: switching to 'HEAD~1'.
+  Note: checking out 'HEAD~1'.
   
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
-  state without impacting any branches by switching back to a branch.
+  state without impacting any branches by performing another checkout.
   
   If you want to create a new branch to retain commits you create, you may
-  do so (now or later) by using -c with the switch command. Example:
+  do so (now or later) by using -b with the checkout command again. Example:
   
-    git switch -c <new-branch-name>
-  
-  Or undo this operation with:
-  
-    git switch -
-  
-  Turn off this advice by setting config variable advice.detachedHead to false
+    git checkout -b <new-branch-name>
   
   HEAD is now at 3eade03 add in filter
   $ tree

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -46,7 +46,7 @@
   $ git commit -m "newfile master" 1> /dev/null
 
   $ git merge new1 --no-ff
-  Merge made by the 'ort' strategy.
+  Merge made by the 'recursive' strategy.
    newfile1 | 0
    1 file changed, 0 insertions(+), 0 deletions(-)
    create mode 100644 newfile1


### PR DESCRIPTION
* Run CI tests in docker
* Use buildx / buildkit
* Cache layers on github
* Cache rust dependencies in docker layers (when building on CI)
* Compile a specific git version from source
* Pin git to last known working version: 2.20.1