### PR TITLE
do not hard-deny warnings (CI already sets RUSTFLAGS)

### DIFF
--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(warnings)]
 #![warn(unused_extern_crates)]
 
 #[macro_export]


### PR DESCRIPTION
Fixes https://github.com/josh-project/josh/issues/1286

CI will still fail when there is a warning, thanks to

https://github.com/josh-project/josh/blob/7b8259b81a9acabb528ddebc4ab30fc712f756fb/.github/workflows/rust.yml#L11