### PR TITLE
Pass username in env variable

### DIFF
--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -346,9 +346,6 @@ async fn call_service(
     req_auth: (josh_proxy::auth::Handle, Request<hyper::Body>),
 ) -> josh::JoshResult<Response<hyper::Body>> {
     let (auth, req) = req_auth;
-    let (username, _) = auth.parse()?;
-
-    tracing::event!(tracing::Level::TRACE, username = username.as_str());
 
     let path = {
         let mut path = req.uri().path().to_owned();


### PR DESCRIPTION
In some cases, like when using auth tokens, users might wrongly
put the secret into the username field, causing to end up in
logs and traces.
Now it is handled with the same secrecy as the password itself.