### PR TITLE
Introduce commit message filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,6 +1581,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sled",
+ "strfmt",
  "tracing",
 ]
 

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -26,6 +26,7 @@ pest_derive = "2.7.10"
 rayon = "1.10.0"
 regex = { workspace = true }
 rs_tracing = { workspace = true }
+strfmt = "0.2.4"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/josh-core/src/filter/grammar.pest
+++ b/josh-core/src/filter/grammar.pest
@@ -22,6 +22,7 @@ char = {
 
 filter_spec = { (
     filter_group
+  | filter_message
   | filter_rev
   | filter_join
   | filter_replace
@@ -39,6 +40,7 @@ filter_nop = { CMD_START ~ "/" }
 filter_presub = { CMD_START ~ ":" ~ argument }
 filter = { CMD_START ~ cmd ~ "=" ~ (argument ~ (";" ~ argument)*)? }
 filter_noarg = { CMD_START ~ cmd }
+filter_message = { CMD_START ~ string }
 
 filter_rev = {
     CMD_START ~ "rev" ~ "("
@@ -71,8 +73,8 @@ filter_replace = {
 filter_squash = {
     CMD_START ~ "squash" ~ "("
     ~ NEWLINE*
-    ~ (rev ~ ":" ~ string)?
-    ~ (CMD_SEP+ ~ (rev ~ ":" ~ string))*
+    ~ (rev ~ filter_spec)?
+    ~ (CMD_SEP+ ~ (rev ~ filter_spec))*
     ~ NEWLINE*
     ~ ")"
 }

--- a/josh-core/src/filter/parse.rs
+++ b/josh-core/src/filter/parse.rs
@@ -85,6 +85,10 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> JoshResult<Op> {
             let mut inner = pair.into_inner();
             make_op(&[inner.next().unwrap().as_str()])
         }
+        Rule::filter_message => {
+            let mut inner = pair.into_inner();
+            Ok(Op::Message(unquote(inner.next().unwrap().as_str())))
+        }
         Rule::filter_group => {
             let v: Vec<_> = pair.into_inner().map(|x| unquote(x.as_str())).collect();
 
@@ -137,9 +141,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> JoshResult<Op> {
             let ids = pair
                 .into_inner()
                 .tuples()
-                .map(|(oid, message)| {
-                    Ok((LazyRef::parse(oid.as_str())?, unquote(message.as_str())))
-                })
+                .map(|(oid, filter)| Ok((LazyRef::parse(oid.as_str())?, parse(filter.as_str())?)))
                 .collect::<JoshResult<_>>()?;
 
             Ok(Op::Squash(Some(ids)))

--- a/josh-filter/src/bin/josh-filter.rs
+++ b/josh-filter/src/bin/josh-filter.rs
@@ -152,7 +152,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
     let input_ref = args.get_one::<String>("input").unwrap();
 
     let mut refs = vec![];
-    let mut ids = vec![];
+    let mut ids: Vec<(git2::Oid, josh::filter::Filter)> = vec![];
 
     let reference = repo.resolve_reference_from_short_name(input_ref).unwrap();
     let input_ref = reference.name().unwrap().to_string();
@@ -167,7 +167,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
         for reference in repo.references_glob(&pattern).unwrap() {
             let reference = reference?;
             let target = reference.peel_to_commit()?.id();
-            ids.push((target, reference.name().unwrap().to_string()));
+            ids.push((target, josh::filter::message(reference.name().unwrap())));
             refs.push((reference.name().unwrap().to_string(), target));
         }
         filterobj = josh::filter::chain(josh::filter::squash(Some(&ids)), filterobj);
@@ -181,7 +181,7 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
             if let [sha, name] = split.as_slice() {
                 let target = git2::Oid::from_str(sha)?;
                 let target = repo.find_object(target, None)?.peel_to_commit()?.id();
-                ids.push((target, name.to_string()));
+                ids.push((target, josh::filter::message(name)));
                 refs.push((name.to_string(), target));
             } else if !split.is_empty() {
                 eprintln!("Warning: malformed line: {:?}", line);

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -6,6 +6,7 @@ pub mod trace;
 #[macro_use]
 extern crate lazy_static;
 
+use josh::history::RewriteData;
 use josh::{josh_error, JoshError, JoshResult};
 use std::fs;
 use std::path::PathBuf;
@@ -459,9 +460,12 @@ fn split_changes(
                         repo,
                         &repo.find_commit(changes[i].1)?,
                         &[&parent],
-                        &new_tree,
-                        None,
-                        None,
+                        RewriteData {
+                            tree: new_tree,
+                            author: None,
+                            committer: None,
+                            message: None,
+                        },
                         false,
                     )?;
                     changes[i].1 = new_commit;

--- a/tests/filter/squash.t
+++ b/tests/filter/squash.t
@@ -40,6 +40,7 @@
 This one tag is an annotated tag, to make sure those are handled as well
   $ git tag -a tag_a -m "created a tag" 1d69b7d
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
+  [1] :"refs/tags/tag_a"
   [1] :author="New Author";"new@e.mail"
   [1] :squash(
       1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
@@ -60,6 +61,9 @@ This one tag is an annotated tag, to make sure those are handled as well
   * 0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb (tag: tag_b) add file1
 
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
+  [1] :"refs/tags/filtered/tag_a"
+  [1] :"refs/tags/tag_a"
+  [1] :"refs/tags/tag_b"
   [1] :squash(
       1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
   )
@@ -114,6 +118,10 @@ This one tag is an annotated tag, to make sure those are handled as well
       975d4c4975912729482cc864d321c5196a969271:"refs/tags/tag_c"
   ):author="New Author";"new@e.mail"
   $ josh-filter -s --file filter.josh --update refs/heads/filtered
+  [1] :"refs/tags/filtered/tag_a"
+  [1] :"refs/tags/tag_a"
+  [1] :"refs/tags/tag_b"
+  [1] :"refs/tags/tag_c"
   [1] :squash(
       1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
   )

--- a/tests/filter/squash_empty_initial.t
+++ b/tests/filter/squash_empty_initial.t
@@ -45,6 +45,7 @@
 
   $ git tag -a tag_a -m "created a tag" 882f2656a5075936eb37bfefde740e0b453e4479
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
+  [1] :"refs/tags/tag_a"
   [1] :author="New Author";"new@e.mail"
   [1] :squash(
       882f2656a5075936eb37bfefde740e0b453e4479:"refs/tags/tag_a"

--- a/tests/proxy/workspace_errors.t
+++ b/tests/proxy/workspace_errors.t
@@ -106,7 +106,7 @@ Error in filter
   remote: 1 | a/b = :b/sub2        
   remote:   |         ^---        
   remote:   |        
-  remote:   = expected EOI, filter_group, filter_subdir, filter_nop, filter_presub, filter, filter_noarg, filter_rev, filter_join, filter_replace, or filter_squash        
+  remote:   = expected EOI, filter_group, filter_subdir, filter_nop, filter_presub, filter, filter_noarg, filter_message, filter_rev, filter_join, filter_replace, or filter_squash        
   remote: 
   remote: a/b = :b/sub2        
   remote: c = :/sub1        


### PR DESCRIPTION
This changes the `:squash()` filter to take an additional filter per commit instead of special handling for the commit message.

Change: message-filter