### PR TITLE
josh-proxy.rs: bind dualstacked

### DIFF
--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -1426,7 +1426,7 @@ fn trace_http_response_code(trace_span: Span, http_status: StatusCode) {
 
 #[tokio::main]
 async fn run_proxy() -> josh::JoshResult<i32> {
-    let addr = format!("0.0.0.0:{}", ARGS.port).parse()?;
+    let addr = format!("[::]:{}", ARGS.port).parse()?;
     let upstream = match (&ARGS.remote.http, &ARGS.remote.ssh) {
         (Some(http), None) => JoshProxyUpstream::Http(http.clone()),
         (None, Some(ssh)) => JoshProxyUpstream::Ssh(ssh.clone()),


### PR DESCRIPTION
Binding on 0.0.0.0 will cause josh to only listen on IPv4, while specifying `[::]` will bind on *both* IPv4 and IPv6.

With this change:

```
❯ ss -ltpn | grep 8000
LISTEN 0      128                *:8000            *:*    users:(("josh-proxy",pid=1894190,fd=10))
```