### PR TITLE
Discover filters only on HEAD

### DIFF
--- a/tests/proxy/clone_subtree_no_master.t
+++ b/tests/proxy/clone_subtree_no_master.t
@@ -75,10 +75,7 @@
   [1]
 
   $ bash ${TESTDIR}/destroy_test_env.sh
-  "real_repo.git" = [
-      ':/sub1',
-      ':/sub2',
-  ]
+  "real_repo.git" = [':/sub1']
   refs
   |-- heads
   |-- josh


### PR DESCRIPTION
Instead of iterating all refs in the repo, which can be very
expensive.
