### PR TITLE
josh-filter: clarify that --reverse also swaps input and output reference

### DIFF
--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -5,6 +5,7 @@ josh-filter
 Command to rewrite history using ``josh`` filter specs.
 By default it will use ``HEAD`` as input and update ``FILTERED_HEAD`` with the filtered
 history, taking a filter specification as argument.
+(Note that input and output are swapped with `--reverse`.)
 
 git-sync
 ========

--- a/src/bin/josh-filter.rs
+++ b/src/bin/josh-filter.rs
@@ -92,7 +92,11 @@ fn make_app() -> clap::Command<'static> {
                 .short('m')
                 .takes_value(true),
         )
-        .arg(clap::Arg::new("reverse").long("reverse"))
+        .arg(
+            clap::Arg::new("reverse").long("reverse").help(
+                "reverse-apply the filter to the output reference to update the input referebce",
+            ),
+        )
         .arg(
             clap::Arg::new("check-permission")
                 .long("check-permission")


### PR DESCRIPTION
That's not at all obvious, I had to read the source code to be sure.