### PR TITLE
Update Rust and Dockerfile dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "hyper_cgi",
     "josh-core",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# syntax=docker/dockerfile:1.4-labs
+# syntax=docker/dockerfile:1.6-labs@sha256:bd24901c537a316a4802d920bf86605f4db8ef676ef7258a3b381e12d90c62c8
 
-ARG ALPINE_VERSION=3.17
+ARG ALPINE_VERSION=3.18
 ARG ARCH=x86_64
 
 FROM alpine:${ALPINE_VERSION} as rust-base
@@ -12,8 +12,8 @@ ENV CARGO_HOME=/usr/local/cargo
 ENV PATH=/usr/local/cargo/bin:${PATH}
 
 ARG ARCH
-ARG RUSTUP_VERSION=1.25.1
-ARG RUST_VERSION=1.66.0
+ARG RUSTUP_VERSION=1.26.0
+ARG RUST_VERSION=1.72.1
 ARG RUST_ARCH=${ARCH}-unknown-linux-musl
 
 # https://github.com/sfackler/rust-openssl/issues/1462
@@ -29,7 +29,7 @@ RUN /tmp/rustup-init \
 
 FROM rust-base as dev-planner
 
-RUN cargo install --version 0.1.51 cargo-chef
+RUN cargo install --version 0.1.62 cargo-chef
 
 WORKDIR /usr/src/josh
 COPY . .
@@ -46,7 +46,7 @@ RUN apk add --no-cache \
 
 WORKDIR /usr/src/josh
 RUN rustup component add rustfmt
-RUN cargo install --version 0.1.51 cargo-chef
+RUN cargo install --version 0.1.62 cargo-chef
 RUN cargo install --verbose --version 0.10.0 graphql_client_cli
 
 RUN apk add --no-cache \

--- a/tests/filter/ambigous_merge.t
+++ b/tests/filter/ambigous_merge.t
@@ -105,7 +105,7 @@
       |-- file2
       `-- fileX
   
-  2 directories, 7 files
+  3 directories, 7 files
 
   $ git log --graph --oneline --decorate master
   *   8cbae19 (HEAD -> master) Merge branch 'hidden_branch1' into hidden_master

--- a/tests/filter/cmdline.t
+++ b/tests/filter/cmdline.t
@@ -72,7 +72,7 @@
   |       `-- master
   `-- tags
   
-  7 directories, 5 files
+  8 directories, 5 files
 
   $ git read-tree HEAD josh/filter/libs/master josh/filter/libs/foo
   $ git commit -m "sync"
@@ -100,7 +100,7 @@
       |-- file1
       `-- file2
   
-  3 directories, 3 files
+  4 directories, 3 files
   $ git log --graph --pretty=%s
   * sync
   * initial

--- a/tests/filter/empty_orphan.t
+++ b/tests/filter/empty_orphan.t
@@ -67,7 +67,7 @@ Empty root commits from unrelated parts of the tree should not be included
       |-- file2
       `-- file3
   
-  1 directory, 5 files
+  2 directories, 5 files
 
   $ git log master --graph --pretty=%s
   *   Merge branch 'other'

--- a/tests/filter/exclude_compose.t
+++ b/tests/filter/exclude_compose.t
@@ -31,7 +31,7 @@
   `-- sub3
       `-- file1
   
-  2 directories, 2 files
+  3 directories, 2 files
   $ git log --graph --pretty=%s
   * add file3
   * add file1
@@ -61,7 +61,7 @@
   `-- sub3
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ josh-filter -s :exclude[sub1=:/sub3] master --update refs/josh/filtered
   [1] :/sub1
@@ -88,4 +88,4 @@
   `-- sub3
       `-- file1
   
-  2 directories, 2 files
+  3 directories, 2 files

--- a/tests/filter/file.t
+++ b/tests/filter/file.t
@@ -62,5 +62,5 @@
   |   `-- master
   `-- tags
   
-  2 directories, 1 file
+  3 directories, 1 file
 

--- a/tests/filter/hide_view.t
+++ b/tests/filter/hide_view.t
@@ -31,7 +31,7 @@
   `-- sub2
       `-- file3
   
-  2 directories, 3 files
+  3 directories, 3 files
 
   $ josh-filter -s c=:exclude[::sub1/] master --update refs/josh/filter/master
   [1] :prefix=c
@@ -47,7 +47,7 @@
       `-- sub2
           `-- file3
   
-  2 directories, 1 file
+  3 directories, 1 file
 
   $ josh-filter -s c=:exclude[::sub1/file2] master --update refs/josh/filter/master
   [2] :/sub1
@@ -68,7 +68,7 @@
       `-- sub2
           `-- file3
   
-  3 directories, 2 files
+  4 directories, 2 files
 
   $ josh-filter -s c=:exclude[::sub2/file3] master --update refs/josh/filter/master
   [2] :/sub1
