### PR TITLE
Make :linear filter non-recursive

### DIFF
--- a/tests/filter/linear.t
+++ b/tests/filter/linear.t
@@ -32,6 +32,7 @@
   * add file1
 
   $ josh-filter -s :linear refs/heads/master --update refs/heads/filtered
+  [3] :linear
 
   $ git log --graph --pretty=%s refs/heads/filtered
   * Merge branch 'branch2'
@@ -56,6 +57,7 @@
   * add file1
 
   $ josh-filter -s :linear refs/heads/master --update refs/heads/filtered --reverse
+  [3] :linear
 
   $ git log --graph --pretty=%s refs/heads/master
   * mod file2


### PR DESCRIPTION
The :linear filter was implemented recursively by accident,
making it very slow on non trivial repos.