### PR TITLE
Add creation of static folder in setup_test_env

### DIFF
--- a/tests/proxy/setup_test_env.sh
+++ b/tests/proxy/setup_test_env.sh
@@ -33,6 +33,7 @@ GIT_DIR="${TESTTMP}/remote/" GIT_PROJECT_ROOT="${TESTTMP}/remote/" GIT_HTTP_EXPO
 echo $! > "${TESTTMP}/server_pid"
 
 # Copy static UI resources
+mkdir -p "${TESTDIR}/../../static"
 cp -R "${TESTDIR}/../../static/" /josh/
 
 if [ -n "${CARGO_TARGET_DIR+x}" ]; then


### PR DESCRIPTION
On first build this was missing and causing the script to fail.

Change: static-create