### PR TITLE
clippy 1.75 fixes

### DIFF
--- a/josh-core/src/cache.rs
+++ b/josh-core/src/cache.rs
@@ -190,7 +190,7 @@ impl Transaction {
         let mut t2 = self.t2.borrow_mut();
         t2.apply_map
             .entry(filter.id())
-            .or_insert_with(HashMap::new)
+            .or_default()
             .insert(from, to);
     }
 
@@ -226,7 +226,7 @@ impl Transaction {
         let mut t2 = self.t2.borrow_mut();
         t2.unapply_map
             .entry(filter.id())
-            .or_insert_with(HashMap::new)
+            .or_default()
             .insert(from, to);
     }
 
@@ -307,7 +307,7 @@ impl Transaction {
             .lock()
             .unwrap()
             .entry(filter.id())
-            .or_insert_with(HashMap::new)
+            .or_default()
             .insert(from, to);
     }
 
@@ -334,7 +334,7 @@ impl Transaction {
         let mut t2 = self.t2.borrow_mut();
         t2.commit_map
             .entry(filter.id())
-            .or_insert_with(HashMap::new)
+            .or_default()
             .insert(from, to);
 
         // In addition to commits that are explicitly requested to be stored, also store

--- a/josh-core/src/filter/parse.rs
+++ b/josh-core/src/filter/parse.rs
@@ -182,11 +182,11 @@ fn parse_group(filter_spec: &str) -> JoshResult<Vec<Filter>> {
             Ok(filters)
         }
         Err(r) => {
-            return Err(josh_error(&format!(
+            Err(josh_error(&format!(
                 "Invalid workspace:\n----\n{}\n\n{}\n----",
                 r.to_string().replace('␊', ""),
                 filter_spec
-            )));
+            )))
         }
     }
 }
@@ -212,11 +212,11 @@ fn parse_workspace(filter_spec: &str) -> JoshResult<Vec<Filter>> {
             Err(josh_error("invalid workspace file"))
         }
         Err(r) => {
-            return Err(josh_error(&format!(
+            Err(josh_error(&format!(
                 "Invalid workspace:\n----\n{}\n\n{}\n----",
                 r.to_string().replace('␊', ""),
                 filter_spec
-            )));
+            )))
         }
     }
 }
@@ -287,10 +287,10 @@ pub fn get_comments(filter_spec: &str) -> JoshResult<String> {
         }
     }
 
-    return Err(josh_error(&format!(
+    Err(josh_error(&format!(
         "Invalid workspace:\n----\n{}\n----",
         filter_spec
-    )));
+    )))
 }
 
 #[derive(Parser)]

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -219,7 +219,7 @@ fn replace_child<'a>(
         }
         builder.write()?
     };
-    return Ok(repo.find_tree(full_tree_id)?);
+    Ok(repo.find_tree(full_tree_id)?)
 }
 
 pub fn insert<'a>(
@@ -634,12 +634,13 @@ pub fn search_candidates(
     Ok(results)
 }
 
+type SearchMatches = Vec<(String, Vec<(usize, String)>)>;
 pub fn search_matches(
     transaction: &cache::Transaction,
     tree: &git2::Tree,
     searchstring: &str,
     candidates: &Vec<String>,
-) -> JoshResult<Vec<(String, Vec<(usize, String)>)>> {
+) -> JoshResult<SearchMatches> {
     let mut results = vec![];
 
     for c in candidates {

--- a/josh-core/src/graphql.rs
+++ b/josh-core/src/graphql.rs
@@ -831,6 +831,7 @@ impl Reference {
     }
 }
 
+type ObjectToPush = (git2::Oid, String, Option<String>);
 pub struct Context {
     pub transaction: std::sync::Arc<std::sync::Mutex<cache::Transaction>>,
     pub transaction_mirror: std::sync::Arc<std::sync::Mutex<cache::Transaction>>,
@@ -838,7 +839,7 @@ pub struct Context {
         std::sync::Mutex<std::collections::HashMap<std::path::PathBuf, Vec<String>>>,
     >,
     pub to_push: std::sync::Arc<
-        std::sync::Mutex<std::collections::HashSet<(git2::Oid, String, Option<String>)>>,
+        std::sync::Mutex<std::collections::HashSet<ObjectToPush>>,
     >,
     pub allow_refs: std::sync::Mutex<bool>,
 }
@@ -955,8 +956,8 @@ impl RepositoryMut {
         };
 
         Ok(RevMut {
-            at: at,
-            filter: filter,
+            at,
+            filter,
         })
     }
 }

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -209,7 +209,7 @@ pub fn rewrite_commit(
         return Ok(repo.commit_signed(b, sig, None)?);
     }
 
