### PR TITLE
Remove unneeded css rule causing jumping icons

### DIFF
--- a/josh-ui/src/App.scss
+++ b/josh-ui/src/App.scss
@@ -138,7 +138,6 @@ pre.commit-message {
   justify-content: space-between;
   padding: .6em 1.7em;
   margin-bottom: 0em;
-  margin-top: 0.2em;
 
   &-select {
     a {


### PR DESCRIPTION
Change: rm-margin-top