### PR TITLE
Only split 'username:password' strings once at the ':'

### DIFF
--- a/josh-proxy/src/auth.rs
+++ b/josh-proxy/src/auth.rs
@@ -47,10 +47,8 @@ impl Handle {
         let s = josh::ok_or!(String::from_utf8(decoded), {
             return Ok(("".to_string(), "".to_string()));
         });
-        if let [username, password] = s.as_str().split(':').collect::<Vec<_>>().as_slice() {
-            return Ok((username.to_string(), password.to_string()));
-        }
-        Ok(("".to_string(), "".to_string()))
+        let (username, password) = s.as_str().split_once(':').unwrap_or(("", ""));
+        return Ok((username.to_string(), password.to_string()));
     }
 }
 


### PR DESCRIPTION
If split multiple times, passwords that contain the ':' character will cause the authentication to fail.