### PR TITLE
Execute simpler filters before more complex ones

### DIFF
--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -315,6 +315,8 @@ pub fn create_repo(path: &std::path::Path) -> josh::JoshResult<()> {
     shell.command("git config receive.advertisePushOptions true");
     let ce = std::env::current_exe().expect("can't find path to exe");
     shell.command("rm -Rf hooks");
+    shell.command("rm -Rf *.lock");
+    shell.command("rm -Rf packed-refs");
     shell.command("mkdir hooks");
     std::os::unix::fs::symlink(ce.clone(), path.join("hooks").join("update"))
         .expect("can't symlink update hook");
@@ -325,7 +327,6 @@ pub fn create_repo(path: &std::path::Path) -> josh::JoshResult<()> {
             .to_string(),
     );
     shell.command("git config gc.auto 0");
-    shell.command("git pack-refs --all");
 
     if std::env::var_os("JOSH_KEEP_NS") == None {
         std::fs::remove_dir_all(path.join("refs/namespaces")).ok();

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -329,7 +329,7 @@ impl Transaction {
 
     pub fn get_missing(&self) -> Vec<(filter::Filter, git2::Oid)> {
         let mut missing = self.t2.borrow().missing.clone();
-        missing.sort();
+        missing.sort_by_key(|(f, i)| (filter::nesting(*f), *f, *i));
         missing.dedup();
         missing.retain(|(f, i)| !self.known(*f, *i));
         self.t2.borrow_mut().missing = missing.clone();


### PR DESCRIPTION
This deterministic execution order divides the filtering of
complex filters into stages that can then be parallelised
with a later patch.