### PR TITLE
Upgrade Rust edition

### DIFF
--- a/hyper_cgi/Cargo.toml
+++ b/hyper_cgi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hyper_cgi"
 version = "22.10.25"
 authors = ["Christian Schilling <initcrash@gmail.com>", "Louis-Marie Givel <louis-marie.givel@esrlabs.com>"]
-edition = "2018"
+edition = "2021"
 license-file = "LICENSE"
 description = "Run CGI scripts with hyper"
 repository = "https://github.com/josh-project/josh"

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "LICENSE"
 description = "GIT virtualization proxy"
 keywords = ["git", "monorepo", "workflow", "scm"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 backtrace = "0.3.69"

--- a/josh-filter/Cargo.toml
+++ b/josh-filter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Christian Schilling <christian.schilling@esrlabs.com>"]
 description = "GIT filter cli"
-edition = "2018"
+edition = "2021"
 keywords = ["git", "monorepo", "workflow", "scm"]
 license-file = "LICENSE"
 name = "josh-filter"

--- a/josh-proxy/Cargo.toml
+++ b/josh-proxy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Christian Schilling <christian.schilling@esrlabs.com>"]
 description = "GIT virtualization proxy"
-edition = "2018"
+edition = "2021"
 keywords = ["git", "monorepo", "workflow", "scm"]
 license-file = "LICENSE"
 name = "josh-proxy"

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -510,7 +510,6 @@ fn create_repo_base(path: &PathBuf) -> josh::JoshResult<josh::shell::Shell> {
                 .cloned()
                 .try_for_each(|(key, value)| -> JoshResult<()> {
                     use gix::config::parse::section::Key;
-                    use std::convert::TryFrom;
 
                     let key = Key::try_from(key)
                         .map_err(|_| josh_error("unable to create config section"))?;

--- a/josh-rpc/Cargo.toml
+++ b/josh-rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "josh-rpc"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 serde = { workspace = true }

--- a/josh-ssh-shell/Cargo.toml
+++ b/josh-ssh-shell/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "josh-ssh-shell"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 clap = { workspace = true }


### PR DESCRIPTION
All crates in workspace are now 2021 Rust

---

**Stack**:
- #1284
- #1283 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*