### PR TITLE
Remove "original" flag from history ui query

### DIFF
--- a/josh-ui/src/FileBrowser.tsx
+++ b/josh-ui/src/FileBrowser.tsx
@@ -36,7 +36,6 @@ export class FileList extends React.Component<FileBrowserProps, State> {
             rev: this.props.rev,
             filter: this.props.filter,
             path: this.props.path,
-            meta: '',
         }).catch((reason) => {
             const data = reason.response.data.rev
 

--- a/josh-ui/src/FileViewer.tsx
+++ b/josh-ui/src/FileViewer.tsx
@@ -45,7 +45,6 @@ export class FileViewer extends React.Component<FileViewerProps, State> {
             rev: this.props.rev,
             filter: this.props.filter,
             path: this.props.path,
-            meta: '',
         }).catch((reason) => {
             const data = reason.response.data.rev
 

--- a/josh-ui/src/Navigation.tsx
+++ b/josh-ui/src/Navigation.tsx
@@ -16,24 +16,17 @@ export type NavigateTarget = {
 export type NavigateCallback = (targetType: NavigateTargetType, target: NavigateTarget) => void
 
 export const QUERY_PATH = gql`
-query PathQuery($rev: String!, $filter: String!, $path: String!, $meta: String!) {
+query PathQuery($rev: String!, $filter: String!, $path: String!) {
   rev(at:$rev, filter:$filter) {
     warnings {
       message
     }
     file(path:$path) {
       text
-      meta(topic: $meta) {
-        data {
-          position: int(at: "/L")
-          text: string(at: "/text")
-        }
-      }
     }
-    dirs(at:$path,depth: 1) { path, meta(topic:$meta) { count } }
+    dirs(at:$path,depth: 1) { path }
     files(at:$path,depth: 1) { 
-      path, 
-      meta(topic:$meta) { count } 
+      path,
     }
   }
 }

--- a/josh-ui/src/Navigation.tsx
+++ b/josh-ui/src/Navigation.tsx
@@ -37,7 +37,7 @@ query HistoryQuery($rev: String!, $filter: String!, $limit: Int) {
     history(limit: $limit) {
       summary
       hash
-      original: rev(original: true) { hash }
+      original: rev { hash }
     }
   }
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -119,6 +119,9 @@ pub fn find_original(
     if contained_in == git2::Oid::zero() {
         return Ok(git2::Oid::zero());
     }
+    if filter == filter::nop() {
+        return Ok(filtered);
+    }
     let mut walk = transaction.repo().revwalk()?;
     walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
     walk.push(contained_in)?;


### PR DESCRIPTION
Due to the way the commits listed are constructed, their commit id
are already the original ones, so no extra search is required.