### PR TITLE
Don't create rewrite refs

### DIFF
--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -296,20 +296,22 @@ async fn do_filter(
             &filter_spec,
         );
 
-        let glob = format!(
-            "refs/josh/rewrites/{}/{:?}/r_*",
-            josh::to_ns(&upstream_repo),
-            filter.id()
-        );
-        for reference in transaction.repo().references_glob(&glob).unwrap() {
-            let reference = reference.unwrap();
-            let refname = reference.name().unwrap();
-            transaction.repo().reference(
-                &temp_ns.reference(refname),
-                reference.target().unwrap(),
-                true,
-                "rewrite",
-            )?;
+        if let Ok(_) = std::env::var("JOSH_REWRITE_REFS") {
+            let glob = format!(
+                "refs/josh/rewrites/{}/{:?}/r_*",
+                josh::to_ns(&upstream_repo),
+                filter.id()
+            );
+            for reference in transaction.repo().references_glob(&glob).unwrap() {
+                let reference = reference.unwrap();
+                let refname = reference.name().unwrap();
+                transaction.repo().reference(
+                    &temp_ns.reference(refname),
+                    reference.target().unwrap(),
+                    true,
+                    "rewrite",
+                )?;
+            }
         }
 
         let mut headref = headref;

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -237,17 +237,19 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> josh::JoshResult<String> 
         )?;
 
         if new_oid != reapply {
-            transaction.repo().reference(
-                &format!(
-                    "refs/josh/rewrites/{}/{:?}/r_{}",
-                    repo_update.base_ns,
-                    filterobj.id(),
-                    reapply
-                ),
-                reapply,
-                true,
-                "reapply",
-            )?;
+            if let Ok(_) = std::env::var("JOSH_REWRITE_REFS") {
+                transaction.repo().reference(
+                    &format!(
+                        "refs/josh/rewrites/{}/{:?}/r_{}",
+                        repo_update.base_ns,
+                        filterobj.id(),
+                        reapply
+                    ),
+                    reapply,
+                    true,
+                    "reapply",
+                )?;
+            }
             let text = format!("REWRITE({} -> {})", new_oid, reapply);
             tracing::debug!("{}", text);
             resp.push(text);

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -242,10 +242,6 @@
   |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
   |   |           `-- HEAD
-  |   |-- rewrites
-  |   |   `-- real_repo.git
-  |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
-  |   |           `-- r_fa3b9622c1bcc8363c27d4eb05d1ae8dae15e871
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -255,6 +251,6 @@
   |-- namespaces
   `-- tags
   
-  19 directories, 9 files
+  16 directories, 8 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -461,12 +461,6 @@ Note that ws/d/ is now present in the ws
   |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
   |   |           `-- HEAD
-  |   |-- rewrites
-  |   |   `-- real_repo.git
-  |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
-  |   |           |-- r_003a2970e4c23b64f915025e9adc2e6ed04bc63a
-  |   |           |-- r_2a6aa2a100b34d0d56e4b5f19e9bfdc2cd6f7d54
-  |   |           `-- r_60bd0e180735e169b5c853545d8b1272ed0fc319
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -476,6 +470,6 @@ Note that ws/d/ is now present in the ws
   |-- namespaces
   `-- tags
   
-  20 directories, 12 files
+  17 directories, 9 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -200,11 +200,6 @@
   |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
   |   |           `-- HEAD
-  |   |-- rewrites
-  |   |   `-- real_repo.git
-  |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
-  |   |           |-- r_9a28fa82a736714d831348bbf62b951be65331b7
-  |   |           `-- r_9bd58f891b4f17736c1b51903837de717fce13a5
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -217,4 +212,4 @@
   |-- namespaces
   `-- tags
   
-  22 directories, 12 files
+  19 directories, 10 files

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -266,12 +266,6 @@
   |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws2
   |   |           `-- HEAD
-  |   |-- rewrites
-  |   |   `-- real_repo.git
-  |   |       |-- 191ead67feb541c237317e25b2c66c5d8f3e33fa
-  |   |       |   `-- r_b3be5ad252e0f493a404a8785653065d7e677f21
-  |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
-  |   |           `-- r_2cbcd105ead63a4fecf486b949db7f44710300e5
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -281,5 +275,5 @@
   |-- namespaces
   `-- tags
   
-  22 directories, 12 files
+  18 directories, 10 files
 

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -199,10 +199,6 @@ Flushed credential cache
   |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
   |   |           `-- HEAD
-  |   |-- rewrites
-  |   |   `-- real_repo.git
-  |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
-  |   |           `-- r_c255706f564f629eed1756b789d761048cfe060a
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -212,4 +208,4 @@ Flushed credential cache
   |-- namespaces
   `-- tags
   
-  18 directories, 8 files
+  15 directories, 7 files

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -458,12 +458,6 @@ Note that ws/d/ is now present in the ws
   |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
   |   |           `-- HEAD
-  |   |-- rewrites
-  |   |   `-- real_repo.git
-  |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
-  |   |           |-- r_3136fff7280627623bf4d71191d1aea783579be0
-  |   |           |-- r_4a199f3a19a292e6639dede0f8602afc19a82dfc
-  |   |           `-- r_91e1e8645d3439b195f3866664092ebc20e63bb5
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -473,6 +467,6 @@ Note that ws/d/ is now present in the ws
   |-- namespaces
   `-- tags
   
-  19 directories, 11 files
+  16 directories, 8 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -321,11 +321,6 @@ Note that ws/d/ is now present in the ws
   |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
   |   |           `-- HEAD
-  |   |-- rewrites
-  |   |   `-- real_repo.git
-  |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
-  |   |           |-- r_44edc62d506b9805a3edfc74db15b1cc0bfc6871
-  |   |           `-- r_707a20731ff94c2dee063a8b274665b1cc730e26
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -335,6 +330,6 @@ Note that ws/d/ is now present in the ws
   |-- namespaces
   `-- tags
   
-  19 directories, 10 files
+  16 directories, 8 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -134,10 +134,6 @@
   |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
   |   |           `-- HEAD
-  |   |-- rewrites
-  |   |   `-- real_repo.git
-  |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
-  |   |           `-- r_9db51080a4d148b32bd4c4e0b39eae8d0b3df763
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -147,6 +143,6 @@
   |-- namespaces
   `-- tags
   
-  16 directories, 6 files
+  13 directories, 5 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -249,10 +249,6 @@
   |   |       |   `-- HEAD
   |   |       `-- %3Aworkspace=ws
   |   |           `-- HEAD
-  |   |-- rewrites
-  |   |   `-- real_repo.git
-  |   |       `-- 7bd92d97e96693ea7fd7eb5757b3580002889948
-  |   |           `-- r_2cbcd105ead63a4fecf486b949db7f44710300e5
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -264,6 +260,6 @@
   |-- namespaces
   `-- tags
   
-  20 directories, 10 files
+  17 directories, 9 files
 
 $ cat ${TESTTMP}/josh-proxy.out


### PR DESCRIPTION
Those are not needed with newer versions of git anymore.
In case this leads to unexpected problems, hide it behind an
env variable as a transitional step so it can still be enabled.