### PR TITLE
Change syntax of replace filter

### DIFF
--- a/docs/src/reference/filters.md
+++ b/docs/src/reference/filters.md
@@ -62,8 +62,8 @@ The resulting tree will contain the contents of the
 workspace root as well as additional files specified in the ``workspace.josh`` file.
 (see [Workspaces](./workspace.md))
 
-### Text replacement **`:replace="regex","replacement"`**
-Applies the supplied regular expression to every file in the input tree.
+### Text replacement **`:replace("regex_0":"replacement_0",...,"regex_N":"replacement_N")`**
+Applies the supplied regular expressions to every file in the input tree.
 
 ### Signature removal **`:unsign`
 The default behaviour of Josh is to copy, if it exsists, the signature of the original commit in

--- a/src/filter/grammar.pest
+++ b/src/filter/grammar.pest
@@ -19,6 +19,7 @@ char = {
 filter_spec = { (
     filter_group
   | filter_rev
+  | filter_replace
   | filter_presub
   | filter_subdir
   | filter_nop
@@ -30,7 +31,7 @@ filter_group = { CMD_START ~ cmd? ~ GROUP_START ~ compose ~ GROUP_END }
 filter_subdir = { CMD_START ~ "/" ~ argument }
 filter_nop = { CMD_START ~ "/" }
 filter_presub = { CMD_START ~ ":" ~ argument }
-filter = { CMD_START ~ cmd ~ "=" ~ (argument ~ ("," ~ argument)*)? }
+filter = { CMD_START ~ cmd ~ "=" ~ (argument ~ (";" ~ argument)*)? }
 filter_noarg = { CMD_START ~ cmd }
 
 filter_rev = {
@@ -38,6 +39,15 @@ filter_rev = {
     ~ NEWLINE*
     ~ (argument ~ filter_spec)?
     ~ (CMD_SEP+ ~ (argument ~ filter_spec))*
+    ~ NEWLINE*
+    ~ ")"
+}
+
+filter_replace = {
+    CMD_START ~ "replace" ~ "("
+    ~ NEWLINE*
+    ~ (string ~ ":" ~ string)?
+    ~ (CMD_SEP+ ~ (string ~ ":" ~ string))*
     ~ NEWLINE*
     ~ ")"
 }

--- a/tests/filter/replace.t
+++ b/tests/filter/replace.t
@@ -32,9 +32,12 @@
   @@ -0,0 +1 @@
   +hello moon
 
-  $ josh-filter -p ':replace="hello","bye":replace="^(?P<l>.*(?m))$","$l!"'
-  :replace=hello,bye:replace="^(?P<l>.*(?m))$","$l!"
-  $ josh-filter --update refs/heads/filtered ':replace="hello","bye":replace="(?m)^(?P<l>.+)$","$l!"'
+  $ josh-filter -p ':replace("hello":"bye","^(?P<l>.*(?m))$":"$l!")'
+  :replace(
+      "hello":"bye"
+      "^(?P<l>.*(?m))$":"$l!"
+  )
+  $ josh-filter --update refs/heads/filtered ':replace("hello":"bye","(?m)^(?P<l>.+)$":"$l!")'
 
   $ git diff ${EMPTY_TREE}..refs/heads/filtered
   diff --git a/hw.txt b/hw.txt
@@ -52,7 +55,7 @@
   @@ -0,0 +1 @@
   +bye moon!
 
-  $ josh-filter --update refs/heads/filtered --reverse ':replace="hello","bye":replace="(?m)^(?P<l>.+)$","$l!"'
+  $ josh-filter --update refs/heads/filtered --reverse ':replace("hello":"bye","(?m)^(?P<l>.+)$":"$l!")'
 
   $ git diff ${EMPTY_TREE}..refs/heads/master
   diff --git a/hw.txt b/hw.txt

--- a/tests/proxy/workspace_errors.t
+++ b/tests/proxy/workspace_errors.t
@@ -104,7 +104,7 @@ Error in filter
   remote: 1 | a/b = :b/sub2        
   remote:   |         ^---        
   remote:   |        
-  remote:   = expected EOI, filter_group, filter_subdir, filter_nop, filter_presub, filter, filter_noarg, or filter_rev        
+  remote:   = expected EOI, filter_group, filter_subdir, filter_nop, filter_presub, filter, filter_noarg, filter_rev, or filter_replace        
   remote: 
   remote: a/b = :b/sub2        
   remote: c = :/sub1        


### PR DESCRIPTION
This only affects the replace filter, which I assume to be very nice. CACHE_VERSION does not need to be updated, because this changes the cache key for the replace filter anyway.

Change: semicolon