### PR TITLE
Upgrade Rust toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG ARCH
 ARG RUSTUP_VERSION=1.27.1
 
 # Update check: https://github.com/rust-lang/rust/tags
-ARG RUST_VERSION=1.79.0
+ARG RUST_VERSION=1.83.0
 ARG RUST_ARCH=${ARCH}-unknown-linux-musl
 
 # https://github.com/sfackler/rust-openssl/issues/1462

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -1300,7 +1300,7 @@ async fn call_service(
         .map(|(x, y)| (x.to_string(), y.to_string()))
         .collect();
 
-    fetch_repos.extend(lazy_refs.iter().map(|(x, y)| x.clone()));
+    fetch_repos.extend(lazy_refs.iter().map(|(x, _y)| x.clone()));
 
     ///////////////
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.83.0"
+components = ["rustfmt"]

--- a/tests/proxy/get_version.t
+++ b/tests/proxy/get_version.t
@@ -2,7 +2,7 @@
   $ cd ${TESTTMP}
 
   $ curl -s http://localhost:8002/version
-  Version: v*.*.* (glob)
+  Version: *.*.* (glob)
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   .


### PR DESCRIPTION
Also pin the toolchain version for local development using the new `rust-toolchain.toml` file