### PR TITLE
Handle @sha urls by creating magic ref

### DIFF
--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -295,16 +295,22 @@ async fn do_filter(
             )?;
         }
 
-        from_to.push((
-            format!(
-                "refs/josh/upstream/{}/{}",
-                &josh::to_ns(&upstream_repo),
-                headref
-            ),
-            temp_ns.reference(&headref),
-        ));
-
         let mut headref = headref;
+
+        if headref.starts_with("refs/") || headref == "HEAD" {
+            from_to.push((
+                format!(
+                    "refs/josh/upstream/{}/{}",
+                    &josh::to_ns(&upstream_repo),
+                    headref
+                ),
+                temp_ns.reference(&headref),
+            ));
+        } else {
+            let headsha = headref.clone();
+            headref = format!("refs/heads/_{}", &headref);
+            from_to.push((headsha, temp_ns.reference(&headref)));
+        }
 
         josh::filter_refs(&transaction, filter, &from_to, josh::filter::empty())?;
         if headref == "HEAD" {

--- a/tests/proxy/clone_sha.t
+++ b/tests/proxy/clone_sha.t
@@ -49,6 +49,11 @@
 
   $ cd ${TESTTMP}
 
+  $ git ls-remote http://localhost:8002/real_repo.git@bb282e9cdc1b972fffd08fd21eead43bc0c83cb8:/.git 
+  bb282e9cdc1b972fffd08fd21eead43bc0c83cb8\tHEAD (esc)
+  bb282e9cdc1b972fffd08fd21eead43bc0c83cb8\trefs/heads/_bb282e9cdc1b972fffd08fd21eead43bc0c83cb8 (esc)
+  bb282e9cdc1b972fffd08fd21eead43bc0c83cb8\trefs/heads/master (esc)
+
   $ git clone -q http://localhost:8002/real_repo.git@bb282e9cdc1b972fffd08fd21eead43bc0c83cb8:/.git full_repo
 
   $ cd full_repo


### PR DESCRIPTION
The @rev url syntax did not work if rev was specified as a sha.
This was because there was no ref for the symref HEAD to point to.
Now a fake ref is created for that purpose.