### PR TITLE
correct description of :rev filter

### DIFF
--- a/docs/src/reference/filters.md
+++ b/docs/src/reference/filters.md
@@ -102,7 +102,7 @@ simply dropping all parents except the first on every commit.
 Produce a history where the commits specified by `<sha_N>` are replaced by the result of applying
 `:filter_N` to it.
 
-It will appear like all *ancestors* of `<sha_N>` are also filtered with `<filter_N>`. If an
+It will appear like `<sha_N>` and all its ancestors are also filtered with `<filter_N>`. If an
 ancestor also has a matching entry in the `:rev(...)` it's filter will *replace* `<filter_N>`
 for all further ancestors (and so on).
 


### PR DESCRIPTION
My understanding of `rev` (backed by how we're using it in practice) is that the filter applies not just to the ancestors of the given commits, but also to those commits themselves. Is that not right?