### PR TITLE
fix: allow building josh from a tarball download

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,23 @@ impl From<git2::Oid> for Oid {
     }
 }
 
-pub const VERSION: &str =
-    git_version::git_version!(args = ["--tags", "--always", "--dirty=-modified"]);
+/// Determine the josh version number with the following precedence:
+///
+/// 1. If in a git checkout, and `git` binary is present, use the
+///    commit ID or nearest tag.
+/// 2. If not in a git checkout, use the value of the `JOSH_VERSION`
+///    environment variable (e.g. a build from a tarball).
+/// 3. If neither options work, fall back to the string "unknown".
+///
+/// This is used to display version numbers at runtime in different
+/// josh components.
+pub const VERSION: &str = git_version::git_version!(
+    args = ["--tags", "--always", "--dirty=-modified"],
+    fallback = match option_env!("JOSH_VERSION") {
+        Some(v) => v,
+        None => "unknown",
+    },
+);
 
 const FRAGMENT: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
     .add(b'/')


### PR DESCRIPTION
The `VERSION` compile-time constant expects `git` and the josh git repository to be present at build time, however this is not the case when building from (for example) a tarball downloaded from GitHub.

The latter is the preferred method of building packages in Nix and other distribution package managers, where fetching the entire git history for the package build is not required and the [revision is known anyways](https://cl.tvl.fyi/c/depot/+/8186/1/third_party/josh/default.nix#16).

This change falls back to using the `JOSH_VERSION` environment variable if it is present at compile-time, or ultimately to the string `unknown` if no version can be determined.

Note that the explicit match is required because methods like `Option<T>::unwrap_or` are not currently `const` in stable Rust, but const destructuring of sum types is.