### PR TITLE
Run cargo check instead of build in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ t: c
 	sh run-tests.sh tests/filter/*.t
 
 c:
-	cargo build --workspace --message-format=json | python3 ./scripts/rerr.py
+	cargo check --workspace --message-format=json | python3 ./scripts/rerr.py
 
 f:
 	cargo fmt

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -211,8 +211,7 @@ async fn static_paths(
             let transaction = josh::cache::Transaction::open(&service.repo_path, None)?;
             josh::housekeeping::discover_filter_candidates(&transaction)?;
             if refresh {
-                let mut updated_refs = josh::housekeeping::refresh_known_filters(&transaction)?;
-                josh::update_refs(&transaction, &mut updated_refs, "");
+                josh::housekeeping::refresh_known_filters(&transaction)?;
             }
             Ok(toml::to_string_pretty(
                 &josh::housekeeping::get_known_filters()?,

--- a/src/housekeeping.rs
+++ b/src/housekeeping.rs
@@ -312,8 +312,7 @@ pub fn run(repo_path: &std::path::Path, do_gc: bool) -> JoshResult<()> {
         housekeeping::discover_filter_candidates(&transaction)?;
     }
     if !std::env::var("JOSH_NO_REFRESH").is_ok() {
-        let mut updated_refs = refresh_known_filters(&transaction)?;
-        update_refs(&transaction, &mut updated_refs, "");
+        refresh_known_filters(&transaction)?;
     }
     info!(
         "{}",

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -122,10 +122,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub3
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -140,4 +136,4 @@
   |-- namespaces
   `-- tags
   
-  14 directories, 5 files
+  11 directories, 4 files

--- a/tests/proxy/authentication.t
+++ b/tests/proxy/authentication.t
@@ -125,10 +125,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -138,4 +134,4 @@
   |-- namespaces
   `-- tags
   
-  11 directories, 3 files
+  8 directories, 2 files

--- a/tests/proxy/caching.t
+++ b/tests/proxy/caching.t
@@ -49,10 +49,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -62,7 +58,7 @@
   |-- namespaces
   `-- tags
   
-  11 directories, 3 files
+  8 directories, 2 files
 
 # setup without caching
   $ EXTRA_OPTS= . ${TESTDIR}/setup_test_env.sh
@@ -112,10 +108,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -125,4 +117,4 @@
   |-- namespaces
   `-- tags
   
-  11 directories, 3 files
+  8 directories, 2 files

--- a/tests/proxy/clone_all.t
+++ b/tests/proxy/clone_all.t
@@ -54,10 +54,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -67,5 +63,5 @@
   |-- namespaces
   `-- tags
   
-  11 directories, 3 files
+  8 directories, 2 files
 

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -75,14 +75,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aprefix=pre
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -92,4 +84,4 @@
   |-- namespaces
   `-- tags
   
-  13 directories, 5 files
+  8 directories, 2 files

--- a/tests/proxy/clone_sha.t
+++ b/tests/proxy/clone_sha.t
@@ -73,10 +73,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -87,5 +83,5 @@
   |-- namespaces
   `-- tags
   
-  11 directories, 4 files
+  8 directories, 3 files
 

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -86,14 +86,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       `-- %3A%2Fsub2
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -103,4 +95,4 @@
   |-- namespaces
   `-- tags
   
-  13 directories, 5 files
+  8 directories, 2 files

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -85,12 +85,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       `-- %3A%2Fsub2
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -100,4 +94,4 @@
   |-- namespaces
   `-- tags
   
-  12 directories, 4 files
+  8 directories, 2 files

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -115,12 +115,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       `-- %3A%2Fsub2
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -132,5 +126,5 @@
   |-- namespaces
   `-- tags
   
-  13 directories, 5 files
+  9 directories, 3 files
 $ cat ${TESTTMP}/josh-proxy.out | grep TAGS

--- a/tests/proxy/empty_commit.t
+++ b/tests/proxy/empty_commit.t
@@ -84,10 +84,6 @@ should still be included.
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -97,4 +93,4 @@ should still be included.
   |-- namespaces
   `-- tags
   
-  11 directories, 3 files
+  8 directories, 2 files

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -301,18 +301,6 @@ Flushed credential cache
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   |-- real_repo.git
-  |   |   |   |-- %3A%2Frepo1
-  |   |   |   |   `-- HEAD
-  |   |   |   `-- %3A%2Frepo2
-  |   |   |       `-- HEAD
-  |   |   |-- repo1.git
-  |   |   |   `-- %3Aprefix=repo1
-  |   |   |       `-- HEAD
-  |   |   `-- repo2.git
-  |   |       `-- %3Aprefix=repo2
-  |   |           `-- HEAD
   |   `-- upstream
   |       |-- real_repo.git
   |       |   |-- HEAD
@@ -332,4 +320,4 @@ Flushed credential cache
   |-- namespaces
   `-- tags
   
-  22 directories, 10 files
+  14 directories, 6 files

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -60,10 +60,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3Aprefix=sub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -73,4 +69,4 @@
   |-- namespaces
   `-- tags
   
-  11 directories, 3 files
+  8 directories, 2 files

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -329,14 +329,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fa
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fa%2Fb
-  |   |       |   `-- HEAD
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -348,4 +340,4 @@
   |-- namespaces
   `-- tags
   
-  14 directories, 6 files
+  9 directories, 3 files

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -95,10 +95,6 @@ Check the branch again
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -109,4 +105,4 @@ Check the branch again
   |-- namespaces
   `-- tags
   
-  11 directories, 4 files
+  8 directories, 3 files

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -57,12 +57,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aprefix=pre
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -72,5 +66,5 @@
   |-- namespaces
   `-- tags
   
-  12 directories, 4 files
+  8 directories, 2 files
 

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -85,10 +85,6 @@ Make sure all temporary namespace got removed
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -98,7 +94,7 @@ Make sure all temporary namespace got removed
   |-- namespaces
   `-- tags
   
-  11 directories, 3 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -83,10 +83,6 @@ Flushed credential cache
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -96,7 +92,7 @@ Flushed credential cache
   |-- namespaces
   `-- tags
   
-  11 directories, 3 files
+  8 directories, 2 files
 
   $ cat ${TESTTMP}/josh-proxy.out | grep graph_descendant_of
   [1]

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -40,10 +40,6 @@ Make sure all temporary namespace got removed
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -53,7 +49,7 @@ Make sure all temporary namespace got removed
   |-- namespaces
   `-- tags
   
-  11 directories, 3 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -146,12 +146,6 @@ Make sure all temporary namespace got removed
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       `-- %3A%3Afile7
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -170,7 +164,7 @@ Make sure all temporary namespace got removed
   |-- namespaces
   `-- tags
   
-  17 directories, 8 files
+  13 directories, 6 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -130,10 +130,6 @@ Make sure all temporary namespace got removed
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -157,7 +153,7 @@ Make sure all temporary namespace got removed
   |-- namespaces
   `-- tags
   
-  19 directories, 9 files
+  16 directories, 8 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -49,12 +49,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       `-- %3A%2Fsub1%3Aprefix=pre
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -64,6 +58,6 @@
   |-- namespaces
   `-- tags
   
-  12 directories, 4 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -88,10 +88,6 @@ Make sure all temporary namespace got removed
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -102,6 +98,6 @@ Make sure all temporary namespace got removed
   |-- namespaces
   `-- tags
   
-  11 directories, 4 files
+  8 directories, 3 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -113,13 +113,6 @@ Put a double slash in the URL to see that it also works
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   |-- real%2Frepo2.git
-  |   |   |   `-- %3A%2Fsub1
-  |   |   |       `-- HEAD
-  |   |   `-- real_repo.git
-  |   |       `-- %3A%2Fsub1
-  |   |           `-- HEAD
   |   `-- upstream
   |       |-- real%2Frepo2.git
   |       |   |-- HEAD
@@ -134,5 +127,5 @@ Put a double slash in the URL to see that it also works
   |-- namespaces
   `-- tags
   
-  16 directories, 6 files
+  11 directories, 4 files
 

--- a/tests/proxy/unrelated_leak.t
+++ b/tests/proxy/unrelated_leak.t
@@ -133,12 +133,6 @@ Flushed credential cache
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       `-- %3A%2Fsub2
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -149,4 +143,4 @@ Flushed credential cache
   |-- namespaces
   `-- tags
   
-  12 directories, 5 files
+  8 directories, 3 files

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -226,20 +226,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub3
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -249,6 +235,6 @@
   |-- namespaces
   `-- tags
   
-  16 directories, 8 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -443,22 +443,6 @@ Note that ws/d/ is now present in the ws
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub3
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws%2Fd
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -468,6 +452,6 @@ Note that ws/d/ is now present in the ws
   |-- namespaces
   `-- tags
   
-  17 directories, 9 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -103,24 +103,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real%2Frepo2.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub3
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws2
-  |   |       |   `-- HEAD
-  |   |       |-- %3Aworkspace=ws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws2
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real%2Frepo2.git
   |           |-- HEAD
@@ -130,6 +112,6 @@
   |-- namespaces
   `-- tags
   
-  18 directories, 10 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -182,22 +182,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub3
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub4
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -210,4 +194,4 @@
   |-- namespaces
   `-- tags
   
-  19 directories, 10 files
+  10 directories, 3 files

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -246,24 +246,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub3
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws2
-  |   |       |   `-- HEAD
-  |   |       |-- %3Aworkspace=ws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws2
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -273,5 +255,5 @@
   |-- namespaces
   `-- tags
   
-  18 directories, 10 files
+  8 directories, 2 files
 

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -185,18 +185,6 @@ Flushed credential cache
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -206,4 +194,4 @@ Flushed credential cache
   |-- namespaces
   `-- tags
   
-  15 directories, 7 files
+  8 directories, 2 files

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -442,20 +442,6 @@ Note that ws/d/ is now present in the ws
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub3
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -465,6 +451,6 @@ Note that ws/d/ is now present in the ws
   |-- namespaces
   `-- tags
   
-  16 directories, 8 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -250,22 +250,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub3
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       |-- %3Aworkspace=ws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws%3A%2Fpre
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -275,6 +259,6 @@
   |-- namespaces
   `-- tags
   
-  17 directories, 9 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -305,20 +305,6 @@ Note that ws/d/ is now present in the ws
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub3
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -328,6 +314,6 @@ Note that ws/d/ is now present in the ws
   |-- namespaces
   `-- tags
   
-  16 directories, 8 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -89,16 +89,6 @@ file was created
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -108,6 +98,6 @@ file was created
   |-- namespaces
   `-- tags
   
-  14 directories, 6 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -126,14 +126,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -143,6 +135,6 @@
   |-- namespaces
   `-- tags
   
-  13 directories, 5 files
+  8 directories, 2 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -233,20 +233,6 @@
   refs
   |-- heads
   |-- josh
-  |   |-- filtered
-  |   |   `-- real_repo.git
-  |   |       |-- %3A%2Fsub1
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub1%2Fsubsub
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub2
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fsub3
-  |   |       |   `-- HEAD
-  |   |       |-- %3A%2Fws
-  |   |       |   `-- HEAD
-  |   |       `-- %3Aworkspace=ws
-  |   |           `-- HEAD
   |   `-- upstream
   |       `-- real_repo.git
   |           |-- HEAD
@@ -258,6 +244,6 @@
   |-- namespaces
   `-- tags
   
-  17 directories, 9 files
+  9 directories, 3 files
 
 $ cat ${TESTTMP}/josh-proxy.out


### PR DESCRIPTION
This file is only intended for getting compile errors into the editor
and check is faster in doing that.