### PR TITLE
Run filter discovery only on changed refs

### DIFF
--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -203,7 +203,13 @@ async fn static_paths(
             if refresh {
                 josh::housekeeping::refresh_known_filters(&transaction, &known_filters)?;
             }
-            Ok(toml::to_string_pretty(&known_filters)?)
+            let mut kf = std::collections::BTreeMap::new();
+            for (k, v) in &known_filters {
+                if v.1.len() != 0 {
+                    kf.insert(k, v.1.clone());
+                }
+            }
+            Ok(toml::to_string_pretty(&kf)?)
         })
         .await??;
 


### PR DESCRIPTION
Walking trees for all refs all the time caused significant resource
usage on the background job.