### PR TITLE
Walk simplified history if :linear is used

### DIFF
--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -840,3 +840,11 @@ mod tests {
         );
     }
 }
+
+pub fn is_linear(filter: Filter) -> bool {
+    return match to_op(filter) {
+        Op::Linear => true,
+        Op::Chain(a, b) => is_linear(a) || is_linear(b),
+        _ => false,
+    };
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -19,6 +19,9 @@ pub fn walk2(
 
     let walk = {
         let mut walk = transaction.repo().revwalk()?;
+        if filter::is_linear(filter) {
+            walk.simplify_first_parent()?;
+        }
         walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
         walk.push(input)?;
         for k in known.iter() {


### PR DESCRIPTION
Without .simplify_first_parent() all commits would be filtered
even if they are only reachable via second parents.