### PR TITLE
Repack everything into a single pack in mirror repo

### DIFF
--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -362,8 +362,9 @@ pub fn run(repo_path: &std::path::Path, do_gc: bool) -> JoshResult<()> {
                 &[
                     "git",
                     "repack",
-                    "-dn",
+                    "-adn",
                     "--keep-unreachable",
+                    "--pack-kept-objects",
                     "--no-write-bitmap-index",
                     "--threads=4"
                 ]


### PR DESCRIPTION
Over time and over certain conditions, josh creates multiple packfiles in the mirror repo. This will eventually make Transaction::open() very slow due to git2 iterating through packfiles in a readdir() loop and producing _a lot_ of i/o syscalls.

This PR changes the arguments of `git repack` for the mirror repo.