### PR TITLE
Don't forward fetches with sha in want

### DIFF
--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -110,6 +110,14 @@ fn fetch_needed(
     head_ref: Option<&str>,
     head_ref_resolved: Option<&str>,
 ) -> Result<bool, FetchError> {
+    if let Some(head_ref) = head_ref {
+        if head_ref != "HEAD" && !head_ref.starts_with("refs/") {
+            // If the request is for fetching a sha, don't fetch, as most upstreams
+            // don't support that. The rev should have been fetched previously by reference.
+            return Ok(false);
+        }
+    }
+
     let fetch_timer_ok = {
         if let Some(last) = service.fetch_timers.read()?.get(remote_url) {
             let since = std::time::Instant::now().duration_since(*last);

--- a/tests/proxy/clone_sha.t
+++ b/tests/proxy/clone_sha.t
@@ -54,6 +54,11 @@
 
   $ cd ${TESTTMP}
 
+  $ git ls-remote http://localhost:8002/real_repo.git | tr '\t' ' '
+  bb282e9cdc1b972fffd08fd21eead43bc0c83cb8 HEAD
+  36c6ab9d481503e14a88f783e87f3791aa8cef99 refs/heads/branch-1
+  bb282e9cdc1b972fffd08fd21eead43bc0c83cb8 refs/heads/master
+
 Checks the following:
 
 1) Two different formats for separating origin ref in the remote URL
@@ -130,7 +135,6 @@ Check (2) and (3) but with a branch ref
   |       |   `-- upstream
   |       |       `-- real_repo.git
   |       |           |-- HEAD
-  |       |           |-- bb282e9cdc1b972fffd08fd21eead43bc0c83cb8
   |       |           `-- refs
   |       |               `-- heads
   |       |                   |-- branch-1
@@ -150,5 +154,5 @@ Check (2) and (3) but with a branch ref
           |-- namespaces
           `-- tags
   
-  35 directories, 23 files
+  35 directories, 22 files
 


### PR DESCRIPTION
Most upstreams don't support this, so it only ever worked when the commit was fetched before.

Change: no-sha-want