### PR TITLE
Make compose and subtract single traversal

### DIFF
--- a/tests/filter/compose_shadow_dir_same_name.t
+++ b/tests/filter/compose_shadow_dir_same_name.t
@@ -86,17 +86,9 @@
   +contents1
 
   $ josh-filter -s ":[:/sub/xx::file3,:/sub1,:/xx,:/sub/xx]"
-  [1] :/sub1
-  [1] ::file3
-  [2] :/sub
-  [3] :/xx
   [3] :[
       :/sub/xx::file3
       :/sub1
-      :/xx
-      :/sub/xx
-  ]
-  [3] :[
       :/xx
       :/sub/xx
   ]

--- a/tests/filter/empty_orphan.t
+++ b/tests/filter/empty_orphan.t
@@ -95,7 +95,6 @@ Empty root commits from unrelated parts of the tree should not be included
   c/file3
 
   $ josh-filter -s c=:exclude[::sub1/] master
-  [4] :prefix=sub1
   [5] :/sub1
   [5] :exclude[::sub1/]
   [6] :prefix=c
@@ -111,7 +110,6 @@ Empty root commits from unrelated parts of the tree should not be included
 
   $ josh-filter -s :prefix=x FILTERED_HEAD
   [3] :prefix=x
-  [4] :prefix=sub1
   [5] :/sub1
   [5] :exclude[::sub1/]
   [6] :prefix=c

--- a/tests/filter/exclude_compose.t
+++ b/tests/filter/exclude_compose.t
@@ -20,8 +20,6 @@
   $ git commit -m "add file3" 1> /dev/null
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
-  [1] :prefix=sub2
-  [2] :/sub2
   [2] :exclude[::sub2/]
   $ git checkout -q hidden 1> /dev/null
   $ tree
@@ -41,14 +39,6 @@
   $ git commit -m "add sub1/file3" 1> /dev/null
 
   $ josh-filter -s :exclude[::sub1/,::sub2/] master --update refs/josh/filtered
