### PR TITLE
Add computed filter resolver support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "serde_yaml",
  "sled",
  "strfmt",
+ "tempfile",
  "tracing",
 ]
 

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -33,3 +33,6 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sled = "0.34.7"
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.10.1"

--- a/josh-core/src/filter/parse.rs
+++ b/josh-core/src/filter/parse.rs
@@ -40,6 +40,8 @@ fn make_op(args: &[&str]) -> JoshResult<Op> {
         ["INDEX"] => Ok(Op::Index),
         ["INVERT"] => Ok(Op::Invert),
         ["FOLD"] => Ok(Op::Fold),
+        ["computed"] => Ok(Op::Computed(vec![])),
+        ["computed", rest @ ..] => Ok(Op::Computed(rest.iter().map(|s| s.to_string()).collect())),
         _ => Err(josh_error(
             formatdoc!(
                 r#"


### PR DESCRIPTION
Add plumbing for computed filters

Introduce a ComputedFilter hook on transactions so a `:computed` filter can be resolved per commit, cached, and have its metadata recorded for reverse lookups. Teach the history helpers to consult that metadata when finding original commits or unapplied filters, returning clear errors when the resolver or its records are missing.

Extend the parser and pretty-printer to understand `:computed` (with optional arguments), and cover the resolver lifecycle, caching, and failure modes with new tests that rely on a tempfile-backed repository.