### PR TITLE
Don't set #![deny(warnings)] on the whole crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(warnings)]
 #![warn(unused_extern_crates)]
 
 #[macro_export]


### PR DESCRIPTION
deny(warnings) is generally considered to be a pretty strong anti-pattern[0] because new warnings can be introduced, either by new versions of rustc or by new versions of dependencies, that the binary author may want to prevent but shouldn't prevent users from building from source. In this case, a newer version of `chrono` deprecated `NaiveDateTime::from_timestamp`, which ended up breaking my CI pipeline because josh is no longer able to build.

Generally, instead, it's better practice to deny *specific* warnings, or build with `-D warnings` in CI.

[0]: https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html