### PR TITLE
Reduce number of commit shown on history page

### DIFF
--- a/josh-ui/src/History.tsx
+++ b/josh-ui/src/History.tsx
@@ -39,7 +39,7 @@ export class HistoryList extends React.Component<HistoryBrowserProps, State> {
         this.state.client.rawRequest(QUERY_HISTORY, {
             rev: this.props.rev,
             filter: this.props.filter,
-            limit: 100,
+            limit: 10,
         }).then((d) => {
             const data = d.data.rev
 


### PR DESCRIPTION
Even with all the optimisations, the history query is till to slow
for such a large limit.