@@ -90,4 +90,4 @@
           |-- file1
           `-- file2
   
-  2 directories, 2 files
+  3 directories, 2 files

--- a/tests/filter/reverse_hide.t
+++ b/tests/filter/reverse_hide.t
@@ -25,7 +25,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
   $ git log --graph --pretty=%s
   * add file1
 
@@ -49,7 +49,7 @@
   `-- sub2
       `-- file2
   
-  2 directories, 3 files
+  3 directories, 3 files
 
 
   $ cat sub1/file3

--- a/tests/filter/reverse_hide_edit.t
+++ b/tests/filter/reverse_hide_edit.t
@@ -25,7 +25,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
   $ git log --graph --pretty=%s
   * add file1
 
@@ -64,5 +64,5 @@
   `-- sub2
       `-- file2
   
-  2 directories, 2 files
+  3 directories, 2 files
 

--- a/tests/filter/reverse_hide_edit_missing_change.t
+++ b/tests/filter/reverse_hide_edit_missing_change.t
@@ -25,7 +25,7 @@
   `-- subx
       `-- filex
   
-  2 directories, 4 files
+  3 directories, 4 files
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   [1] :exclude[::sub2/]
@@ -39,7 +39,7 @@
   `-- subx
       `-- filex
   
-  1 directory, 2 files
+  2 directories, 2 files
   $ git log --graph --pretty=%s
   * add file1
 
@@ -88,5 +88,5 @@
   `-- subx
       `-- filex
   
-  2 directories, 4 files
+  3 directories, 4 files
 

--- a/tests/filter/reverse_merge.t
+++ b/tests/filter/reverse_merge.t
@@ -35,7 +35,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
   $ echo contents3 > sub1/file3
   $ git add sub1/file3
   $ git commit -m "add file3" 1> /dev/null
@@ -52,7 +52,7 @@
       |-- file1
       `-- file2
   
-  1 directory, 2 files
+  2 directories, 2 files
   $ echo contents4 > sub1/file4
   $ git add sub1/file4
   $ git commit -m "add file4" 1> /dev/null
@@ -93,7 +93,7 @@
   `-- sub2
       `-- file2
   
-  2 directories, 5 files
+  3 directories, 5 files
 
 
 

--- a/tests/filter/reverse_split.t
+++ b/tests/filter/reverse_split.t
@@ -30,7 +30,7 @@
   `-- rest
       `-- file2.b
   
-  2 directories, 2 files
+  3 directories, 2 files
   $ git log --graph --pretty=%s
   * add file2.b
   * add file1.a
@@ -82,5 +82,5 @@
   |-- file3.a
   `-- file4.b
   
-  0 directories, 4 files
+  1 directory, 4 files
 

--- a/tests/filter/subtree_prefix.t
+++ b/tests/filter/subtree_prefix.t
@@ -29,7 +29,7 @@ Articially create a subtree merge
   `-- subtree
       `-- file2
   
-  1 directory, 2 files
+  2 directories, 2 files
   $ git log --graph --pretty=%s
   *   subtree merge
   |\  

--- a/tests/filter/workspace_combine_filter.t
+++ b/tests/filter/workspace_combine_filter.t
@@ -47,7 +47,7 @@
   `-- ws2
       `-- workspace.josh
   
-  6 directories, 5 files
+  7 directories, 5 files
 
   $ josh-filter -s :workspace=ws
   [1] :/sub1
@@ -79,7 +79,7 @@
           `-- subsub
               `-- file2
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ git checkout master 2> /dev/null
   $ josh-filter -s :workspace=ws2
@@ -133,4 +133,4 @@
       `-- blub
           `-- file1
   
-  6 directories, 4 files
+  7 directories, 4 files

--- a/tests/filter/workspace_exclude.t
+++ b/tests/filter/workspace_exclude.t
@@ -54,7 +54,7 @@
   |       `-- file2
   `-- workspace.josh
   
-  3 directories, 3 files
+  4 directories, 3 files
 
   $ echo ws_content > fileX
   $ echo ws_content > file1
@@ -91,7 +91,7 @@
       |-- fileX
       `-- workspace.josh
   
-  4 directories, 6 files
+  5 directories, 6 files
 
   $ cat ws/file1
   ws_content

--- a/tests/filter/workspace_implicit_filter.t
+++ b/tests/filter/workspace_implicit_filter.t
@@ -50,4 +50,4 @@
   |       `-- file2
   `-- workspace.josh
   
-  3 directories, 3 files
+  4 directories, 3 files

--- a/tests/filter/workspace_modify_chain.t
+++ b/tests/filter/workspace_modify_chain.t
@@ -40,7 +40,7 @@
   `-- subsub
       `-- file2
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ echo ws_content > subsub/fileX
   $ echo ws_content > subsub/file1
@@ -69,7 +69,7 @@
   `-- ws
       `-- workspace.josh
   
-  4 directories, 6 files
+  5 directories, 6 files
 
   $ cat ws/file1
   *: No such file or directory (glob)

--- a/tests/filter/workspace_multiple_globs.t
+++ b/tests/filter/workspace_multiple_globs.t
@@ -61,4 +61,4 @@
   |       `-- file1
   `-- workspace.josh
   
-  6 directories, 4 files
+  7 directories, 4 files

--- a/tests/filter/workspace_shadow_file.t
+++ b/tests/filter/workspace_shadow_file.t
@@ -45,7 +45,7 @@
       |   `-- file1
       `-- workspace.josh
   
-  4 directories, 4 files
+  5 directories, 4 files
 
   $ cat sub1/file1
   contents1
