### PR TITLE
Log a backtrace when errors happen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ experimental = ["search"]
 members = ["josh-proxy", "josh-ui", "."]
 
 [dependencies]
+backtrace = "0.3"
 bincode = "1.3"
 bitvec = "1.0"
 chrono = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,8 @@ where
     fn from(item: T) -> Self {
         tracing::event!(tracing::Level::ERROR, item = ?item, error = true);
         log::error!("JoshError: {:?}", item);
+        let bt = backtrace::Backtrace::new();
+        log::error!("Backtrace: {:?}", bt);
         josh_error(&format!("converted {:?}", item))
     }
 }


### PR DESCRIPTION
Because of the error conversion, error locations where always
reported as coming from lib.rs.
With the stack trace it should be possible to see where the
original error was coming from.