### PR TITLE
Split josh-graphql and josh-templates out of josh-core

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,8 @@
 !josh-proxy
 !josh-rpc
 !josh-ssh-shell
+!josh-templates
+!josh-graphql
 !josh-ui/*.json
 !josh-ui/*.rs
 !josh-ui/*.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,16 +1563,12 @@ version = "22.4.15"
 dependencies = [
  "backtrace",
  "bitvec",
- "chrono",
- "form_urlencoded",
  "git-version",
  "git2",
  "glob",
- "handlebars",
  "hex",
  "indoc",
  "itertools 0.13.0",
- "juniper",
  "lazy_static",
  "log",
  "percent-encoding",
@@ -1585,8 +1581,6 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sled",
- "strfmt",
- "toml",
  "tracing",
 ]
 
@@ -1599,11 +1593,31 @@ dependencies = [
  "env_logger",
  "git2",
  "josh",
+ "josh-graphql",
+ "josh-templates",
  "juniper",
  "rs_tracing",
  "serde",
  "serde_json",
  "serde_yaml",
+]
+
+[[package]]
+name = "josh-graphql"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "git2",
+ "josh",
+ "juniper",
+ "lazy_static",
+ "regex",
+ "rs_tracing",
+ "serde_json",
+ "serde_yaml",
+ "strfmt",
+ "toml",
+ "tracing",
 ]
 
 [[package]]
@@ -1622,7 +1636,9 @@ dependencies = [
  "hyper_cgi",
  "indoc",
  "josh",
+ "josh-graphql",
  "josh-rpc",
+ "josh-templates",
  "juniper",
  "lazy_static",
  "opentelemetry",
@@ -1674,6 +1690,19 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "josh-templates"
+version = "0.1.0"
+dependencies = [
+ "form_urlencoded",
+ "git2",
+ "handlebars",
+ "josh",
+ "josh-graphql",
+ "juniper",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,11 @@ members = [
     "hyper_cgi",
     "josh-core",
     "josh-filter",
+    "josh-graphql",
     "josh-proxy",
     "josh-rpc",
     "josh-ssh-shell",
+    "josh-templates",
     "josh-ui",
 ]
 

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -15,7 +15,6 @@ bitvec = "1.0.1"
 git-version = "0.3.9"
 git2 = { workspace = true }
 glob = "0.3.1"
-handlebars = "5.1.2"
 hex = "0.4.3"
 indoc = "2.0.5"
 itertools = "0.13.0"
@@ -31,13 +30,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sled = "0.34.7"
-strfmt = "0.2.4"
-toml = { workspace = true }
 tracing = { workspace = true }
-juniper = { workspace = true }
-form_urlencoded = "1.2.1"
-
-[dependencies.chrono]
-default-features = false
-features = ["alloc", "std"]
-version = "0.4.38"

--- a/josh-core/src/filter/parse.rs
+++ b/josh-core/src/filter/parse.rs
@@ -293,6 +293,6 @@ pub fn get_comments(filter_spec: &str) -> JoshResult<String> {
     )));
 }
 
-#[derive(Parser)]
+#[derive(pest_derive::Parser)]
 #[grammar = "filter/grammar.pest"]
 struct Grammar;

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -25,21 +25,10 @@ macro_rules! ok_or {
 #[macro_use]
 extern crate rs_tracing;
 
-#[macro_use]
-extern crate handlebars;
-
-#[macro_use]
-extern crate pest_derive;
-
-#[macro_use]
-extern crate serde_json;
-
 pub mod cache;
 pub mod filter;
-pub mod graphql;
 pub mod history;
 pub mod housekeeping;
-pub mod query;
 pub mod shell;
 
 pub struct Change {
@@ -190,7 +179,7 @@ macro_rules! regex_parsed {
 impl $name {
     fn from_str(path: &str) -> Option<$name> {
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref REGEX: regex::Regex =
         regex::Regex::new($re)
             .expect("can't compile regex");
@@ -368,7 +357,7 @@ type Users = std::collections::HashMap<String, User>;
 
 #[derive(Debug, serde::Deserialize)]
 struct User {
-    pub groups: toml::value::Array,
+    pub groups: Vec<String>,
 }
 
 type Groups = std::collections::HashMap<String, std::collections::HashMap<String, Group>>;
@@ -400,7 +389,7 @@ pub fn get_acl(
             let mut blacklist = filter::empty();
             for g in &u.groups {
                 let lists = groups.get(repo).and_then(|repo| {
-                    repo.get(g.as_str()?).map(|group| {
+                    repo.get(g.as_str()).map(|group| {
                         let w = filter::parse(&group.whitelist);
                         let b = filter::parse(&group.blacklist);
                         (w, b)

--- a/josh-filter/Cargo.toml
+++ b/josh-filter/Cargo.toml
@@ -11,6 +11,8 @@ version = "22.4.15"
 
 [dependencies]
 josh = { path = "../josh-core" }
+josh-graphql = { path = "../josh-graphql" }
+josh-templates = { path = "../josh-templates" }
 env_logger = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/josh-filter/src/bin/josh-filter.rs
+++ b/josh-filter/src/bin/josh-filter.rs
@@ -399,12 +399,12 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
     }
 
     if let Some(gql_query) = args.get_one::<String>("graphql") {
-        let context = josh::graphql::context(transaction.try_clone()?, transaction.try_clone()?);
+        let context = josh_graphql::context(transaction.try_clone()?, transaction.try_clone()?);
         *context.allow_refs.lock()? = true;
         let (res, _errors) = juniper::execute_sync(
             gql_query,
             None,
-            &josh::graphql::repo_schema(".".to_string(), true),
+            &josh_graphql::repo_schema(".".to_string(), true),
             &std::collections::HashMap::new(),
             &context,
         )?;
@@ -420,7 +420,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
         let commit_id = transaction.repo().refname_to_id(update_target)?;
         print!(
             "{}",
-            josh::query::render(&transaction, "", commit_id, query, false)?
+            josh_templates::render(&transaction, "", commit_id, query, false)?
                 .map(|x| x.0)
                 .unwrap_or("File not found".to_string())
         );

--- a/josh-graphql/Cargo.toml
+++ b/josh-graphql/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "josh-graphql"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+josh = { path = "../josh-core" }
+juniper = { workspace = true }
+git2 = { workspace = true }
+rs_tracing = { workspace = true }
+regex = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+strfmt = "0.2.4"
+toml = { workspace = true }
+tracing = { workspace = true }
+lazy_static = { workspace = true }
+
+[dependencies.chrono]
+default-features = false
+features = ["alloc", "std"]
+version = "0.4.38"

--- a/josh-graphql/src/lib.rs
+++ b/josh-graphql/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod graphql;
+pub use graphql::{commit_schema, context, repo_schema};
+
+#[macro_use]
+extern crate rs_tracing;

--- a/josh-proxy/Cargo.toml
+++ b/josh-proxy/Cargo.toml
@@ -20,6 +20,8 @@ hyper-tls = "0.5.0"
 hyper_cgi = { path = "../hyper_cgi" }
 indoc = "2.0.5"
 josh = {path = "../josh-core" }
+josh-templates = { path = "../josh-templates" }
+josh-graphql = { path = "../josh-graphql" }
 lazy_static = { workspace = true }
 opentelemetry = "0.23.0"
 opentelemetry-jaeger = "0.22.0"

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -1446,7 +1446,7 @@ async fn serve_query(
         let commit_id =
             josh::filter_commit(&transaction, filter, commit_id, josh::filter::empty())?;
 
-        josh::query::render(&transaction, "", commit_id, &q, true)
+        josh_templates::render(&transaction, "", commit_id, &q, true)
     })
     .in_current_span()
     .await?;
@@ -1807,7 +1807,7 @@ async fn serve_graphql(
                     .to_string(),
             )?;
 
-            Ok(Arc::new(josh::graphql::context(
+            Ok(Arc::new(josh_graphql::graphql::context(
                 transaction,
                 transaction_mirror,
             )))
@@ -1815,7 +1815,7 @@ async fn serve_graphql(
         .await??
     };
 
-    let root_node = Arc::new(josh::graphql::repo_schema(
+    let root_node = Arc::new(josh_graphql::graphql::repo_schema(
         upstream_repo
             .strip_suffix(".git")
             .unwrap_or(&upstream_repo)

--- a/josh-templates/Cargo.toml
+++ b/josh-templates/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "josh-templates"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+git2 = { workspace = true }
+josh = { path = "../josh-core" }
+josh-graphql = { path = "../josh-graphql" }
+juniper = { workspace = true }
+serde_json = { workspace = true }
+handlebars = "5.1.2"
+form_urlencoded = "1.2.1"

--- a/josh-templates/src/lib.rs
+++ b/josh-templates/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod templates;
+pub use templates::render;


### PR DESCRIPTION
This reduces number of dependencies of josh-core