@@ -68,7 +68,7 @@
   |   `-- file1
   `-- workspace.josh
   
-  3 directories, 3 files
+  4 directories, 3 files
 
   $ cat c/file1
   ws_content
@@ -94,7 +94,7 @@
       |-- workspace.josh
       `-- ws_created_file
   
-  4 directories, 5 files
+  5 directories, 5 files
 
   $ cat sub1/file1
   ws_content

--- a/tests/filter/workspace_single_file.t
+++ b/tests/filter/workspace_single_file.t
@@ -78,7 +78,7 @@
   |       `-- file2
   `-- workspace.josh
   
-  2 directories, 4 files
+  3 directories, 4 files
 
   $ josh-filter -s :workspace=ws2 master --update refs/josh/master
   [1] :/sub1
@@ -130,4 +130,4 @@
   |       `-- file2
   `-- workspace.josh
   
-  2 directories, 4 files
+  3 directories, 4 files

--- a/tests/filter/workspace_trailing_slash.t
+++ b/tests/filter/workspace_trailing_slash.t
@@ -72,7 +72,7 @@
   `-- ws
       `-- c
   
-  2 directories, 1 file
+  3 directories, 1 file
 
   $ git checkout -q HEAD~1
   $ tree
@@ -86,5 +86,5 @@
   `-- ws
       `-- c
   
-  5 directories, 3 files
+  6 directories, 3 files
 

--- a/tests/filter/workspace_unique.t
+++ b/tests/filter/workspace_unique.t
@@ -67,4 +67,4 @@ so the workspace.josh will still appear in the root of the workspace
   |       `-- file2
   `-- workspace.josh
   
-  3 directories, 4 files
+  4 directories, 4 files

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -44,7 +44,7 @@
   `-- sub3
       `-- file3
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file3
@@ -86,7 +86,7 @@
   |-- file2x
   `-- file3
   
-  0 directories, 2 files
+  1 directory, 2 files
 
   $ echo content4 > file_new 1> /dev/null
   $ git add .
@@ -115,7 +115,7 @@
       |-- file3
       `-- file_new
   
-  1 directory, 4 files
+  2 directories, 4 files
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [
@@ -216,4 +216,4 @@
           |-- namespaces
           `-- tags
   
-  53 directories, 39 files
+  54 directories, 39 files

--- a/tests/proxy/authentication.t
+++ b/tests/proxy/authentication.t
@@ -27,7 +27,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ git push
   To http://localhost:8001/real_repo.git
@@ -75,7 +75,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ cat sub1/file1
   contents1
@@ -106,7 +106,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ cd ${TESTTMP}/real_repo
   $ curl -s http://localhost:8001/_noauth
@@ -175,4 +175,4 @@
           |-- namespaces
           `-- tags
   
-  32 directories, 19 files
+  33 directories, 19 files

--- a/tests/proxy/caching.t
+++ b/tests/proxy/caching.t
@@ -110,7 +110,7 @@
           |-- namespaces
           `-- tags
   
-  36 directories, 23 files
+  37 directories, 23 files
 
 # setup without caching
   $ EXTRA_OPTS= . ${TESTDIR}/setup_test_env.sh
@@ -229,4 +229,4 @@
           |-- namespaces
           `-- tags
   
-  40 directories, 27 files
+  41 directories, 27 files

--- a/tests/proxy/clone_absent_head.t
+++ b/tests/proxy/clone_absent_head.t
@@ -33,7 +33,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ git push
   To http://localhost:8001/real_repo.git
@@ -67,7 +67,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ cat sub1/file1
   contents1
@@ -127,6 +127,6 @@
           |-- namespaces
           `-- tags
   
-  26 directories, 16 files
+  27 directories, 16 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/clone_all.t
+++ b/tests/proxy/clone_all.t
@@ -26,7 +26,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ git push
   To http://localhost:8001/real_repo.git
@@ -43,7 +43,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ cat sub1/file1
   contents1
@@ -100,5 +100,5 @@
           |-- namespaces
           `-- tags
   
-  30 directories, 17 files
+  31 directories, 17 files
 

--- a/tests/proxy/clone_blocked.t
+++ b/tests/proxy/clone_blocked.t
@@ -39,5 +39,5 @@
           |-- heads
           `-- tags
   
-  20 directories, 10 files
+  21 directories, 10 files
 

--- a/tests/proxy/clone_invalid_filter.t
+++ b/tests/proxy/clone_invalid_filter.t
@@ -39,7 +39,7 @@
   `-- sub2
       `-- file2
   
-  3 directories, 2 files
+  4 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file2

--- a/tests/proxy/clone_invalid_url.t
+++ b/tests/proxy/clone_invalid_url.t
@@ -62,5 +62,5 @@
           |-- heads
           `-- tags
   
-  20 directories, 10 files
+  21 directories, 10 files
 

--- a/tests/proxy/clone_locked_refs.t
+++ b/tests/proxy/clone_locked_refs.t
@@ -203,4 +203,4 @@
           |-- namespaces
           `-- tags
   
-  52 directories, 40 files
+  53 directories, 40 files

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -36,7 +36,7 @@
   `-- sub2
       `-- file2
   
-  2 directories, 2 files
+  3 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -60,7 +60,7 @@
       `-- sub2
           `-- file2
   