-  [1] :/sub1
-  [1] :prefix=sub1
-  [1] :prefix=sub2
-  [2] :/sub2
-  [2] :[
-      ::sub1/
-      ::sub2/
-  ]
   [2] :exclude[
       ::sub1/
       ::sub2/
@@ -64,20 +54,11 @@
   2 directories, 1 file
 
   $ josh-filter -s :exclude[sub1=:/sub3] master --update refs/josh/filtered
-  [1] :/sub1
-  [1] :prefix=sub2
-  [2] :/sub2
-  [2] :/sub3
-  [2] :[
-      ::sub1/
-      ::sub2/
-  ]
   [2] :exclude[
       ::sub1/
       ::sub2/
   ]
   [2] :exclude[::sub2/]
-  [2] :prefix=sub1
   [3] :exclude[:/sub3:prefix=sub1]
 
   $ git checkout -q refs/josh/filtered

--- a/tests/filter/file.t
+++ b/tests/filter/file.t
@@ -29,11 +29,6 @@
   $ git commit -m "initial" 1> /dev/null
 
   $ josh-filter -s --file file.josh
-  [1] :prefix=a
-  [1] :prefix=b
-  [2] :/sub1
-  [2] :/sub2
-  [2] :prefix=c
   [3] :[
       c = :/sub1
       a/b = :/sub2
@@ -44,11 +39,6 @@
   * add file1
 
   $ josh-filter -s --single --file file.josh
-  [2] :prefix=a
-  [2] :prefix=b
-  [3] :/sub1
-  [3] :/sub2
-  [3] :prefix=c
   [4] :[
       c = :/sub1
       a/b = :/sub2

--- a/tests/filter/hide_view.t
+++ b/tests/filter/hide_view.t
@@ -35,9 +35,7 @@
 
   $ josh-filter -s c=:exclude[::sub1/] master --update refs/josh/filter/master
   [1] :prefix=c
-  [2] :/sub1
   [2] :exclude[::sub1/]
-  [2] :prefix=sub1
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
   * add file3
@@ -50,11 +48,8 @@
   3 directories, 1 file
 
   $ josh-filter -s c=:exclude[::sub1/file2] master --update refs/josh/filter/master
-  [2] :/sub1
-  [2] ::sub1/file2
   [2] :exclude[::sub1/]
   [2] :exclude[::sub1/file2]
-  [2] :prefix=sub1
   [3] :prefix=c
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
@@ -71,13 +66,9 @@
   4 directories, 2 files
 
   $ josh-filter -s c=:exclude[::sub2/file3] master --update refs/josh/filter/master
-  [2] :/sub1
-  [2] ::sub1/file2
-  [2] ::sub2/file3
   [2] :exclude[::sub1/]
   [2] :exclude[::sub1/file2]
   [2] :exclude[::sub2/file3]
-  [2] :prefix=sub1
   [4] :prefix=c
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s

--- a/tests/filter/reverse_hide.t
+++ b/tests/filter/reverse_hide.t
@@ -16,8 +16,6 @@
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   [1] :exclude[::sub2/]
-  [1] :prefix=sub2
-  [2] :/sub2
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
   $ tree
@@ -35,8 +33,6 @@
 
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   [1] :exclude[::sub2/]
-  [1] :prefix=sub2
-  [2] :/sub2
 
   $ git checkout master
   Switched to branch 'master'
@@ -70,8 +66,6 @@
   $ git commit -m "empty commit" --allow-empty 1> /dev/null
 
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
-  [1] :prefix=sub2
-  [2] :/sub2
   [2] :exclude[::sub2/]
   $ git log --graph --pretty=%s refs/heads/master
   * empty commit

--- a/tests/filter/reverse_hide_edit.t
+++ b/tests/filter/reverse_hide_edit.t
@@ -16,8 +16,6 @@
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   [1] :exclude[::sub2/]
-  [1] :prefix=sub2
-  [2] :/sub2
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
   $ tree
@@ -35,8 +33,6 @@
 
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   [1] :exclude[::sub2/]
-  [1] :prefix=sub2
-  [2] :/sub2
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/reverse_hide_edit_missing_change.t
+++ b/tests/filter/reverse_hide_edit_missing_change.t
@@ -29,8 +29,6 @@
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   [1] :exclude[::sub2/]
-  [2] :/sub2
-  [2] :prefix=sub2
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
   $ tree
@@ -50,8 +48,6 @@
 
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   [1] :exclude[::sub2/]
-  [2] :/sub2
-  [2] :prefix=sub2
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/reverse_merge.t
+++ b/tests/filter/reverse_merge.t
@@ -25,8 +25,6 @@
   * add sub2
 
   $ josh-filter -s :exclude[::sub2/] branch1 --update refs/heads/hidden_branch1
-  [1] :/sub2
-  [1] :prefix=sub2
   [2] :exclude[::sub2/]
   $ git checkout hidden_branch1
   Switched to branch 'hidden_branch1'
@@ -41,8 +39,6 @@
   $ git commit -m "add file3" 1> /dev/null
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden_master
-  [1] :/sub2
-  [1] :prefix=sub2
   [3] :exclude[::sub2/]
   $ git checkout hidden_master
   Switched to branch 'hidden_master'
@@ -76,8 +72,6 @@
   * add file1
 
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden_master
-  [1] :/sub2
-  [1] :prefix=sub2
   [3] :exclude[::sub2/]
 
   $ git checkout master

--- a/tests/filter/reverse_split.t
+++ b/tests/filter/reverse_split.t
@@ -14,13 +14,10 @@
   $ git commit -m "add file2.b" 1> /dev/null
 
   $ josh-filter -s $FILTER master --update refs/heads/filtered
-  [1] ::*.a
-  [1] :prefix=a
   [2] :[
       a = ::*.a
       :prefix=rest
   ]
-  [2] :prefix=rest
   $ git checkout filtered 1> /dev/null
   Switched to branch 'filtered'
   $ tree
@@ -41,13 +38,10 @@
   $ git commit -m "add files" 1> /dev/null
 
   $ josh-filter -s $FILTER --reverse master --update refs/heads/filtered
-  [1] ::*.a
-  [1] :prefix=a
   [2] :[
       a = ::*.a
       :prefix=rest
   ]
-  [2] :prefix=rest
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/workspace_combine_filter.t
+++ b/tests/filter/workspace_combine_filter.t
@@ -50,12 +50,6 @@
   7 directories, 5 files
 
   $ josh-filter -s :workspace=ws
-  [1] :/sub1
-  [1] :/subsub
-  [1] :prefix=sub1
-  [1] :prefix=sub2
-  [1] :prefix=subsub
-  [2] :/sub2
   [2] :[
       ::sub1/
       ::sub2/subsub/
@@ -83,27 +77,13 @@
 
   $ git checkout master 2> /dev/null
   $ josh-filter -s :workspace=ws2
-  [1] :/sub1
-  [1] :/subsub
-  [1] :prefix=blub
-  [1] :prefix=sub1
-  [1] :prefix=sub2
-  [1] :prefix=sub3
-  [1] :prefix=subsub
-  [2] :/sub2
-  [2] :/sub3
   [2] :[
       ::sub1/
       ::sub2/subsub/
   ]
-  [2] :prefix=a
   [2] :prefix=x
   [2] :workspace=ws
   [2] :workspace=ws2
-  [3] :[
-      ::sub2/subsub/
-      ::sub3/
-  ]
   [3] :[
       a = :[
           ::sub2/subsub/

--- a/tests/filter/workspace_exclude.t
+++ b/tests/filter/workspace_exclude.t
@@ -24,14 +24,6 @@
   $ git commit -m "add ws" 1> /dev/null
 
   $ josh-filter -s :workspace=ws master --update refs/heads/filtered
-  [1] :/sub1
-  [1] :/subsub
-  [1] ::file1
-  [1] :exclude[::file1]
-  [1] :prefix=a
-  [1] :prefix=sub2
-  [1] :prefix=subsub
-  [2] :/sub2
   [2] :[
       a = :/sub1:exclude[::file1]
       ::sub2/subsub/
@@ -62,14 +54,6 @@
   $ git commit -m "add 1X" 1> /dev/null
 
   $ josh-filter -s :workspace=ws --reverse master --update refs/heads/filtered
-  [1] :/sub1
-  [1] :/subsub
-  [1] ::file1
-  [1] :exclude[::file1]
-  [1] :prefix=a
-  [1] :prefix=sub2
-  [1] :prefix=subsub
-  [2] :/sub2
   [2] :[
       a = :/sub1:exclude[::file1]
       ::sub2/subsub/

--- a/tests/filter/workspace_implicit_filter.t
+++ b/tests/filter/workspace_implicit_filter.t
@@ -23,12 +23,6 @@
   $ git commit -m "add ws" 1> /dev/null
 
   $ josh-filter -s :workspace=ws master --update refs/josh/master
-  [1] :/sub1
-  [1] :/subsub
-  [1] :prefix=sub1
-  [1] :prefix=sub2
-  [1] :prefix=subsub
-  [2] :/sub2
   [2] :[
       ::sub1/
       ::sub2/subsub/

--- a/tests/filter/workspace_multiple_globs.t
+++ b/tests/filter/workspace_multiple_globs.t
@@ -28,14 +28,10 @@
   $ git commit -m "add ws" 1> /dev/null
 
   $ josh-filter -s :workspace=ws master --update refs/josh/master
-  [1] ::**/file1
-  [1] :prefix=b
-  [2] ::**/file2
   [2] :[
       a = ::**/file2
       b = ::**/file1
   ]
-  [2] :prefix=a
   [2] :workspace=ws
 
   $ git log --graph --pretty=%s refs/josh/master

--- a/tests/filter/workspace_redirect.t
+++ b/tests/filter/workspace_redirect.t
@@ -33,25 +33,12 @@
   $ git commit -m "add ws_new" 1> /dev/null
 
   $ josh-filter -s :workspace=ws master --update refs/heads/filtered
-  [1] :/sub1
-  [1] :/subsub
-  [1] :prefix=a
-  [1] :prefix=sub2
-  [1] :prefix=subsub
-  [2] :/sub2
   [2] :[
       a = :/sub1
       ::sub2/subsub/
   ]
   [2] :workspace=ws
   $ josh-filter -s :workspace=ws_new master --update refs/heads/filtered_new
-  [1] :/sub1
-  [1] :/subsub
-  [1] :prefix=a
-  [1] :prefix=sub2
-  [1] :prefix=subsub
-  [2] :/sub2
-  [2] ::ws_new
   [2] :[
       a = :/sub1
       ::sub2/subsub/
@@ -151,18 +138,10 @@
   $ git commit -m "add ws recursion" 1> /dev/null
 
   $ josh-filter -s :workspace=ws master --update refs/heads/filtered
-  [1] :/sub1
-  [1] :/subsub
-  [1] :prefix=a
-  [1] :prefix=sub2
-  [1] :prefix=subsub
-  [2] :/sub2
   [2] :[
       a = :/sub1
       ::sub2/subsub/
   ]
   [2] :workspace=ws
-  [3] ::ws
-  [3] ::ws_new
   [3] :exclude[::ws]
   [3] :exclude[::ws_new]

--- a/tests/filter/workspace_single_file.t
+++ b/tests/filter/workspace_single_file.t
@@ -38,17 +38,6 @@
   $ git commit -m "add ws2" 1> /dev/null
 
   $ josh-filter -s :workspace=ws master --update refs/josh/master
-  [1] :/sub1
-  [1] :/subsub
-  [1] ::file1
-  [1] ::file2
-  [1] :[
-      ::file1
-      ::file2
-  ]
-  [1] :prefix=sub2
-  [1] :prefix=subsub
-  [2] :/sub2
   [2] :[
       :/sub1:[
           ::file1
@@ -81,18 +70,6 @@
   3 directories, 4 files
 
   $ josh-filter -s :workspace=ws2 master --update refs/josh/master
-  [1] :/sub1
-  [1] :/subsub
-  [1] ::file1
-  [1] ::file2
-  [1] :[
-      ::file1
-      ::file2
-  ]
-  [1] :prefix=sub2
-  [1] :prefix=subsub
-  [2] :/sub2
-  [2] ::sub2/subsub
   [2] :[
       :/sub1:[
           ::file1

--- a/tests/filter/workspace_trailing_slash.t
+++ b/tests/filter/workspace_trailing_slash.t
@@ -23,11 +23,6 @@
   $ git commit -m "add ws" 1> /dev/null
 
   $ josh-filter -s :workspace=ws master --update refs/josh/master
-  [1] :/sub1
-  [1] :prefix=a
-  [1] :prefix=b
-  [1] :prefix=c
-  [2] :/sub2
   [2] :[
       c = :/sub1
       a/b = :/sub2
@@ -48,11 +43,6 @@
   $ git commit -m "add trailing slash" 1> /dev/null
 
   $ josh-filter -s :workspace=ws master --update refs/josh/master
-  [1] :/sub1
-  [1] :prefix=a
-  [1] :prefix=b
-  [1] :prefix=c
-  [2] :/sub2
   [2] :[
       c = :/sub1
       a/b = :/sub2

--- a/tests/filter/workspace_unique.t
+++ b/tests/filter/workspace_unique.t
@@ -29,18 +29,6 @@ so the workspace.josh will still appear in the root of the workspace
   $ git commit -m "add ws" 1> /dev/null
 
   $ josh-filter -s :workspace=ws master --update refs/josh/master
-  [1] :/sub1
-  [1] :/subsub
-  [1] ::file1
-  [1] ::ws/workspace.josh
-  [1] :[
-      ::file1
-      :prefix=a
-  ]
-  [1] :prefix=a
-  [1] :prefix=sub2
-  [1] :prefix=subsub
-  [2] :/sub2
   [2] :[
       :/sub1:[
           ::file1

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -568,8 +568,6 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
       |   |-- 09
       |   |   `-- b613e901acc0b5e4279ec6732261134a06f667
-      |   |-- 0b
-      |   |   `-- 976ee9223f2a23c5339d6cb3bda2196dbae6b1
       |   |-- 0c
       |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
       |   |-- 10
@@ -591,8 +589,6 @@ Note that ws/d/ is now present in the ws
       |   |   `-- d20398ffe09015ada5794763b97c750b61bdc4
       |   |-- 27
       |   |   `-- d0eee16bdbe4a1ade0ebf877f97467de3b218e
-      |   |-- 28
-      |   |   `-- a3e71d163a9eb30c3639b16a16f57077abf29b
       |   |-- 2a
       |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
       |   |   |-- 3e798288165d5b090a10460984776489bcc7cc
@@ -674,7 +670,6 @@ Note that ws/d/ is now present in the ws
       |   |-- 98
       |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
       |   |-- 99
-      |   |   |-- 8e4d99b52680e8fc6d50d98cddad2a4e36a604
       |   |   `-- acd82fe2a9b89022d1aee5a580c123a8161f4a
       |   |-- 9c
       |   |   `-- 78c532d93505a2a24430635b342b91db22fee0
@@ -732,8 +727,7 @@ Note that ws/d/ is now present in the ws
       |   |-- e9
       |   |   `-- 9a2c69c0fb10af8dd1524e7f976df3d898f6ac
       |   |-- ea
-      |   |   |-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
+      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
       |   |-- ec
       |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
       |   |-- ee
@@ -761,6 +755,6 @@ Note that ws/d/ is now present in the ws
           |-- namespaces
           `-- tags
   
-  156 directories, 164 files
+  154 directories, 160 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -343,8 +343,6 @@
       |   |   `-- 80a5b3af9023d11cb7f37bc1f80d1d1805bfdb
       |   |-- 6c
       |   |   `-- 68dd37602c8e2036362ab81b12829c4d6c0867
-      |   |-- 6f
-      |   |   `-- 4738ef61827430896308fa64a1d16a29f3d037
       |   |-- 74
       |   |   `-- 3fcd7100630aea3ab423c23ec9c012549467ad
       |   |-- 75
@@ -353,8 +351,6 @@
       |   |   `-- 9e718288ea6c1390adb2b1b6cd8c2c73f2785b
       |   |-- 78
       |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 7b
-      |   |   `-- 2c507bf65a8974bf12cc3ecaa2d64c83725b89
       |   |-- 7c
       |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
       |   |-- 7f
@@ -380,8 +376,6 @@
       |   |-- 9f
       |   |   |-- 24b55d4263082d93987e2c0ff6b24df3323f5b
       |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
-      |   |-- a3
-      |   |   `-- c7a71fc22700d5f53defd99609e96296417985
       |   |-- a7
       |   |   |-- 7106b607ba6489028e85eeec937463cc29c39a
       |   |   `-- cf4e83688bf0ec633d4e4abae4b74dce4852ba
@@ -401,8 +395,6 @@
       |   |   `-- a4b41bb449aa6f5f0be272340b83b3f3317ff8
       |   |-- c2
       |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
-      |   |-- c4
-      |   |   `-- ccf3ecba27a8189d2a616afa8c278f75d0bc1a
       |   |-- c5
       |   |   `-- ab31f80e2b8c97a7d354d252272a9eaebd4581
       |   |-- c7
@@ -441,4 +433,4 @@
           |-- namespaces
           `-- tags
   
-  133 directories, 128 files
+  129 directories, 124 files

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -274,8 +274,7 @@ Flushed credential cache
       |   |-- 66
       |   |   `-- 1bafe5fb60524a9efafd413c42e4c2d706bae8
       |   |-- 6c
-      |   |   |-- 8233465e92d353e2ef47c02dc568ea44a32339
-      |   |   `-- 9e5f368b68b7e511f7b0ce25cbedd2a3b42abb
+      |   |   `-- 8233465e92d353e2ef47c02dc568ea44a32339
       |   |-- 70
       |   |   `-- 5dcb4e33bd0dd3f95d5831fc8dc8a41ca3e566
       |   |-- 7b
@@ -296,16 +295,12 @@ Flushed credential cache
       |   |   `-- 398140f110f4009f1fce46e15f9fc140d6908b
       |   |-- 9d
       |   |   `-- 613be55337cdfab189935d8dbd1d4f427ef75e
-      |   |-- a1
-      |   |   `-- fe09109ceb8c170db78421172e3674ff18f762
       |   |-- b7
       |   |   `-- 8eb888451be077531b50794384c2faec025765
       |   |-- cd
       |   |   `-- 9ae8cb61e7d1aaa7b90766ff9aa9b3dc78c856
       |   |-- db
       |   |   `-- 9120ba624b0afe79d37a5a262d8deb14e13707
-      |   |-- df
-      |   |   `-- 19fd70c60593952f558740288b01384068e17c
       |   |-- f0
       |   |   `-- 2803a3f6b703de58a33b330f70b5034e0ebcf8
       |   |-- f7
@@ -317,4 +312,4 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  73 directories, 61 files
+  71 directories, 58 files

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -568,8 +568,6 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
       |   |-- 09
       |   |   `-- b613e901acc0b5e4279ec6732261134a06f667
-      |   |-- 0b
-      |   |   `-- 976ee9223f2a23c5339d6cb3bda2196dbae6b1
       |   |-- 0c
       |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
       |   |-- 0e
@@ -589,8 +587,6 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 189c97a0ef53368b7ec335baa7a1b86bd76f8e
       |   |-- 23
       |   |   `-- d20398ffe09015ada5794763b97c750b61bdc4
-      |   |-- 28
-      |   |   `-- a3e71d163a9eb30c3639b16a16f57077abf29b
       |   |-- 2a
       |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
       |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
@@ -685,7 +681,6 @@ Note that ws/d/ is now present in the ws
       |   |-- 98
       |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
       |   |-- 99
-      |   |   |-- 8e4d99b52680e8fc6d50d98cddad2a4e36a604
       |   |   `-- acd82fe2a9b89022d1aee5a580c123a8161f4a
       |   |-- 9c
       |   |   `-- 78c532d93505a2a24430635b342b91db22fee0
@@ -744,8 +739,7 @@ Note that ws/d/ is now present in the ws
       |   |-- e9
       |   |   `-- 9a2c69c0fb10af8dd1524e7f976df3d898f6ac
       |   |-- ea
-      |   |   |-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
+      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
       |   |-- ec
       |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
       |   |-- ee
@@ -772,6 +766,6 @@ Note that ws/d/ is now present in the ws
           |-- namespaces
           `-- tags
   
-  165 directories, 167 files
+  163 directories, 163 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -344,8 +344,6 @@
       |   |   `-- 668d7af968c8eed910db7539a57b18dd62a50e
       |   |-- 04
       |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
-      |   |-- 0b
-      |   |   `-- 976ee9223f2a23c5339d6cb3bda2196dbae6b1
       |   |-- 0c
       |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
       |   |-- 13
@@ -361,8 +359,6 @@
       |   |   `-- 5dccdc2e37df9aaccec46009520154219134e7
       |   |-- 27
       |   |   `-- d0eee16bdbe4a1ade0ebf877f97467de3b218e
-      |   |-- 28
-      |   |   `-- a3e71d163a9eb30c3639b16a16f57077abf29b
       |   |-- 2a
       |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
       |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
@@ -428,8 +424,6 @@
       |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
       |   |-- 98
       |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
-      |   |-- 99
-      |   |   `-- 8e4d99b52680e8fc6d50d98cddad2a4e36a604
       |   |-- 9d
       |   |   `-- e3bbb26e2b40f02ca8de195933eb620bbf0b6a
       |   |-- 9e
@@ -475,8 +469,7 @@
       |   |-- e8
       |   |   `-- d34a664c80ff36cdff2c41c1fd3964f6e30f00
       |   |-- ea
-      |   |   |-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
+      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
       |   |-- ec
       |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
       |   |-- ef
@@ -499,6 +492,6 @@
           |-- namespaces
           `-- tags
   
-  127 directories, 124 files
+  124 directories, 120 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -427,8 +427,6 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
       |   |-- 09
       |   |   `-- b613e901acc0b5e4279ec6732261134a06f667
-      |   |-- 0b
-      |   |   `-- 976ee9223f2a23c5339d6cb3bda2196dbae6b1
       |   |-- 0c
       |   |   |-- 66ddcaed3f256f7dacc400a684aa1b91ac638f
       |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
@@ -448,8 +446,6 @@ Note that ws/d/ is now present in the ws
       |   |   `-- d20398ffe09015ada5794763b97c750b61bdc4
       |   |-- 27
       |   |   `-- 5b45aec0a1c944c3a4c71cc71ee08d0c9ea347
-      |   |-- 28
-      |   |   `-- a3e71d163a9eb30c3639b16a16f57077abf29b
       |   |-- 2a
       |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
       |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
@@ -536,7 +532,6 @@ Note that ws/d/ is now present in the ws
       |   |-- 98
       |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
       |   |-- 99
-      |   |   |-- 8e4d99b52680e8fc6d50d98cddad2a4e36a604
       |   |   `-- acd82fe2a9b89022d1aee5a580c123a8161f4a
       |   |-- 9c
       |   |   `-- 78c532d93505a2a24430635b342b91db22fee0
@@ -586,8 +581,7 @@ Note that ws/d/ is now present in the ws
       |   |-- e9
       |   |   `-- 9a2c69c0fb10af8dd1524e7f976df3d898f6ac
       |   |-- ea
-      |   |   |-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
+      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
       |   |-- ec
       |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
       |   |-- ed
@@ -612,6 +606,6 @@ Note that ws/d/ is now present in the ws
           |-- namespaces
           `-- tags
   
-  153 directories, 156 files
+  151 directories, 152 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -174,18 +174,12 @@
       |-- objects
       |   |-- 00
       |   |   `-- 14c74ac19f876065ca26a4e9b578c2bc61ef18
-      |   |-- 02
-      |   |   `-- b7be05e5c483a13e211c5d3dcc30eb8a7047c9
-      |   |-- 0b
-      |   |   `-- 976ee9223f2a23c5339d6cb3bda2196dbae6b1
       |   |-- 0f
       |   |   `-- 61d50b4e5a814afb71b3da5a2986efd37bc605
       |   |-- 13
       |   |   `-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
       |   |-- 20
       |   |   `-- c53646e34e6079f7dc3090be5c2c3fdd81a4f3
-      |   |-- 28
-      |   |   `-- a3e71d163a9eb30c3639b16a16f57077abf29b
       |   |-- 2a
       |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
       |   |-- 2d
@@ -200,9 +194,6 @@
       |   |   `-- ade035db71b1ce109c190c3e587aff04b82c55
       |   |-- 43
       |   |   `-- c475ca897b62fd739409aee5db69b0c480aa0d
-      |   |-- 45
-      |   |   |-- f61831a4d523bb75b6f283e2770f1c86060e15
-      |   |   `-- f882bfcdf75d0987e19b48a32717c6d06eabed
       |   |-- 4b
       |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
       |   |-- 4c
@@ -233,8 +224,6 @@
       |   |   `-- 4f260811f923775b9f6433ee9ec063ebe19efd
       |   |-- 95
       |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
-      |   |-- 99
-      |   |   `-- 8e4d99b52680e8fc6d50d98cddad2a4e36a604
       |   |-- 9d
       |   |   `-- b51080a4d148b32bd4c4e0b39eae8d0b3df763
       |   |-- 9e
@@ -276,6 +265,6 @@
           |-- namespaces
           `-- tags
   
-  81 directories, 71 files
+  76 directories, 65 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW


### PR DESCRIPTION
Previously those filters where first creating the
filtered histories of their inputs to populate the
cache. It has shown in profiling though that in
practice it is faster to apply those nested filters
directly without pre building history.