### PR TITLE
Use linear revwalk for find_original when used in history query

### DIFF
--- a/src/bin/josh-filter.rs
+++ b/src/bin/josh-filter.rs
@@ -357,12 +357,14 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
     }
 
     if let Some(gql_query) = args.value_of("graphql") {
+        let context = josh::graphql::context(transaction.try_clone()?, transaction.try_clone()?);
+        *context.allow_refs.lock()? = true;
         let (res, _errors) = juniper::execute_sync(
             gql_query,
             None,
             &josh::graphql::repo_schema(".".to_string(), true),
             &std::collections::HashMap::new(),
-            &josh::graphql::context(transaction.try_clone()?, transaction.try_clone()?),
+            &context,
         )?;
 
         let j = serde_json::to_string(&res)?;

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -132,6 +132,7 @@ impl Revision {
                 self.filter,
                 self.commit_id,
                 filter_commit.id(),
+                false,
             )?
         } else {
             self.commit_id
@@ -156,8 +157,14 @@ impl Revision {
             .parent_ids()
             .map(|id| Revision {
                 filter: self.filter,
-                commit_id: history::find_original(&transaction, self.filter, self.commit_id, id)
-                    .unwrap_or_else(|_| git2::Oid::zero()),
+                commit_id: history::find_original(
+                    &transaction,
+                    self.filter,
+                    self.commit_id,
+                    id,
+                    false,
+                )
+                .unwrap_or_else(|_| git2::Oid::zero()),
             })
             .collect();
 
@@ -198,7 +205,8 @@ impl Revision {
         {
             rs_tracing::trace_scoped!("walk");
             for i in 0..ids.len() {
-                ids[i] = history::find_original(&transaction, self.filter, contained_in, ids[i])?;
+                ids[i] =
+                    history::find_original(&transaction, self.filter, contained_in, ids[i], true)?;
                 contained_in = transaction
                     .repo()
                     .find_commit(ids[i])?

--- a/src/history.rs
+++ b/src/history.rs
@@ -115,6 +115,7 @@ pub fn find_original(
     filter: filter::Filter,
     contained_in: git2::Oid,
     filtered: git2::Oid,
+    linear: bool,
 ) -> JoshResult<git2::Oid> {
     if contained_in == git2::Oid::zero() {
         return Ok(git2::Oid::zero());
@@ -124,6 +125,9 @@ pub fn find_original(
     }
     let mut walk = transaction.repo().revwalk()?;
     walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+    if linear {
+        walk.simplify_first_parent()?;
+    }
     walk.push(contained_in)?;
 
     for original in walk {
@@ -311,7 +315,7 @@ pub fn unapply_filter(
             *original
         } else {
             tracing::info!("Had to go through the whole thing",);
-            find_original(transaction, filterobj, original_target, new)?
+            find_original(transaction, filterobj, original_target, new, false)?
         };
         return Ok(ret);
     }


### PR DESCRIPTION
Because the history always returns simplified history we can
make this assumption here and get a big performance benefit.