-  3 directories, 2 files
+  4 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -135,4 +135,4 @@
           |-- namespaces
           `-- tags
   
-  37 directories, 24 files
+  38 directories, 24 files

--- a/tests/proxy/clone_sha.t
+++ b/tests/proxy/clone_sha.t
@@ -26,7 +26,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ git push -q
 
@@ -83,7 +83,7 @@ Check (2) and (3) but with a branch ref
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ cat sub1/file1
   contents1
@@ -150,5 +150,5 @@ Check (2) and (3) but with a branch ref
           |-- namespaces
           `-- tags
   
-  34 directories, 23 files
+  35 directories, 23 files
 

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -39,7 +39,7 @@
   `-- sub2
       `-- file2
   
-  3 directories, 2 files
+  4 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -57,7 +57,7 @@
   `-- subsub
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ git log --graph --pretty=%s master
   * add file1
@@ -71,7 +71,7 @@
   .
   `-- file1
   
-  0 directories, 1 file
+  1 directory, 1 file
 
   $ git log --graph --pretty=%s master
   * add file1
@@ -146,4 +146,4 @@
           |-- namespaces
           `-- tags
   
-  36 directories, 23 files
+  37 directories, 23 files

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -36,7 +36,7 @@
   `-- sub2
       `-- file2
   
-  2 directories, 2 files
+  3 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -69,7 +69,7 @@
   .
   `-- file1
   
-  0 directories, 1 file
+  1 directory, 1 file
 
   $ git log --graph --pretty=%s
   * add file1
@@ -140,4 +140,4 @@
           |-- namespaces
           `-- tags
   
-  34 directories, 21 files
+  35 directories, 21 files

--- a/tests/proxy/clone_subtree_no_master.t
+++ b/tests/proxy/clone_subtree_no_master.t
@@ -36,7 +36,7 @@
   `-- sub2
       `-- file2
   
-  2 directories, 2 files
+  3 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -132,4 +132,4 @@
           |-- namespaces
           `-- tags
   
-  34 directories, 20 files
+  35 directories, 20 files

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -50,7 +50,7 @@
   `-- sub2
       `-- file2
   
-  2 directories, 3 files
+  3 directories, 3 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -77,7 +77,7 @@
   |-- file1
   `-- file12
   
-  0 directories, 2 files
+  1 directory, 2 files
 
   $ git log --graph --pretty=%s
   * add file12
@@ -99,7 +99,7 @@
   .
   `-- file1
   
-  0 directories, 1 file
+  1 directory, 1 file
 
   $ git log --graph --pretty=%s
   * add file1
@@ -178,5 +178,5 @@
           |-- namespaces
           `-- tags
   
-  37 directories, 26 files
+  38 directories, 26 files
 $ cat ${TESTTMP}/josh-proxy.out | grep TAGS

--- a/tests/proxy/clone_with_meta.t
+++ b/tests/proxy/clone_with_meta.t
@@ -86,7 +86,7 @@
   `-- sub2
       `-- file2
   
-  2 directories, 2 files
+  3 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -103,7 +103,7 @@
       `-- sub2
           `-- file2
   
-  3 directories, 2 files
+  4 directories, 2 files
 
   $ cd ${TESTTMP}
   $ git clone -q http://localhost:8002/with_prefix.git:/my_prefix/sub1.git
@@ -112,7 +112,7 @@
   .
   `-- file1
   
-  0 directories, 1 file
+  1 directory, 1 file
 
 
   $ bash ${TESTDIR}/destroy_test_env.sh
@@ -213,4 +213,4 @@
           |-- namespaces
           `-- tags
   
-  49 directories, 35 files
+  50 directories, 35 files

--- a/tests/proxy/empty_commit.t
+++ b/tests/proxy/empty_commit.t
@@ -46,7 +46,7 @@ should still be included.
       |-- file1
       `-- file2
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -69,7 +69,7 @@ should still be included.
       |-- file1
       `-- file2
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -140,4 +140,4 @@ should still be included.
           |-- namespaces
           `-- tags
   
-  35 directories, 22 files
+  36 directories, 22 files

--- a/tests/proxy/filter_prefix.t
+++ b/tests/proxy/filter_prefix.t
@@ -48,7 +48,7 @@
       |   `-- on_change
       `-- tmpl_file
   
-  3 directories, 4 files
+  4 directories, 4 files
 
   $ git clone http://localhost:8002/real_repo.git:/sub2.git
   Cloning into 'sub2'...
@@ -56,6 +56,6 @@
   sub2
   `-- file2
   
-  0 directories, 1 file
+  1 directory, 1 file
   $ curl -s http://localhost:8002/real_repo.git:/sub1.git?get=file1
   contents1

--- a/tests/proxy/get_version.t
+++ b/tests/proxy/get_version.t
@@ -37,4 +37,4 @@
           |-- heads
           `-- tags
   
-  20 directories, 10 files
+  21 directories, 10 files

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -51,7 +51,7 @@ Flushed credential cache
   `-- repo1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
 $ curl -s http://localhost:8002/flush
 Flushed credential cache
@@ -72,7 +72,7 @@ Flushed credential cache
   `-- repo2
       `-- file2
   
-  2 directories, 2 files
+  3 directories, 2 files
 
   $ git checkout master
   Switched to branch 'master'
@@ -101,7 +101,7 @@ Flushed credential cache
   `-- repo2
       `-- file2
   
-  2 directories, 3 files
+  3 directories, 3 files
 
   $ git push 2> /dev/null
 
@@ -118,7 +118,7 @@ Flushed credential cache
   |-- file1
   `-- new_file1
   
