### PR TITLE
Fix graphql history issue 

### DIFF
--- a/tests/filter/graphql_history.t
+++ b/tests/filter/graphql_history.t
@@ -41,4 +41,4 @@
   > EOF
 
   $ josh-filter -g "$(cat query2)"
-  null
+  {"rev":{"history":[{"summary":"add ws"}]}}


### PR DESCRIPTION
When a workspace is created, it includes commits of history of the
mapped modules. Since find_original is unable to trace them back to
their original commit we need to skip them, like we skip commits from
the right side of the merges