### PR TITLE
Split objects stores

### DIFF
--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -115,7 +115,7 @@ async fn fetch_upstream(
 
     if fetch_cached_ok && !headref.is_empty() {
         let transaction = josh::cache::Transaction::open(
-            &service.repo_path,
+            &service.repo_path.join("mirror"),
             Some(&format!(
                 "refs/josh/upstream/{}/",
                 &josh::to_ns(&upstream_repo),
@@ -132,7 +132,7 @@ async fn fetch_upstream(
 
     let fetch_timers = service.fetch_timers.clone();
     let heads_map = service.heads_map.clone();
-    let br_path = service.repo_path.clone();
+    let br_path = service.repo_path.join("mirror");
 
     let s = tracing::span!(tracing::Level::TRACE, "fetch worker");
     let us = upstream_repo.clone();
@@ -147,7 +147,7 @@ async fn fetch_upstream(
 
     let us = upstream_repo.clone();
     let s = tracing::span!(tracing::Level::TRACE, "get_head worker");
-    let br_path = service.repo_path.clone();
+    let br_path = service.repo_path.join("mirror");
     let ru = remote_url.clone();
     let a = auth.clone();
     let hres = tokio::task::spawn_blocking(move || {
@@ -208,10 +208,16 @@ async fn static_paths(
         let refresh = path == "/filters/refresh";
 
         let body_str = tokio::task::spawn_blocking(move || -> josh::JoshResult<_> {
-            let transaction = josh::cache::Transaction::open(&service.repo_path, None)?;
-            josh::housekeeping::discover_filter_candidates(&transaction)?;
+            let transaction_mirror =
+                josh::cache::Transaction::open(&service.repo_path.join("mirror"), None)?;
+            josh::housekeeping::discover_filter_candidates(&transaction_mirror)?;
             if refresh {
-                josh::housekeeping::refresh_known_filters(&transaction)?;
+                let transaction_overlay =
+                    josh::cache::Transaction::open(&service.repo_path.join("overlay"), None)?;
+                josh::housekeeping::refresh_known_filters(
+                    &transaction_mirror,
+                    &transaction_overlay,
+                )?;
             }
             Ok(toml::to_string_pretty(
                 &josh::housekeeping::get_known_filters()?,
@@ -282,31 +288,13 @@ async fn do_filter(
         josh::housekeeping::remember_filter(&upstream_repo, &filter_spec);
 
         let transaction = josh::cache::Transaction::open(
-            &repo_path,
+            &repo_path.join("mirror"),
             Some(&format!(
                 "refs/josh/upstream/{}/",
                 &josh::to_ns(&upstream_repo),
             )),
         )?;
         let mut refslist = josh::housekeeping::list_refs(transaction.repo(), &upstream_repo)?;
-
-        if let Ok(_) = std::env::var("JOSH_REWRITE_REFS") {
-            let glob = format!(
-                "refs/josh/rewrites/{}/{:?}/r_*",
-                josh::to_ns(&upstream_repo),
-                filter.id()
-            );
-            for reference in transaction.repo().references_glob(&glob).unwrap() {
-                let reference = reference.unwrap();
-                let refname = reference.name().unwrap();
-                transaction.repo().reference(
-                    &temp_ns.reference(refname),
-                    reference.target().unwrap(),
-                    true,
-                    "rewrite",
-                )?;
-            }
-        }
 
         let mut headref = headref;
 
@@ -332,24 +320,25 @@ async fn do_filter(
                 .unwrap_or(&"invalid".to_string())
                 .clone();
         }
-        let mut updated_refs =
-            josh::filter_refs(&transaction, filter, &refslist, josh::filter::empty())?;
-        josh::housekeeping::namespace_refs(&mut updated_refs, &temp_ns.name(), &upstream_repo);
-        josh::update_refs(
-            &transaction,
-            &mut updated_refs,
-            &temp_ns.reference(&headref),
-        );
+        {
+            let t2 = josh::cache::Transaction::open(&repo_path.join("overlay"), None)?;
+            t2.repo()
+                .odb()?
+                .add_disk_alternate(&repo_path.join("mirror").join("objects").to_str().unwrap())?;
+            let mut updated_refs =
+                josh::filter_refs(&t2, filter, &refslist, josh::filter::empty())?;
+            josh::housekeeping::namespace_refs(&mut updated_refs, &temp_ns.name(), &upstream_repo);
+            josh::update_refs(&t2, &mut updated_refs, &temp_ns.reference(&headref));
+            t2.repo()
+                .reference_symbolic(
+                    &temp_ns.reference("HEAD"),
+                    &temp_ns.reference(&headref),
+                    true,
+                    "",
+                )
+                .ok();
+        }
 
-        transaction
-            .repo()
-            .reference_symbolic(
-                &temp_ns.reference("HEAD"),
-                &temp_ns.reference(&headref),
-                true,
-                "",
-            )
-            .ok();
         Ok(())
     })
     .await?;
@@ -556,13 +545,23 @@ async fn call_service(
     }
 
     if parsed_url.api == "/~/graphql" {
-        let context = std::sync::Arc::new(josh::graphql::context(josh::cache::Transaction::open(
-            &serv.repo_path,
+        let transaction_mirror = josh::cache::Transaction::open(
+            &serv.repo_path.join("mirror"),
             Some(&format!(
                 "refs/josh/upstream/{}/",
                 &josh::to_ns(&parsed_url.upstream_repo),
             )),
-        )?));
+        )?;
+        let transaction = josh::cache::Transaction::open(&serv.repo_path.join("overlay"), None)?;
+        transaction.repo().odb()?.add_disk_alternate(
+            &serv
+                .repo_path
+                .join("mirror")
+                .join("objects")
+                .to_str()
+                .unwrap(),
+        )?;
+        let context = std::sync::Arc::new(josh::graphql::context(transaction, transaction_mirror));
         let root_node = std::sync::Arc::new(josh::graphql::repo_schema(
             parsed_url
                 .upstream_repo
@@ -576,13 +575,19 @@ async fn call_service(
             .await?;
         tokio::task::spawn_blocking(move || -> josh::JoshResult<_> {
             let temp_ns = Arc::new(josh_proxy::TmpGitNamespace::new(
-                &serv.repo_path,
+                &serv.repo_path.join("overlay"),
                 tracing::Span::current(),
             ));
 
             for (reference, oid) in context.to_push.lock()?.iter() {
                 josh_proxy::push_head_url(
                     context.transaction.lock()?.repo(),
+                    &serv
+                        .repo_path
+                        .join("mirror")
+                        .join("objects")
+                        .to_str()
+                        .unwrap(),
                     *oid,
                     &reference,
                     &remote_url,
@@ -599,11 +604,6 @@ async fn call_service(
         return Ok(gql_result);
     }
 
-    let repo_path = serv
-        .repo_path
-        .to_str()
-        .ok_or(josh::josh_error("repo_path.to_str"))?;
-
     let temp_ns = prepare_namespace(
         serv.clone(),
         &parsed_url.upstream_repo,
@@ -619,11 +619,20 @@ async fn call_service(
             let res = tokio::task::spawn_blocking(move || -> josh::JoshResult<_> {
                 let _e = s.enter();
                 let transaction = josh::cache::Transaction::open(
-                    &serv.repo_path,
+                    &serv.repo_path.join("overlay"),
                     Some(&format!(
                         "refs/josh/upstream/{}/",
                         &josh::to_ns(&parsed_url.upstream_repo),
                     )),
+                )?;
+
+                transaction.repo().odb()?.add_disk_alternate(
+                    &serv
+                        .repo_path
+                        .join("mirror")
+                        .join("objects")
+                        .to_str()
+                        .unwrap(),
                 )?;
 
                 josh::query::render(transaction.repo(), "", &temp_ns.reference(&headref), &q)
@@ -651,6 +660,20 @@ async fn call_service(
         }
     }
 
+    let repo_path = serv
+        .repo_path
+        .join("overlay")
+        .to_str()
+        .ok_or(josh::josh_error("repo_path.to_str"))?
+        .to_string();
+
+    let mirror_repo_path = serv
+        .repo_path
+        .join("mirror")
+        .to_str()
+        .ok_or(josh::josh_error("repo_path.to_str"))?
+        .to_string();
+
     let span = tracing::span!(tracing::Level::TRACE, "hyper_cgi");
     let _enter = span.enter();
     let mut context_propagator = HashMap::<String, String>::default();
@@ -668,16 +691,25 @@ async fn call_service(
         filter_spec: parsed_url.filter.clone(),
         base_ns: josh::to_ns(&parsed_url.upstream_repo),
         git_ns: temp_ns.name().to_string(),
-        git_dir: repo_path.to_string(),
+        git_dir: repo_path.clone(),
+        mirror_git_dir: mirror_repo_path.clone(),
         stacked_changes: ARGS.is_present("stacked-changes"),
         context_propagator: context_propagator,
     };
 
     let mut cmd = Command::new("git");
     cmd.arg("http-backend");
-    cmd.current_dir(&serv.repo_path);
-    cmd.env("GIT_DIR", repo_path);
+    cmd.current_dir(&serv.repo_path.join("overlay"));
+    cmd.env("GIT_DIR", &repo_path);
     cmd.env("GIT_HTTP_EXPORT_ALL", "");
+    cmd.env(
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        serv.repo_path
+            .join("mirror")
+            .join("objects")
+            .to_str()
+            .ok_or(josh::josh_error("repo_path.to_str"))?,
+    );
     cmd.env("GIT_NAMESPACE", temp_ns.name().clone());
     cmd.env("GIT_PROJECT_ROOT", repo_path);
     cmd.env("JOSH_REPO_UPDATE", serde_json::to_string(&repo_update)?);
@@ -706,7 +738,7 @@ async fn prepare_namespace(
     headref: &str,
 ) -> josh::JoshResult<std::sync::Arc<josh_proxy::TmpGitNamespace>> {
     let temp_ns = Arc::new(josh_proxy::TmpGitNamespace::new(
-        &serv.repo_path,
+        &serv.repo_path.join("overlay"),
         tracing::Span::current(),
     ));
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,7 @@ fi
 export PATH="${TARGET_DIR}/debug/:${PATH}"
 export PATH="$(pwd)/scripts/:${PATH}"
 
+export JOSH_COMMIT_TIME=0
 export GIT_AUTHOR_NAME=Josh
 export GIT_AUTHOR_EMAIL=josh@example.com
 export GIT_AUTHOR_DATE="2005-04-07T22:13:13"

--- a/src/bin/josh-filter.rs
+++ b/src/bin/josh-filter.rs
@@ -362,7 +362,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
             None,
             &josh::graphql::repo_schema(".".to_string(), true),
             &std::collections::HashMap::new(),
-            &josh::graphql::context(transaction.try_clone()?),
+            &josh::graphql::context(transaction.try_clone()?, transaction.try_clone()?),
         )?;
 
         let j = serde_json::to_string(&res)?;

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -401,11 +401,12 @@ struct Markers {
 #[graphql_object(context = Context)]
 impl Markers {
     fn data(&self, context: &Context) -> FieldResult<Vec<Document>> {
+        let transaction_mirror = context.transaction_mirror.lock()?;
         let transaction = context.transaction.lock()?;
 
-        let refname = transaction.refname("refs/josh/meta");
+        let refname = transaction_mirror.refname("refs/josh/meta");
 
-        let r = transaction.repo().revparse_single(&refname);
+        let r = transaction_mirror.repo().revparse_single(&refname);
         let tree = if let Ok(r) = r {
             let commit = transaction.repo().find_commit(r.id())?;
             commit.tree()?
@@ -452,11 +453,12 @@ impl Markers {
     }
 
     fn count(&self, context: &Context) -> FieldResult<i32> {
+        let transaction_mirror = context.transaction_mirror.lock()?;
         let transaction = context.transaction.lock()?;
 
-        let refname = transaction.refname("refs/josh/meta");
+        let refname = transaction_mirror.refname("refs/josh/meta");
 
-        let r = transaction.repo().revparse_single(&refname);
+        let r = transaction_mirror.repo().revparse_single(&refname);
         let mtree = if let Ok(r) = r {
             let commit = transaction.repo().find_commit(r.id())?;
             commit.tree()?
@@ -679,8 +681,8 @@ impl Reference {
     }
 
     fn rev(&self, context: &Context, filter: Option<String>) -> FieldResult<Revision> {
-        let transaction = context.transaction.lock()?;
-        let commit_id = transaction
+        let transaction_mirror = context.transaction_mirror.lock()?;
+        let commit_id = transaction_mirror
             .repo()
             .find_reference(&self.refname)?
             .target()
@@ -695,6 +697,7 @@ impl Reference {
 
 pub struct Context {
     pub transaction: std::sync::Arc<std::sync::Mutex<cache::Transaction>>,
+    pub transaction_mirror: std::sync::Arc<std::sync::Mutex<cache::Transaction>>,
     pub to_push: std::sync::Arc<std::sync::Mutex<Vec<(String, git2::Oid)>>>,
 }
 
@@ -745,13 +748,15 @@ impl RepositoryMut {
         context: &Context,
     ) -> FieldResult<bool> {
         let transaction = context.transaction.lock()?;
-        let rev = transaction.refname("refs/josh/meta");
+        let transaction_mirror = context.transaction_mirror.lock()?;
 
-        transaction
+        let rev = transaction_mirror.refname("refs/josh/meta");
+
+        transaction_mirror
             .repo()
             .find_commit(git2::Oid::from_str(&commit)?)?;
 
-        let r = transaction.repo().revparse_single(&rev);
+        let r = transaction_mirror.repo().revparse_single(&rev);
         let (tree, parent) = if let Ok(r) = r {
             let commit = transaction.repo().find_commit(r.id())?;
             let tree = commit.tree()?;
@@ -794,10 +799,20 @@ impl RepositoryMut {
             tree = filter::tree::insert(transaction.repo(), &tree, path, blob, 0o0100644)?;
         }
 
+        let signature = if let Ok(time) = std::env::var("JOSH_COMMIT_TIME") {
+            git2::Signature::new(
+                "josh",
+                "josh@josh-project.dev",
+                &git2::Time::new(time.parse()?, 0),
+            )
+        } else {
+            git2::Signature::now("josh", "josh@josh-project.dev")
+        }?;
+
         let oid = transaction.repo().commit(
             None,
-            &transaction.repo().signature()?,
-            &transaction.repo().signature()?,
+            &signature,
+            &signature,
             "marker",
             &tree,
             &parent.as_ref().into_iter().collect::<Vec<_>>(),
@@ -819,7 +834,7 @@ impl Repository {
     }
 
     fn refs(&self, context: &Context, pattern: Option<String>) -> FieldResult<Vec<Reference>> {
-        let transaction = context.transaction.lock()?;
+        let transaction_mirror = context.transaction_mirror.lock()?;
         let refname = format!(
             "{}{}",
             self.ns,
@@ -830,7 +845,7 @@ impl Repository {
 
         let mut refs = vec![];
 
-        for reference in transaction.repo().references_glob(&refname)? {
+        for reference in transaction_mirror.repo().references_glob(&refname)? {
             let r = reference?;
             let name = r
                 .name()
@@ -847,11 +862,11 @@ impl Repository {
     fn rev(&self, context: &Context, at: String, filter: Option<String>) -> FieldResult<Revision> {
         let rev = format!("{}{}", self.ns, at);
 
-        let transaction = context.transaction.lock()?;
+        let transaction_mirror = context.transaction_mirror.lock()?;
         let commit_id = if let Ok(id) = git2::Oid::from_str(&at) {
             id
         } else {
-            transaction.repo().revparse_single(&rev)?.id()
+            transaction_mirror.repo().revparse_single(&rev)?.id()
         };
 
         Ok(Revision {
@@ -867,8 +882,9 @@ regex_parsed!(
     [reference]
 );
 
-pub fn context(transaction: cache::Transaction) -> Context {
+pub fn context(transaction: cache::Transaction, transaction_mirror: cache::Transaction) -> Context {
     Context {
+        transaction_mirror: std::sync::Arc::new(std::sync::Mutex::new(transaction_mirror)),
         transaction: std::sync::Arc::new(std::sync::Mutex::new(transaction)),
         to_push: std::sync::Arc::new(std::sync::Mutex::new(vec![])),
     }

--- a/src/housekeeping.rs
+++ b/src/housekeeping.rs
@@ -270,9 +270,10 @@ pub fn get_info(
     Ok(serde_json::to_string(&s)?)
 }
 
-#[tracing::instrument(skip(transaction))]
+#[tracing::instrument(skip(transaction_mirror, transaction_overlay))]
 pub fn refresh_known_filters(
-    transaction: &cache::Transaction,
+    transaction_mirror: &cache::Transaction,
+    transaction_overlay: &cache::Transaction,
 ) -> JoshResult<Vec<(String, git2::Oid)>> {
     let known_filters = KNOWN_FILTERS.lock()?;
     let mut updated_refs = vec![];
@@ -283,12 +284,12 @@ pub fn refresh_known_filters(
             tracing::trace!("background rebuild: {:?} {:?}", upstream_repo, filter_spec);
 
             if let Ok((from, to_ref)) = memorize_from_to(
-                transaction.repo(),
+                transaction_mirror.repo(),
                 &to_filtered_ref(upstream_repo, filter_spec),
                 upstream_repo,
             ) {
                 let mut u = filter_refs(
-                    transaction,
+                    &transaction_overlay,
                     filter::parse(filter_spec)?,
                     &[from],
                     filter::empty(),
@@ -309,26 +310,61 @@ pub fn get_known_filters() -> JoshResult<std::collections::BTreeMap<String, BTre
         .collect())
 }
 
-pub fn run(repo_path: &Path, do_gc: bool) -> JoshResult<()> {
-    let transaction = cache::Transaction::open(repo_path, None)?;
-    if std::env::var("JOSH_NO_DISCOVER").is_err() {
-        discover_filter_candidates(&transaction)?;
-    }
-    if std::env::var("JOSH_NO_REFRESH").is_err() {
-        refresh_known_filters(&transaction)?;
-    }
+pub fn run(repo_path: &std::path::Path, do_gc: bool) -> JoshResult<()> {
+    let transaction_mirror = cache::Transaction::open(&repo_path.join("mirror"), None)?;
+    let transaction_overlay = cache::Transaction::open(&repo_path.join("overlay"), None)?;
+
+    transaction_overlay
+        .repo()
+        .odb()?
+        .add_disk_alternate(&repo_path.join("mirror").join("objects").to_str().unwrap())?;
+
     info!(
         "{}",
-        run_command(transaction.repo().path(), "git count-objects -v").replace('\n', "  ")
+        run_command(transaction_mirror.repo().path(), "git count-objects -v").replace("\n", "  ")
     );
+    info!(
+        "{}",
+        run_command(transaction_overlay.repo().path(), "git count-objects -v").replace("\n", "  ")
+    );
+    if !std::env::var("JOSH_NO_DISCOVER").is_ok() {
+        housekeeping::discover_filter_candidates(&transaction_mirror)?;
+    }
+    if !std::env::var("JOSH_NO_REFRESH").is_ok() {
+        refresh_known_filters(&transaction_mirror, &transaction_overlay)?;
+    }
     if do_gc {
         info!(
             "\n----------\n{}\n----------",
-            run_command(transaction.repo().path(), "git repack -adkbn --threads=1")
+            run_command(
+                transaction_mirror.repo().path(),
+                "git repack -dkbn --no-write-bitmap-index --threads=4"
+            )
         );
         info!(
             "\n----------\n{}\n----------",
-            run_command(transaction.repo().path(), "git count-objects -vH")
+            run_command(
+                transaction_mirror.repo().path(),
+                "git multi-pack-index write --bitmap"
+            )
+        );
+        info!(
+            "\n----------\n{}\n----------",
+            run_command(
+                transaction_overlay.repo().path(),
+                "git repack -dkbn --no-write-bitmap-index --threads=4"
+            )
+        );
+        info!(
+            "\n----------\n{}\n----------",
+            run_command(
+                transaction_overlay.repo().path(),
+                "git multi-pack-index write --bitmap"
+            )
+        );
+        info!(
+            "\n----------\n{}\n----------",
+            run_command(transaction_mirror.repo().path(), "git count-objects -vH")
         );
     }
     Ok(())

--- a/src/query.rs
+++ b/src/query.rs
@@ -42,12 +42,13 @@ impl GraphQLHelper {
         }
 
         let transaction = cache::Transaction::open(&self.repo_path, None)?;
+        let transaction_overlay = cache::Transaction::open(&self.repo_path, None)?;
         let (res, _errors) = juniper::execute_sync(
             &query,
             None,
             &graphql::commit_schema(self.commit_id),
             &variables,
-            &graphql::context(transaction),
+            &graphql::context(transaction, transaction_overlay),
         )?;
 
         let j = serde_json::to_string(&res)?;
@@ -140,12 +141,13 @@ pub fn render(
                 variables.insert(k.to_string(), juniper::InputValue::scalar(v));
             }
             let transaction = cache::Transaction::open(repo.path(), None)?;
+            let transaction_overlay = cache::Transaction::open(repo.path(), None)?;
             let (res, _errors) = juniper::execute_sync(
                 template,
                 None,
                 &graphql::commit_schema(commit_id),
                 &variables,
-                &graphql::context(transaction),
+                &graphql::context(transaction, transaction_overlay),
             )?;
 
             let j = serde_json::to_string_pretty(&res)?;

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -119,21 +119,98 @@
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub3']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               |-- changes
-  |               |   `-- 1
-  |               |       `-- 1
-  |               |-- for
-  |               |   `-- master
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 18
+  |   |   |   `-- 5984b1d05c7ba7842828bdc8669c69eed48540
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 22
+  |   |   |   `-- a3c9e53508f9532b5109352448c0051ff0a018
+  |   |   |-- 2a
+  |   |   |   `-- f8fd9cc75470c09c6442895133a815806018fc
+  |   |   |-- 50
+  |   |   |   `-- e9d1a4ad68f5edd03432b540ae6d56995810f5
+  |   |   |-- 63
+  |   |   |   `-- 9874a1a8b362d3042d6bc74339166a13fa78b3
+  |   |   |-- 76
+  |   |   |   `-- b2b18cc389f8dc88727cb143f362f3b4a07788
+  |   |   |-- 8e
+  |   |   |   `-- 9eedb14562d157b873eb24a08d6c0cd225624b
+  |   |   |-- ad
+  |   |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+  |   |   |-- b0
+  |   |   |   `-- c372112e15e6946f82bebf73b70f5b3e0d5066
+  |   |   |-- e5
+  |   |   |   `-- 70b660ac9df7044f7262287a3828b44bb001b3
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- eb
+  |   |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               |-- changes
+  |       |               |   `-- 1
+  |       |               |       `-- 1
+  |       |               |-- for
+  |       |               |   `-- master
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 18
+      |   |   `-- 5984b1d05c7ba7842828bdc8669c69eed48540
+      |   |-- 22
+      |   |   `-- a3c9e53508f9532b5109352448c0051ff0a018
+      |   |-- 35
+      |   |   `-- 13da41fec4409551ee7aead656b211996b8f1d
+      |   |-- 47
+      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
+      |   |-- 50
+      |   |   `-- e9d1a4ad68f5edd03432b540ae6d56995810f5
+      |   |-- 76
+      |   |   `-- b2b18cc389f8dc88727cb143f362f3b4a07788
+      |   |-- 7c
+      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
+      |   |-- 8e
+      |   |   `-- 9eedb14562d157b873eb24a08d6c0cd225624b
+      |   |-- b0
+      |   |   `-- c372112e15e6946f82bebf73b70f5b3e0d5066
+      |   |-- c3
+      |   |   `-- 4ad756a74e200f89b43b0d6f21b41eb284b454
+      |   |-- d5
+      |   |   `-- 89c2fd7b5d736b868c4e196898cd9f578eb77f
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  11 directories, 4 files
+  53 directories, 39 files

--- a/tests/proxy/authentication.t
+++ b/tests/proxy/authentication.t
@@ -122,16 +122,57 @@
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 91
+      |   |   `-- 0a3d87d1a2d548fdb3d188ffb65bb9c6bd1679
+      |   |-- f2
+      |   |   `-- 3daa65f7acedf146f24dd04c1d2704dde25f4f
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  32 directories, 19 files

--- a/tests/proxy/caching.t
+++ b/tests/proxy/caching.t
@@ -46,19 +46,68 @@
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 5a
+  |   |   |   `-- 29d3ef74b34ca534513c6499e9c9011371fab4
+  |   |   |-- 8e
+  |   |   |   `-- 9aa8ffc35bbc452f9654b834047168ce02dc48
+  |   |   |-- ad
+  |   |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 06
+      |   |   `-- 8bef6976001fadcf131ff077eac37662ed3b7c
+      |   |-- 2e
+      |   |   `-- 310c493edb401f297aba1fc499506e4c85ca87
+      |   |-- 63
+      |   |   `-- 7f0347d31dad180d6fc7f6720c187b05a8754c
+      |   |-- 77
+      |   |   `-- d7000ec2f13c49605cd675075e1852881e4fea
+      |   |-- bd
+      |   |   `-- c926c483c4dfa77e84105c6967e74d8ff9bf5f
+      |   |-- eb
+      |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  36 directories, 23 files
 
 # setup without caching
   $ EXTRA_OPTS= . ${TESTDIR}/setup_test_env.sh
@@ -105,16 +154,73 @@
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 06
+  |   |   |   `-- 8bef6976001fadcf131ff077eac37662ed3b7c
+  |   |   |-- 2e
+  |   |   |   `-- 310c493edb401f297aba1fc499506e4c85ca87
+  |   |   |-- 5a
+  |   |   |   `-- 29d3ef74b34ca534513c6499e9c9011371fab4
+  |   |   |-- 63
+  |   |   |   `-- 7f0347d31dad180d6fc7f6720c187b05a8754c
+  |   |   |-- 77
+  |   |   |   `-- d7000ec2f13c49605cd675075e1852881e4fea
+  |   |   |-- 8e
+  |   |   |   `-- 9aa8ffc35bbc452f9654b834047168ce02dc48
+  |   |   |-- ad
+  |   |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 06
+      |   |   `-- 8bef6976001fadcf131ff077eac37662ed3b7c
+      |   |-- 2e
+      |   |   `-- 310c493edb401f297aba1fc499506e4c85ca87
+      |   |-- 63
+      |   |   `-- 7f0347d31dad180d6fc7f6720c187b05a8754c
+      |   |-- 77
+      |   |   `-- d7000ec2f13c49605cd675075e1852881e4fea
+      |   |-- bd
+      |   |   `-- c926c483c4dfa77e84105c6967e74d8ff9bf5f
+      |   |-- eb
+      |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  40 directories, 27 files

--- a/tests/proxy/clone_absent_head.t
+++ b/tests/proxy/clone_absent_head.t
@@ -85,12 +85,50 @@
   warning: You appear to have cloned an empty repository.
 
   $ bash ${TESTDIR}/destroy_test_env.sh
-  refs
-  |-- heads
+  .
   |-- josh
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- info
+  |   |   `-- pack
+  |   |-- packed-refs
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  4 directories, 0 files
+  26 directories, 16 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/clone_all.t
+++ b/tests/proxy/clone_all.t
@@ -51,17 +51,54 @@
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  30 directories, 17 files
 

--- a/tests/proxy/clone_blocked.t
+++ b/tests/proxy/clone_blocked.t
@@ -7,9 +7,37 @@
   [128]
 
   $ bash ${TESTDIR}/destroy_test_env.sh
-  refs
-  |-- heads
-  `-- tags
+  .
+  |-- josh
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          `-- tags
   
-  2 directories, 0 files
+  20 directories, 10 files
 

--- a/tests/proxy/clone_invalid_url.t
+++ b/tests/proxy/clone_invalid_url.t
@@ -30,9 +30,37 @@
   [128]
 
   $ bash ${TESTDIR}/destroy_test_env.sh
-  refs
-  |-- heads
-  `-- tags
+  .
+  |-- josh
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          `-- tags
   
-  2 directories, 0 files
+  20 directories, 10 files
 

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -72,16 +72,67 @@
       ':/sub2',
       ':prefix=pre',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 23
+  |   |   |   `-- 87c32648eefdee78386575672ac091da849b08
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- ff
+  |   |   |   `-- e8d082c1034053534ea8068f4205ac72a1098e
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 00
+      |   |   `-- f1db8b2e4bd1bf8337e0fe3a2ad9aeea478280
+      |   |-- 1f
+      |   |   `-- 0b9d8a7b40a35bb4ff64ffc0f08369df23bc61
+      |   |-- b5
+      |   |   `-- af4d1258141efaadc32e369f4dc4b1f6c524e4
+      |   |-- e9
+      |   |   `-- 67e7a8371f8e269cb1d9bb6b2fff5be29e8578
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  37 directories, 24 files

--- a/tests/proxy/clone_sha.t
+++ b/tests/proxy/clone_sha.t
@@ -70,18 +70,55 @@
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           |-- bb282e9cdc1b972fffd08fd21eead43bc0c83cb8
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           |-- bb282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 3 files
+  30 directories, 18 files
 

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -83,16 +83,65 @@
       ':/sub1/subsub',
       ':/sub2',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 03
+  |   |   |   `-- dfdf502bbb4622e74f4e5794dbc1ea91b3617c
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 43
+  |   |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
+  |   |   |-- 78
+  |   |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+  |   |   |-- 79
+  |   |   |   `-- e0ba46b1d4838b2b50e4b05c2e420e4dca0fd7
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- f5
+  |   |   |   `-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- ea
+      |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  36 directories, 23 files

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -82,16 +82,61 @@
       ':/sub1',
       ':/sub2',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 23
+  |   |   |   `-- 87c32648eefdee78386575672ac091da849b08
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- ff
+  |   |   |   `-- e8d082c1034053534ea8068f4205ac72a1098e
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  34 directories, 21 files

--- a/tests/proxy/clone_subtree_no_master.t
+++ b/tests/proxy/clone_subtree_no_master.t
@@ -76,15 +76,60 @@
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           `-- refs
-  |               `-- heads
-  |                   `-- main
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 23
+  |   |   |   `-- 87c32648eefdee78386575672ac091da849b08
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- ff
+  |   |   |   `-- e8d082c1034053534ea8068f4205ac72a1098e
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- main
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 1 file
+  34 directories, 20 files

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -112,19 +112,70 @@
       ':/sub1',
       ':/sub2',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               |-- heads
-  |               |   `-- master
-  |               `-- tags
-  |                   `-- a_tag
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 17
+  |   |   |   `-- 27e7d219402e1ce54587731575e941130d09ac
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 56
+  |   |   |   `-- e190237f1fa5d07f52fc7de0e4b7d04128c79d
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   |-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |   |-- c3f8026800792a43ffbc932153f4864509378e
+  |   |   |   `-- f54cff926d013ce65a3b1cf4e8d239c43beb4b
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- fa
+  |   |   |   `-- 432ae56bb033f625197b126825c347ff557661
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               |-- heads
+  |       |               |   `-- master
+  |       |               `-- tags
+  |       |                   `-- a_tag
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 6e
+      |   |   `-- 99e1e5ba1de7225f0d09a0b91d2e29ae15569c
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  9 directories, 3 files
+  37 directories, 26 files
 $ cat ${TESTTMP}/josh-proxy.out | grep TAGS

--- a/tests/proxy/destroy_test_env.sh
+++ b/tests/proxy/destroy_test_env.sh
@@ -2,7 +2,5 @@
 curl -s http://localhost:8002/filters/refresh
 killall -2 josh-proxy
 cd ${TESTTMP}/remote/scratch
-#${TESTDIR}/../../target/debug/josh-filter -vs
-tree refs
-#cat ${TESTTMP}/josh-proxy.out
+tree -I hooks
 

--- a/tests/proxy/empty_commit.t
+++ b/tests/proxy/empty_commit.t
@@ -81,16 +81,63 @@ should still be included.
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 6b
+  |   |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+  |   |   |-- 6c
+  |   |   |   `-- e34162a27f0c0cd1072a5f42cc0424dec4d1be
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- ba
+  |   |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c6
+  |   |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- df
+  |   |   |   `-- 06f78a28f5e967f9b09e77d91b88fc524de347
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  35 directories, 22 files

--- a/tests/proxy/get_version.t
+++ b/tests/proxy/get_version.t
@@ -5,8 +5,36 @@
   Version: r*.*.* (glob)
 
   $ bash ${TESTDIR}/destroy_test_env.sh
-  refs
-  |-- heads
-  `-- tags
+  .
+  |-- josh
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          `-- tags
   
-  2 directories, 0 files
+  20 directories, 10 files

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -298,26 +298,126 @@ Flushed credential cache
   ]
   "repo1.git" = [':prefix=repo1']
   "repo2.git" = [':prefix=repo2']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       |-- real_repo.git
-  |       |   |-- HEAD
-  |       |   `-- refs
-  |       |       `-- heads
-  |       |           `-- master
-  |       |-- repo1.git
-  |       |   |-- HEAD
-  |       |   `-- refs
-  |       |       `-- heads
-  |       |           `-- master
-  |       `-- repo2.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 05
+  |   |   |   `-- f817563be151d278c6021ef1c8cd643d2b6051
+  |   |   |-- 20
+  |   |   |   `-- d8b46606bc5a0982127be06396bcc250aa37c2
+  |   |   |-- 33
+  |   |   |   `-- b9ecdf50077ab1f3e99ba58deedccf7a874e9a
+  |   |   |-- 4b
+  |   |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+  |   |   |-- 58
+  |   |   |   `-- d391109744bf61f6e0118a15bcb0e720a73edc
+  |   |   |-- 5d
+  |   |   |   |-- 98d297b3b16d5946dada2496accc9f99dc7056
+  |   |   |   `-- ebb339446b2a1070687359250e906e45493c37
+  |   |   |-- 5e
+  |   |   |   `-- c1a6d7931801b54c885942b687c8eb948c189e
+  |   |   |-- 60
+  |   |   |   `-- bbf7e0d9cbc75bbc27f6c48a2000259ef0dbb1
+  |   |   |-- 66
+  |   |   |   `-- 35d16da81e6c791e209053e835e5d1fe4295e6
+  |   |   |-- 6e
+  |   |   |   `-- 9a62b40f85b0952ea06023a8ee1fb99685e6f7
+  |   |   |-- 71
+  |   |   |   `-- 28ce7713fc45163e65c7ac4a9057ed1913a569
+  |   |   |-- 8a
+  |   |   |   `-- cb3f4e4afe9db19fa0ed69097535b733874d36
+  |   |   |-- 9c
+  |   |   |   `-- b7c3c14c5c084f6a6897b6e6bab231fae98ae5
+  |   |   |-- a1
+  |   |   |   `-- 21124629c3abdc05b28746b5f5890bd9fb5672
+  |   |   |-- ad
+  |   |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+  |   |   |-- bb
+  |   |   |   `-- da8cbc6403022ce120659bb957505fc14e9dc1
+  |   |   |-- c4
+  |   |   |   |-- 8a5acfa23bd6192d897a1c5ca80a0f1d1b4a62
+  |   |   |   `-- df336cf6578b6dac651a33fd265d92308c0e39
+  |   |   |-- cd
+  |   |   |   `-- 9183f60c957365409843269ecefa3ba30a6dad
+  |   |   |-- e1
+  |   |   |   `-- 898301e7be2b3450a7b0578bc0dd9abd4f51b1
+  |   |   |-- e4
+  |   |   |   `-- af7700f8c091d18cc15f39c184490125fb0d17
+  |   |   |-- e5
+  |   |   |   `-- 2c4e8d6c1f4960b92676424944ff3951f472aa
+  |   |   |-- e6
+  |   |   |   |-- 7656b1f8854bcc258b9dddddc469d7e6d0b139
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- f9
+  |   |   |   `-- 97320406328b16277aca038db747cf60232267
+  |   |   |-- fa
+  |   |   |   `-- 84d25825561f0e21863ad0e93b58517bcdccfe
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       |-- real_repo.git
+  |       |       |   |-- HEAD
+  |       |       |   `-- refs
+  |       |       |       `-- heads
+  |       |       |           `-- master
+  |       |       |-- repo1.git
+  |       |       |   |-- HEAD
+  |       |       |   `-- refs
+  |       |       |       `-- heads
+  |       |       |           `-- master
+  |       |       `-- repo2.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 5d
+      |   |   `-- 98d297b3b16d5946dada2496accc9f99dc7056
+      |   |-- 6e
+      |   |   `-- 9a62b40f85b0952ea06023a8ee1fb99685e6f7
+      |   |-- 6f
+      |   |   `-- e45a9254eb9dd78951a804fa94a035a937ef0b
+      |   |-- 71
+      |   |   `-- 28ce7713fc45163e65c7ac4a9057ed1913a569
+      |   |-- 80
+      |   |   `-- 472110df082d0a921ecdcd6f0dd0021f48e019
+      |   |-- 85
+      |   |   `-- c3ce1926696ef4bdf2eff358bd83b079dcc8d4
+      |   |-- 9c
+      |   |   `-- b7c3c14c5c084f6a6897b6e6bab231fae98ae5
+      |   |-- c4
+      |   |   `-- df336cf6578b6dac651a33fd265d92308c0e39
+      |   |-- e5
+      |   |   `-- 2c4e8d6c1f4960b92676424944ff3951f472aa
+      |   |-- f9
+      |   |   `-- 97320406328b16277aca038db747cf60232267
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  14 directories, 6 files
+  66 directories, 54 files

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -57,16 +57,79 @@
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':prefix=sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 0f
+  |   |   |   `-- 7ceed53e5b4ab96efad3c0b77e2c00d10169ba
+  |   |   |-- 41
+  |   |   |   `-- 8fcc975168e0bfc9dd53bbb98f740da2e983c0
+  |   |   |-- 53
+  |   |   |   `-- 9f411b73b3c22bc218bece495a841880fd4e2c
+  |   |   |-- ad
+  |   |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+  |   |   |-- b7
+  |   |   |   `-- 85a0b60f6ef7044b4c59c318e18e2c47686085
+  |   |   |-- c6
+  |   |   |   `-- 6fb92e3be8e4dc4c89f94d796f3a4b1833e0fa
+  |   |   |-- e4
+  |   |   |   `-- 5f0325cd9fab82d962b758e556d9bf8079fc37
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- eb
+  |   |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 22
+      |   |   `-- b22885799153b100fdb3445c59c4c3f4482ed3
+      |   |-- 24
+      |   |   `-- 6b71ecf742c084ec41ba6f2c4e355ca4806ef0
+      |   |-- 5a
+      |   |   `-- 29d3ef74b34ca534513c6499e9c9011371fab4
+      |   |-- 68
+      |   |   `-- 9a59b2fad33839a7e8d6c1c02ce94095d8fe1e
+      |   |-- 85
+      |   |   `-- 352a4584261ab3b54e32aa4ddfe04e80c6800e
+      |   |-- 8e
+      |   |   `-- 9aa8ffc35bbc452f9654b834047168ce02dc48
+      |   |-- c3
+      |   |   `-- 0a8aef421831a8492d21efde601e90a742544f
+      |   |-- db
+      |   |   `-- dfb5702a23dd0a3502f4d6ce7287a3a4d85abe
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  43 directories, 30 files

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -326,18 +326,219 @@
       ':/a/b',
       ':/sub1',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               |-- heads
-  |               |   `-- master
-  |               `-- josh
-  |                   `-- meta
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 00
+  |   |   |   |-- 0fdb96141588097517f5361a52fd15f516236c
+  |   |   |   `-- 398737066733a879fdeac01f830d2b7c2212c7
+  |   |   |-- 10
+  |   |   |   `-- e44181805d5aa02e9ae9d42f8e6f16a177712e
+  |   |   |-- 11
+  |   |   |   `-- 474f8beca288b120a723a57c7d201ddc07672f
+  |   |   |-- 12
+  |   |   |   |-- 1288d478f72ac23fd2f6fa9ef40dcafc0dac9f
+  |   |   |   `-- f00e90b6ef79117ce6e650416b8cf517099b78
+  |   |   |-- 13
+  |   |   |   `-- 1043174b309a606a52c4f810cf509d4c120a69
+  |   |   |-- 1e
+  |   |   |   `-- 64dc7136eae9c6b88e4ab831322f3c72a5c0e4
+  |   |   |-- 23
+  |   |   |   `-- d5514a250d2387066895bc2575d329be7c9c38
+  |   |   |-- 24
+  |   |   |   |-- 9fd13d8f23051a218b48657ff1f2433de40b49
+  |   |   |   `-- d379f3645131d769fe0e5de2d075a69417ea94
+  |   |   |-- 32
+  |   |   |   `-- 1f48cf6c921bde6a53891503bfdefad0040b59
+  |   |   |-- 37
+  |   |   |   `-- 7526ccc19d67a0bc3fd88edcc76e355f99a225
+  |   |   |-- 3d
+  |   |   |   `-- d7fdbfe787ed80cb58a5905851a1840102e5f2
+  |   |   |-- 3e
+  |   |   |   `-- 4d66668e6f1dbadc079f36a84768a916bcb8f9
+  |   |   |-- 3f
+  |   |   |   `-- 724ed36477d2d9b4e849b85ce739be8f9ddd3e
+  |   |   |-- 43
+  |   |   |   `-- ba4ca11186832c55431d069bcc673a697ac081
+  |   |   |-- 49
+  |   |   |   `-- 0782f700bcfb460af23fd4804534b219f845a6
+  |   |   |-- 6f
+  |   |   |   `-- a39dde3631ce9a1934bcbb94b838237769a44e
+  |   |   |-- 77
+  |   |   |   `-- cc643f01813fec7eaac6388bbe44886e2659bd
+  |   |   |-- 8e
+  |   |   |   `-- a81685295ad3ab09a9961a259982ae768d0e0e
+  |   |   |-- 95
+  |   |   |   |-- 2e0ed4fdd6cc6daf3d1c4fcb138fddc8ffdabb
+  |   |   |   `-- c8826895fb97c2656fdc348d0dab5f943d9f7e
+  |   |   |-- 98
+  |   |   |   `-- 51c22e33a18b65ecc2dfcb07ac21ee53ecae8d
+  |   |   |-- 9e
+  |   |   |   `-- 6ec84b9177b428ce4a7343fca238e864cdf3d7
+  |   |   |-- a9
+  |   |   |   `-- 4835bf48c2916fbd6984c20564315e9c58660d
+  |   |   |-- af
+  |   |   |   `-- cd0562612cb622b5b647e6a849b3a452c29fb8
+  |   |   |-- b0
+  |   |   |   `-- f8e35251e96a874f6c597a2eb2f597b4d4aed2
+  |   |   |-- b2
+  |   |   |   `-- 8b2106a36e97a096e33a95825aff9f7d4860b5
+  |   |   |-- b7
+  |   |   |   `-- 39c5e88e64a494ccf6a0980788c2b2ef429f28
+  |   |   |-- bf
+  |   |   |   |-- 0cb72a9a6b2834ffaba469d238001f983787f8
+  |   |   |   `-- 3ce158537f47e137717eb738930e95facdd300
+  |   |   |-- ca
+  |   |   |   `-- 8c6bc19dc6ec1ea4f60d4982b003edb4e26c26
+  |   |   |-- cd
+  |   |   |   `-- 7388ce64302b3a643177b76d6f0beac6779478
+  |   |   |-- d1
+  |   |   |   `-- 86c79c2a8e295d663e9fbd8dc65a33fc8bd160
+  |   |   |-- d4
+  |   |   |   `-- 407037b9a530bea6873143bbe61c7ad6d26feb
+  |   |   |-- d6
+  |   |   |   `-- 49338b5bec68500d266921a289a518b956452c
+  |   |   |-- d7
+  |   |   |   `-- ff5d05ada0212e6e904857429c406791b10c46
+  |   |   |-- da
+  |   |   |   `-- 26c060e8cf0ec0e99a9f851044cc2e76e245b4
+  |   |   |-- db
+  |   |   |   `-- 7ce571bb0c987e4e4aadbbd727867158c4a309
+  |   |   |-- df
+  |   |   |   `-- 0fb9ea1e23fb68a3c589d9b356b6a52bbd3c6f
+  |   |   |-- e7
+  |   |   |   `-- e7b082cc60acffc7991c438f6a03833bad2641
+  |   |   |-- f8
+  |   |   |   `-- 1b303f7a6f22739b9513836d934f622243c15a
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               |-- heads
+  |       |               |   `-- master
+  |       |               `-- josh
+  |       |                   `-- meta
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 00
+      |   |   |-- 0fdb96141588097517f5361a52fd15f516236c
+      |   |   `-- 398737066733a879fdeac01f830d2b7c2212c7
+      |   |-- 10
+      |   |   `-- e44181805d5aa02e9ae9d42f8e6f16a177712e
+      |   |-- 11
+      |   |   `-- 474f8beca288b120a723a57c7d201ddc07672f
+      |   |-- 12
+      |   |   `-- 1288d478f72ac23fd2f6fa9ef40dcafc0dac9f
+      |   |-- 13
+      |   |   `-- 1043174b309a606a52c4f810cf509d4c120a69
+      |   |-- 18
+      |   |   `-- c7ee0bdd23edd6563b453e8773f3815f45022d
+      |   |-- 23
+      |   |   |-- 87c59576f220507ff0e0de060ceacd71ff41a3
+      |   |   `-- d5514a250d2387066895bc2575d329be7c9c38
+      |   |-- 24
+      |   |   |-- 9fd13d8f23051a218b48657ff1f2433de40b49
+      |   |   `-- d379f3645131d769fe0e5de2d075a69417ea94
+      |   |-- 30
+      |   |   `-- bad8e97384f1ac8cbccd35304d85c9e12b5665
+      |   |-- 37
+      |   |   `-- 7526ccc19d67a0bc3fd88edcc76e355f99a225
+      |   |-- 3d
+      |   |   `-- d7fdbfe787ed80cb58a5905851a1840102e5f2
+      |   |-- 43
+      |   |   `-- ba4ca11186832c55431d069bcc673a697ac081
+      |   |-- 49
+      |   |   `-- 0782f700bcfb460af23fd4804534b219f845a6
+      |   |-- 5b
+      |   |   `-- c77f5c5a22619575241e72415aac832204e714
+      |   |-- 61
+      |   |   `-- 3cf076586b0dec8f8547b5bfd27f4327e2e489
+      |   |-- 62
+      |   |   `-- 4b4ae13c87b02e347717cedff72da5e175c689
+      |   |-- 6f
+      |   |   `-- a39dde3631ce9a1934bcbb94b838237769a44e
+      |   |-- 77
+      |   |   `-- cc643f01813fec7eaac6388bbe44886e2659bd
+      |   |-- 91
+      |   |   `-- 509498b7b323626ac259fae13f6c50eea5c947
+      |   |-- 95
+      |   |   |-- 2e0ed4fdd6cc6daf3d1c4fcb138fddc8ffdabb
+      |   |   `-- c8826895fb97c2656fdc348d0dab5f943d9f7e
+      |   |-- 98
+      |   |   `-- 51c22e33a18b65ecc2dfcb07ac21ee53ecae8d
+      |   |-- 9e
+      |   |   `-- 6ec84b9177b428ce4a7343fca238e864cdf3d7
+      |   |-- a9
+      |   |   `-- 4835bf48c2916fbd6984c20564315e9c58660d
+      |   |-- af
+      |   |   `-- cd0562612cb622b5b647e6a849b3a452c29fb8
+      |   |-- b0
+      |   |   |-- d4426b7d7d8157600c990d18b62e8a237bffa6
+      |   |   `-- f8e35251e96a874f6c597a2eb2f597b4d4aed2
+      |   |-- b1
+      |   |   `-- d540fbdaef90043e873b454fca330ec20d57f3
+      |   |-- b2
+      |   |   `-- 8b2106a36e97a096e33a95825aff9f7d4860b5
+      |   |-- b5
+      |   |   `-- 2a6b1f3afba295c5463036ce7dd3f2a675b915
+      |   |-- b7
+      |   |   `-- 39c5e88e64a494ccf6a0980788c2b2ef429f28
+      |   |-- bf
+      |   |   |-- 0cb72a9a6b2834ffaba469d238001f983787f8
+      |   |   `-- 3ce158537f47e137717eb738930e95facdd300
+      |   |-- ca
+      |   |   `-- 8c6bc19dc6ec1ea4f60d4982b003edb4e26c26
+      |   |-- cd
+      |   |   `-- 7388ce64302b3a643177b76d6f0beac6779478
+      |   |-- d1
+      |   |   `-- 86c79c2a8e295d663e9fbd8dc65a33fc8bd160
+      |   |-- d4
+      |   |   `-- 407037b9a530bea6873143bbe61c7ad6d26feb
+      |   |-- d6
+      |   |   `-- 49338b5bec68500d266921a289a518b956452c
+      |   |-- d7
+      |   |   |-- 15747fe0dcdc8e0a2e57d2c8bfcbc5ddfe1544
+      |   |   `-- ff5d05ada0212e6e904857429c406791b10c46
+      |   |-- db
+      |   |   `-- 7ce571bb0c987e4e4aadbbd727867158c4a309
+      |   |-- df
+      |   |   `-- 0fb9ea1e23fb68a3c589d9b356b6a52bbd3c6f
+      |   |-- e0
+      |   |   `-- 77d6ab1d2b2335e25b879c22c32fb3d9d64188
+      |   |-- e7
+      |   |   `-- e7b082cc60acffc7991c438f6a03833bad2641
+      |   |-- ed
+      |   |   `-- fdf0b26b57e156cb1f118a633af077d9ba128a
+      |   |-- f8
+      |   |   `-- 1b303f7a6f22739b9513836d934f622243c15a
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  9 directories, 3 files
+  107 directories, 106 files

--- a/tests/proxy/no_proxy.t
+++ b/tests/proxy/no_proxy.t
@@ -33,8 +33,36 @@
    * [new branch]      master -> master
 
   $ bash ${TESTDIR}/destroy_test_env.sh
-  refs
-  |-- heads
-  `-- tags
+  .
+  |-- josh
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          `-- tags
   
-  2 directories, 0 files
+  20 directories, 10 files

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -92,17 +92,76 @@ Check the branch again
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   |-- master
-  |                   `-- new-branch
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 0b
+  |   |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+  |   |   |-- 37
+  |   |   |   `-- c3f9a18f21fe53e0be9ea657220ba4537dbca7
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 5f
+  |   |   |   `-- 2752aa0d3b643a6e95d754c3fd272318a02434
+  |   |   |-- 6b
+  |   |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- ae
+  |   |   |   `-- a557394ce29f000108607abd97f19fed4d1b7c
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   |-- master
+  |       |                   `-- new-branch
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 28
+      |   |   `-- d20855c7b65b5a9948283516ae62739360544d
+      |   |-- 49
+      |   |   `-- b12216dab2cefdb1cc0fcda7ab6bc9f8b882ab
+      |   |-- 56
+      |   |   `-- dc1f749ea31f735f981a42bc6c23e92baf2085
+      |   |-- 75
+      |   |   `-- 1ef4576e133fc6279ccf882cb812a9b4dcf5dd
+      |   |-- 9d
+      |   |   `-- aeafb9864cf43055ae93beb0afd6c7d144bfa4
+      |   |-- a5
+      |   |   `-- 5a119d24890de3a3e470f941217479629e50c6
+      |   |-- b5
+      |   |   `-- afbb444fd22857e78ee11ddd92b7dd2f5c7d11
+      |   |-- de
+      |   |   `-- 7cba2eb70af5ce3555c3670e7641f2f547db74
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 3 files
+  41 directories, 29 files

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -54,17 +54,68 @@
       ':/sub1',
       ':prefix=pre',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0f
+      |   |   `-- 17ab2c89a1278ecb6a7438e915e491884d3efb
+      |   |-- 1f
+      |   |   `-- 0b9d8a7b40a35bb4ff64ffc0f08369df23bc61
+      |   |-- 55
+      |   |   `-- 4b59f0a39f6968f0101b8a0471f8a65bc25020
+      |   |-- 6b
+      |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+      |   |-- b5
+      |   |   `-- af4d1258141efaadc32e369f4dc4b1f6c524e4
+      |   |-- b7
+      |   |   `-- cf821182baff3432190af3ae2f1029d8e7ceb0
+      |   |-- f9
+      |   |   `-- 9a2dde698e6d3fc31cbeedea6d0204399f90ce
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  37 directories, 24 files
 

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -82,19 +82,68 @@ Make sure all temporary namespace got removed
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 6b
+      |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+      |   |-- 81
+      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
+      |   |-- ba
+      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
+      |   |-- c6
+      |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+      |   |-- d8
+      |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  36 directories, 23 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_review_already_in.t
+++ b/tests/proxy/push_review_already_in.t
@@ -46,17 +46,56 @@ test for that.
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = []
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 12
+  |   |   |   `-- f00e90b6ef79117ce6e650416b8cf517099b78
+  |   |   |-- 3e
+  |   |   |   `-- 4d66668e6f1dbadc079f36a84768a916bcb8f9
+  |   |   |-- 60
+  |   |   |   `-- 599f2548a694cee8452bda9c0516027bbbb148
+  |   |   |-- 74
+  |   |   |   `-- 3f7c56e1cdebc5452c558fea593d48abf45b05
+  |   |   |-- 9a
+  |   |   |   `-- cea2cd36eb8d8d45cd5399c782d6348a3c8e35
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  31 directories, 18 files
 

--- a/tests/proxy/push_review_nop_behind.t
+++ b/tests/proxy/push_review_nop_behind.t
@@ -53,16 +53,59 @@ This is a regression test for that problem.
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = []
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 12
+  |   |   |   `-- f00e90b6ef79117ce6e650416b8cf517099b78
+  |   |   |-- 3e
+  |   |   |   `-- 4d66668e6f1dbadc079f36a84768a916bcb8f9
+  |   |   |-- 60
+  |   |   |   `-- 599f2548a694cee8452bda9c0516027bbbb148
+  |   |   |-- 74
+  |   |   |   `-- 3f7c56e1cdebc5452c558fea593d48abf45b05
+  |   |   |-- 9a
+  |   |   |   `-- cea2cd36eb8d8d45cd5399c782d6348a3c8e35
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 06
+      |   |   `-- a050bd4a0d471e6f410bd76252cd6d215899ed
+      |   |-- f5
+      |   |   `-- 01f09caa6b247b64793a9d8cf1db76a9e92442
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  33 directories, 20 files

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -80,19 +80,78 @@ Flushed credential cache
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 6b
+  |   |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+  |   |   |-- 81
+  |   |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- ba
+  |   |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c6
+  |   |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 17
+      |   |   `-- d81bc99ff2b4a426c236dc1a36f7a2d1027c7b
+      |   |-- 1c
+      |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+      |   |-- 89
+      |   |   `-- 52f96884e0ee453406177bebbf4f74a8a8d1be
+      |   |-- ad
+      |   |   `-- f650cd06e5434fe6deff7639b04c802d63fa5a
+      |   |-- b2
+      |   |   `-- 6a812a71a431e71d30949f25013ca63f8493c3
+      |   |-- d8
+      |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  41 directories, 28 files
 
   $ cat ${TESTTMP}/josh-proxy.out | grep graph_descendant_of
   [1]

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -37,19 +37,68 @@ Make sure all temporary namespace got removed
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 6b
+      |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+      |   |-- 81
+      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
+      |   |-- ba
+      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
+      |   |-- c6
+      |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+      |   |-- d8
+      |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  36 directories, 23 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -143,28 +143,109 @@ Make sure all temporary namespace got removed
       '::file2',
       '::file7',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   |-- @changes
-  |                   |   `-- master
-  |                   |       `-- josh@example.com
-  |                   |           |-- 1234
-  |                   |           `-- foo7
-  |                   |-- @heads
-  |                   |   `-- master
-  |                   |       |-- foo@example.com
-  |                   |       `-- josh@example.com
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3a
+  |   |   |   `-- d32b3bd3bb778441e7eae43930d8dc6293eddc
+  |   |   |-- 3b
+  |   |   |   `-- 0e3dbefd779ec54d92286047f32d3129161c0d
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 49
+  |   |   |   `-- 50fa502f51b7bfda0d7975dbff9b0f9a9481ca
+  |   |   |-- 6b
+  |   |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+  |   |   |-- 85
+  |   |   |   `-- 90a3b0b3086ab857b91581c320e377dc9780ea
+  |   |   |-- 90
+  |   |   |   `-- be1f3056c4f471f977a28497b8d4b392c55a02
+  |   |   |-- 9a
+  |   |   |   `-- 91b9f3056d29fafb535b6e801f26449b291daf
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- b2
+  |   |   |   `-- dd517c55420a48cb543e0195b4751bf514b941
+  |   |   |-- ec
+  |   |   |   `-- 41aad70b4b898baf48efeb795a7753d9674152
+  |   |   |-- ed
+  |   |   |   `-- b2a5b9c65fae1d20c1b1fb777d1ea025456faa
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   |-- @changes
+  |       |                   |   `-- master
+  |       |                   |       `-- josh@example.com
+  |       |                   |           |-- 1234
+  |       |                   |           `-- foo7
+  |       |                   |-- @heads
+  |       |                   |   `-- master
+  |       |                   |       |-- foo@example.com
+  |       |                   |       `-- josh@example.com
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 08
+      |   |   `-- c82a20e92d548ff32f86d634b82da6756e1f5f
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 0f
+      |   |   `-- 8d6bce4783eb0366cc72cb5f6fb7952c360d89
+      |   |-- 23
+      |   |   `-- b2396b6521abcd906f16d8492c5aeacaee06ed
+      |   |-- 38
+      |   |   `-- 25d17d9f46345e352ea6d1d0a89f2be16a1b2c
+      |   |-- 3a
+      |   |   `-- d32b3bd3bb778441e7eae43930d8dc6293eddc
+      |   |-- 3b
+      |   |   `-- 0e3dbefd779ec54d92286047f32d3129161c0d
+      |   |-- 6b
+      |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+      |   |-- 96
+      |   |   `-- 539577d449c8e5446b5339c20436a13ec51f41
+      |   |-- 9a
+      |   |   `-- 91b9f3056d29fafb535b6e801f26449b291daf
+      |   |-- ae
+      |   |   `-- a557394ce29f000108607abd97f19fed4d1b7c
+      |   |-- b2
+      |   |   `-- dd517c55420a48cb543e0195b4751bf514b941
+      |   |-- ec
+      |   |   `-- 41aad70b4b898baf48efeb795a7753d9674152
+      |   |-- ed
+      |   |   `-- b2a5b9c65fae1d20c1b1fb777d1ea025456faa
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  13 directories, 6 files
+  57 directories, 43 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -127,33 +127,110 @@ Make sure all temporary namespace got removed
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   |-- @changes
-  |                   |   |-- master
-  |                   |   |   `-- josh@example.com
-  |                   |   |       |-- 1234
-  |                   |   |       `-- foo7
-  |                   |   `-- other_branch
-  |                   |       `-- josh@example.com
-  |                   |           |-- 1234
-  |                   |           `-- foo7
-  |                   |-- @heads
-  |                   |   |-- master
-  |                   |   |   `-- josh@example.com
-  |                   |   `-- other_branch
-  |                   |       `-- josh@example.com
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 2b
+  |   |   |   `-- b94719cad2e76eb5dbcae874a2b0e44521e802
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 6b
+  |   |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- b2
+  |   |   |   `-- ea883bc5df63565960a38cad7a57f73ac66eaa
+  |   |   |-- ba
+  |   |   |   |-- 7e17233d9f79c96cb694959eb065302acd96a6
+  |   |   |   `-- c8af20b53d712874a32944874c66a21afa91f9
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c6
+  |   |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- e3
+  |   |   |   `-- a269743538338b0d059eda2f72976ec29220a8
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   |-- @changes
+  |       |                   |   |-- master
+  |       |                   |   |   `-- josh@example.com
+  |       |                   |   |       |-- 1234
+  |       |                   |   |       `-- foo7
+  |       |                   |   `-- other_branch
+  |       |                   |       `-- josh@example.com
+  |       |                   |           |-- 1234
+  |       |                   |           `-- foo7
+  |       |                   |-- @heads
+  |       |                   |   |-- master
+  |       |                   |   |   `-- josh@example.com
+  |       |                   |   `-- other_branch
+  |       |                   |       `-- josh@example.com
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 11
+      |   |   `-- 06a6f09b169109f5ebd17428219142c67e84b9
+      |   |-- 2b
+      |   |   `-- b94719cad2e76eb5dbcae874a2b0e44521e802
+      |   |-- 40
+      |   |   `-- 3e13a101fd75090369ffc317afafcfb646c576
+      |   |-- 4b
+      |   |   `-- 5ffb79a1f3852443bd747a6b213bf1e4abe168
+      |   |-- 6b
+      |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+      |   |-- 88
+      |   |   `-- 2b84c5d3241087bc41982a744b72b7a174c49e
+      |   |-- a3
+      |   |   `-- 065162ecee0fecc977ec04a275e10b5e15a39c
+      |   |-- b2
+      |   |   `-- ea883bc5df63565960a38cad7a57f73ac66eaa
+      |   |-- ba
+      |   |   |-- 7e17233d9f79c96cb694959eb065302acd96a6
+      |   |   `-- c8af20b53d712874a32944874c66a21afa91f9
+      |   |-- be
+      |   |   `-- 33ab805ad4ef7ddda5b51e4a78ec0fac6b699a
+      |   |-- c6
+      |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+      |   |-- e3
+      |   |   `-- a269743538338b0d059eda2f72976ec29220a8
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  16 directories, 8 files
+  57 directories, 44 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -46,18 +46,75 @@
       ':/sub1',
       ':/sub1:prefix=pre',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 32
+      |   |   `-- bc15e3ec04d5d9d2a216055ea51bafb2249877
+      |   |-- 50
+      |   |   `-- bcd696c2041bb31c0a9a1111dfa2686fc6fea6
+      |   |-- 52
+      |   |   `-- 2525c3e5980592ddb5eb385ac1262dc6764af3
+      |   |-- 6b
+      |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+      |   |-- 81
+      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
+      |   |-- ba
+      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
+      |   |-- c6
+      |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+      |   |-- d8
+      |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
+      |   |-- e6
+      |   |   `-- 2cc0b3d612792395dd9ac2ca649da0e6e54620
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  40 directories, 27 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -85,19 +85,76 @@ Make sure all temporary namespace got removed
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   |-- master
-  |                   `-- new_branch
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 6b
+  |   |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+  |   |   |-- 81
+  |   |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- ba
+  |   |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- c6
+  |   |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   |-- master
+  |       |                   `-- new_branch
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 6b
+      |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+      |   |-- 81
+      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
+      |   |-- ba
+      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
+      |   |-- c6
+      |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+      |   |-- d8
+      |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 3 files
+  40 directories, 28 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -110,22 +110,91 @@ Put a double slash in the URL to see that it also works
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real/repo2.git" = [':/sub1']
   "real_repo.git" = [':/sub1']
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       |-- real%2Frepo2.git
-  |       |   |-- HEAD
-  |       |   `-- refs
-  |       |       `-- heads
-  |       |           `-- master
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 4d
+  |   |   |   `-- ac9298952aef560bf9691199f53e2b4ff08e3a
+  |   |   |-- 92
+  |   |   |   `-- 2907f7780152deee70dab1a14810d985391e90
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- bb
+  |   |   |   `-- 282e9cdc1b972fffd08fd21eead43bc0c83cb8
+  |   |   |-- bc
+  |   |   |   `-- d5520aa5122136789528261b56f05d317a0841
+  |   |   |-- c8
+  |   |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+  |   |   |-- cf
+  |   |   |   `-- 1e357468e54c4b6234558e00a8fb75c60942a9
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       |-- real%2Frepo2.git
+  |       |       |   |-- HEAD
+  |       |       |   `-- refs
+  |       |       |       `-- heads
+  |       |       |           `-- master
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 3c
+      |   |   `-- cd09de42d21f7e5318bc5eaf258bf82e4103e6
+      |   |-- 5c
+      |   |   `-- 1144a1e71fe21014b2afec1ed3a3298bd46200
+      |   |-- 6b
+      |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+      |   |-- 81
+      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
+      |   |-- 8d
+      |   |   `-- 08b32a321a9d226e3b22d01793f62a6c9b22e2
+      |   |-- b1
+      |   |   `-- 0b7acda365c0c0ed8f7482ccaf201ebbc6dd12
+      |   |-- ba
+      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
+      |   |-- c6
+      |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+      |   |-- d8
+      |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
+      |   |-- dc
+      |   |   `-- d1fcde90e4a52777feaf5d7e608f33e5eda53f
+      |   |-- e3
+      |   |   `-- 1c69658259e37ed5ad682c49a53ec5dc066aec
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  11 directories, 4 files
+  49 directories, 35 files
 

--- a/tests/proxy/unrelated_leak.t
+++ b/tests/proxy/unrelated_leak.t
@@ -130,17 +130,119 @@ Flushed credential cache
       ':/sub1',
       ':/sub2',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   |-- from_filtered
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 24
+  |   |   |   `-- ce298ca12ec52cff187ef6638a2ba3d1c9503d
+  |   |   |-- 25
+  |   |   |   `-- 7cc5642cb1a054f08cc83f2d943e56fd3ebe99
+  |   |   |-- 26
+  |   |   |   `-- 1fdca7dd1cc67009c11551191e84aa1ba21c20
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 3e
+  |   |   |   `-- b22065e1ba8caa4e5f20a9eaadd1803996dff5
+  |   |   |-- 42
+  |   |   |   `-- e0161c1ad82c05895e0f2caeae95925ac5ae6a
+  |   |   |-- 66
+  |   |   |   `-- 472b80301b889cf27a92d43fc2c2d8fbf4729d
+  |   |   |-- 6b
+  |   |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- 86
+  |   |   |   `-- 5c34e9a2c40198324cdc2fc796827653cb11df
+  |   |   |-- 8a
+  |   |   |   `-- f523d3883c24610cf99813ea15df65eb20ea84
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- a1
+  |   |   |   `-- 1885ec53fe483199d9515bf4662e5cf94d9a9e
+  |   |   |-- c2
+  |   |   |   `-- f224659ea69f54d3960b776237069bfbf2ed6e
+  |   |   |-- d5
+  |   |   |   `-- 26cba5e5dae29edfc16218060d56958081c453
+  |   |   |-- db
+  |   |   |   |-- 0fd21be0dea377057285e6119361753587f667
+  |   |   |   `-- 184bf11ece7fbeb99395ab7676b80e7d98631a
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   |-- from_filtered
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0b
+      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 1c
+      |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+      |   |-- 24
+      |   |   `-- ce298ca12ec52cff187ef6638a2ba3d1c9503d
+      |   |-- 26
+      |   |   `-- 1fdca7dd1cc67009c11551191e84aa1ba21c20
+      |   |-- 36
+      |   |   `-- 8bfdc83325632d67cb93d96f095f0b04e4e26d
+      |   |-- 37
+      |   |   `-- fad4aaffb0ee24ab0ad6767701409bfbc52330
+      |   |-- 3f
+      |   |   `-- 7ab67d01db03914916161b51dbda1a4635f8d2
+      |   |-- 42
+      |   |   `-- e0161c1ad82c05895e0f2caeae95925ac5ae6a
+      |   |-- 6b
+      |   |   `-- 46faacade805991bcaea19382c9d941828ce80
+      |   |-- 86
+      |   |   `-- 5c34e9a2c40198324cdc2fc796827653cb11df
+      |   |-- 8a
+      |   |   `-- f523d3883c24610cf99813ea15df65eb20ea84
+      |   |-- b7
+      |   |   `-- 97411c60180287c8da2d26c325038c44fd78b0
+      |   |-- c8
+      |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
+      |   |-- cd
+      |   |   `-- e160edcb6f5ed11cc6d74e64bf06679420c10c
+      |   |-- da
+      |   |   `-- 0d1f304c4686b5ed11c682fa9c8d1544c49b96
+      |   |-- db
+      |   |   `-- 184bf11ece7fbeb99395ab7676b80e7d98631a
+      |   |-- dc
+      |   |   `-- 0dbab6030c0673ece5706b067e74ca8a573397
+      |   |-- e0
+      |   |   `-- 6f0e81ff3d5f8d60ba86bf4f99b47c8aa47654
+      |   |-- e1
+      |   |   `-- 70e962d0fb4b94a491a176a7f39a6207ada3e8
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 3 files
+  62 directories, 51 files

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -223,18 +223,193 @@
       ':/ws',
       ':workspace=ws',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 11
+  |   |   |   `-- 731d321eddb29674191126ed5ce3413778ed14
+  |   |   |-- 15
+  |   |   |   `-- 2ebf6a60e4428105c586b12ee7aeb6f93b5653
+  |   |   |-- 19
+  |   |   |   `-- 279da7740f0db978e164b200fe34169f3c633c
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 2a
+  |   |   |   `-- f8fd9cc75470c09c6442895133a815806018fc
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 4b
+  |   |   |   `-- 7fa9ec1191b73a254422912b7cc2ce0abb78dc
+  |   |   |-- 56
+  |   |   |   `-- 11a41651a4fa991359cdf42033d6c898e6de31
+  |   |   |-- 67
+  |   |   |   `-- b73963ec5931b9643bf807162edf17636c1f20
+  |   |   |-- 74
+  |   |   |   `-- 0fc371f1c763aa861ac545dbb1c776ee44eb61
+  |   |   |-- 76
+  |   |   |   `-- 3691155f96d914089c1907339635f396254786
+  |   |   |-- 7f
+  |   |   |   `-- b42a80a5502f047ac602ba190f477c06b9e2df
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- 90
+  |   |   |   `-- ef73747f450299b3dd21586c3e0253e901eaac
+  |   |   |-- 93
+  |   |   |   `-- 24e89dea23615a773d6c11dfc1449ee46ff49e
+  |   |   |-- 9c
+  |   |   |   `-- 99a1f2c6ff42ff8e15218590173a242edbe6b6
+  |   |   |-- 9f
+  |   |   |   `-- e18c87ee4cc1d96e0b62880ac6be1c42b30d4b
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- d0
+  |   |   |   `-- 631b4684c4ba6c6f3a533780ac946649d893b7
+  |   |   |-- d5
+  |   |   |   `-- 18148177d23b6fd4ea7834fe9c0a462661576f
+  |   |   |-- dc
+  |   |   |   `-- 5f7e833b5a58dfd6fb216ff1867c14bf9c61cb
+  |   |   |-- e5
+  |   |   |   `-- 98bc9f9a8557dd6411fe3f2b1d82c387ede41e
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- f5
+  |   |   |   `-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |-- fa
+  |   |   |   `-- 42650f00240a3fcde5aa7e4850f925a97a48d0
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 10
+      |   |   `-- 4395792f8b6494b9a0fad94ebaf2d1b57422b8
+      |   |-- 13
+      |   |   `-- 7228bdcd2ae40007860a69d05168279d95117a
+      |   |-- 26
+      |   |   `-- 6864a895cac573b04a44bd40ee3bd8fe458a5f
+      |   |-- 2e
+      |   |   `-- aadc29a9215c79ff47c4b3a82a024816eb195a
+      |   |-- 39
+      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
+      |   |-- 3d
+      |   |   `-- 22f66f0814eac3e4b5c9dfe4cf1f6b679157ce
+      |   |-- 3e
+      |   |   `-- 838be41249b645bb9d17a5fdc8cc6bbca5f353
+      |   |-- 40
+      |   |   `-- 4703da297c8621c4806c8a145e08c7ddc54a3e
+      |   |-- 42
+      |   |   `-- 0b8bc82569d478e5af945068843a993a50de2d
+      |   |-- 43
+      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4d
+      |   |   `-- 5d64cb11e557bba3e609d2b7a605bb80806e94
+      |   |-- 59
+      |   |   `-- 661ed23a4ab82e9dc4f4b4b46f108e21962740
+      |   |-- 5a
+      |   |   `-- f4045367114a7584eefa64b95bb69d7f840aef
+      |   |-- 5e
+      |   |   `-- 7c803167e280bcdbb85f245e45820ab9a139dc
+      |   |-- 64
+      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
+      |   |-- 69
+      |   |   `-- d753308940fb9a6c60bf04d0b1c7421fd91aba
+      |   |-- 77
+      |   |   `-- 788a139643ad181e2b1684dd7f8a31e3da6249
+      |   |-- 78
+      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 7a
+      |   |   `-- 4c609f497d3360d4e8e451ab86262b321da64a
+      |   |-- 85
+      |   |   `-- 5c8765f063f6ab4a2563eb2de090a6c9b9deb4
+      |   |-- 98
+      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
+      |   |-- 9c
+      |   |   `-- afb9379b412184574e4f15a86c54609a07e6af
+      |   |-- 9f
+      |   |   |-- 51da357b05e7040f93fac55358555dba47f474
+      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- a3
+      |   |   `-- d19dcb2f51fa1efd55250f60df559c2b8270b8
+      |   |-- a4
+      |   |   `-- 36b5a3ef821ad5db735ff557d1cb2c8cbb3599
+      |   |-- b1
+      |   |   `-- 76252014d4a10d3ec078667ecf45dd9a140951
+      |   |-- b7
+      |   |   `-- 5b16149287cb154dc97714814f3be0f9f52d2c
+      |   |-- b8
+      |   |   |-- 558337a04104de5267b07276dac31a923708eb
+      |   |   `-- ddfe2d00f876ae2513a5b26a560485762f6bfa
+      |   |-- bb
+      |   |   `-- 76696a87dd29d841caa7f0d48e2f4e5359d369
+      |   |-- bc
+      |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+      |   |-- be
+      |   |   |-- 06ec33a91b8a108bd135b5a42a84292b035d6b
+      |   |   `-- 1afe91719c4fb58e09207874905f09858cfb66
+      |   |-- c1
+      |   |   `-- 8d1454dda3f68d09d2736441353a44d5962b08
+      |   |-- c2
+      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
+      |   |-- c5
+      |   |   `-- dd0ee2c3106a581cdea7db0c4297ef82c0f874
+      |   |-- c6
+      |   |   `-- 735a7b0d9da9bf6ef5e445ad2f4ce3d825ceb0
+      |   |-- cc
+      |   |   `-- 1d9224522c5f62049f867b6e7ba50177ef3fb5
+      |   |-- d7
+      |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+      |   |-- e2
+      |   |   `-- 7e2eec980a81625f680243092205b23ea040ad
+      |   |-- ea
+      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
+      |   |-- f0
+      |   |   `-- 91e02d893a86b20486acf5b0585899634fc755
+      |   |-- f2
+      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
+      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |-- f6
+      |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+      |   |-- f9
+      |   |   `-- 98899b80851f251ca131ccbd9846b7a15efba2
+      |   |-- fa
+      |   |   `-- 3b9622c1bcc8363c27d4eb05d1ae8dae15e871
+      |   |-- fc
+      |   |   `-- 332f8a40afcb71e997704bb301c93802b193bc
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  97 directories, 88 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -440,18 +440,346 @@ Note that ws/d/ is now present in the ws
       ':/ws/d',
       ':workspace=ws',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 04
+  |   |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
+  |   |   |-- 0f
+  |   |   |   `-- 7ceed53e5b4ab96efad3c0b77e2c00d10169ba
+  |   |   |-- 10
+  |   |   |   `-- 8eb9a1d2082ac57860d2358d445156e35558a9
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 1e
+  |   |   |   `-- 6ea69c6325d02f1dbc9614935f88ce9d2afbac
+  |   |   |-- 2a
+  |   |   |   `-- f8fd9cc75470c09c6442895133a815806018fc
+  |   |   |-- 2c
+  |   |   |   `-- 50404f5c69295bd3d4d0cb5475be9cc2aada23
+  |   |   |-- 2d
+  |   |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
+  |   |   |-- 2f
+  |   |   |   `-- 10c52e8ac3117e818b2b8a527c03d9345104c3
+  |   |   |-- 33
+  |   |   |   `-- dcdc06e9d605c8aca2375b96f7d431d2eb41d7
+  |   |   |-- 36
+  |   |   |   `-- 52f9baa44258d0f505314830ad37d16eafc981
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 41
+  |   |   |   `-- 8fcc975168e0bfc9dd53bbb98f740da2e983c0
+  |   |   |-- 48
+  |   |   |   `-- a2132905aa1413bc0ac9762b4365c9222911c5
+  |   |   |-- 53
+  |   |   |   `-- 9f411b73b3c22bc218bece495a841880fd4e2c
+  |   |   |-- 58
+  |   |   |   `-- b0c1e483109b33f416e0ae08487b4d1b6bfd5b
+  |   |   |-- 5d
+  |   |   |   `-- 605cee0c66b1c25a15a2d435b2786cc0bc24c5
+  |   |   |-- 5e
+  |   |   |   `-- 34ec2fa3c3188874f0a6b12ddf76a167df4229
+  |   |   |-- 60
+  |   |   |   `-- cb31dd78d6a5cdee8bfbd165e8c3f674f8e83f
+  |   |   |-- 6d
+  |   |   |   `-- 4b5c23a94a89c7f26266ccf635647fd4002b19
+  |   |   |-- 73
+  |   |   |   `-- d8490d4c86b1e4bfa023ea950ec67ea4e9ca9a
+  |   |   |-- 75
+  |   |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
+  |   |   |-- 7c
+  |   |   |   `-- 5a3be33ee5b7e18364f041b05de8ac08bf82ee
+  |   |   |-- 82
+  |   |   |   `-- 678b3bcd868634f36ad4ec719cca378028dfa4
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- 87
+  |   |   |   `-- 7af85c0624835da58fe4b2fa9a259a44213acf
+  |   |   |-- 8a
+  |   |   |   `-- 7fb63d6ac5e60e16941591969c5f8a8d23b8a5
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- a1
+  |   |   |   |-- 1e8a91058875f157ca1246bdc403b88e93cd94
+  |   |   |   `-- a7760c60ac08ecdcac395823637989a4d681a6
+  |   |   |-- ad
+  |   |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+  |   |   |-- b7
+  |   |   |   `-- 85a0b60f6ef7044b4c59c318e18e2c47686085
+  |   |   |-- bc
+  |   |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+  |   |   |-- c6
+  |   |   |   `-- 6fb92e3be8e4dc4c89f94d796f3a4b1833e0fa
+  |   |   |-- d3
+  |   |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
+  |   |   |-- d7
+  |   |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+  |   |   |-- e4
+  |   |   |   `-- 5f0325cd9fab82d962b758e556d9bf8079fc37
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- eb
+  |   |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
+  |   |   |-- f0
+  |   |   |   `-- 21d4b73a0df674b5729a23e36a1d5632e63b30
+  |   |   |-- f5
+  |   |   |   `-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |-- f6
+  |   |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+  |   |   |-- fd
+  |   |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 00
+      |   |   `-- 3a2970e4c23b64f915025e9adc2e6ed04bc63a
+      |   |-- 02
+      |   |   |-- 634a53b8e05b0a9a8f09db835ab4f35ad0e2e6
+      |   |   `-- 668d7af968c8eed910db7539a57b18dd62a50e
+      |   |-- 04
+      |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
+      |   |-- 07
+      |   |   `-- 2421631aa7c7bb28d705a1f3eaf893dd228f42
+      |   |-- 09
+      |   |   `-- b613e901acc0b5e4279ec6732261134a06f667
+      |   |-- 0b
+      |   |   `-- 976ee9223f2a23c5339d6cb3bda2196dbae6b1
+      |   |-- 0c
+      |   |   |-- d4309cc22b5903503a7196f49c24cf358a578a
+      |   |   `-- ee64f3b2f9f9dd40a2b36afdccb728b753659c
+      |   |-- 0d
+      |   |   |-- c2a5964e4ec35013dac4b0537f1116ea91341c
+      |   |   `-- d8698200c1dae7c92c6550607e6affcd91df29
+      |   |-- 10
+      |   |   `-- 8eb9a1d2082ac57860d2358d445156e35558a9
+      |   |-- 12
+      |   |   `-- f49faa307e33da834e082e022f0b5c83d0f3e1
+      |   |-- 13
+      |   |   |-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
+      |   |   `-- fa30d95222c1c055e613c116b32e17bac4d0c4
+      |   |-- 14
+      |   |   |-- 1a3bdf0a2739ded6e233ababff0cd490fd0c56
+      |   |   `-- da1560586adda328cca1fbf58c026d6730444f
+      |   |-- 17
+      |   |   |-- 039634b139f6fba381ff8bc55b9c5de210f87f
+      |   |   `-- ac72002199728c133087acfa6b23009e00a52a
+      |   |-- 19
+      |   |   `-- b9637ac9437ea11d42632cd65ca2313952c32f
+      |   |-- 1b
+      |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
+      |   |-- 22
+      |   |   `-- 0f8fb06cc7988cb683eba1c007b8e8aa1c9474
+      |   |-- 28
+      |   |   `-- a3e71d163a9eb30c3639b16a16f57077abf29b
+      |   |-- 2a
+      |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
+      |   |   |-- 3e798288165d5b090a10460984776489bcc7cc
+      |   |   `-- 6aa2a100b34d0d56e4b5f19e9bfdc2cd6f7d54
+      |   |-- 2c
+      |   |   |-- 50404f5c69295bd3d4d0cb5475be9cc2aada23
+      |   |   `-- 913262d99f8cd15ea711a89e943cd902fb87a0
+      |   |-- 2d
+      |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
+      |   |-- 2f
+      |   |   |-- 10c52e8ac3117e818b2b8a527c03d9345104c3
+      |   |   `-- 888ca5fb8487446a5718b64ddbd9e644d46b00
+      |   |-- 31
+      |   |   `-- efdeb5de300e7a344ebb5b006c0380f2223d45
+      |   |-- 36
+      |   |   `-- 52f9baa44258d0f505314830ad37d16eafc981
+      |   |-- 39
+      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
+      |   |-- 40
+      |   |   `-- c389b6b248e13f3cb88dcd79467d7396a4489e
+      |   |-- 41
+      |   |   `-- a263629db0fc09dcc5299c3a2eb3025ece9ea0
+      |   |-- 43
+      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
+      |   |-- 47
+      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
+      |   |-- 4b
+      |   |   |-- 6c1f65548a50c9ee26e3aec66946b48e65d08f
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4c
+      |   |   `-- a9fbf65ee12663ac24db4be4cab10e53d6d6e7
+      |   |-- 5b
+      |   |   `-- 560252b0c3c6abc5e0327596a49efb15e494cb
+      |   |-- 5e
+      |   |   |-- 34ec2fa3c3188874f0a6b12ddf76a167df4229
+      |   |   `-- 9213824faf1eb95d0c522329518489196374fd
+      |   |-- 5f
+      |   |   `-- 8dd30d5f721bf061d079d3f4375c1621716bb0
+      |   |-- 60
+      |   |   `-- bd0e180735e169b5c853545d8b1272ed0fc319
+      |   |-- 63
+      |   |   `-- 66535ea7764245934ee9568d0780ba3872b33c
+      |   |-- 64
+      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
+      |   |-- 6a
+      |   |   `-- 80a5b3af9023d11cb7f37bc1f80d1d1805bfdb
+      |   |-- 6c
+      |   |   `-- 68dd37602c8e2036362ab81b12829c4d6c0867
+      |   |-- 6d
+      |   |   `-- 4b5c23a94a89c7f26266ccf635647fd4002b19
+      |   |-- 70
+      |   |   `-- eb05d32223342a549cfb00c20b1464bf1b9513
+      |   |-- 71
+      |   |   |-- f38e799ec3f84476b6ef128a6bafcadc97a4b1
+      |   |   `-- fb4611471b5f67b815e54590ca24224d4f8786
+      |   |-- 75
+      |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
+      |   |-- 76
+      |   |   |-- 0794ed895b1bafed7f86aa3bd30d22e6b41a67
+      |   |   |-- e4334b07b5105496b7b92efcb0a9ffddb3a5e8
+      |   |   `-- f6b16c8aa19468ea877f11340830c469b76232
+      |   |-- 78
+      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 7c
+      |   |   |-- 30b7adfa79351301a11882adf49f438ec294f8
+      |   |   `-- b370bb5a475ca3fde0cf3369c4a3fcbb5c23d3
+      |   |-- 7d
+      |   |   `-- fca2962177d9c9925fedf2fbdd79fc7e9309fc
+      |   |-- 7f
+      |   |   |-- 39c7601f2c1ca44fdc9237efa34f2887daa2b4
+      |   |   `-- c8ee5474068055f7740240dfce6fa6e38bbf4d
+      |   |-- 82
+      |   |   |-- 4c0e846b41e1eb9f95d141b47bbb9ff9baef17
+      |   |   `-- 678b3bcd868634f36ad4ec719cca378028dfa4
+      |   |-- 87
+      |   |   `-- 7af85c0624835da58fe4b2fa9a259a44213acf
+      |   |-- 8c
+      |   |   `-- c4bb045e98da7cf00714d91ac77c7ea7e08b63
+      |   |-- 8d
+      |   |   `-- 603d2815e0a920045ac900135485b9fec9c9d8
+      |   |-- 92
+      |   |   `-- 1819911214b87cff59a38006d63bfccad279f0
+      |   |-- 93
+      |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
+      |   |-- 95
+      |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
+      |   |-- 97
+      |   |   `-- cdedf56398e9e3830d0db5bb329d91c443ce81
+      |   |-- 98
+      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
+      |   |-- 99
+      |   |   |-- 8e4d99b52680e8fc6d50d98cddad2a4e36a604
+      |   |   `-- acd82fe2a9b89022d1aee5a580c123a8161f4a
+      |   |-- 9c
+      |   |   `-- 78c532d93505a2a24430635b342b91db22fee0
+      |   |-- 9e
+      |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
+      |   |-- 9f
+      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- a1
+      |   |   |-- 1e8a91058875f157ca1246bdc403b88e93cd94
+      |   |   |-- 269dc50ffcdc1b87664a061926bf9a072a3456
+      |   |   |-- a7760c60ac08ecdcac395823637989a4d681a6
+      |   |   `-- c31372c5de4fb705ffdcbf5a4ec5c5103231d9
+      |   |-- a8
+      |   |   `-- 2dc4c2496b446840754c9dc9f1393b08592b26
+      |   |-- af
+      |   |   `-- 410d4293058c26007526cc7798cfc56472c7f8
+      |   |-- b1
+      |   |   `-- c3c9b731fea98c82ce8e9286e213fcb033f70d
+      |   |-- b2
+      |   |   `-- 7fe8d094037d5b5b911893496bb2ee0f40d820
+      |   |-- b7
+      |   |   `-- bb51e63095336302e4f6b0eead63cb716eb630
+      |   |-- b8
+      |   |   `-- 012aab20a6c6a0c2dc3b428d3578aadc9c527f
+      |   |-- b9
+      |   |   `-- 90567474f1f8af9784478614483684e88ccf4f
+      |   |-- ba
+      |   |   `-- f9dcf1394d5152de67b115f55f25e4dc0a2398
+      |   |-- bb
+      |   |   `-- 9f40f82fbc8cabcb1aee561cf488412e5f2415
+      |   |-- bc
+      |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+      |   |-- bf
+      |   |   `-- 7841c0db704465dda4b387d5da09694647d188
+      |   |-- c1
+      |   |   `-- 489fc8fd6ae9ac08c0168d7cabaf5645b922fa
+      |   |-- c2
+      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
+      |   |-- cb
+      |   |   `-- bceb2fb07839b8796fadb2b6a8b785b8fd7440
+      |   |-- d0
+      |   |   `-- 93bf5d3c220f754bc7208ccb7bc7662df6a7c9
+      |   |-- d3
+      |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
+      |   |-- d6
+      |   |   `-- 81a08f543313f2a8bd86fab920e2271d0403d1
+      |   |-- d7
+      |   |   |-- 330ea337031af43ba1cf6982a873a40b9170ac
+      |   |   `-- e36a04a3c59c966815fae6db6fe5d518a3456a
+      |   |-- da
+      |   |   `-- af0560e4e779353311a9039b31ea4f0f1dec37
+      |   |-- e1
+      |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
+      |   |-- e2
+      |   |   `-- 4b99efdd25fce896ef9fd0e9614163504c59cd
+      |   |-- e7
+      |   |   `-- cee3592aaac624fd48c258daa5d62d17352043
+      |   |-- e9
+      |   |   `-- 8909530f1ecc7b6438c268e3d6870107450eba
+      |   |-- ea
+      |   |   |-- 1ae75547e348b07cb28a721a06ef6580ff67f0
+      |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
+      |   |-- ec
+      |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
+      |   |-- ee
+      |   |   `-- b52a9c8fe143baf970160aa4716ff5c019d8cb
+      |   |-- f1
+      |   |   `-- f2c1bd855237608d4293f1ee98fee640e78405
+      |   |-- f2
+      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
+      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |-- f5
+      |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+      |   |-- f6
+      |   |   |-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+      |   |   `-- 7e3cdbde0a4bc95d09a1344d2d1f163b5aa172
+      |   |-- f7
+      |   |   `-- 35d04266733d64d2f49ab23a183a5207e8961d
+      |   |-- f8
+      |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
+      |   |-- fd
+      |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  162 directories, 176 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -100,18 +100,131 @@
       ':workspace=ws',
       ':workspace=ws2',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real%2Frepo2.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 00
+  |   |   |   `-- 2be85829685bf007607e29f41876f8545b49b4
+  |   |   |-- 07
+  |   |   |   `-- 5d66afd812cff42ae5cb2c519c9ec4633a27b6
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 2a
+  |   |   |   `-- f8fd9cc75470c09c6442895133a815806018fc
+  |   |   |-- 31
+  |   |   |   `-- 29b2527c5f75549a92894a1880721fa41f71cb
+  |   |   |-- 36
+  |   |   |   `-- a3ec5b54f46139a654590771ef2105c8bc3e39
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 46
+  |   |   |   `-- 3a4148064e9b240f94d89c2ac1b364a3b3e0fb
+  |   |   |-- 54
+  |   |   |   `-- 0973df4b43b3a62a587478586b5e30a43f641f
+  |   |   |-- 64
+  |   |   |   `-- e9e79e2a7ea34aee2245d66978eb35061f937c
+  |   |   |-- 6e
+  |   |   |   `-- 42c071a7fdd44d6553ef80961792d02eadb426
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- 95
+  |   |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
+  |   |   |-- 9a
+  |   |   |   `-- 23bc8b294f42dc6dbc5819b740080136a01747
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- a1
+  |   |   |   `-- 5b03f87416c0047cadcd4df249b724457e2474
+  |   |   |-- c7
+  |   |   |   `-- 98928982c619b7a84367d1839641e65b5cff95
+  |   |   |-- da
+  |   |   |   `-- 8f70fcf336cf187d9087e5cb1fdb2f02d030a7
+  |   |   |-- db
+  |   |   |   `-- 776e24b339cb0942b25e93e0015f50d8a5db5d
+  |   |   |-- dc
+  |   |   |   `-- 43836f860aafe77011c0c258d8719c6a125fe8
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- ec
+  |   |   |   `-- 5fc80d09f99c7420410c357d5377dc712155f3
+  |   |   |-- f5
+  |   |   |   `-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |-- f8
+  |   |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
+  |   |   |-- ff
+  |   |   |   `-- 86946d0cbeb90f4c84f8824c5fd617299ee895
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real%2Frepo2.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 1b
+      |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
+      |   |-- 22
+      |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
+      |   |-- 27
+      |   |   `-- 5b45aec0a1c944c3a4c71cc71ee08d0c9ea347
+      |   |-- 39
+      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
+      |   |-- 43
+      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 65
+      |   |   `-- 786136396010946815eff820697a6d0578c113
+      |   |-- 6b
+      |   |   `-- e0d68b8e87001c8b91281636e21d6387010332
+      |   |-- 78
+      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 7f
+      |   |   `-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
+      |   |-- 83
+      |   |   `-- 3812f1557e561166754add564fe32228dd1703
+      |   |-- 98
+      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
+      |   |-- 9c
+      |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
+      |   |-- 9f
+      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- b6
+      |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
+      |   |-- c2
+      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
+      |   |-- f2
+      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  68 directories, 55 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -179,19 +179,297 @@
       ':/ws',
       ':workspace=ws',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               |-- changes
-  |               |   `-- 1
-  |               |       `-- 1
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 14
+  |   |   |   `-- b2fb20fa2ded4b41451bf716e0d4741e4fcf49
+  |   |   |-- 16
+  |   |   |   `-- f299bec8b6eece08fd28777d7cff5edf6132ed
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 22
+  |   |   |   `-- f927526ccfaac5b87f90bc1a31ba5bd2d315ab
+  |   |   |-- 27
+  |   |   |   `-- 5b45aec0a1c944c3a4c71cc71ee08d0c9ea347
+  |   |   |-- 28
+  |   |   |   `-- 8746e9035732a1fe600ee331de94e70f9639cb
+  |   |   |-- 2a
+  |   |   |   |-- f771a31e4b62d67b59d74a74aba97d1eadcfab
+  |   |   |   `-- f8fd9cc75470c09c6442895133a815806018fc
+  |   |   |-- 30
+  |   |   |   `-- 48804b01e298df4a6e1bc60a1e3b2ca0b016bd
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 40
+  |   |   |   `-- c05934b8b40a6aea7835c4e97f1d2acb06bc97
+  |   |   |-- 4d
+  |   |   |   `-- aab0f68d3893d3b39725ce9f81d68cc8d5503d
+  |   |   |-- 5a
+  |   |   |   `-- fcddfe10e63e4b970f0a16ea5ab410bd51c5c7
+  |   |   |-- 65
+  |   |   |   `-- ca339b2d1d093f69c18e1a752833927c2591e2
+  |   |   |-- 82
+  |   |   |   `-- 8956f4a5f717b3ba66596cc200e7bb51a5633f
+  |   |   |-- 83
+  |   |   |   `-- 60d96c8d9e586f0f79d6b712a72d22894840ac
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- 88
+  |   |   |   `-- 3b1bd99f9c48cec992469c1ec20d2d3ea4bec0
+  |   |   |-- 8b
+  |   |   |   `-- d303a67f516a2748cedf487129dfb937fcbbf6
+  |   |   |-- 90
+  |   |   |   `-- 2bb8ff1ff20c4fcc3e2f9dcdf7bfa85e0fc004
+  |   |   |-- 95
+  |   |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
+  |   |   |-- a0
+  |   |   |   |-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |   `-- 9bec5980768ee3584be8ac8f148dd60bac370b
+  |   |   |-- a7
+  |   |   |   `-- 5eedb18d4cd23e4ad3e5af9c1f71006bc9390b
+  |   |   |-- b5
+  |   |   |   `-- a6423d90bd82e4473a1bebe68f1295d4f9d6a8
+  |   |   |-- c6
+  |   |   |   `-- 61ed4784f26f89d47e5ea0be3f404ee494e072
+  |   |   |-- d0
+  |   |   |   `-- 337df37921f762673a4ee9008f98bf2f9524d3
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- ed
+  |   |   |   `-- 42dbbeb77e5cf17175f2a048c97e965507a57d
+  |   |   |-- f5
+  |   |   |   |-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |   `-- 719cbf23e85915620cec2b2b8bd6fec8d80088
+  |   |   |-- f8
+  |   |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
+  |   |   |-- fb
+  |   |   |   `-- 0eb97a05a4dabbbf4901729d7189e7d95e732d
+  |   |   |-- fd
+  |   |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               |-- changes
+  |       |               |   `-- 1
+  |       |               |       `-- 1
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 00
+      |   |   `-- 0c330fa2c083613dfd2b0dce1dde1201b6357c
+      |   |-- 02
+      |   |   `-- 667f8e29e4b012540e81065f01c16031c2df27
+      |   |-- 03
+      |   |   `-- abc9b48b4da3daca498937b225ff8d54ba8c56
+      |   |-- 0c
+      |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
+      |   |-- 16
+      |   |   `-- f299bec8b6eece08fd28777d7cff5edf6132ed
+      |   |-- 19
+      |   |   `-- cff5ef0fce401a1a33c2ac2713d6356cbc1b15
+      |   |-- 1b
+      |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
+      |   |-- 1f
+      |   |   `-- 536d8f72fc8763fbab95342ed8013585f1e3b6
+      |   |-- 20
+      |   |   `-- 31777de79cd7c74834915674377e96d6864cc9
+      |   |-- 22
+      |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
+      |   |-- 26
+      |   |   |-- 2c83b56549e1690e3f878c4df4be1af11c19f0
+      |   |   `-- 6864a895cac573b04a44bd40ee3bd8fe458a5f
+      |   |-- 28
+      |   |   `-- 619ba172ac02f6f6ee83091721f9b345648ec9
+      |   |-- 2e
+      |   |   `-- 994f29aa1828fece591a9d63a61e93b4c2c629
+      |   |-- 2f
+      |   |   `-- 888ca5fb8487446a5718b64ddbd9e644d46b00
+      |   |-- 30
+      |   |   `-- 48804b01e298df4a6e1bc60a1e3b2ca0b016bd
+      |   |-- 31
+      |   |   `-- efdeb5de300e7a344ebb5b006c0380f2223d45
+      |   |-- 37
+      |   |   `-- b1b5fd12651414e4d9cb8a37812003d86569d6
+      |   |-- 39
+      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
+      |   |-- 3e
+      |   |   `-- c3e854c68442bfaa047033e1ade729892017a0
+      |   |-- 40
+      |   |   `-- f5442dba6d6c0b11ad798818f921834c5c2242
+      |   |-- 42
+      |   |   `-- 71a51984620f9bb8706bcbfb80d33f66d99dfc
+      |   |-- 43
+      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
+      |   |-- 47
+      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4d
+      |   |   `-- aab0f68d3893d3b39725ce9f81d68cc8d5503d
+      |   |-- 50
+      |   |   |-- 207be2e0fadfbe2ca8d5e0616a71e7ec01f3e2
+      |   |   `-- 724c0a6bac8e87c89b64f6c409a2e0382ff65e
+      |   |-- 55
+      |   |   `-- 652697c232470cde4141b0e1bbbe2c6ac91260
+      |   |-- 56
+      |   |   `-- 45805dcc75cfe4922b9cb301c40a4a4b35a59d
+      |   |-- 57
+      |   |   `-- a36663dff20a0906952548a999b9d3ff770dc4
+      |   |-- 58
+      |   |   `-- b0c1e483109b33f416e0ae08487b4d1b6bfd5b
+      |   |-- 5e
+      |   |   `-- 7ff045529989036cbd11bc32b2eaf5a8311aea
+      |   |-- 60
+      |   |   `-- 5066c26f66fca5a424aa32bd042ae71c7c8705
+      |   |-- 65
+      |   |   `-- 786136396010946815eff820697a6d0578c113
+      |   |-- 6a
+      |   |   `-- 80a5b3af9023d11cb7f37bc1f80d1d1805bfdb
+      |   |-- 6c
+      |   |   `-- 68dd37602c8e2036362ab81b12829c4d6c0867
+      |   |-- 6f
+      |   |   `-- 4738ef61827430896308fa64a1d16a29f3d037
+      |   |-- 74
+      |   |   `-- 3fcd7100630aea3ab423c23ec9c012549467ad
+      |   |-- 75
+      |   |   `-- e89ed8367a6ac09038ca4517967569e1c60858
+      |   |-- 76
+      |   |   `-- 9e718288ea6c1390adb2b1b6cd8c2c73f2785b
+      |   |-- 78
+      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 7b
+      |   |   `-- 2c507bf65a8974bf12cc3ecaa2d64c83725b89
+      |   |-- 7c
+      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
+      |   |-- 7f
+      |   |   `-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
+      |   |-- 84
+      |   |   `-- 6138fabc729dd858de061ae04cfeb8327e6e32
+      |   |-- 85
+      |   |   `-- 8b0beb2af29b2e3a41bda2f19e4cfc7901170d
+      |   |-- 89
+      |   |   `-- ae198bc1b2f11718bd1e76fbe6473054801274
+      |   |-- 8f
+      |   |   `-- 1b78740f35dafecc063980e2afb231b9ee74a3
+      |   |-- 91
+      |   |   `-- c0b3ea5e7c1dbeae440c93116450f6c4de65c1
+      |   |-- 93
+      |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
+      |   |-- 97
+      |   |   `-- 738bf1d1a305512158d536564d3fccbcb0dbec
+      |   |-- 98
+      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
+      |   |-- 9a
+      |   |   `-- 28fa82a736714d831348bbf62b951be65331b7
+      |   |-- 9b
+      |   |   `-- d58f891b4f17736c1b51903837de717fce13a5
+      |   |-- 9c
+      |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
+      |   |-- 9f
+      |   |   |-- 24b55d4263082d93987e2c0ff6b24df3323f5b
+      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- a1
+      |   |   `-- 732ade400c9d36a9de8ccdcb0996e6782f6f9c
+      |   |-- a3
+      |   |   `-- c7a71fc22700d5f53defd99609e96296417985
+      |   |-- a7
+      |   |   `-- cf4e83688bf0ec633d4e4abae4b74dce4852ba
+      |   |-- aa
+      |   |   `-- 9a76a1ceffe8671346cd7526a4dc86b0d7cc40
+      |   |-- af
+      |   |   `-- 7c13846465562922d156aef649f6844d51798b
+      |   |-- b0
+      |   |   `-- 82cc90b0da2483c71d04b222774c2d5e9fcd5c
+      |   |-- b1
+      |   |   `-- 73c90bd6823f700119dfc7c23b6a8e417705a4
+      |   |-- b5
+      |   |   `-- c12ea9494f5e3824d5f7e979dcc56d898036b6
+      |   |-- b6
+      |   |   |-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
+      |   |   `-- cfe79e25ecd337b379e7ec06d7939dbcb2f6a0
+      |   |-- bd
+      |   |   `-- 56f16bf42ff74e68cfb7a59869c81920b02b87
+      |   |-- be
+      |   |   `-- c9383652a22b8a07acb86d5357a75f988286dc
+      |   |-- bf
+      |   |   `-- a4b41bb449aa6f5f0be272340b83b3f3317ff8
+      |   |-- c2
+      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
+      |   |-- c4
+      |   |   `-- ccf3ecba27a8189d2a616afa8c278f75d0bc1a
+      |   |-- c5
+      |   |   `-- ab31f80e2b8c97a7d354d252272a9eaebd4581
+      |   |-- c7
+      |   |   `-- c20449d3cd7e2084419fa525c7b36eb7d5ef8c
+      |   |-- d0
+      |   |   `-- 11f44f9309139b667471901d7e3e4f6a035050
+      |   |-- d1
+      |   |   `-- 0560b09f01be0e4cad8794cda515077f8ff945
+      |   |-- d2
+      |   |   `-- e93ec04d109f8125b77be4ade54fff6db0c320
+      |   |-- d3
+      |   |   `-- d28f0a10d8f6be1a5f85c80e3c40bb2b5671cb
+      |   |-- d4
+      |   |   `-- c6c9ce1c5286d73c55da95d50fbf65ed90bcea
+      |   |-- d8
+      |   |   |-- 631b65275580884aa3cfbac4b2aafc570fb616
+      |   |   `-- cbfe4d87d6b800f15edbb26b0c448598e901ab
+      |   |-- d9
+      |   |   `-- 9cfb874f6f7317db8ce0224aa80dd2ba462570
+      |   |-- dc
+      |   |   `-- 268932c3e0a21d51ec34fb88c6947f51faa430
+      |   |-- dd
+      |   |   |-- 29249d0f31950d5337ec484230651c3c4cf8ad
+      |   |   `-- 9ebd9f693084e229dbcc0998906e42eab1acd5
+      |   |-- e1
+      |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
+      |   |-- e5
+      |   |   `-- a8caaa59058b8beb8a603a3b4447c07218a617
+      |   |-- e6
+      |   |   `-- 3efb2615e1c17f0d0b6e610da85da09438cd29
+      |   |-- e9
+      |   |   `-- 9a2c69c0fb10af8dd1524e7f976df3d898f6ac
+      |   |-- ec
+      |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
+      |   |-- ee
+      |   |   `-- 8d4f1ce160fe9a1d8083c0135bf61024f10b34
+      |   |-- f2
+      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |-- f4
+      |   |   `-- a8b4b45b62d433fad5952677ff015c49ed8199
+      |   |-- fd
+      |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  10 directories, 3 files
+  148 directories, 143 files

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -243,17 +243,253 @@
       ':workspace=ws',
       ':workspace=ws2',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 11
+  |   |   |   `-- e2559617afa238a8332c15d15fff48d5b57c83
+  |   |   |-- 14
+  |   |   |   `-- b2fb20fa2ded4b41451bf716e0d4741e4fcf49
+  |   |   |-- 17
+  |   |   |   `-- 6e8e0eda7dc644342b4cbce4196b968886fff3
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 27
+  |   |   |   `-- 5b45aec0a1c944c3a4c71cc71ee08d0c9ea347
+  |   |   |-- 2a
+  |   |   |   |-- f771a31e4b62d67b59d74a74aba97d1eadcfab
+  |   |   |   `-- f8fd9cc75470c09c6442895133a815806018fc
+  |   |   |-- 2d
+  |   |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 51
+  |   |   |   `-- 7813c12644d29529502e7445a026b549129817
+  |   |   |-- 58
+  |   |   |   `-- 6af2034d76913e16ad09d5a7b683938badb049
+  |   |   |-- 5a
+  |   |   |   |-- f4045367114a7584eefa64b95bb69d7f840aef
+  |   |   |   `-- fcddfe10e63e4b970f0a16ea5ab410bd51c5c7
+  |   |   |-- 65
+  |   |   |   `-- ca339b2d1d093f69c18e1a752833927c2591e2
+  |   |   |-- 68
+  |   |   |   `-- b1430cedd477c8117976bdb8aba3cee8b9aa9e
+  |   |   |-- 76
+  |   |   |   `-- cd9e690c1d36eb4cdbf3cd244e9defda4ff3ad
+  |   |   |-- 82
+  |   |   |   `-- 8956f4a5f717b3ba66596cc200e7bb51a5633f
+  |   |   |-- 83
+  |   |   |   `-- 60d96c8d9e586f0f79d6b712a72d22894840ac
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- 90
+  |   |   |   `-- 2bb8ff1ff20c4fcc3e2f9dcdf7bfa85e0fc004
+  |   |   |-- 95
+  |   |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
+  |   |   |-- a0
+  |   |   |   |-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |   `-- 9bec5980768ee3584be8ac8f148dd60bac370b
+  |   |   |-- a3
+  |   |   |   `-- d19dcb2f51fa1efd55250f60df559c2b8270b8
+  |   |   |-- a4
+  |   |   |   `-- 1772e0c7cdad1a13b7a7bc38c0d382a5a827ce
+  |   |   |-- a5
+  |   |   |   `-- bc2cb1497c5491656a72647f07791fe11f4d8f
+  |   |   |-- a7
+  |   |   |   `-- 5eedb18d4cd23e4ad3e5af9c1f71006bc9390b
+  |   |   |-- b9
+  |   |   |   `-- 1faa49e725f148de89346f193a4a4295e071cd
+  |   |   |-- bc
+  |   |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+  |   |   |-- c3
+  |   |   |   `-- 13e8583c38d3ca1a2d987570f9dde3666eed0c
+  |   |   |-- d3
+  |   |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
+  |   |   |-- d7
+  |   |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- ed
+  |   |   |   `-- 42dbbeb77e5cf17175f2a048c97e965507a57d
+  |   |   |-- f5
+  |   |   |   |-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |   `-- 719cbf23e85915620cec2b2b8bd6fec8d80088
+  |   |   |-- f6
+  |   |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+  |   |   |-- f8
+  |   |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 00
+      |   |   `-- e02597bb7117c22dc0b551a4062607895fc3d3
+      |   |-- 11
+      |   |   `-- e2559617afa238a8332c15d15fff48d5b57c83
+      |   |-- 13
+      |   |   `-- 7228bdcd2ae40007860a69d05168279d95117a
+      |   |-- 19
+      |   |   `-- 742d815e52ef8d0bb16ddb1a2b7640c3144d0c
+      |   |-- 1b
+      |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
+      |   |-- 1d
+      |   |   `-- 2a35c53f4e5901c9cc083a94b417c15837cad8
+      |   |-- 22
+      |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
+      |   |-- 23
+      |   |   `-- e561766ccaeac759e40f343e5e6cb2d15ba665
+      |   |-- 26
+      |   |   `-- 6864a895cac573b04a44bd40ee3bd8fe458a5f
+      |   |-- 2b
+      |   |   `-- a493ff63f057671e2e3be745f9bff9477d7b93
+      |   |-- 2c
+      |   |   `-- bcd105ead63a4fecf486b949db7f44710300e5
+      |   |-- 2d
+      |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
+      |   |-- 2e
+      |   |   `-- aadc29a9215c79ff47c4b3a82a024816eb195a
+      |   |-- 2f
+      |   |   `-- a28dd621122cd858cf13f53f88dfe37eef5424
+      |   |-- 34
+      |   |   `-- e6cdfeada6ead6f8df3602f54f5a05bfd4c670
+      |   |-- 37
+      |   |   `-- c3159b05efb7c51e9157e5140a462898ab1a16
+      |   |-- 39
+      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
+      |   |-- 3e
+      |   |   `-- 1e9c8f8f495df88d344fe5c4cb3ff27b74149d
+      |   |-- 43
+      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
+      |   |-- 45
+      |   |   `-- c7960fc4d4b38a6a28dcc27f0ae158afa59747
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4d
+      |   |   `-- 5d64cb11e557bba3e609d2b7a605bb80806e94
+      |   |-- 4e
+      |   |   `-- 514efb7a3a8be95d66b564399ae7f0dfebb72e
+      |   |-- 51
+      |   |   `-- 7813c12644d29529502e7445a026b549129817
+      |   |-- 58
+      |   |   `-- 6af2034d76913e16ad09d5a7b683938badb049
+      |   |-- 5a
+      |   |   `-- f4045367114a7584eefa64b95bb69d7f840aef
+      |   |-- 5c
+      |   |   `-- 874339dcbbc0c34c083557c2e652380c3cb3d6
+      |   |-- 5f
+      |   |   `-- a942ed9d35f280b35df2c4ef7acd23319271a5
+      |   |-- 60
+      |   |   |-- 5066c26f66fca5a424aa32bd042ae71c7c8705
+      |   |   `-- da713d13cb085a9b7629cdc3a1d88d83dd49ae
+      |   |-- 64
+      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
+      |   |-- 65
+      |   |   `-- 786136396010946815eff820697a6d0578c113
+      |   |-- 68
+      |   |   `-- b1430cedd477c8117976bdb8aba3cee8b9aa9e
+      |   |-- 6b
+      |   |   `-- e0d68b8e87001c8b91281636e21d6387010332
+      |   |-- 6f
+      |   |   `-- 707bfe4b7a16450de3f2cf3d8b23eccad0f74c
+      |   |-- 78
+      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 7f
+      |   |   `-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
+      |   |-- 83
+      |   |   `-- 3812f1557e561166754add564fe32228dd1703
+      |   |-- 98
+      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
+      |   |-- 9b
+      |   |   `-- 518075958ed3bda719b38249cd91fcef1da965
+      |   |-- 9c
+      |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
+      |   |-- 9f
+      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- a3
+      |   |   `-- d19dcb2f51fa1efd55250f60df559c2b8270b8
+      |   |-- a4
+      |   |   `-- 1772e0c7cdad1a13b7a7bc38c0d382a5a827ce
+      |   |-- ad
+      |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+      |   |-- ae
+      |   |   `-- 3b5ae2be9441da66ee2a69926b45d0e3a5adb2
+      |   |-- b0
+      |   |   `-- fdeb65d9b9069015ef9c0f735a4f6f2f28fe77
+      |   |-- b3
+      |   |   `-- be5ad252e0f493a404a8785653065d7e677f21
+      |   |-- b6
+      |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
+      |   |-- b8
+      |   |   `-- ddfe2d00f876ae2513a5b26a560485762f6bfa
+      |   |-- b9
+      |   |   `-- 1faa49e725f148de89346f193a4a4295e071cd
+      |   |-- bb
+      |   |   `-- bd62ec41c785d12270e69b9d49f9babe62fcd6
+      |   |-- bc
+      |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+      |   |-- c2
+      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
+      |   |-- c5
+      |   |   `-- dd0ee2c3106a581cdea7db0c4297ef82c0f874
+      |   |-- c6
+      |   |   `-- 735a7b0d9da9bf6ef5e445ad2f4ce3d825ceb0
+      |   |-- d3
+      |   |   |-- 1a8dce16b9b197a1411e750602e62d8d2f97ae
+      |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
+      |   |-- d7
+      |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+      |   |-- dd
+      |   |   `-- b4ddc1cd0609e65a0537a9243a3f73410c8b11
+      |   |-- e2
+      |   |   `-- 532f1207290ed9a961f9fc377a6b7afe415312
+      |   |-- e7
+      |   |   `-- cc5fdb96f774bb7a1cf2300a88a43a04f1ea4b
+      |   |-- ea
+      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
+      |   |-- eb
+      |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
+      |   |-- ee
+      |   |   `-- 5bbeab31c4de6c44afb01fa077befd53977492
+      |   |-- f2
+      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
+      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |-- f5
+      |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+      |   |-- f6
+      |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  126 directories, 120 files
 

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -182,16 +182,137 @@ Flushed credential cache
       ':/ws',
       ':workspace=ws',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 15
+  |   |   |   `-- 4448600af55384a18a4f683fea4c3d4cf5290e
+  |   |   |-- 1e
+  |   |   |   `-- a5cc01771cfa9087f346b7d812dfbe33c1e6b1
+  |   |   |-- 26
+  |   |   |   `-- cadcac11584c2c798ff38995ebd4d27490885a
+  |   |   |-- 2b
+  |   |   |   `-- 20b4f8abb6d70648e2573e2f798a18e0079f9e
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 81
+  |   |   |   |-- c59c0666268c2ae7a0d39003e14eb951bb87e3
+  |   |   |   `-- cd4ba9bc0f79007940b528627c085f048ec516
+  |   |   |-- 88
+  |   |   |   `-- e9ef64b0c92e2881fb759e1cf774e75d398d4f
+  |   |   |-- 8e
+  |   |   |   `-- 4d581b934717eb1f52fcdf21e731e7d7899717
+  |   |   |-- 91
+  |   |   |   `-- 6a12fa6687633241c43db9a96277d6fd056870
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- ad
+  |   |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+  |   |   |-- ae
+  |   |   |   `-- 64c764b19ab4cb9c8d4ad32ae9dc04a30eb42a
+  |   |   |-- b3
+  |   |   |   `-- dc01c39cba3251ec3a349fc585bd57ee4136f8
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- eb
+  |   |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
+  |   |   |-- f7
+  |   |   |   `-- 99a2ffcfae170f01efea806ff109e5e702191a
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 0a
+      |   |   `-- 3e20b963d30a7071105313fada241306df8695
+      |   |-- 0f
+      |   |   `-- 70f195d1852ceed0a13b3839eee7aeb07571f7
+      |   |-- 2b
+      |   |   `-- 20b4f8abb6d70648e2573e2f798a18e0079f9e
+      |   |-- 31
+      |   |   `-- f15ce76ce6a453ecc90f5852e70babf3554707
+      |   |-- 3d
+      |   |   `-- 96ae1a24134d32cf3eca0629fb4fd1d095693a
+      |   |-- 41
+      |   |   `-- 3c883bf377b8a2b9ec80ba847a926f5d50e751
+      |   |-- 46
+      |   |   `-- ac801dc88e2ce2a836fbc7f6e3e35a7c7892ab
+      |   |-- 4a
+      |   |   `-- 9ee6ea51565adf5c005dd1bc93f4b42f335be3
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4e
+      |   |   `-- 531443c5533e6d1b2503d0fad238cfc8491807
+      |   |-- 51
+      |   |   `-- 45dedc66248700cf33e354ef555877bc24f533
+      |   |-- 66
+      |   |   `-- 1bafe5fb60524a9efafd413c42e4c2d706bae8
+      |   |-- 6c
+      |   |   |-- 8233465e92d353e2ef47c02dc568ea44a32339
+      |   |   `-- 9e5f368b68b7e511f7b0ce25cbedd2a3b42abb
+      |   |-- 7d
+      |   |   `-- 5816334652b9738e33e4ceaf925573c3414e0c
+      |   |-- 85
+      |   |   `-- ee20960c56619305e098b301d8253888b6ce5b
+      |   |-- 88
+      |   |   `-- e9ef64b0c92e2881fb759e1cf774e75d398d4f
+      |   |-- 8e
+      |   |   `-- 4d581b934717eb1f52fcdf21e731e7d7899717
+      |   |-- 8f
+      |   |   `-- 2bb1e9e57ae77c662a82586d21fb7ee54e7c65
+      |   |-- 91
+      |   |   `-- 6a12fa6687633241c43db9a96277d6fd056870
+      |   |-- 97
+      |   |   `-- 398140f110f4009f1fce46e15f9fc140d6908b
+      |   |-- 9d
+      |   |   `-- 613be55337cdfab189935d8dbd1d4f427ef75e
+      |   |-- a1
+      |   |   `-- fe09109ceb8c170db78421172e3674ff18f762
+      |   |-- ae
+      |   |   `-- 64c764b19ab4cb9c8d4ad32ae9dc04a30eb42a
+      |   |-- c2
+      |   |   `-- 55706f564f629eed1756b789d761048cfe060a
+      |   |-- db
+      |   |   `-- 9120ba624b0afe79d37a5a262d8deb14e13707
+      |   |-- df
+      |   |   `-- 19fd70c60593952f558740288b01384068e17c
+      |   |-- f0
+      |   |   `-- 2803a3f6b703de58a33b330f70b5034e0ebcf8
+      |   |-- f7
+      |   |   `-- 99a2ffcfae170f01efea806ff109e5e702191a
+      |   |-- f8
+      |   |   `-- 0574b1c92818683f0283f78078031282fff75a
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  71 directories, 60 files

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -439,18 +439,345 @@ Note that ws/d/ is now present in the ws
       ':/ws',
       ':workspace=ws',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 04
+  |   |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
+  |   |   |-- 0f
+  |   |   |   `-- 7ceed53e5b4ab96efad3c0b77e2c00d10169ba
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 1e
+  |   |   |   `-- 6ea69c6325d02f1dbc9614935f88ce9d2afbac
+  |   |   |-- 21
+  |   |   |   `-- cd34cf0a5b7f59eaa6beab4d2e3d0c76bdf8ac
+  |   |   |-- 2a
+  |   |   |   `-- f8fd9cc75470c09c6442895133a815806018fc
+  |   |   |-- 2c
+  |   |   |   `-- 50404f5c69295bd3d4d0cb5475be9cc2aada23
+  |   |   |-- 2d
+  |   |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
+  |   |   |-- 2f
+  |   |   |   `-- 10c52e8ac3117e818b2b8a527c03d9345104c3
+  |   |   |-- 33
+  |   |   |   `-- dcdc06e9d605c8aca2375b96f7d431d2eb41d7
+  |   |   |-- 34
+  |   |   |   `-- c24765275d6f3ec5d6baeaaa4299471d6f7df0
+  |   |   |-- 35
+  |   |   |   `-- 09aec137bbedd7925edc2069421db0aeff4684
+  |   |   |-- 36
+  |   |   |   `-- 52f9baa44258d0f505314830ad37d16eafc981
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 41
+  |   |   |   `-- 8fcc975168e0bfc9dd53bbb98f740da2e983c0
+  |   |   |-- 48
+  |   |   |   `-- a2132905aa1413bc0ac9762b4365c9222911c5
+  |   |   |-- 53
+  |   |   |   `-- 9f411b73b3c22bc218bece495a841880fd4e2c
+  |   |   |-- 58
+  |   |   |   `-- b0c1e483109b33f416e0ae08487b4d1b6bfd5b
+  |   |   |-- 59
+  |   |   |   `-- 632d8d838ce9390679767c02c6bfe6c0d244a9
+  |   |   |-- 5d
+  |   |   |   `-- 605cee0c66b1c25a15a2d435b2786cc0bc24c5
+  |   |   |-- 60
+  |   |   |   `-- cb31dd78d6a5cdee8bfbd165e8c3f674f8e83f
+  |   |   |-- 6d
+  |   |   |   `-- 4b5c23a94a89c7f26266ccf635647fd4002b19
+  |   |   |-- 75
+  |   |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
+  |   |   |-- 7a
+  |   |   |   `-- c71a2d1648e7de21f4fbe4935cf54b44bfef9a
+  |   |   |-- 7c
+  |   |   |   `-- 5a3be33ee5b7e18364f041b05de8ac08bf82ee
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- 8a
+  |   |   |   `-- 7fb63d6ac5e60e16941591969c5f8a8d23b8a5
+  |   |   |-- 98
+  |   |   |   `-- c996c3ca42384d9328e0d3ad12ae9bf496e786
+  |   |   |-- 9c
+  |   |   |   `-- 41f84a301918bbba26e7109efa440f973cec2a
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- a1
+  |   |   |   `-- 1e8a91058875f157ca1246bdc403b88e93cd94
+  |   |   |-- ad
+  |   |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+  |   |   |-- b7
+  |   |   |   `-- 85a0b60f6ef7044b4c59c318e18e2c47686085
+  |   |   |-- bc
+  |   |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+  |   |   |-- c6
+  |   |   |   `-- 6fb92e3be8e4dc4c89f94d796f3a4b1833e0fa
+  |   |   |-- d3
+  |   |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
+  |   |   |-- d7
+  |   |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+  |   |   |-- e4
+  |   |   |   |-- 1565cb5139d39c394a5fb54fe9c567b5453944
+  |   |   |   `-- 5f0325cd9fab82d962b758e556d9bf8079fc37
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- eb
+  |   |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
+  |   |   |-- f5
+  |   |   |   |-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+  |   |   |-- f6
+  |   |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+  |   |   |-- fd
+  |   |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 02
+      |   |   `-- 668d7af968c8eed910db7539a57b18dd62a50e
+      |   |-- 04
+      |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
+      |   |-- 09
+      |   |   `-- b613e901acc0b5e4279ec6732261134a06f667
+      |   |-- 0b
+      |   |   `-- 976ee9223f2a23c5339d6cb3bda2196dbae6b1
+      |   |-- 0c
+      |   |   |-- d4309cc22b5903503a7196f49c24cf358a578a
+      |   |   `-- ee64f3b2f9f9dd40a2b36afdccb728b753659c
+      |   |-- 12
+      |   |   `-- f49faa307e33da834e082e022f0b5c83d0f3e1
+      |   |-- 13
+      |   |   |-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
+      |   |   `-- fa30d95222c1c055e613c116b32e17bac4d0c4
+      |   |-- 14
+      |   |   `-- da1560586adda328cca1fbf58c026d6730444f
+      |   |-- 17
+      |   |   |-- 039634b139f6fba381ff8bc55b9c5de210f87f
+      |   |   `-- ac72002199728c133087acfa6b23009e00a52a
+      |   |-- 19
+      |   |   `-- b9637ac9437ea11d42632cd65ca2313952c32f
+      |   |-- 1b
+      |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
+      |   |-- 20
+      |   |   `-- 189c97a0ef53368b7ec335baa7a1b86bd76f8e
+      |   |-- 21
+      |   |   `-- cd34cf0a5b7f59eaa6beab4d2e3d0c76bdf8ac
+      |   |-- 28
+      |   |   `-- a3e71d163a9eb30c3639b16a16f57077abf29b
+      |   |-- 2a
+      |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
+      |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
+      |   |-- 2c
+      |   |   |-- 50404f5c69295bd3d4d0cb5475be9cc2aada23
+      |   |   |-- 56d130ff53e8110607c808d7d4d0317e61d91e
+      |   |   `-- 913262d99f8cd15ea711a89e943cd902fb87a0
+      |   |-- 2d
+      |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
+      |   |-- 2f
+      |   |   |-- 10c52e8ac3117e818b2b8a527c03d9345104c3
+      |   |   `-- 888ca5fb8487446a5718b64ddbd9e644d46b00
+      |   |-- 31
+      |   |   |-- 36fff7280627623bf4d71191d1aea783579be0
+      |   |   |-- af3d0a5be6cc36a10a6b984673087c2d068432
+      |   |   `-- efdeb5de300e7a344ebb5b006c0380f2223d45
+      |   |-- 34
+      |   |   `-- c24765275d6f3ec5d6baeaaa4299471d6f7df0
+      |   |-- 36
+      |   |   `-- 52f9baa44258d0f505314830ad37d16eafc981
+      |   |-- 39
+      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
+      |   |-- 40
+      |   |   `-- c389b6b248e13f3cb88dcd79467d7396a4489e
+      |   |-- 41
+      |   |   `-- a263629db0fc09dcc5299c3a2eb3025ece9ea0
+      |   |-- 43
+      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
+      |   |-- 44
+      |   |   `-- 625a9b34b1c6747c29903c3e641a4b2e580673
+      |   |-- 47
+      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
+      |   |-- 49
+      |   |   `-- 72ae19097180428a9230e3cc70255501d7ab66
+      |   |-- 4a
+      |   |   `-- 199f3a19a292e6639dede0f8602afc19a82dfc
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4c
+      |   |   `-- a9fbf65ee12663ac24db4be4cab10e53d6d6e7
+      |   |-- 59
+      |   |   `-- 632d8d838ce9390679767c02c6bfe6c0d244a9
+      |   |-- 5a
+      |   |   `-- 8a4b8c1452d54f1ca88454067369112809a4d2
+      |   |-- 5b
+      |   |   `-- 560252b0c3c6abc5e0327596a49efb15e494cb
+      |   |-- 5e
+      |   |   `-- 9213824faf1eb95d0c522329518489196374fd
+      |   |-- 5f
+      |   |   `-- 8dd30d5f721bf061d079d3f4375c1621716bb0
+      |   |-- 64
+      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
+      |   |-- 6a
+      |   |   `-- 80a5b3af9023d11cb7f37bc1f80d1d1805bfdb
+      |   |-- 6b
+      |   |   `-- ea49f3ab464fb1795ab9c622aad1047de07d8e
+      |   |-- 6c
+      |   |   `-- 68dd37602c8e2036362ab81b12829c4d6c0867
+      |   |-- 6d
+      |   |   |-- 4b5c23a94a89c7f26266ccf635647fd4002b19
+      |   |   `-- 5a5046f3a9591a32ec47bc38a1da879aca6743
+      |   |-- 6f
+      |   |   `-- 33ff469334600e2a53433208efc1cd734b49b3
+      |   |-- 70
+      |   |   `-- eb05d32223342a549cfb00c20b1464bf1b9513
+      |   |-- 71
+      |   |   `-- f38e799ec3f84476b6ef128a6bafcadc97a4b1
+      |   |-- 75
+      |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
+      |   |-- 76
+      |   |   `-- f6b16c8aa19468ea877f11340830c469b76232
+      |   |-- 78
+      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 7a
+      |   |   `-- c71a2d1648e7de21f4fbe4935cf54b44bfef9a
+      |   |-- 7c
+      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
+      |   |-- 7d
+      |   |   `-- fca2962177d9c9925fedf2fbdd79fc7e9309fc
+      |   |-- 7f
+      |   |   |-- 39c7601f2c1ca44fdc9237efa34f2887daa2b4
+      |   |   `-- c8ee5474068055f7740240dfce6fa6e38bbf4d
+      |   |-- 82
+      |   |   `-- 4c0e846b41e1eb9f95d141b47bbb9ff9baef17
+      |   |-- 8c
+      |   |   `-- c4bb045e98da7cf00714d91ac77c7ea7e08b63
+      |   |-- 8d
+      |   |   `-- 603d2815e0a920045ac900135485b9fec9c9d8
+      |   |-- 91
+      |   |   `-- e1e8645d3439b195f3866664092ebc20e63bb5
+      |   |-- 92
+      |   |   `-- 1819911214b87cff59a38006d63bfccad279f0
+      |   |-- 93
+      |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
+      |   |-- 94
+      |   |   |-- 41c1b9a5eb6356cd9f7a1640d2683283ac6053
+      |   |   `-- 690d41c15b7c64888795b4c30ab29808402465
+      |   |-- 95
+      |   |   |-- 19a72b0b8d581a4e859d412cfe9c2689acac53
+      |   |   `-- d99506044285b3088aef86540c478f09606763
+      |   |-- 97
+      |   |   `-- cdedf56398e9e3830d0db5bb329d91c443ce81
+      |   |-- 98
+      |   |   |-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
+      |   |   `-- c996c3ca42384d9328e0d3ad12ae9bf496e786
+      |   |-- 99
+      |   |   |-- 8e4d99b52680e8fc6d50d98cddad2a4e36a604
+      |   |   `-- acd82fe2a9b89022d1aee5a580c123a8161f4a
+      |   |-- 9c
+      |   |   |-- 41f84a301918bbba26e7109efa440f973cec2a
+      |   |   `-- 78c532d93505a2a24430635b342b91db22fee0
+      |   |-- 9e
+      |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
+      |   |-- 9f
+      |   |   |-- 8d9c0adcbc65e17dfb359c6e3dee7520649c88
+      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- a1
+      |   |   |-- 1e8a91058875f157ca1246bdc403b88e93cd94
+      |   |   |-- 269dc50ffcdc1b87664a061926bf9a072a3456
+      |   |   `-- c31372c5de4fb705ffdcbf5a4ec5c5103231d9
+      |   |-- ab
+      |   |   `-- a295fbe181a47f04650542b7d5582fbd983b98
+      |   |-- af
+      |   |   `-- 410d4293058c26007526cc7798cfc56472c7f8
+      |   |-- b1
+      |   |   |-- 55ee8a0221a6d1f94982ab3624f47f7e4931e2
+      |   |   `-- c3c9b731fea98c82ce8e9286e213fcb033f70d
+      |   |-- b7
+      |   |   `-- bb51e63095336302e4f6b0eead63cb716eb630
+      |   |-- b9
+      |   |   `-- 90567474f1f8af9784478614483684e88ccf4f
+      |   |-- ba
+      |   |   `-- f9dcf1394d5152de67b115f55f25e4dc0a2398
+      |   |-- bc
+      |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+      |   |-- c1
+      |   |   `-- 489fc8fd6ae9ac08c0168d7cabaf5645b922fa
+      |   |-- c2
+      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
+      |   |-- cb
+      |   |   `-- bceb2fb07839b8796fadb2b6a8b785b8fd7440
+      |   |-- d3
+      |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
+      |   |-- d7
+      |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+      |   |-- da
+      |   |   `-- af0560e4e779353311a9039b31ea4f0f1dec37
+      |   |-- e1
+      |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
+      |   |-- e2
+      |   |   `-- 4b99efdd25fce896ef9fd0e9614163504c59cd
+      |   |-- e7
+      |   |   `-- cee3592aaac624fd48c258daa5d62d17352043
+      |   |-- e9
+      |   |   `-- 8909530f1ecc7b6438c268e3d6870107450eba
+      |   |-- ea
+      |   |   |-- 1ae75547e348b07cb28a721a06ef6580ff67f0
+      |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
+      |   |-- ec
+      |   |   |-- 3fdddf2a63a195676075359997b74b8394cd72
+      |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
+      |   |-- ee
+      |   |   `-- b52a9c8fe143baf970160aa4716ff5c019d8cb
+      |   |-- f2
+      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
+      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |-- f5
+      |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+      |   |-- f6
+      |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+      |   |-- f7
+      |   |   `-- 35d04266733d64d2f49ab23a183a5207e8961d
+      |   |-- f8
+      |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
+      |   |-- fc
+      |   |   |-- 7ceaecdcf6db0a7970cc351877fd5439c515ba
+      |   |   `-- c182ce4e8039ae321c009746e9a5b42a224bf5
+      |   |-- fd
+      |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  162 directories, 175 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -247,18 +247,265 @@
       ':workspace=ws',
       ':workspace=ws:/pre',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 2a
+  |   |   |   `-- f8fd9cc75470c09c6442895133a815806018fc
+  |   |   |-- 2b
+  |   |   |   `-- 7018edda866b44c516fb04e839ea39700efab3
+  |   |   |-- 2c
+  |   |   |   `-- 019b4143b03630bb24119a53063028dd29278f
+  |   |   |-- 2e
+  |   |   |   `-- 3a8b1b949c599093a761dfe0c7b67d5cb2c379
+  |   |   |-- 39
+  |   |   |   `-- 5f7f4760aa877be41b269a500ff31ac1d269a0
+  |   |   |-- 3b
+  |   |   |   `-- f87f094d6ca4a2ce40589d77455058f62a7c90
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 46
+  |   |   |   `-- 7711599b943110e1c7eb163bbf0405686ebf3d
+  |   |   |-- 4c
+  |   |   |   `-- febd0af63043a59aa060491d8ff6664e434b15
+  |   |   |-- 53
+  |   |   |   `-- e006435dc62586ba2a60d63068f58c84f98a17
+  |   |   |-- 54
+  |   |   |   `-- c9bf12801b1ef6d4868d31a788e06d9c54549d
+  |   |   |-- 6e
+  |   |   |   `-- 3bc46526a71f258d493af2e19c6ff83c2df4fd
+  |   |   |-- 71
+  |   |   |   `-- 23ddfb609a7c13f41dcb25ab6cdf28667244cc
+  |   |   |-- 79
+  |   |   |   `-- 388d184069e254a0db889a3df7cf5daba91603
+  |   |   |-- 7f
+  |   |   |   `-- ec045dbd23b0596f513ff06bda5ebd6ccb909f
+  |   |   |-- 80
+  |   |   |   `-- f0cf0a2d152a122aac5288107b5da8da3a1b23
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- 87
+  |   |   |   `-- 4e45d38fa7fc718bd3690dd5f559792350267c
+  |   |   |-- 8b
+  |   |   |   `-- bf1f6fa6b0a01b986db884beb2f434b641bf13
+  |   |   |-- 96
+  |   |   |   |-- 61805f4c2c58fbeb14f2e573c29100c6193b3b
+  |   |   |   `-- 91d65eea514970d4d75afd2490e7f1581f9df1
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- d0
+  |   |   |   `-- 38198d656db500dcd177e32f89395de5805715
+  |   |   |-- d1
+  |   |   |   `-- 8254e66bcbb678dc87313cbdb61c152964ac45
+  |   |   |-- d9
+  |   |   |   `-- b9f715dbeb38158273bce8cabd40e8b894a6da
+  |   |   |-- e0
+  |   |   |   `-- c616efb9f8811a592e92fa90d3fcb6a39027dc
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- f5
+  |   |   |   `-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 00
+      |   |   `-- 5d8d52eafd3d5f0b2272be08b36693b2b5b76b
+      |   |-- 02
+      |   |   `-- 668d7af968c8eed910db7539a57b18dd62a50e
+      |   |-- 04
+      |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
+      |   |-- 05
+      |   |   `-- 57735d7abe36fcec6cdb31800640a030618fcf
+      |   |-- 0b
+      |   |   `-- 976ee9223f2a23c5339d6cb3bda2196dbae6b1
+      |   |-- 0c
+      |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
+      |   |-- 12
+      |   |   `-- f49faa307e33da834e082e022f0b5c83d0f3e1
+      |   |-- 13
+      |   |   `-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
+      |   |-- 16
+      |   |   `-- 2e9b45be8bbc12e975d13c0089eccbbcba9b56
+      |   |-- 17
+      |   |   `-- b82a3b31749dc7d6dbc5a528eb19a103a5bdb9
+      |   |-- 1d
+      |   |   `-- 6d81877130bc5a54c8ea27e8497f838cfe9aa3
+      |   |-- 20
+      |   |   `-- 5dccdc2e37df9aaccec46009520154219134e7
+      |   |-- 27
+      |   |   `-- d0eee16bdbe4a1ade0ebf877f97467de3b218e
+      |   |-- 28
+      |   |   `-- a3e71d163a9eb30c3639b16a16f57077abf29b
+      |   |-- 2a
+      |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
+      |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
+      |   |-- 2c
+      |   |   `-- fb80c68126f24a61b2778ce3f55d65d93f5e90
+      |   |-- 2f
+      |   |   |-- 10c52e8ac3117e818b2b8a527c03d9345104c3
+      |   |   `-- 888ca5fb8487446a5718b64ddbd9e644d46b00
+      |   |-- 30
+      |   |   `-- ab6d81f7ffe88ab3a82ff74ff09439b2d5afa7
+      |   |-- 31
+      |   |   `-- efdeb5de300e7a344ebb5b006c0380f2223d45
+      |   |-- 34
+      |   |   `-- be7abf6de2d37711a568059e7aa150ed428a43
+      |   |-- 39
+      |   |   |-- 0caf88590ab9ce40b6092c82a5f5e68041e4a6
+      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
+      |   |-- 3d
+      |   |   `-- fa0c895e0725543219faa20e3ffbadcee13de4
+      |   |-- 43
+      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
+      |   |-- 46
+      |   |   `-- 3b7672b3bcf00bbd95e650076c375528d5f5c3
+      |   |-- 47
+      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 53
+      |   |   `-- 0148978e42a91926dbe2f5fe0c71fe63aacf8e
+      |   |-- 5a
+      |   |   `-- 38ed8e4d96b624c6ef7e36f8b696d52be785db
+      |   |-- 5b
+      |   |   `-- 545e12c5b297509b8d99df5f0b952a2dd7862d
+      |   |-- 64
+      |   |   |-- 6fd2c5bfe156d57ba03f62f2fe735ddbb74e22
+      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
+      |   |-- 67
+      |   |   `-- 48a16f7d9b29607fcd4df93681361a6105a14a
+      |   |-- 69
+      |   |   `-- a612aea46e9d365755e3b930d8aa4458e7bbf6
+      |   |-- 6f
+      |   |   `-- 4ee6b7661cc1905bb762d80a94c4337d43697d
+      |   |-- 70
+      |   |   `-- 1b7746c347750d035ddd29ad67ad2f2c4851a8
+      |   |-- 74
+      |   |   `-- 2851fe09cb59a1a3e1d6abb1490e4758cdb291
+      |   |-- 75
+      |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
+      |   |-- 78
+      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 7a
+      |   |   `-- f95bc6e271a8e8153770db325e6df3581f3182
+      |   |-- 7c
+      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
+      |   |-- 7f
+      |   |   `-- c8ee5474068055f7740240dfce6fa6e38bbf4d
+      |   |-- 89
+      |   |   `-- 8b763a1483259f4667f399a019b96f52a28f8c
+      |   |-- 93
+      |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
+      |   |-- 98
+      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
+      |   |-- 99
+      |   |   `-- 8e4d99b52680e8fc6d50d98cddad2a4e36a604
+      |   |-- 9d
+      |   |   `-- e3bbb26e2b40f02ca8de195933eb620bbf0b6a
+      |   |-- 9e
+      |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
+      |   |-- 9f
+      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- a3
+      |   |   `-- d027b4cc082c08af95fcbe03eecd9a62a08c48
+      |   |-- a7
+      |   |   `-- 3af649c49fa4b0facff36fafdc1e2bef594d4e
+      |   |-- a8
+      |   |   `-- 9d5f7c0590398ab42e716cc0c4e4cc112d37d5
+      |   |-- aa
+      |   |   `-- 0654329f0642e4505db87c24aea80ba52fd689
+      |   |-- ac
+      |   |   |-- 0969c65843463b2d0e86fd4c6efcae33012332
+      |   |   `-- f2103d2724dcae1b16af24901a9abb657a9e32
+      |   |-- af
+      |   |   `-- 410d4293058c26007526cc7798cfc56472c7f8
+      |   |-- b0
+      |   |   `-- 3b5fbc9a12109cd3f5308929e4812b3c998da6
+      |   |-- b8
+      |   |   `-- 54e8ec3db62174179b215404936a58f1bb6a79
+      |   |-- b9
+      |   |   `-- 90567474f1f8af9784478614483684e88ccf4f
+      |   |-- ba
+      |   |   `-- 7e71e9f4937922f7993824e136827d1beac1ed
+      |   |-- bc
+      |   |   |-- 61a0ff30ea25db7bcfc9a67fdae747904ed55f
+      |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+      |   |-- bf
+      |   |   `-- 3f93ef98d196c9a282daaca6658c11799510c3
+      |   |-- c1
+      |   |   `-- 489fc8fd6ae9ac08c0168d7cabaf5645b922fa
+      |   |-- c2
+      |   |   |-- 054840bbf17ac9939d8165a0b88f1065ff57f7
+      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
+      |   |-- c5
+      |   |   `-- 30c1385a6297aa79fd3d1ced94b089ca760fd6
+      |   |-- cd
+      |   |   |-- 0544cd5f702a9b3418205ec0425c6ae77f9e3e
+      |   |   `-- 7c94c08f59302a2b1587a01d4fd1680d7378c9
+      |   |-- d7
+      |   |   |-- 330ea337031af43ba1cf6982a873a40b9170ac
+      |   |   `-- 94016e24d97a10d550de2384527f80f9fecfc8
+      |   |-- e1
+      |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
+      |   |-- e8
+      |   |   `-- d34a664c80ff36cdff2c41c1fd3964f6e30f00
+      |   |-- ea
+      |   |   |-- 1ae75547e348b07cb28a721a06ef6580ff67f0
+      |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
+      |   |-- ec
+      |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
+      |   |-- ef
+      |   |   `-- 4639405a27655c750c3ca6249b35fbf3ea25ca
+      |   |-- f0
+      |   |   `-- 932972a6075f9a82e1ca23d65f9983145abd9e
+      |   |-- f2
+      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
+      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |-- f6
+      |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+      |   |-- f7
+      |   |   `-- 7930069cbf71e47b72fb4e5ede3dff15123884
+      |   |-- fa
+      |   |   `-- 1745f6c84f945b51a305aa9751c466e26fb78a
+      |   |-- ff
+      |   |   `-- 207ba6445d9963e77bc387044ee63bd9ea7387
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  129 directories, 128 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -302,18 +302,326 @@ Note that ws/d/ is now present in the ws
       ':/ws',
       ':workspace=ws',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 01
+  |   |   |   `-- 1335f884d15a84a6113337bb30a0be95c39fb9
+  |   |   |-- 04
+  |   |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
+  |   |   |-- 0c
+  |   |   |   `-- 66ddcaed3f256f7dacc400a684aa1b91ac638f
+  |   |   |-- 0f
+  |   |   |   `-- 7ceed53e5b4ab96efad3c0b77e2c00d10169ba
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 1e
+  |   |   |   `-- 6ea69c6325d02f1dbc9614935f88ce9d2afbac
+  |   |   |-- 2a
+  |   |   |   `-- f8fd9cc75470c09c6442895133a815806018fc
+  |   |   |-- 2c
+  |   |   |   `-- 50404f5c69295bd3d4d0cb5475be9cc2aada23
+  |   |   |-- 2f
+  |   |   |   `-- 10c52e8ac3117e818b2b8a527c03d9345104c3
+  |   |   |-- 33
+  |   |   |   `-- dcdc06e9d605c8aca2375b96f7d431d2eb41d7
+  |   |   |-- 34
+  |   |   |   `-- c24765275d6f3ec5d6baeaaa4299471d6f7df0
+  |   |   |-- 36
+  |   |   |   `-- 52f9baa44258d0f505314830ad37d16eafc981
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 41
+  |   |   |   `-- 8fcc975168e0bfc9dd53bbb98f740da2e983c0
+  |   |   |-- 48
+  |   |   |   `-- a2132905aa1413bc0ac9762b4365c9222911c5
+  |   |   |-- 53
+  |   |   |   `-- 9f411b73b3c22bc218bece495a841880fd4e2c
+  |   |   |-- 58
+  |   |   |   `-- b0c1e483109b33f416e0ae08487b4d1b6bfd5b
+  |   |   |-- 5d
+  |   |   |   `-- 605cee0c66b1c25a15a2d435b2786cc0bc24c5
+  |   |   |-- 6d
+  |   |   |   `-- 4b5c23a94a89c7f26266ccf635647fd4002b19
+  |   |   |-- 75
+  |   |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
+  |   |   |-- 7a
+  |   |   |   `-- c71a2d1648e7de21f4fbe4935cf54b44bfef9a
+  |   |   |-- 7c
+  |   |   |   `-- 5a3be33ee5b7e18364f041b05de8ac08bf82ee
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- 8a
+  |   |   |   `-- 7fb63d6ac5e60e16941591969c5f8a8d23b8a5
+  |   |   |-- 95
+  |   |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- a5
+  |   |   |   `-- bc2cb1497c5491656a72647f07791fe11f4d8f
+  |   |   |-- aa
+  |   |   |   `-- ec05db5b89383100d4b35b6cf56c0bf36fa224
+  |   |   |-- ad
+  |   |   |   |-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+  |   |   |   `-- b5eed79dabe4a141b3e336a64bc1ea6ae70396
+  |   |   |-- b7
+  |   |   |   `-- 85a0b60f6ef7044b4c59c318e18e2c47686085
+  |   |   |-- bc
+  |   |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+  |   |   |-- c6
+  |   |   |   `-- 6fb92e3be8e4dc4c89f94d796f3a4b1833e0fa
+  |   |   |-- d7
+  |   |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+  |   |   |-- e4
+  |   |   |   `-- 5f0325cd9fab82d962b758e556d9bf8079fc37
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- eb
+  |   |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
+  |   |   |-- ed
+  |   |   |   `-- efd7dc70381a72b7af5bff2e49b8eb60cb9237
+  |   |   |-- ef
+  |   |   |   `-- a3db3aed4c83fdd92ec9f72845df8898839fdd
+  |   |   |-- f5
+  |   |   |   `-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |-- f6
+  |   |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+  |   |   |-- f8
+  |   |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
+  |   |   |-- fd
+  |   |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 02
+      |   |   `-- 668d7af968c8eed910db7539a57b18dd62a50e
+      |   |-- 04
+      |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
+      |   |-- 09
+      |   |   `-- b613e901acc0b5e4279ec6732261134a06f667
+      |   |-- 0b
+      |   |   `-- 976ee9223f2a23c5339d6cb3bda2196dbae6b1
+      |   |-- 0c
+      |   |   |-- 66ddcaed3f256f7dacc400a684aa1b91ac638f
+      |   |   |-- d4309cc22b5903503a7196f49c24cf358a578a
+      |   |   `-- ee64f3b2f9f9dd40a2b36afdccb728b753659c
+      |   |-- 12
+      |   |   `-- f49faa307e33da834e082e022f0b5c83d0f3e1
+      |   |-- 13
+      |   |   |-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
+      |   |   `-- fa30d95222c1c055e613c116b32e17bac4d0c4
+      |   |-- 14
+      |   |   `-- da1560586adda328cca1fbf58c026d6730444f
+      |   |-- 17
+      |   |   |-- 039634b139f6fba381ff8bc55b9c5de210f87f
+      |   |   `-- ac72002199728c133087acfa6b23009e00a52a
+      |   |-- 19
+      |   |   `-- b9637ac9437ea11d42632cd65ca2313952c32f
+      |   |-- 20
+      |   |   `-- 189c97a0ef53368b7ec335baa7a1b86bd76f8e
+      |   |-- 22
+      |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
+      |   |-- 27
+      |   |   `-- 5b45aec0a1c944c3a4c71cc71ee08d0c9ea347
+      |   |-- 28
+      |   |   `-- a3e71d163a9eb30c3639b16a16f57077abf29b
+      |   |-- 2a
+      |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
+      |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
+      |   |-- 2c
+      |   |   |-- 50404f5c69295bd3d4d0cb5475be9cc2aada23
+      |   |   |-- 56d130ff53e8110607c808d7d4d0317e61d91e
+      |   |   `-- 913262d99f8cd15ea711a89e943cd902fb87a0
+      |   |-- 2f
+      |   |   |-- 10c52e8ac3117e818b2b8a527c03d9345104c3
+      |   |   `-- 888ca5fb8487446a5718b64ddbd9e644d46b00
+      |   |-- 31
+      |   |   |-- af3d0a5be6cc36a10a6b984673087c2d068432
+      |   |   `-- efdeb5de300e7a344ebb5b006c0380f2223d45
+      |   |-- 34
+      |   |   `-- c24765275d6f3ec5d6baeaaa4299471d6f7df0
+      |   |-- 36
+      |   |   `-- 52f9baa44258d0f505314830ad37d16eafc981
+      |   |-- 39
+      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
+      |   |-- 40
+      |   |   `-- c389b6b248e13f3cb88dcd79467d7396a4489e
+      |   |-- 41
+      |   |   `-- a263629db0fc09dcc5299c3a2eb3025ece9ea0
+      |   |-- 43
+      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
+      |   |-- 44
+      |   |   |-- 625a9b34b1c6747c29903c3e641a4b2e580673
+      |   |   `-- edc62d506b9805a3edfc74db15b1cc0bfc6871
+      |   |-- 47
+      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4c
+      |   |   `-- a9fbf65ee12663ac24db4be4cab10e53d6d6e7
+      |   |-- 5a
+      |   |   `-- 8a4b8c1452d54f1ca88454067369112809a4d2
+      |   |-- 5b
+      |   |   `-- 560252b0c3c6abc5e0327596a49efb15e494cb
+      |   |-- 5e
+      |   |   `-- 9213824faf1eb95d0c522329518489196374fd
+      |   |-- 5f
+      |   |   `-- 8dd30d5f721bf061d079d3f4375c1621716bb0
+      |   |-- 64
+      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
+      |   |-- 65
+      |   |   `-- 786136396010946815eff820697a6d0578c113
+      |   |-- 67
+      |   |   `-- 12cb1b8c89e3b2272182f140c81aef3b718671
+      |   |-- 6a
+      |   |   `-- 80a5b3af9023d11cb7f37bc1f80d1d1805bfdb
+      |   |-- 6b
+      |   |   `-- ea49f3ab464fb1795ab9c622aad1047de07d8e
+      |   |-- 6c
+      |   |   `-- 68dd37602c8e2036362ab81b12829c4d6c0867
+      |   |-- 6d
+      |   |   |-- 4b5c23a94a89c7f26266ccf635647fd4002b19
+      |   |   `-- 5a5046f3a9591a32ec47bc38a1da879aca6743
+      |   |-- 70
+      |   |   |-- 7a20731ff94c2dee063a8b274665b1cc730e26
+      |   |   `-- eb05d32223342a549cfb00c20b1464bf1b9513
+      |   |-- 71
+      |   |   `-- f38e799ec3f84476b6ef128a6bafcadc97a4b1
+      |   |-- 75
+      |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
+      |   |-- 78
+      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 7a
+      |   |   `-- c71a2d1648e7de21f4fbe4935cf54b44bfef9a
+      |   |-- 7c
+      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
+      |   |-- 7d
+      |   |   |-- e033196d3f74f40139647122f499286a97498b
+      |   |   `-- fca2962177d9c9925fedf2fbdd79fc7e9309fc
+      |   |-- 7f
+      |   |   |-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
+      |   |   |-- 39c7601f2c1ca44fdc9237efa34f2887daa2b4
+      |   |   `-- c8ee5474068055f7740240dfce6fa6e38bbf4d
+      |   |-- 82
+      |   |   `-- 4c0e846b41e1eb9f95d141b47bbb9ff9baef17
+      |   |-- 8c
+      |   |   `-- c4bb045e98da7cf00714d91ac77c7ea7e08b63
+      |   |-- 8d
+      |   |   `-- 603d2815e0a920045ac900135485b9fec9c9d8
+      |   |-- 92
+      |   |   `-- 1819911214b87cff59a38006d63bfccad279f0
+      |   |-- 93
+      |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
+      |   |-- 94
+      |   |   `-- 690d41c15b7c64888795b4c30ab29808402465
+      |   |-- 95
+      |   |   `-- d99506044285b3088aef86540c478f09606763
+      |   |-- 97
+      |   |   `-- cdedf56398e9e3830d0db5bb329d91c443ce81
+      |   |-- 98
+      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
+      |   |-- 99
+      |   |   |-- 8e4d99b52680e8fc6d50d98cddad2a4e36a604
+      |   |   `-- acd82fe2a9b89022d1aee5a580c123a8161f4a
+      |   |-- 9c
+      |   |   `-- 78c532d93505a2a24430635b342b91db22fee0
+      |   |-- 9e
+      |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
+      |   |-- 9f
+      |   |   |-- 7fe44ebf4b96d3fc03aa7bffff6baa4a84eb63
+      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- a1
+      |   |   |-- 269dc50ffcdc1b87664a061926bf9a072a3456
+      |   |   `-- c31372c5de4fb705ffdcbf5a4ec5c5103231d9
+      |   |-- a4
+      |   |   `-- b68220bdf7fb846eb9780f7846a2f4bf7cbcc3
+      |   |-- ab
+      |   |   `-- a295fbe181a47f04650542b7d5582fbd983b98
+      |   |-- af
+      |   |   `-- 410d4293058c26007526cc7798cfc56472c7f8
+      |   |-- b1
+      |   |   `-- 55ee8a0221a6d1f94982ab3624f47f7e4931e2
+      |   |-- b7
+      |   |   `-- bb51e63095336302e4f6b0eead63cb716eb630
+      |   |-- b9
+      |   |   `-- 90567474f1f8af9784478614483684e88ccf4f
+      |   |-- ba
+      |   |   `-- f9dcf1394d5152de67b115f55f25e4dc0a2398
+      |   |-- bc
+      |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+      |   |-- c1
+      |   |   `-- 489fc8fd6ae9ac08c0168d7cabaf5645b922fa
+      |   |-- c2
+      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
+      |   |-- cb
+      |   |   `-- bceb2fb07839b8796fadb2b6a8b785b8fd7440
+      |   |-- d7
+      |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+      |   |-- e1
+      |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
+      |   |-- e2
+      |   |   `-- 4b99efdd25fce896ef9fd0e9614163504c59cd
+      |   |-- e7
+      |   |   `-- cee3592aaac624fd48c258daa5d62d17352043
+      |   |-- e9
+      |   |   `-- 8909530f1ecc7b6438c268e3d6870107450eba
+      |   |-- ea
+      |   |   |-- 1ae75547e348b07cb28a721a06ef6580ff67f0
+      |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
+      |   |-- ec
+      |   |   |-- 3fdddf2a63a195676075359997b74b8394cd72
+      |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
+      |   |-- ed
+      |   |   `-- efd7dc70381a72b7af5bff2e49b8eb60cb9237
+      |   |-- ee
+      |   |   `-- b52a9c8fe143baf970160aa4716ff5c019d8cb
+      |   |-- f2
+      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
+      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |-- f6
+      |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+      |   |-- f7
+      |   |   `-- 35d04266733d64d2f49ab23a183a5207e8961d
+      |   |-- fc
+      |   |   |-- 7ceaecdcf6db0a7970cc351877fd5439c515ba
+      |   |   `-- c182ce4e8039ae321c009746e9a5b42a224bf5
+      |   |-- fd
+      |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  154 directories, 164 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -86,18 +86,87 @@ file was created
       ':/ws',
       ':workspace=ws',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 0d
+  |   |   |   `-- aea91dddfc42dea2123d0d83c6a21470e5e0e9
+  |   |   |-- 0f
+  |   |   |   `-- 83fa83f707ea8a648efd7f701e9147c170acad
+  |   |   |-- 1c
+  |   |   |   `-- cf878cdccad4c0de7f9530fa317f8e068de98a
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 68
+  |   |   |   `-- 562b26584f1088791b2dd81a974b7ecf4618d5
+  |   |   |-- 72
+  |   |   |   `-- c107ae37a43953a886b61a97c72bfaa1b86e8b
+  |   |   |-- 95
+  |   |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- a4
+  |   |   |   `-- c6dcc717e6ba84bbe41c7dce76349e8bd39d0d
+  |   |   |-- ad
+  |   |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- f5
+  |   |   |   `-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |-- fc
+  |   |   |   `-- ec311dce010e6eb21b79097eecc7cb8d70eeda
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 06
+      |   |   `-- f56dd7e7b5abf977267595ccfc3f1a5f1eea28
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4f
+      |   |   `-- be5e3e9300ad2318545b9b8197029d55ac5395
+      |   |-- 78
+      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 98
+      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
+      |   |-- a8
+      |   |   `-- 6544ef29b946481d26cb4cfb55844342069c0e
+      |   |-- eb
+      |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  46 directories, 33 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -123,18 +123,160 @@
       ':/ws',
       ':workspace=ws',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               `-- heads
-  |                   `-- master
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 13
+  |   |   |   `-- d9e121d4af98be6fc945b81d3c867172ade127
+  |   |   |-- 2a
+  |   |   |   `-- 9ac6425f7d937881422893fa4b9f6ee0cb9814
+  |   |   |-- 7a
+  |   |   |   `-- c89975da33b797feba305f5cc12bfb33b83c5d
+  |   |   |-- 7b
+  |   |   |   `-- 36ca25a7488f59e4f41c95567066fbf23bfb0e
+  |   |   |-- 85
+  |   |   |   |-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |   `-- edae8ccb9e64ebbf32249f228c9c0533ee9ffa
+  |   |   |-- a0
+  |   |   |   `-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |-- e1
+  |   |   |   `-- 0c349e6060048d38d2949670b1160e0de87aa5
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               `-- heads
+  |       |                   `-- master
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 00
+      |   |   `-- 14c74ac19f876065ca26a4e9b578c2bc61ef18
+      |   |-- 02
+      |   |   `-- b7be05e5c483a13e211c5d3dcc30eb8a7047c9
+      |   |-- 0b
+      |   |   `-- 976ee9223f2a23c5339d6cb3bda2196dbae6b1
+      |   |-- 0f
+      |   |   `-- 61d50b4e5a814afb71b3da5a2986efd37bc605
+      |   |-- 13
+      |   |   `-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
+      |   |-- 20
+      |   |   `-- c53646e34e6079f7dc3090be5c2c3fdd81a4f3
+      |   |-- 28
+      |   |   `-- a3e71d163a9eb30c3639b16a16f57077abf29b
+      |   |-- 2a
+      |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
+      |   |-- 2d
+      |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
+      |   |-- 2f
+      |   |   `-- 10c52e8ac3117e818b2b8a527c03d9345104c3
+      |   |-- 36
+      |   |   `-- e70a0bbbb8847771f037d5682f33cd26223bc5
+      |   |-- 37
+      |   |   `-- c3159b05efb7c51e9157e5140a462898ab1a16
+      |   |-- 39
+      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
+      |   |-- 3e
+      |   |   `-- ade035db71b1ce109c190c3e587aff04b82c55
+      |   |-- 43
+      |   |   `-- c475ca897b62fd739409aee5db69b0c480aa0d
+      |   |-- 45
+      |   |   |-- f61831a4d523bb75b6f283e2770f1c86060e15
+      |   |   `-- f882bfcdf75d0987e19b48a32717c6d06eabed
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4c
+      |   |   `-- af7229f3533f1e776f493fe4f1bc4cb234e72f
+      |   |-- 52
+      |   |   `-- 8f8f0a55b99f0324a9f189343c24317e34c60d
+      |   |-- 57
+      |   |   `-- 034d73887096f7850c3ffa2a61a959c61fa7f1
+      |   |-- 59
+      |   |   `-- ce9b0ca657f0fd704efc832cea8cf64da5bbf5
+      |   |-- 5e
+      |   |   `-- a433bcec0b828c04d26f0fb03b40535dc4f855
+      |   |-- 64
+      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
+      |   |-- 65
+      |   |   `-- b0ecf29d3808ba274af864643f5a3f9c8706f1
+      |   |-- 66
+      |   |   `-- b81c71c0ad10acdb2b4df3b04eef8abd79e64b
+      |   |-- 6e
+      |   |   `-- 8d20f7effed65135756c3d3428ccf7d7efb818
+      |   |-- 73
+      |   |   `-- 3cdae47736c40c40238fa2902185b30a5a1831
+      |   |-- 75
+      |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
+      |   |-- 77
+      |   |   `-- b5962d8bd7ad507a02af9767c4cf68c0781200
+      |   |-- 84
+      |   |   `-- 2d4785bdebe66a26cd2c094a2373cfc6b936ed
+      |   |-- 88
+      |   |   `-- 4f260811f923775b9f6433ee9ec063ebe19efd
+      |   |-- 95
+      |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
+      |   |-- 99
+      |   |   `-- 8e4d99b52680e8fc6d50d98cddad2a4e36a604
+      |   |-- 9d
+      |   |   `-- b51080a4d148b32bd4c4e0b39eae8d0b3df763
+      |   |-- 9e
+      |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
+      |   |-- 9f
+      |   |   `-- bcd9b793b58ad59d17dfe9f1d18382566bc069
+      |   |-- a2
+      |   |   `-- ad9d7bed2fe8d70e88273ee480142893bf1a8b
+      |   |-- b5
+      |   |   `-- f6121773050641aa77d3f4f8f02f1e22d10b2e
+      |   |-- ba
+      |   |   `-- 300b195019b96ef5d20dfe135143b0e8df7636
+      |   |-- bc
+      |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+      |   |-- c1
+      |   |   `-- 489fc8fd6ae9ac08c0168d7cabaf5645b922fa
+      |   |-- c2
+      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
+      |   |-- d3
+      |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
+      |   |-- d7
+      |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+      |   |-- ea
+      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
+      |   |-- f2
+      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
+      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |-- f5
+      |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+      |   |-- f6
+      |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  8 directories, 2 files
+  81 directories, 71 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -230,20 +230,219 @@
       ':/ws',
       ':workspace=ws',
   ]
-  refs
-  |-- heads
+  .
   |-- josh
-  |   `-- upstream
-  |       `-- real_repo.git
-  |           |-- HEAD
-  |           `-- refs
-  |               |-- heads
-  |               |   `-- master
-  |               `-- tags
-  |                   `-- tag_from_ws_1
-  |-- namespaces
-  `-- tags
+  |   `-- 11
+  |       `-- sled
+  |           |-- blobs
+  |           |-- conf
+  |           `-- db
+  |-- mirror
+  |   |-- FETCH_HEAD
+  |   |-- HEAD
+  |   |-- config
+  |   |-- description
+  |   |-- info
+  |   |   `-- exclude
+  |   |-- objects
+  |   |   |-- 11
+  |   |   |   `-- e2559617afa238a8332c15d15fff48d5b57c83
+  |   |   |-- 14
+  |   |   |   `-- b2fb20fa2ded4b41451bf716e0d4741e4fcf49
+  |   |   |-- 17
+  |   |   |   `-- 6e8e0eda7dc644342b4cbce4196b968886fff3
+  |   |   |-- 1c
+  |   |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+  |   |   |-- 27
+  |   |   |   `-- 5b45aec0a1c944c3a4c71cc71ee08d0c9ea347
+  |   |   |-- 2a
+  |   |   |   |-- f771a31e4b62d67b59d74a74aba97d1eadcfab
+  |   |   |   `-- f8fd9cc75470c09c6442895133a815806018fc
+  |   |   |-- 2d
+  |   |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
+  |   |   |-- 3d
+  |   |   |   `-- 77ff51363c9825cc2a221fc0ba5a883a1a2c72
+  |   |   |-- 5a
+  |   |   |   |-- f4045367114a7584eefa64b95bb69d7f840aef
+  |   |   |   `-- fcddfe10e63e4b970f0a16ea5ab410bd51c5c7
+  |   |   |-- 65
+  |   |   |   `-- ca339b2d1d093f69c18e1a752833927c2591e2
+  |   |   |-- 76
+  |   |   |   `-- cd9e690c1d36eb4cdbf3cd244e9defda4ff3ad
+  |   |   |-- 82
+  |   |   |   `-- 8956f4a5f717b3ba66596cc200e7bb51a5633f
+  |   |   |-- 83
+  |   |   |   `-- 60d96c8d9e586f0f79d6b712a72d22894840ac
+  |   |   |-- 85
+  |   |   |   `-- 837e6104d0a81b944c067e16ddc83c7a38739f
+  |   |   |-- 90
+  |   |   |   `-- 2bb8ff1ff20c4fcc3e2f9dcdf7bfa85e0fc004
+  |   |   |-- 95
+  |   |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
+  |   |   |-- a0
+  |   |   |   |-- 24003ee1acc6bf70318a46e7b6df651b9dc246
+  |   |   |   `-- 9bec5980768ee3584be8ac8f148dd60bac370b
+  |   |   |-- a3
+  |   |   |   `-- d19dcb2f51fa1efd55250f60df559c2b8270b8
+  |   |   |-- a4
+  |   |   |   `-- 1772e0c7cdad1a13b7a7bc38c0d382a5a827ce
+  |   |   |-- a5
+  |   |   |   `-- bc2cb1497c5491656a72647f07791fe11f4d8f
+  |   |   |-- a7
+  |   |   |   `-- 5eedb18d4cd23e4ad3e5af9c1f71006bc9390b
+  |   |   |-- bc
+  |   |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+  |   |   |-- c3
+  |   |   |   `-- 13e8583c38d3ca1a2d987570f9dde3666eed0c
+  |   |   |-- d3
+  |   |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
+  |   |   |-- d7
+  |   |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+  |   |   |-- e6
+  |   |   |   `-- 9de29bb2d1d6434b8b29ae775ad8c2e48c5391
+  |   |   |-- ed
+  |   |   |   `-- 42dbbeb77e5cf17175f2a048c97e965507a57d
+  |   |   |-- f5
+  |   |   |   |-- 386e2d5fba005c1589dcbd9735fa1896af637c
+  |   |   |   `-- 719cbf23e85915620cec2b2b8bd6fec8d80088
+  |   |   |-- f6
+  |   |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+  |   |   |-- f8
+  |   |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
+  |   |   |-- info
+  |   |   `-- pack
+  |   `-- refs
+  |       |-- heads
+  |       |-- josh
+  |       |   `-- upstream
+  |       |       `-- real_repo.git
+  |       |           |-- HEAD
+  |       |           `-- refs
+  |       |               |-- heads
+  |       |               |   `-- master
+  |       |               `-- tags
+  |       |                   `-- tag_from_ws_1
+  |       `-- tags
+  `-- overlay
+      |-- HEAD
+      |-- config
+      |-- description
+      |-- info
+      |   `-- exclude
+      |-- objects
+      |   |-- 00
+      |   |   `-- e02597bb7117c22dc0b551a4062607895fc3d3
+      |   |-- 11
+      |   |   `-- e2559617afa238a8332c15d15fff48d5b57c83
+      |   |-- 13
+      |   |   `-- 7228bdcd2ae40007860a69d05168279d95117a
+      |   |-- 19
+      |   |   `-- 742d815e52ef8d0bb16ddb1a2b7640c3144d0c
+      |   |-- 1b
+      |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
+      |   |-- 1d
+      |   |   `-- 2a35c53f4e5901c9cc083a94b417c15837cad8
+      |   |-- 22
+      |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
+      |   |-- 26
+      |   |   `-- 6864a895cac573b04a44bd40ee3bd8fe458a5f
+      |   |-- 2c
+      |   |   `-- bcd105ead63a4fecf486b949db7f44710300e5
+      |   |-- 2d
+      |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
+      |   |-- 2e
+      |   |   `-- aadc29a9215c79ff47c4b3a82a024816eb195a
+      |   |-- 37
+      |   |   `-- c3159b05efb7c51e9157e5140a462898ab1a16
+      |   |-- 39
+      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
+      |   |-- 43
+      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
+      |   |-- 45
+      |   |   `-- c7960fc4d4b38a6a28dcc27f0ae158afa59747
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4d
+      |   |   `-- 5d64cb11e557bba3e609d2b7a605bb80806e94
+      |   |-- 5a
+      |   |   `-- f4045367114a7584eefa64b95bb69d7f840aef
+      |   |-- 5c
+      |   |   `-- 874339dcbbc0c34c083557c2e652380c3cb3d6
+      |   |-- 5f
+      |   |   `-- a942ed9d35f280b35df2c4ef7acd23319271a5
+      |   |-- 60
+      |   |   |-- 5066c26f66fca5a424aa32bd042ae71c7c8705
+      |   |   `-- da713d13cb085a9b7629cdc3a1d88d83dd49ae
+      |   |-- 64
+      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
+      |   |-- 65
+      |   |   `-- 786136396010946815eff820697a6d0578c113
+      |   |-- 6b
+      |   |   `-- e0d68b8e87001c8b91281636e21d6387010332
+      |   |-- 78
+      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 7f
+      |   |   `-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
+      |   |-- 83
+      |   |   `-- 3812f1557e561166754add564fe32228dd1703
+      |   |-- 96
+      |   |   `-- f5351b972284f81d7246836f82f6be06c6631f
+      |   |-- 98
+      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
+      |   |-- 9c
+      |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
+      |   |-- 9f
+      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- a0
+      |   |   `-- 28e4ad33176e7db6f3d4a5fc7e92257cfe213e
+      |   |-- a3
+      |   |   `-- d19dcb2f51fa1efd55250f60df559c2b8270b8
+      |   |-- a4
+      |   |   `-- 1772e0c7cdad1a13b7a7bc38c0d382a5a827ce
+      |   |-- ae
+      |   |   `-- 3b5ae2be9441da66ee2a69926b45d0e3a5adb2
+      |   |-- b0
+      |   |   `-- fdeb65d9b9069015ef9c0f735a4f6f2f28fe77
+      |   |-- b1
+      |   |   `-- c1b15558aebbce0682f25933cb729e9acd209c
+      |   |-- b6
+      |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
+      |   |-- b8
+      |   |   `-- ddfe2d00f876ae2513a5b26a560485762f6bfa
+      |   |-- bb
+      |   |   `-- bd62ec41c785d12270e69b9d49f9babe62fcd6
+      |   |-- bc
+      |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
+      |   |-- c2
+      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
+      |   |-- c5
+      |   |   `-- dd0ee2c3106a581cdea7db0c4297ef82c0f874
+      |   |-- c6
+      |   |   `-- 735a7b0d9da9bf6ef5e445ad2f4ce3d825ceb0
+      |   |-- d3
+      |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
+      |   |-- d7
+      |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+      |   |-- ea
+      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
+      |   |-- ed
+      |   |   `-- 8ae0c02d30bd34d7a8584cb0930d0d7a58df26
+      |   |-- ee
+      |   |   `-- 5bbeab31c4de6c44afb01fa077befd53977492
+      |   |-- f2
+      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
+      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |-- f5
+      |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+      |   |-- f6
+      |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
+      |   |-- info
+      |   `-- pack
+      `-- refs
+          |-- heads
+          |-- namespaces
+          `-- tags
   
-  9 directories, 3 files
+  109 directories, 102 files
 
 $ cat ${TESTTMP}/josh-proxy.out


### PR DESCRIPTION
Instead of storing all objects in one big object store, this will
keep mirrored (objects that are found on the upstream) and computed
(objects that are produced by filtering) in separate git object
databases.
The git alternates mechanism is then used to make objects available
to the other repo when needed.

The reason for this change is a very significant performance
degradation during `git fetch` on very large repos. The huge amount
of loose objects slowed down `git index-pack` (which is run after
downloading the packfile). With this change all the loose objects
produced by josh filtering are not visible to `index pack` and
thus cannot affect it's performance anymore.