-  0 directories, 2 files
+  1 directory, 2 files
 
   $ cd ${TESTTMP}/repo1
   $ echo new_content2 > new_file2 1> /dev/null
@@ -148,7 +148,7 @@ Flushed credential cache
   `-- repo2
       `-- file2
   
-  2 directories, 4 files
+  3 directories, 4 files
 
   $ git log --graph --pretty=%s
   *   Import 2
@@ -182,7 +182,7 @@ Flushed credential cache
   |-- new_file1
   `-- new_file2
   
-  0 directories, 3 files
+  1 directory, 3 files
   $ git log --graph --pretty=%s
   *   Import 2
   |\  
@@ -242,7 +242,7 @@ Flushed credential cache
   |-- new_file1
   `-- new_file2
   
-  0 directories, 3 files
+  1 directory, 3 files
   $ git log --graph --pretty=%s
   *   Import 3
   |\  
@@ -289,7 +289,7 @@ Flushed credential cache
   `-- repo2
       `-- file2
   
-  2 directories, 4 files
+  3 directories, 4 files
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [
@@ -421,4 +421,4 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  66 directories, 54 files
+  67 directories, 54 files

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -52,7 +52,7 @@
       |-- newfile1
       `-- newfile_master
   
-  1 directory, 3 files
+  2 directories, 3 files
 
 
   $ bash ${TESTDIR}/destroy_test_env.sh
@@ -132,4 +132,4 @@
           |-- namespaces
           `-- tags
   
-  43 directories, 30 files
+  44 directories, 30 files

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -48,7 +48,7 @@
   `-- sub1
       `-- file1
   
-  3 directories, 2 files
+  4 directories, 2 files
 
   $ git push
   To http://localhost:8001/real_repo.git
@@ -68,7 +68,7 @@
   `-- sub1
       `-- file1
   
-  3 directories, 2 files
+  4 directories, 2 files
 
   $ cat sub1/file1
   contents
@@ -554,4 +554,4 @@
           |-- namespaces
           `-- tags
   
-  108 directories, 106 files
+  109 directories, 106 files

--- a/tests/proxy/no_proxy.t
+++ b/tests/proxy/no_proxy.t
@@ -26,7 +26,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ git push
   To http://localhost:8001/real_repo.git
@@ -65,4 +65,4 @@
           |-- heads
           `-- tags
   
-  20 directories, 10 files
+  21 directories, 10 files

--- a/tests/proxy/no_proxy_lfs.t
+++ b/tests/proxy/no_proxy_lfs.t
@@ -35,7 +35,7 @@
   `-- sub1
       `-- file1.large
   
-  1 directory, 1 file
+  2 directories, 1 file
 
   $ git config lfs.http://localhost:8001/real_repo.git/info/lfs.locksverify false
 
@@ -80,4 +80,4 @@
           |-- heads
           `-- tags
   
-  20 directories, 10 files
+  21 directories, 10 files

--- a/tests/proxy/push_graphql.t
+++ b/tests/proxy/push_graphql.t
@@ -120,5 +120,5 @@
           |-- heads
           `-- tags
   
-  31 directories, 20 files
+  32 directories, 20 files
 

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -167,4 +167,4 @@ Check the branch again
           |-- namespaces
           `-- tags
   
-  41 directories, 29 files
+  42 directories, 29 files

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -47,7 +47,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [
@@ -117,5 +117,5 @@
           |-- namespaces
           `-- tags
   
-  37 directories, 24 files
+  38 directories, 24 files
 

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -56,7 +56,7 @@
       |-- file1
       `-- file2
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ cat sub1/file2
   contents2
@@ -70,7 +70,7 @@
       |-- file1
       `-- file2
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ cat sub1/file2
   contents2
@@ -146,7 +146,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  36 directories, 23 files
+  37 directories, 23 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_review_already_in.t
+++ b/tests/proxy/push_review_already_in.t
@@ -97,5 +97,5 @@ test for that.
           |-- namespaces
           `-- tags
   
-  31 directories, 18 files
+  32 directories, 18 files
 

--- a/tests/proxy/push_review_nop_behind.t
+++ b/tests/proxy/push_review_nop_behind.t
@@ -108,4 +108,4 @@ This is a regression test for that problem.
           |-- namespaces
           `-- tags
   
-  33 directories, 20 files
+  34 directories, 20 files

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -61,7 +61,7 @@ Flushed credential cache
       |-- file1
       `-- file3
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ git rebase master -q
   $ git log --graph --pretty=%s
@@ -76,7 +76,7 @@ Flushed credential cache
       |-- file2
       `-- file3
   
-  1 directory, 3 files
+  2 directories, 3 files
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [
@@ -154,7 +154,7 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  41 directories, 28 files
+  42 directories, 28 files
 
   $ cat ${TESTTMP}/josh-proxy.out | grep graph_descendant_of
   [1]

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -101,7 +101,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  36 directories, 23 files
+  37 directories, 23 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -109,7 +109,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 2 files
+  2 directories, 2 files
 
 To avoid stacked changes to cause excessive amounts of refs, refs get filtered to only
 get listed if they differ from HEAD
@@ -251,7 +251,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  56 directories, 44 files
+  57 directories, 44 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_split.t
+++ b/tests/proxy/push_stacked_split.t
@@ -181,7 +181,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  59 directories, 46 files
+  60 directories, 46 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -119,7 +119,7 @@
   `-- sub1
       `-- file1
   
-  1 directory, 1 file
+  2 directories, 1 file
 
 Make sure all temporary namespace got removed
   $ tree ${TESTTMP}/remote/scratch/real_repo.git/refs/ | grep request_
@@ -230,7 +230,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  54 directories, 44 files
+  55 directories, 44 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -39,7 +39,7 @@
       |-- file1
       `-- file2
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [
@@ -115,6 +115,6 @@
           |-- namespaces
           `-- tags
   
-  40 directories, 27 files
+  41 directories, 27 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -74,7 +74,7 @@ Flushed credential cache
       |-- file1
       `-- file2
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ cat sub1/file2
   contents2
@@ -158,6 +158,6 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  40 directories, 28 files
+  41 directories, 28 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -81,7 +81,7 @@ Put a double slash in the URL to see that it also works
       |-- file1
       `-- file2
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ cat sub1/file2
   contents2
@@ -102,7 +102,7 @@ Put a double slash in the URL to see that it also works
       |-- file1
       `-- file2
   
-  1 directory, 2 files
+  2 directories, 2 files
 
   $ cat sub1/file2
   contents2_repo2
@@ -202,5 +202,5 @@ Put a double slash in the URL to see that it also works
           |-- namespaces
           `-- tags
   
-  49 directories, 35 files
+  50 directories, 35 files
 

--- a/tests/proxy/unrelated_leak.t
+++ b/tests/proxy/unrelated_leak.t
@@ -246,4 +246,4 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  62 directories, 51 files
+  63 directories, 51 files

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -97,7 +97,7 @@
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ cat workspace.josh
   # comment
@@ -122,7 +122,7 @@
   |       `-- file1
   `-- workspace.josh
   
-  2 directories, 2 files
+  3 directories, 2 files
 
   $ git checkout master 1> /dev/null
   Previous HEAD position was e27e2ee add file1
@@ -171,7 +171,7 @@
   `-- ws
       `-- workspace.josh
   
-  5 directories, 9 files
+  6 directories, 9 files
 
   $ cat ws/workspace.josh
   # comment
@@ -212,7 +212,7 @@
   `-- ws
       `-- workspace.josh
   
-  5 directories, 7 files
+  6 directories, 7 files
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [
@@ -414,6 +414,6 @@
           |-- namespaces
           `-- tags
   
-  99 directories, 90 files
+  100 directories, 90 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -102,7 +102,7 @@ Flushed credential cache
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ git log --graph --pretty=%s
   * add workspace
@@ -190,7 +190,7 @@ Flushed credential cache
   |   `-- file3
   `-- workspace.josh
   
-  5 directories, 4 files
+  6 directories, 4 files
 
   $ git log --graph --pretty=%s
   *   mod workspace
@@ -211,7 +211,7 @@ Flushed credential cache
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ git checkout HEAD~1 1> /dev/null
   Previous HEAD position was 003a297 add workspace
@@ -225,7 +225,7 @@ Flushed credential cache
       `-- subsub
           `-- file1
   
-  4 directories, 2 files
+  5 directories, 2 files
 
   $ git checkout master 1> /dev/null
   Previous HEAD position was 2a03ad0 add file2
@@ -309,7 +309,7 @@ Note that d/ is still in the tree but now it is not overlayed
   |-- workspace.josh
   `-- ws_file
   
-  6 directories, 7 files
+  7 directories, 7 files
 
   $ cat workspace.josh
   c = :/sub1
@@ -371,7 +371,7 @@ Note that ws/d/ is now present in the ws
       |-- workspace.josh
       `-- ws_file
   
-  6 directories, 10 files
+  7 directories, 10 files
   $ git log --graph --pretty=%s
   * try to modify ws
   * add in filter
@@ -407,7 +407,7 @@ Note that ws/d/ is now present in the ws
       |-- workspace.josh
       `-- ws_file
   
-  5 directories, 9 files
+  6 directories, 9 files
 
   $ git checkout HEAD~1 1> /dev/null
   Previous HEAD position was a1a7760 add in filter
@@ -428,7 +428,7 @@ Note that ws/d/ is now present in the ws
   `-- ws
       `-- workspace.josh
   
-  5 directories, 7 files
+  6 directories, 7 files
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [
@@ -818,6 +818,6 @@ Note that ws/d/ is now present in the ws
           |-- namespaces
           `-- tags
   
-  177 directories, 199 files
+  178 directories, 199 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -225,6 +225,6 @@
           |-- namespaces
           `-- tags
   
-  68 directories, 55 files
+  69 directories, 55 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -101,7 +101,7 @@
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -476,4 +476,4 @@
           |-- namespaces
           `-- tags
   
-  149 directories, 146 files
+  150 directories, 146 files

--- a/tests/proxy/workspace_errors.t
+++ b/tests/proxy/workspace_errors.t
@@ -38,7 +38,7 @@
   .
   `-- file1
   
-  0 directories, 1 file
+  1 directory, 1 file
 
 Error: comment in the middle
   $ cat > workspace.josh <<EOF

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -92,7 +92,7 @@
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ cat workspace.josh
   a/b = :/sub2
@@ -112,7 +112,7 @@
   |       `-- file1
   `-- workspace.josh
   
-  2 directories, 2 files
+  3 directories, 2 files
 
   $ git checkout master 1> /dev/null
   Previous HEAD position was 833812f add file1
@@ -161,7 +161,7 @@
   `-- ws
       `-- workspace.josh
   
-  5 directories, 9 files
+  6 directories, 9 files
 
   $ cat ws/workspace.josh
   c = :/sub1
@@ -495,5 +495,5 @@
           |-- namespaces
           `-- tags
   
-  128 directories, 122 files
+  129 directories, 122 files
 

--- a/tests/proxy/workspace_in_workspace_prefix.t
+++ b/tests/proxy/workspace_in_workspace_prefix.t
@@ -92,7 +92,7 @@
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ cat workspace.josh
   a/b = :/sub2
@@ -112,7 +112,7 @@
   |       `-- file1
   `-- workspace.josh
   
-  2 directories, 2 files
+  3 directories, 2 files
 
   $ git checkout master 1> /dev/null
   Previous HEAD position was 833812f add file1
@@ -161,7 +161,7 @@
   `-- ws
       `-- workspace.josh
   
-  5 directories, 9 files
+  6 directories, 9 files
 
   $ cat ws/workspace.josh
   c = :/sub1

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -82,7 +82,7 @@ Flushed credential cache
   |       `-- file1
   `-- workspace.josh
   
-  3 directories, 3 files
+  4 directories, 3 files
   $ cat workspace.josh
   a = :/sub1:[
       ::subsub1/
@@ -164,7 +164,7 @@ Flushed credential cache
   |       `-- file1
   `-- workspace.josh
   
-  3 directories, 3 files
+  4 directories, 3 files
 
   $ git log --graph --pretty=%s
   * mod workspace
@@ -317,4 +317,4 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  72 directories, 61 files
+  73 directories, 61 files

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -102,7 +102,7 @@ Flushed credential cache
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ git log --graph --pretty="%s - %an <%ae>"
   *   Merge from :workspace=ws - JOSH <josh@josh-project.dev>
@@ -196,7 +196,7 @@ Flushed credential cache
   |   `-- file3
   `-- workspace.josh
   
-  5 directories, 4 files
+  6 directories, 4 files
 
   $ git log --graph --pretty=%s
   *   mod workspace
@@ -219,7 +219,7 @@ Flushed credential cache
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ git checkout HEAD~1 1> /dev/null
   Previous HEAD position was d91fa49 Merge from :workspace=ws
@@ -228,7 +228,7 @@ Flushed credential cache
   .
   `-- workspace.josh
   
-  0 directories, 1 file
+  1 directory, 1 file
 
   $ git checkout master 1> /dev/null
   Previous HEAD position was 9441c1b add workspace
@@ -309,7 +309,7 @@ Flushed credential cache
   |-- workspace.josh
   `-- ws_file
   
-  5 directories, 6 files
+  6 directories, 6 files
 
   $ cat workspace.josh
   c = :/sub1
@@ -369,7 +369,7 @@ Note that ws/d/ is now present in the ws
       |-- workspace.josh
       `-- ws_file
   
-  5 directories, 9 files
+  6 directories, 9 files
   $ git log --graph --pretty=%s
   * try to modify ws
   * add in filter
@@ -407,7 +407,7 @@ Note that ws/d/ is now present in the ws
       |-- workspace.josh
       `-- ws_file
   
-  5 directories, 9 files
+  6 directories, 9 files
 
   $ git checkout HEAD~1 1> /dev/null
   Previous HEAD position was c88a8ce add in filter
@@ -428,7 +428,7 @@ Note that ws/d/ is now present in the ws
   `-- ws
       `-- workspace.josh
   
-  5 directories, 7 files
+  6 directories, 7 files
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [
@@ -809,6 +809,6 @@ Note that ws/d/ is now present in the ws
           |-- namespaces
           `-- tags
   
-  175 directories, 193 files
+  176 directories, 193 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -104,7 +104,7 @@
   `-- d
       `-- file3
   
-  5 directories, 3 files
+  6 directories, 3 files
  
   $ git log --graph --pretty=%s
   *   mod workspace
@@ -123,7 +123,7 @@
       `-- subsub
           `-- file1
   
-  4 directories, 2 files
+  5 directories, 2 files
  
   $ git checkout HEAD~1 1> /dev/null
   Previous HEAD position was 2a03ad0 add file2
@@ -134,7 +134,7 @@
       `-- subsub
           `-- file1
   
-  2 directories, 1 file
+  3 directories, 1 file
  
   $ git checkout master 1> /dev/null
   Previous HEAD position was 02668d7 add file1
@@ -178,7 +178,7 @@
       |   `-- ws_file
       `-- workspace.josh
   
-  6 directories, 9 files
+  7 directories, 9 files
   $ git log --graph --pretty=%s
   * add in filter
   * mod workspace
@@ -211,7 +211,7 @@
   `-- ws
       `-- workspace.josh
   
-  5 directories, 7 files
+  6 directories, 7 files
   $ cat sub1/subsub/file1
   contents1
  
@@ -234,7 +234,7 @@
   `-- ws
       `-- workspace.josh
   
-  5 directories, 7 files
+  6 directories, 7 files
  
  
   $ bash ${TESTDIR}/destroy_test_env.sh
@@ -525,6 +525,6 @@
           |-- namespaces
           `-- tags
   
-  137 directories, 139 files
+  138 directories, 139 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -101,7 +101,7 @@
   |   `-- file3
   `-- workspace.josh
   
-  5 directories, 4 files
+  6 directories, 4 files
 
   $ git log --graph --pretty=%s
   *   mod workspace
@@ -122,7 +122,7 @@
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ git checkout -q HEAD~1 1> /dev/null
   $ tree
@@ -134,7 +134,7 @@
       `-- subsub
           `-- file1
   
-  4 directories, 2 files
+  5 directories, 2 files
 
   $ git checkout -q master 1> /dev/null
 
@@ -200,7 +200,7 @@ Note that d/ is still in the tree but now it is not overlayed
   |-- workspace.josh
   `-- ws_file
   
-  5 directories, 6 files
+  6 directories, 6 files
 
 
 
@@ -232,7 +232,7 @@ Note that ws/d/ is now present in the ws
       |-- workspace.josh
       `-- ws_file
   
-  5 directories, 9 files
+  6 directories, 9 files
   $ git log --graph --pretty=%s
   * try to modify ws
   * add in filter
@@ -271,7 +271,7 @@ Note that ws/d/ is now present in the ws
       |-- workspace.josh
       `-- ws_file
   
-  5 directories, 9 files
+  6 directories, 9 files
 
   $ git checkout -q HEAD~1 1> /dev/null
   $ git clean -ffdx 1> /dev/null
@@ -290,7 +290,7 @@ Note that ws/d/ is now present in the ws
   `-- ws
       `-- workspace.josh
   
-  5 directories, 7 files
+  6 directories, 7 files
 
 
   $ bash ${TESTDIR}/destroy_test_env.sh
@@ -652,6 +652,6 @@ Note that ws/d/ is now present in the ws
           |-- namespaces
           `-- tags
   
-  166 directories, 182 files
+  167 directories, 182 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_mv_folder.t
+++ b/tests/proxy/workspace_mv_folder.t
@@ -102,7 +102,7 @@ Flushed credential cache
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ git log --graph --pretty=%s
   *   Merge from :workspace=ws
@@ -188,7 +188,7 @@ Flushed credential cache
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ git log --graph --pretty=%s
   * mod workspace
@@ -223,7 +223,7 @@ Flushed credential cache
   `-- ws
       `-- workspace.josh
   
-  4 directories, 6 files
+  5 directories, 6 files
   $ git log --graph --pretty=%s
   * mod workspace
   *   Merge from :workspace=ws

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -63,7 +63,7 @@ file was created
   |-- file1
   `-- workspace.josh
   
-  2 directories, 3 files
+  3 directories, 3 files
 
   $ git log --graph --pretty=%s
   * add file1
@@ -77,7 +77,7 @@ file was created
   |-- file1
   `-- workspace.josh
   
-  0 directories, 2 files
+  1 directory, 2 files
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [
@@ -177,6 +177,6 @@ file was created
           |-- namespaces
           `-- tags
   
-  51 directories, 38 files
+  52 directories, 38 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -50,7 +50,7 @@
   |       `-- file2
   `-- workspace.josh
   
-  2 directories, 2 files
+  3 directories, 2 files
 
   $ git log --graph --pretty=%s
   * add file2
@@ -96,7 +96,7 @@
   `-- ws
       `-- workspace.josh
   
-  4 directories, 4 files
+  5 directories, 4 files
   $ git log --graph --pretty=%s
   * publish
   * add in filter
@@ -115,7 +115,7 @@
       |       `-- newfile_1
       `-- workspace.josh
   
-  4 directories, 4 files
+  5 directories, 4 files
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [
@@ -280,6 +280,6 @@
           |-- namespaces
           `-- tags
   
-  82 directories, 73 files
+  83 directories, 73 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -92,7 +92,7 @@
   |       `-- file1
   `-- workspace.josh
   
-  4 directories, 3 files
+  5 directories, 3 files
 
   $ cat workspace.josh
   a/b = :/sub2
@@ -451,6 +451,6 @@
           |-- namespaces
           `-- tags
   
-  113 directories, 107 files
+  114 directories, 107 files
 
 $ cat ${TESTTMP}/josh-proxy.out


### PR DESCRIPTION
* Pin dockerfile frontend version using `@sha256`. This results in faster launch of tests because Docker daemon does not need to connect to the registry to check whether the tag has changed. It also results in more predictable builds
* Update rust version to latest
    * Use `resolver = "2"`. If this is unset, newer rustc will complain about it
* Update alpine base image version
    * `tree` has changed behaviour, so update cram test files
* Update cargo-chef version