### PR TITLE
Check whether TmpGitNamespace request path exists before removing

### DIFF
--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -799,14 +799,18 @@ impl Drop for TmpGitNamespace {
         if std::env::var_os("JOSH_KEEP_NS").is_some() {
             return;
         }
+
         let request_tmp_namespace = self.repo_path.join("refs/namespaces").join(&self.name);
-        std::fs::remove_dir_all(&request_tmp_namespace).unwrap_or_else(|e| {
-            tracing::error!(
-                "remove_dir_all {:?} failed, error:{:?}",
-                request_tmp_namespace,
-                e
-            )
-        });
+
+        if std::path::Path::new(&request_tmp_namespace).exists() {
+            fs::remove_dir_all(&request_tmp_namespace).unwrap_or_else(|err| {
+                tracing::error!(
+                    "remove_dir_all {} failed, error: {}",
+                    request_tmp_namespace.display(),
+                    err
+                )
+            });
+        }
     }
 }
 


### PR DESCRIPTION
When TmpGitNamespace is dropped before any filtering / git work is done, for example due to an unrelated error, it will attempt to remove directory that doesn't exist because no code that actually uses the namespace path has run. This adds a check before remove_dir_all call to prevent tracing spam.

commit-id:9feb11b7