### PR TITLE
update to handlebars v5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "4.4.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39b3bc2a8f715298032cf5087e58573809374b08160aa7d750582bdb82d2683"
+checksum = "c73166c591e67fb4bf9bc04011b4e35f12e89fe8d676193aa263df065955a379"
 dependencies = [
  "log",
  "pest",

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -15,7 +15,7 @@ bitvec = "1.0.1"
 git-version = "0.3.5"
 git2 = { workspace = true }
 glob = "0.3.1"
-handlebars = "4.4.0"
+handlebars = "5.1.1"
 hex = "0.4.3"
 indoc = "2.0.4"
 itertools = "0.11.0"

--- a/josh-core/src/query.rs
+++ b/josh-core/src/query.rs
@@ -102,13 +102,13 @@ impl handlebars::HelperDef for GraphQLHelper {
         _: &handlebars::Handlebars,
         _: &handlebars::Context,
         rc: &mut handlebars::RenderContext,
-    ) -> Result<handlebars::ScopedJson<'reg, 'rc>, handlebars::RenderError> {
+    ) -> Result<handlebars::ScopedJson<'rc>, handlebars::RenderError> {
         return Ok(handlebars::ScopedJson::Derived(
             self.josh_helper(
                 h.hash(),
                 rc.get_current_template_name().unwrap_or(&"/".to_owned()),
             )
-            .map_err(|e| handlebars::RenderError::new(format!("{}", e)))?,
+            .map_err(|e| handlebars::RenderErrorReason::Other(format!("{}", e)))?,
         ));
     }
 }

--- a/tests/filter/graphql_hbs.t
+++ b/tests/filter/graphql_hbs.t
@@ -335,7 +335,7 @@
   - add file2
   - add file1
   $ josh-filter -q "render=sub1/tmpl_file_err&tmpl_param1=tmpl_param_value1&tmpl_p2=val2"
-  ERROR: Error rendering "sub1/tmpl_file_err" line 1, col 14: Variable "tmpl_param12" not found in strict mode.
+  ERROR: Error rendering "sub1/tmpl_file_err" line 1, col 14: Failed to access variable in strict mode Some("tmpl_param12")
   [1]
   $ josh-filter :/sub1 -q render=file2
   contents2

--- a/tests/proxy/query.t
+++ b/tests/proxy/query.t
@@ -79,7 +79,7 @@ Graphql works
 Failing render for lack of variable
   $ curl -i -s http://localhost:8002/real_repo.git?render=tmpl_file
   HTTP/1.1 422 Unprocessable Entity\r (esc)
-  content-length: 100\r (esc)
+  content-length: 112\r (esc)
   date: *\r (esc) (glob)
   \r (esc)
   JoshError(Error rendering "tmpl_file" line 1, col 8: Failed to access variable in strict mode Some("param_val")) (no-eol)

--- a/tests/proxy/query.t
+++ b/tests/proxy/query.t
@@ -82,7 +82,7 @@ Failing render for lack of variable
   content-length: 100\r (esc)
   date: *\r (esc) (glob)
   \r (esc)
-  JoshError(Error rendering "tmpl_file" line 1, col 8: Variable "param_val" not found in strict mode.) (no-eol)
+  JoshError(Error rendering "tmpl_file" line 1, col 8: Failed to access variable in strict mode Some("param_val")) (no-eol)
 
 
 


### PR DESCRIPTION
updates handlebars to 5.1.1
version 5 simplified some lifetimes and introduced the use of RenderErrorReason to create RenderError. RenderError::new and other functions have been deprecated.