-    return Ok(repo.odb()?.write(git2::ObjectType::Commit, &b)?);
+    Ok(repo.odb()?.write(git2::ObjectType::Commit, &b)?)
 }
 
 fn find_oldest_similar_commit(
@@ -278,6 +278,7 @@ fn find_new_branch_base(
 }
 
 #[tracing::instrument(skip(transaction, change_ids))]
+#[allow(clippy::too_many_arguments)]
 pub fn unapply_filter(
     transaction: &cache::Transaction,
     filterobj: filter::Filter,
@@ -603,8 +604,8 @@ pub fn remove_commit_signature<'a>(
     Ok(r)
 }
 
-pub fn drop_commit<'a>(
-    original_commit: &'a git2::Commit,
+pub fn drop_commit(
+    original_commit: &git2::Commit,
     filtered_parent_ids: Vec<git2::Oid>,
     transaction: &cache::Transaction,
     filter: filter::Filter,

--- a/josh-core/src/query.rs
+++ b/josh-core/src/query.rs
@@ -179,7 +179,7 @@ pub fn render(
                 None,
             ) {
                 to.repo().odb()?.add_disk_alternate(
-                    &transaction
+                    transaction
                         .repo()
                         .path()
                         .parent()
@@ -191,7 +191,7 @@ pub fn render(
                 )?;
                 (
                     to,
-                    cache::Transaction::open(&transaction.repo().path(), None)?,
+                    cache::Transaction::open(transaction.repo().path(), None)?,
                 )
             } else {
                 (
@@ -239,7 +239,7 @@ pub fn render(
     handlebars.register_helper(
         "graphql",
         Box::new(GraphQLHelper {
-            repo_path: repo_path,
+            repo_path,
             ref_prefix: ref_prefix.to_owned(),
             commit_id,
         }),
@@ -248,6 +248,6 @@ pub fn render(
 
     match handlebars.render(path, &json!(params)) {
         Ok(res) => Ok(Some(res)),
-        Err(res) => return Err(josh_error(&format!("{}", res))),
+        Err(res) => Err(josh_error(&format!("{}", res))),
     }
 }

--- a/josh-filter/src/bin/josh-filter.rs
+++ b/josh-filter/src/bin/josh-filter.rs
@@ -223,7 +223,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
             mempack.dump(repo, &mut buf).unwrap();
             if buf.len() > 32 {
                 let mut w = odb.packwriter().unwrap();
-                w.write(&buf).unwrap();
+                w.write_all(&buf).unwrap();
                 w.commit().unwrap();
             }
         }
@@ -297,19 +297,19 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
     };
 
     let mut updated_refs = josh::filter_refs(&transaction, filterobj, &refs, permissions_filter)?;
-    for i in 0..updated_refs.len() {
-        if updated_refs[i].0 == input_ref {
+    for updated_ref in &mut updated_refs {
+        if updated_ref.0 == input_ref {
             if reverse {
-                updated_refs[i].0 = "refs/JOSH_TMP".to_string();
+                updated_ref.0 = "refs/JOSH_TMP".to_string();
             } else {
-                updated_refs[i].0 = target.to_string();
+                updated_ref.0 = target.to_string();
             }
         } else {
-            updated_refs[i].0 =
-                updated_refs[i]
+            updated_ref.0 =
+                updated_ref
                     .0
                     .replacen("refs/heads/", "refs/heads/filtered/", 1);
-            updated_refs[i].0 = updated_refs[i]
+            updated_ref.0 = updated_ref
                 .0
                 .replacen("refs/tags/", "refs/tags/filtered/", 1);
         }

--- a/josh-proxy/src/cli.rs
+++ b/josh-proxy/src/cli.rs
@@ -10,7 +10,7 @@ fn parse_remote(s: &str) -> Result<Remote, &'static str> {
             Ok(Remote::Http(s.to_string()))
         }
         s if s.starts_with("ssh://") => Ok(Remote::Ssh(s.to_string())),
-        _ => return Err("unsupported scheme"),
+        _ => Err("unsupported scheme"),
     }
 }
 

--- a/josh-ssh-shell/src/bin/josh-ssh-shell.rs
+++ b/josh-ssh-shell/src/bin/josh-ssh-shell.rs
@@ -35,21 +35,21 @@ fn die(message: &str) -> ! {
 
 #[derive(thiserror::Error, Debug)]
 enum CallError {
-    FifoError(#[from] std::io::Error),
-    RequestError(#[from] reqwest::Error),
-    RemoteError { status: StatusCode, body: Vec<u8> },
+    Fifo(#[from] std::io::Error),
+    Request(#[from] reqwest::Error),
+    Remote { status: StatusCode, body: Vec<u8> },
 }
 
 impl Display for CallError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            CallError::FifoError(e) => {
+            CallError::Fifo(e) => {
                 write!(f, "{:?}", e)
             }
-            CallError::RequestError(e) => {
+            CallError::Request(e) => {
                 write!(f, "{:?}", e)
             }
-            CallError::RemoteError { status, body } => {
+            CallError::Remote { status, body } => {
                 write!(f, "Remote backend returned error: ")?;
                 write!(f, "status code: {}, ", status)?;
                 write!(f, "body: {}", String::from_utf8_lossy(body).into_owned())
@@ -158,7 +158,7 @@ async fn handle_command(
 
         match status {
             StatusCode::OK | StatusCode::NO_CONTENT => Ok(()),
-            code => Err(CallError::RemoteError {
+            code => Err(CallError::Remote {
                 status: code,
                 body: bytes.to_vec(),
             }),


### PR DESCRIPTION
various fixes for warning generated by clip 1.75

allowed clippy::too_many_arguments for unapply_filter and push_head_url because those would have required to change the function signature.