### PR TITLE
Use faster compose implementation for symmetric filters

### DIFF
--- a/src/filter/opt.rs
+++ b/src/filter/opt.rs
@@ -445,6 +445,8 @@ pub fn invert(filter: Filter) -> JoshResult<Filter> {
         _ => return Err(josh_error("no invert")),
     });
 
+    let result = optimize(result);
+
     INVERTED.lock().unwrap().insert(original, result);
     Ok(result)
 }

--- a/src/filter/tree.rs
+++ b/src/filter/tree.rs
@@ -796,6 +796,20 @@ fn populate(
     Ok(result_tree)
 }
 
+pub fn compose_fast<'a>(
+    transaction: &'a cache::Transaction,
+    trees: Vec<git2::Oid>,
+) -> super::JoshResult<git2::Tree<'a>> {
+    rs_tracing::trace_scoped!("compose_fast");
+    let repo = transaction.repo();
+    let mut result = tree::empty_id();
+    for tree in trees {
+        result = overlay(repo, tree, result)?;
+    }
+
+    Ok(repo.find_tree(result)?)
+}
+
 pub fn compose<'a>(
     transaction: &'a cache::Transaction,
     trees: Vec<(&super::filter::Filter, git2::Tree<'a>)>,


### PR DESCRIPTION
Such filters can never have any non unique mappings
and as such don't need the complexity of the more general
algorithm that ensures uniqueness.
The simpler implementation compose_fast() results in large
speedups (2x and more) when trying different compose filters
on the Josh repo.