### PR TITLE
Add a very simple history view to the UI

### DIFF
--- a/josh-ui/src/App.scss
+++ b/josh-ui/src/App.scss
@@ -119,6 +119,15 @@ nav {
   }
 }
 
+.commit-list-entry {
+  @include ui-link-clickable;
+  padding: .4em .4em;
+
+  &:hover {
+    background: $color-background-highlight;
+  }
+}
+
 .ui-button {
   $shadow-depth: 0.1em;
 

--- a/josh-ui/src/App.tsx
+++ b/josh-ui/src/App.tsx
@@ -16,6 +16,7 @@ import {RepoSelector} from './RepoSelector';
 import {NavigateCallback, NavigateTarget, NavigateTargetType} from "./Navigation";
 import {match} from "ts-pattern";
 import {FileViewer} from "./FileViewer";
+import {HistoryList} from "./History";
 import {Breadcrumbs} from "./Breadcrumbs";
 
 function useNavigateCallback(): NavigateCallback {
@@ -29,6 +30,7 @@ function useNavigateCallback(): NavigateCallback {
         }
 
         const pathname = match(targetType)
+            .with(NavigateTargetType.History, () => '/history')
             .with(NavigateTargetType.Directory, () => '/browse')
             .with(NavigateTargetType.File, () => '/view')
             .run()
@@ -102,6 +104,24 @@ function Browse() {
     </div>
 }
 
+function History() {
+    const param = useGetSearchParam()
+
+    return <div>
+        <TopNav
+            repo={param('repo')} 
+            filter={param('filter')} />
+
+        <HistoryList
+            repo={param('repo')}
+            filter={param('filter')}
+            rev={param('rev')}
+            navigateCallback={useNavigateCallback()}
+        />
+    </div>
+}
+
+
 function View() {
     const param = useGetSearchParam()
 
@@ -136,6 +156,7 @@ function App() {
                 <Route index element={<Navigate to="/select" />} />
                 <Route path='/select' element={<Select />} />
                 <Route path='/browse' element={<Browse />} />
+                <Route path='/history' element={<History />} />
                 <Route path='/view' element={<View />} />
             </Routes>
         </BrowserRouter>

--- a/josh-ui/src/History.tsx
+++ b/josh-ui/src/History.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import {GraphQLClient} from 'graphql-request'
+import {getServer} from "./Server";
+import {NavigateCallback, NavigateTargetType, QUERY_HISTORY} from "./Navigation";
+import {match} from "ts-pattern";
+
+export type HistoryBrowserProps = {
+    repo: string
+    filter: string
+    rev: string
+    navigateCallback: NavigateCallback
+}
+
+type Commit = {
+    summary: string
+    hash: string
+}
+
+
+type State = {
+    commits: Commit[]
+    client: GraphQLClient
+}
+
+export class HistoryList extends React.Component<HistoryBrowserProps, State> {
+    state: State = {
+        commits: [],
+        client: new GraphQLClient(`${getServer()}/~/graphql/${this.props.repo}`, {
+            mode: 'cors'
+        }),
+    };
+
+    startRequest() {
+        this.state.client.rawRequest(QUERY_HISTORY, {
+            rev: this.props.rev,
+            filter: this.props.filter,
+            limit: 100,
+        }).then((d) => {
+            const data = d.data.rev
+
+            this.setState({
+                commits: data.history
+            })
+        })
+    }
+
+    componentDidMount() {
+        this.startRequest()
+    }
+
+    componentDidUpdate(prevProps: Readonly<HistoryBrowserProps>, prevState: Readonly<State>, snapshot?: any) {
+        if (prevProps !== this.props) {
+            this.setState({
+                commits: [],
+            })
+
+            this.startRequest()
+        }
+    }
+
+    componentWillUnmount() {
+        // TODO cancel request?
+    }
+
+    renderList(values: Commit[]) {
+
+        const navigate = (rev: string, e: React.MouseEvent<HTMLDivElement>) => {
+            this.props.navigateCallback(NavigateTargetType.Directory, {
+                repo:   this.props.repo,
+                path:   '',
+                filter: this.props.filter,
+                rev:    rev,
+            })
+        }
+
+        return values.map((entry) => {
+            const className = `commit-list-entry commit-list-entry-dir`
+            return <div className={className} key={entry.hash} onClick={navigate.bind(this, entry.hash)}>
+                <span className="hash">{entry.hash.slice(0,8)}</span>
+                <span className="summary">{entry.summary}</span>
+            </div>
+        })
+    }
+
+    render() {
+        if (this.state.commits.length === 0) {
+            return <div className={'history-browser-loading'}>Loading...</div>
+        } else {
+            return <div className={'history-browser-list'}>
+                {this.renderList(this.state.commits)}
+            </div>
+        }
+    }
+}

--- a/josh-ui/src/Navigation.tsx
+++ b/josh-ui/src/Navigation.tsx
@@ -1,6 +1,7 @@
 import { gql } from 'graphql-request'
 
 export enum NavigateTargetType {
+  History,
   File,
   Directory
 }
@@ -33,6 +34,16 @@ query PathQuery($rev: String!, $filter: String!, $path: String!, $meta: String!)
     files(at:$path,depth: 1) { 
       path, 
       meta(topic:$meta) { count } 
+    }
+  }
+}
+`
+export const QUERY_HISTORY = gql`
+query HistoryQuery($rev: String!, $filter: String!, $limit: Number) {
+  rev(at:$rev, filter:$filter) {
+    history(limit: $limit) {
+      summary
+      hash
     }
   }
 }

--- a/josh-ui/src/RepoSelector.tsx
+++ b/josh-ui/src/RepoSelector.tsx
@@ -140,7 +140,7 @@ export class RepoSelector extends React.Component<RepoSelectorProps, State> {
             return
         }
 
-        this.props.navigateCallback(NavigateTargetType.Directory, {
+        this.props.navigateCallback(NavigateTargetType.History, {
             repo:   parsedInput.target[0].getOrElse('') + '.git',
             path:   '',
             filter: parsedInput.target[1].getOrElse(':/'),


### PR DESCRIPTION
Also makes it the default view after selecting a repo. The rationale
here is that when browsing files, the revision should usually not
change, so this way file browsing happens at a fixed sha.
