### PR TITLE
Fix search in GraphQL with non symetric filters

### DIFF
--- a/josh-core/src/graphql.rs
+++ b/josh-core/src/graphql.rs
@@ -427,7 +427,7 @@ impl Revision {
     ) -> FieldResult<Option<Vec<SearchResult>>> {
         let max_complexity = max_complexity.unwrap_or(6) as usize;
         let transaction = context.transaction.lock()?;
-        let ifilterobj = filter::chain(self.filter, filter::parse(":SQUASH:INDEX")?);
+        let ifilterobj = filter::parse(":SQUASH:INDEX")?;
         let tree = transaction.repo().find_commit(self.commit_id)?.tree()?;
 
         let tree = filter::apply(&transaction, self.filter, tree)?;

--- a/tests/experimental/indexer.t
+++ b/tests/experimental/indexer.t
@@ -84,6 +84,24 @@
       ]
     }
   }
+  $ josh-filter :/ -g 'query { rev(at: "refs/heads/master", filter: ":/sub2") { results: search(string: "e") { path { path }, matches { line, text }} }}'
+  {
+    "rev": {
+      "results": [
+        {
+          "path": {
+            "path": "file3"
+          },
+          "matches": [
+            {
+              "line": 1,
+              "text": "One more to see what happens"
+            }
+          ]
+        }
+      ]
+    }
+  }
 
   $ git diff ${EMPTY_TREE}..refs/heads/index
   diff --git a/SUB1 b/SUB1


### PR DESCRIPTION
The filter was applied twice in the index tree, resulting in paths not matching the searched tree.

Change: fix-search