### PR TITLE
Implement invert for :replace

### DIFF
--- a/josh-core/src/filter/opt.rs
+++ b/josh-core/src/filter/opt.rs
@@ -496,6 +496,7 @@ pub fn invert(filter: Filter) -> JoshResult<Filter> {
         Op::Prefix(path) => Some(Op::Subdir(path)),
         Op::Glob(pattern) => Some(Op::Glob(pattern)),
         Op::Rev(_) => Some(Op::Nop),
+        Op::RegexReplace(_) => Some(Op::Nop),
         _ => None,
     };
 

--- a/tests/filter/replace.t
+++ b/tests/filter/replace.t
@@ -72,3 +72,20 @@
   +++ b/subdir/hw.txt
   @@ -0,0 +1 @@
   +hello moon
+
+  $ josh-filter --update refs/heads/filtered ':[xdir=:/subdir,:replace("hello":"bye","(?m)^(?P<l>.+)$":"$l!")]'
+  $ git diff ${EMPTY_TREE}..refs/heads/filtered
+  diff --git a/hw.txt b/hw.txt
+  new file mode 100644
+  index 0000000..9836695
+  --- /dev/null
+  +++ b/hw.txt
+  @@ -0,0 +1 @@
+  +bye world!
+  diff --git a/xdir/hw.txt b/xdir/hw.txt
+  new file mode 100644
+  index 0000000..1b95c6e
+  --- /dev/null
+  +++ b/xdir/hw.txt
+  @@ -0,0 +1 @@
+  +hello moon


### PR DESCRIPTION
Inversion is needed for composition. Since we can't restore the original string of a replacement,
the invert ist :nop

See: #1476
Change: invert-replace