### PR TITLE
Make ::path match directories as well as files

### DIFF
--- a/docs/src/reference/filters.md
+++ b/docs/src/reference/filters.md
@@ -81,8 +81,8 @@ allowed.
 ### Match directories **`::X/`**
 All matching subdirectories in the input root
 
-### Match files **`::X`**
-All matching files in the input root
+### Match files or directories **`::X`**
+All matching files or directories in the input root
 
 ### Match nested directories **`::**/X/`**
 All subdirectories matching the pattern in arbitrarily deep subdirectories of the input

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -759,11 +759,7 @@ fn apply2<'a>(
                 .get_path(path)
                 .map(|x| (x.id(), x.filemode()))
                 .unwrap_or((git2::Oid::zero(), 0o0100644));
-            if repo.find_blob(file).is_ok() {
-                tree::insert(repo, &tree::empty(repo), path, file, mode)
-            } else {
-                Ok(tree::empty(repo))
-            }
+            tree::insert(repo, &tree::empty(repo), path, file, mode)
         }
 
         Op::Subdir(path) => {

--- a/tests/filter/workspace_single_file.t
+++ b/tests/filter/workspace_single_file.t
@@ -28,6 +28,15 @@
   $ git add ws
   $ git commit -m "add ws" 1> /dev/null
 
+  $ mkdir ws2
+  $ cat > ws2/workspace.josh <<EOF
+  > :/sub1::file1
+  > :/sub1::file2
+  > ::sub2/subsub
+  > EOF
+  $ git add ws2
+  $ git commit -m "add ws2" 1> /dev/null
+
   $ josh-filter -s :workspace=ws master --update refs/josh/master
   [1] :/sub1
   [1] :/subsub
@@ -60,6 +69,58 @@
   100755 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile2 (esc)
   040000 tree 81b2a24c53f9090c6f6a23176a2a5660e6f48317\tsub2 (esc)
   100644 blob 63f07c908400fab3a663e52e480970d8458bc86a\tworkspace.josh (esc)
+  $ tree
+  .
+  |-- file1
+  |-- file2
+  |-- sub2
+  |   `-- subsub
+  |       `-- file2
+  `-- workspace.josh
+  
+  2 directories, 4 files
+
+  $ josh-filter -s :workspace=ws2 master --update refs/josh/master
+  [1] :/sub1
+  [1] :/subsub
+  [1] ::file1
+  [1] ::file2
+  [1] :[
+      ::file1
+      ::file2
+  ]
+  [1] :prefix=sub2
+  [1] :prefix=subsub
+  [2] :/sub2
+  [2] ::sub2/subsub
+  [2] :[
+      :/sub1:[
+          ::file1
+          ::file2
+      ]
+      ::sub2/subsub
+  ]
+  [2] :[
+      :/sub1:[
+          ::file1
+          ::file2
+      ]
+      ::sub2/subsub/
+  ]
+  [2] :workspace=ws
+  [2] :workspace=ws2
+
+  $ git log --graph --pretty=%s refs/josh/master
+  * add ws2
+  * add file2
+  * add file1
+
+  $ git checkout refs/josh/master 2> /dev/null
+  $ git ls-tree HEAD
+  100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile1 (esc)
+  100755 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile2 (esc)
+  040000 tree 81b2a24c53f9090c6f6a23176a2a5660e6f48317\tsub2 (esc)
+  100644 blob f7863ebb4c21391857fe5d27bc381553a2056223\tworkspace.josh (esc)
   $ tree
   .
   |-- file1

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -224,6 +224,8 @@ Make sure all temporary namespace got removed
       |   |   `-- c67dccc160a868cefdab0bd9d7141b7276c4f3
       |   |-- 49
       |   |   `-- 03654ec80c5cff86ab37a0b9d7bcf8332e8c54
+      |   |-- 4b
+      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
       |   |-- 57
       |   |   `-- a39cc050b1493cf6313822f0de3cee3ca4f39a
       |   |-- 6b
@@ -249,7 +251,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  55 directories, 43 files
+  56 directories, 44 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE


### PR DESCRIPTION
Previously `::path/` only matched directories while `::path` only matched files.
With this change `::path` matches both, while keeping the behaviour of `::path/` as is.
This is in line on how things are handled in git's gitignore pattern syntax.

Change: match-dirs-and-files