### PR TITLE
Update cli.md

### DIFF
--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -9,7 +9,7 @@ history, taking a filter specification as argument.
 
 It can be installed with the following Cargo command, assuming Rust is installed:
 ```shell
-cargo install josh --git https://github.com/josh-project/josh.git
+cargo install josh-filter --git https://github.com/josh-project/josh.git
 ```
 
 git-sync


### PR DESCRIPTION
Installing using the given command didn't work:

```
cargo install josh --git https://github.com/josh-project/josh.git
    Updating git repository `https://github.com/josh-project/josh.git`
error: there is nothing to install in `josh v22.4.15 (https://github.com/josh-project/josh.git#60dc5873)`, because it has no binaries
`cargo install` is only for installing programs, and can't be used with libraries.
To use a library crate, add it as a dependency to a Cargo project with `cargo add`.
```

Changing this to `cargo install josh-filter …` successfully installed `josh-filter`