### PR TITLE
Add :prune=trivial-merge filter

### DIFF
--- a/docs/src/reference/filters.md
+++ b/docs/src/reference/filters.md
@@ -114,6 +114,13 @@ commits that don't match any of the other shas.
 Produce the history that would be the result of pushing the passed branches with the
 passed filters into the upstream.
 
+### Prune trivial merge commits **:prune=trivial-merge**
+
+Produce a history that skips all merge commits whose tree is identical to the first parents
+tree.
+Normally Josh will keep all commits in the filtered history whose tree differs from any of it's
+parents.
+
 Filter order matters
 --------------------
 

--- a/josh-core/src/filter/opt.rs
+++ b/josh-core/src/filter/opt.rs
@@ -489,6 +489,7 @@ pub fn invert(filter: Filter) -> JoshResult<Filter> {
     let result = match to_op(filter) {
         Op::Nop => Some(Op::Nop),
         Op::Linear => Some(Op::Nop),
+        Op::Prune => Some(Op::Prune),
         Op::Unsign => Some(Op::Unsign),
         Op::Empty => Some(Op::Empty),
         Op::Subdir(path) => Some(Op::Prefix(path)),

--- a/josh-core/src/filter/parse.rs
+++ b/josh-core/src/filter/parse.rs
@@ -35,6 +35,22 @@ fn make_op(args: &[&str]) -> JoshResult<Op> {
         ["SQUASH"] => Ok(Op::Squash(None)),
         ["SQUASH", _ids @ ..] => Err(josh_error("SQUASH with ids can't be parsed")),
         ["linear"] => Ok(Op::Linear),
+        ["prune", "trivial-merge"] => Ok(Op::Prune),
+        ["prune"] => Err(josh_error(indoc!(
+            r#"
+            Filter ":prune" requires an argument.
+
+            Note: use "=" to provide the argument value:
+
+              :prune=trivial-merge
+            "#
+        ))),
+        ["prune", _] => Err(josh_error(indoc!(
+            r#"
+            Filter ":prune" only supports "trivial-merge"
+            as argument value.
+            "#
+        ))),
         ["unsign"] => Ok(Op::Unsign),
         ["PATHS"] => Ok(Op::Paths),
         ["INDEX"] => Ok(Op::Index),

--- a/tests/filter/prune_trivial_merge.t
+++ b/tests/filter/prune_trivial_merge.t
@@ -1,0 +1,47 @@
+  $ export RUST_BACKTRACE=1
+  $ git init -q 1> /dev/null
+
+  $ echo contents1 > file1
+  $ git add .
+  $ git commit -m "add file1" 1> /dev/null
+
+  $ git log --graph --pretty=%s
+  * add file1
+
+  $ git checkout -b branch1
+  Switched to a new branch 'branch1'
+  $ echo contents2 > file2
+  $ git add .
+  $ git commit -m "add file2" 1> /dev/null
+
+  $ git checkout master
+  Switched to branch 'master'
+
+  $ echo contents3 > file1
+  $ git add .
+  $ git commit -m "mod file1" 1> /dev/null
+
+  $ git merge -q  branch1 --no-ff
+  $ git log --graph --pretty=%s
+  *   Merge branch 'branch1'
+  |\  
+  | * add file2
+  * | mod file1
+  |/  
+  * add file1
+
+  $ josh-filter -s ::file1
+  [3] ::file1
+  $ git log --graph --pretty=%s FILTERED_HEAD
+  *   Merge branch 'branch1'
+  |\  
+  * | mod file1
+  |/  
+  * add file1
+  $ josh-filter -s ::file1:prune=trivial-merge
+  [2] :prune=trivial-merge
+  [3] ::file1
+
+  $ git log --graph --pretty=%s FILTERED_HEAD
+  * mod file1
+  * add file1


### PR DESCRIPTION
The default history simplification will not drop merge commits if their tree differs from any parent.
In most cases however merges that don't differ from the first parent are not wanted in the output history.
This new filter allows to prune them.

Change: prune-trivial-merges