### PR TITLE
Skip empty commits on push

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -511,9 +511,17 @@ pub fn unapply_filter(
             false,
         )?;
 
-        if let Some(ref mut change_ids) = change_ids {
-            change_ids.push(get_change_id(&module_commit, ret));
-        }
+        ret = if original_parents_refs.len() == 1
+            && new_tree.id() == original_parents_refs[0].tree_id()
+            && Some(module_commit.tree_id()) != module_commit.parents().next().map(|x| x.tree_id())
+        {
+            original_parents_refs[0].id()
+        } else {
+            if let Some(ref mut change_ids) = change_ids {
+                change_ids.push(get_change_id(&module_commit, ret));
+            }
+            ret
+        };
 
         bm.insert(module_commit.id(), ret);
     }

--- a/tests/filter/reverse_hide.t
+++ b/tests/filter/reverse_hide.t
@@ -59,3 +59,22 @@
   * add sub1/file3
   * add file2
   * add file1
+
+  $ git checkout hidden 1> /dev/null
+  Switched to branch 'hidden'
+
+  $ mkdir sub2
+  $ echo contents4 > sub2/file4
+  $ git add sub2/file4
+  $ git commit -m "add sub2/file4" 1> /dev/null
+  $ git commit -m "empty commit" --allow-empty 1> /dev/null
+
+  $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
+  [1] :prefix=sub2
+  [2] :/sub2
+  [2] :exclude[::sub2/]
+  $ git log --graph --pretty=%s refs/heads/master
+  * empty commit
+  * add sub1/file3
+  * add file2
+  * add file1


### PR DESCRIPTION
This happens when pushing to a remote with an ::exclude[...] and adding local files to the repo that are not supposed to be pushed.
Previously this resulted in commits with empty diffs.

Change: skip-empty-push