### PR TITLE
Split file and path queries

### DIFF
--- a/josh-ui/src/FileBrowser.tsx
+++ b/josh-ui/src/FileBrowser.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import {GraphQLClient} from 'graphql-request'
 import {getServer} from "./Server";
-import {NavigateCallback, NavigateTargetType, QUERY_PATH} from "./Navigation";
+import {NavigateCallback, NavigateTargetType, QUERY_DIR} from "./Navigation";
 import {match} from "ts-pattern";
 
 export type FileBrowserProps = {
@@ -32,12 +32,12 @@ export class FileList extends React.Component<FileBrowserProps, State> {
     };
 
     startRequest() {
-        this.state.client.rawRequest(QUERY_PATH, {
+        this.state.client.rawRequest(QUERY_DIR, {
             rev: this.props.rev,
             filter: this.props.filter,
             path: this.props.path,
-        }).catch((reason) => {
-            const data = reason.response.data.rev
+        }).then((d) => {
+            const data = d.data.rev
 
             this.setState({
                 dirs: data.dirs.map((v: FileOrDir) => v.path),

--- a/josh-ui/src/FileViewer.tsx
+++ b/josh-ui/src/FileViewer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Editor from "@monaco-editor/react";
-import {NavigateCallback, QUERY_PATH} from "./Navigation";
+import {NavigateCallback, QUERY_FILE} from "./Navigation";
 import {GraphQLClient} from "graphql-request";
 import {getServer} from "./Server";
 import {match} from "ts-pattern";
@@ -41,12 +41,12 @@ export class FileViewer extends React.Component<FileViewerProps, State> {
     }
 
     componentDidMount() {
-        this.state.client.rawRequest(QUERY_PATH, {
+        this.state.client.rawRequest(QUERY_FILE, {
             rev: this.props.rev,
             filter: this.props.filter,
             path: this.props.path,
-        }).catch((reason) => {
-            const data = reason.response.data.rev
+        }).then((d) => {
+            const data = d.data.rev
 
             this.setState({
                 content: data.file.text

--- a/josh-ui/src/Navigation.tsx
+++ b/josh-ui/src/Navigation.tsx
@@ -15,14 +15,11 @@ export type NavigateTarget = {
 
 export type NavigateCallback = (targetType: NavigateTargetType, target: NavigateTarget) => void
 
-export const QUERY_PATH = gql`
-query PathQuery($rev: String!, $filter: String!, $path: String!) {
+export const QUERY_DIR = gql`
+query($rev: String!, $filter: String!, $path: String!) {
   rev(at:$rev, filter:$filter) {
     warnings {
       message
-    }
-    file(path:$path) {
-      text
     }
     dirs(at:$path,depth: 1) { path }
     files(at:$path,depth: 1) { 
@@ -31,8 +28,19 @@ query PathQuery($rev: String!, $filter: String!, $path: String!) {
   }
 }
 `
+
+export const QUERY_FILE = gql`
+query($rev: String!, $filter: String!, $path: String!) {
+  rev(at:$rev, filter:$filter) {
+    file(path:$path) {
+      text
+    }
+  }
+}
+`
+
 export const QUERY_HISTORY = gql`
-query HistoryQuery($rev: String!, $filter: String!, $limit: Int) {
+query($rev: String!, $filter: String!, $limit: Int) {
   rev(at:$rev, filter:$filter) {
     history(limit: $limit) {
       summary


### PR DESCRIPTION
Previously those where one query that always had errors because
either it was trying to access a file as a dir or the other way
round.

Change-Id: split-dir-file