### PR TITLE
Remove comment about ssh being read only

### DIFF
--- a/docs/src/reference/container.md
+++ b/docs/src/reference/container.md
@@ -111,7 +111,7 @@
 
 ## Configuring SSH access
 
-Josh supports SSH access (just pull without pushing, for now).
+Josh supports SSH access.
 To use SSH, you need to add the following lines to your `~/.ssh/config`:
 
 ```


### PR DESCRIPTION
Push support has long been implemented and this is a leftover.

Change: rm-leftover-ssh-note