### PR TITLE
Fix workspace discovery

### DIFF
--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -209,11 +209,12 @@ pub fn find_all_workspaces_and_subdirectories(
     let _trace_s = span!(Level::TRACE, "find_all_workspaces_and_subdirectories");
     let mut hs = std::collections::HashSet::new();
     tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
-        if entry.name() == Some("workspace.josh") {
-            hs.insert(format!(":workspace={}", root.trim_matches('/')));
-        }
         if root.is_empty() {
             return 0;
+        }
+
+        if entry.name() == Some("workspace.josh") {
+            hs.insert(format!(":workspace={}", root.trim_matches('/')));
         }
         let v = format!("::{}/", root.trim_matches('/'));
         if v.chars().filter(|x| *x == '/').count() < 3 {

--- a/josh-filter/src/bin/josh-filter.rs
+++ b/josh-filter/src/bin/josh-filter.rs
@@ -233,9 +233,6 @@ fn run_filter(args: Vec<String>) -> josh::JoshResult<i32> {
         let r = repo.revparse_single(&input_ref)?;
         let hs = josh::housekeeping::find_all_workspaces_and_subdirectories(&r.peel_to_tree()?)?;
         for i in hs {
-            if i.contains(":workspace=") {
-                continue;
-            }
             let (mut updated_refs, _) = josh::filter_refs(
                 &transaction,
                 josh::filter::parse(&i)?,

--- a/tests/filter/workspace_discover.t
+++ b/tests/filter/workspace_discover.t
@@ -1,0 +1,103 @@
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1
+  $ echo contents1 > sub1/file1
+  $ echo contents1 > sub1/file2
+  $ chmod +x sub1/file2
+  $ git add sub1
+  $ git commit -m "add file1" 1> /dev/null
+  $ git ls-tree -r HEAD
+  100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tsub1/file1 (esc)
+  100755 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tsub1/file2 (esc)
+
+  $ mkdir -p sub2/subsub
+  $ echo contents1 > sub2/subsub/file2
+  $ git add sub2
+  $ git commit -m "add file2" 1> /dev/null
+
+  $ mkdir ws
+  $ cat > ws/workspace.josh <<EOF
+  > :/sub1::file1
+  > :/sub1::file2
+  > ::sub2/subsub/
+  > EOF
+  $ git add ws
+  $ git commit -m "add ws" 1> /dev/null
+
+  $ mkdir ws2
+  $ cat > ws2/workspace.josh <<EOF
+  > :/sub1::file1
+  > :/sub1::file2
+  > ::sub2/subsub
+  > EOF
+  $ git add ws2
+  $ git commit -m "add ws2" 1> /dev/null
+
+  $ josh-filter -s
+  $ josh-filter -d -s
+  [1] :/sub1
+  [1] :/subsub
+  [1] :prefix=sub1
+  [1] :prefix=sub2
+  [1] :prefix=subsub
+  [1] :prefix=ws
+  [1] :prefix=ws2
+  [2] :/sub2
+  [2] :/ws
+  [2] :/ws2
+  [2] :[
+      :/sub1:[
+          ::file1
+          ::file2
+      ]
+      ::sub2/subsub
+  ]
+  [2] :[
+      :/sub1:[
+          ::file1
+          ::file2
+      ]
+      ::sub2/subsub/
+  ]
+  [2] :workspace=ws
+  [2] :workspace=ws2
+
+  $ cat > workspace.josh <<EOF
+  > :/sub1::file1
+  > :/sub1::file2
+  > ::sub2/subsub
+  > EOF
+  $ git add .
+  $ git commit -m "add root ws" 1> /dev/null
+
+  $ josh-filter -d -s
+  [1] :/sub1
+  [1] :/subsub
+  [1] :prefix=sub1
+  [1] :prefix=sub2
+  [1] :prefix=subsub
+  [1] :prefix=ws
+  [1] :prefix=ws2
+  [2] :/sub2
+  [2] :/ws
+  [2] :/ws2
+  [2] :[
+      :/sub1:[
+          ::file1
+          ::file2
+      ]
+      ::sub2/subsub
+  ]
+  [2] :[
+      :/sub1:[
+          ::file1
+          ::file2
+      ]
+      ::sub2/subsub/
+  ]
+  [2] :workspace=ws
+  [2] :workspace=ws2


### PR DESCRIPTION
The workspace discovery logic looks for all
workspace.josh files in the tree and populates
the "known filters" list.
However a workspace.josh file in the root of the
tree results in a filter with invalid syntax, so it is skipped now.

Change: fix-ws-discovery