### PR TITLE
Add open_from_env helper

### DIFF
--- a/josh-core/src/cache.rs
+++ b/josh-core/src/cache.rs
@@ -87,13 +87,27 @@ impl Transaction {
         ))
     }
 
+    pub fn open_from_env(load_cache: bool) -> JoshResult<Transaction> {
+        let repo = git2::Repository::open_from_env()?;
+        let path = repo.path().to_owned();
+        if load_cache {
+            load(&path)?
+        };
+
+        Ok(Transaction::new(
+            repo,
+            gix::ThreadSafeRepository::open(path)?.to_thread_local(),
+            None,
+        ))
+    }
+
     pub fn status(&self, _msg: &str) {
         /* let mut t2 = self.t2.borrow_mut(); */
         /* write!(t2.out, "{}", msg).ok(); */
         /* t2.out.flush().ok(); */
     }
 
-    pub fn new(
+    fn new(
         repo: git2::Repository,
         oxide_repo: gix::Repository,
         ref_prefix: Option<&str>,

--- a/josh-filter/src/bin/josh-filter.rs
+++ b/josh-filter/src/bin/josh-filter.rs
@@ -147,15 +147,9 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
 
     let mut filterobj = josh::filter::parse(&specstr)?;
 
-    let repo = git2::Repository::open_from_env()?;
-    if !args.get_flag("no-cache") {
-        josh::cache::load(repo.path())?;
-    }
+    let transaction = josh::cache::Transaction::open_from_env(!args.get_flag("no-cache"))?;
 
-    let oxide_repo = gix::ThreadSafeRepository::open(repo.path())?;
-    let transaction = josh::cache::Transaction::new(repo, oxide_repo.to_thread_local(), None);
     let repo = transaction.repo();
-
     let input_ref = args.get_one::<String>("input").unwrap();
 
     let mut refs = vec![];
@@ -418,9 +412,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
     std::mem::drop(finish);
 
     if let Some(query) = args.get_one::<String>("query") {
-        let repo = git2::Repository::open_from_env()?;
-        let oxide_repo = gix::ThreadSafeRepository::open(repo.path())?;
-        let transaction = josh::cache::Transaction::new(repo, oxide_repo.to_thread_local(), None);
+        let transaction = josh::cache::Transaction::open_from_env(false)?;
         let commit_id = transaction.repo().refname_to_id(update_target)?;
         print!(
             "{}",


### PR DESCRIPTION
This allows to make cache::new a private function and remove some boilerplate from josh-filter.rs

Change: open-from-env