### PR TITLE
Use define instead of #![deny(warning)]

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLFAGS: "-D warnings"
 
 jobs:
   build:

--- a/josh-filter/src/bin/josh-filter.rs
+++ b/josh-filter/src/bin/josh-filter.rs
@@ -1,4 +1,3 @@
-#![deny(warnings)]
 #![warn(unused_extern_crates)]
 
 #[macro_use]

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -1,4 +1,3 @@
-#![deny(warnings)]
 #[macro_use]
 extern crate lazy_static;
 extern crate clap;

--- a/tester.sh
+++ b/tester.sh
@@ -48,6 +48,7 @@ if [[ ! -v CARGO_TARGET_DIR ]]; then
     exit 1
 fi
 
+export RUSTFLFAGS="-D warnings"
 cargo build --workspace --exclude josh-ui --features hyper_cgi/test-server
 ( cd josh-ssh-dev-server ; go build -o "\${CARGO_TARGET_DIR}/josh-ssh-dev-server" )
 sh run-tests.sh ${TESTS}


### PR DESCRIPTION
Setting #![deny(warnings) in the source can cause josh fail to build on different versions of rustc.
This way we only ensure there are no warnings on our "officially supported" rustc version, but allow building on other versions as well.

Change: warnings