### PR TITLE
Support quoted string as filter arguments

### DIFF
--- a/docs/src/reference/filters.md
+++ b/docs/src/reference/filters.md
@@ -17,6 +17,12 @@ When used as part of an URL filters can not contain whitespace or newlines. When
 however whitespace can be inserted between filters (not after the leading colon).
 Additionally newlines can be used instead of ``,`` inside of composition filters.
 
+Some filters take arguments, and arguments can optionally be quoted using double quotes,
+if special characters used by the filter language need to be used (like `:` or space):
+
+    :filter=argument1,"argument2"
+
+
 ## Available filters
 
 ### Subdirectory **`:/a`**

--- a/src/filter/grammar.pest
+++ b/src/filter/grammar.pest
@@ -6,6 +6,15 @@ CMD_SEP = _{(","|NEWLINE)}
 ALNUM = _{( ASCII_ALPHANUMERIC | "_" | "-" | "+" | "." | "*" | "~")}
 GROUP_START = _{ "[" }
 GROUP_END = _{ "]" }
+PATH = _{ (ALNUM | "/")+ }
+filter_path = { PATH }
+
+string = ${ "\"" ~ inner ~ "\"" }
+inner = @{ char* }
+char = {
+    !("\"" | "\\") ~ ANY
+    | "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t")
+}
 
 filter_spec = { (
     filter_group
@@ -23,7 +32,7 @@ filter_presub = { CMD_START ~ ":" ~ argument }
 filter = { CMD_START ~ cmd ~ "=" ~ (argument ~ ("," ~ argument)*)? }
 filter_noarg = { CMD_START ~ cmd }
 
-argument = { (ALNUM | "/" )+ }
+argument = { string | PATH }
 
 cmd = { ALNUM+ }
 

--- a/src/filter/mod.rs
+++ b/src/filter/mod.rs
@@ -128,10 +128,14 @@ fn pretty2(op: &Op, indent: usize, compose: bool) -> String {
         },
         Op::Chain(a, b) => match (to_op(*a), to_op(*b)) {
             (Op::Subdir(p1), Op::Prefix(p2)) if p1 == p2 => {
-                format!("::{}/", p1.to_string_lossy())
+                format!("::{}/", parse::quote(&p1.to_string_lossy()))
             }
             (a, Op::Prefix(p)) if compose => {
-                format!("{} = {}", p.to_string_lossy(), pretty2(&a, indent, false))
+                format!(
+                    "{} = {}",
+                    parse::quote(&p.to_string_lossy()),
+                    pretty2(&a, indent, false)
+                )
             }
             (a, b) => format!(
                 "{}{}",
@@ -184,12 +188,12 @@ fn spec2(op: &Op) -> String {
             format!(":exclude[{}]", spec(*b))
         }
         Op::Workspace(path) => {
-            format!(":workspace={}", path.to_string_lossy())
+            format!(":workspace={}", parse::quote(&path.to_string_lossy()))
         }
 
         Op::Chain(a, b) => match (to_op(*a), to_op(*b)) {
             (Op::Subdir(p1), Op::Prefix(p2)) if p1 == p2 => {
-                format!("::{}/", p1.to_string_lossy())
+                format!("::{}/", parse::quote(&p1.to_string_lossy()))
             }
             (a, b) => format!("{}{}", spec2(&a), spec2(&b)),
         },
@@ -203,10 +207,10 @@ fn spec2(op: &Op) -> String {
         Op::Fold => ":FOLD".to_string(),
         Op::Squash => ":SQUASH".to_string(),
         Op::Linear => ":linear".to_string(),
-        Op::Subdir(path) => format!(":/{}", path.to_string_lossy()),
-        Op::File(path) => format!("::{}", path.to_string_lossy()),
-        Op::Prefix(path) => format!(":prefix={}", path.to_string_lossy()),
-        Op::Glob(pattern) => format!("::{}", pattern),
+        Op::Subdir(path) => format!(":/{}", parse::quote(&path.to_string_lossy())),
+        Op::File(path) => format!("::{}", parse::quote(&path.to_string_lossy())),
+        Op::Prefix(path) => format!(":prefix={}", parse::quote(&path.to_string_lossy())),
+        Op::Glob(pattern) => format!("::{}", parse::quote(&pattern)),
     }
 }
 

--- a/tests/filter/pretty_print.t
+++ b/tests/filter/pretty_print.t
@@ -2,10 +2,14 @@
 
   $ josh-filter -p :/a
   :/a
+  $ josh-filter -p :/"a"
+  :/a
   $ josh-filter --reverse -p :/a
   :prefix=a
   $ josh-filter -p :/a~
   :/a~
+  $ josh-filter -p ':/"a%\"$"'
+  :/"a%\"$"
   $ josh-filter -p :/a:/b
   :/a/b
   $ josh-filter -p :[:/a:/b,:/a/b]


### PR DESCRIPTION
Previously, not all valid directory names could be used
as filter arguments, any directory name can be used.

Change-Id: quoted-args