### PR TITLE
Decode percent encoding in url

### DIFF
--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -1185,7 +1185,9 @@ async fn call_service(
         while path.contains("//") {
             path = path.replace("//", "/");
         }
-        path
+        percent_encoding::percent_decode_str(&path)
+            .decode_utf8_lossy()
+            .to_string()
     };
 
     if let Some(resource_path) = path.strip_prefix("/~/ui") {


### PR DESCRIPTION
Some filters take quoted string arguements. As it is not possible to use quotes in an URL directly it is necessary to percent encode them.

Change: percent-decode