### PR TITLE
Improve support for sparse cache.

### DIFF
--- a/josh-core/src/cache_sled.rs
+++ b/josh-core/src/cache_sled.rs
@@ -80,7 +80,12 @@ fn insert_sled_tree(filter: Filter) -> sled::Tree {
 }
 
 impl CacheBackend for SledCacheBackend {
-    fn read(&self, filter: Filter, from: git2::Oid) -> JoshResult<Option<git2::Oid>> {
+    fn read(
+        &self,
+        filter: Filter,
+        from: git2::Oid,
+        _sequence_number: u128,
+    ) -> JoshResult<Option<git2::Oid>> {
         let mut trees = self.trees.lock()?;
         let tree = trees
             .entry(filter.id())
@@ -94,7 +99,13 @@ impl CacheBackend for SledCacheBackend {
         }
     }
 
-    fn write(&self, filter: Filter, from: git2::Oid, to: git2::Oid) -> JoshResult<()> {
+    fn write(
+        &self,
+        filter: Filter,
+        from: git2::Oid,
+        to: git2::Oid,
+        _sequence_number: u128,
+    ) -> JoshResult<()> {
         let mut trees = self.trees.lock()?;
         let tree = trees
             .entry(filter.id())

--- a/tests/experimental/indexer.t
+++ b/tests/experimental/indexer.t
@@ -20,6 +20,7 @@
 
   $ josh-filter -s :INDEX --update refs/heads/index
   [3] :INDEX
+  [3] sequence_number
   [6] _trigram_index
 
   $ josh-filter :/ --search "Another"

--- a/tests/filter/ambiguous_merge.t
+++ b/tests/filter/ambiguous_merge.t
@@ -39,6 +39,7 @@
   $ josh-filter -s ::sub1/ branch1 --update refs/heads/hidden_branch1
   [2] :prefix=sub1
   [3] :/sub1
+  [5] sequence_number
   $ git checkout hidden_branch1
   Switched to branch 'hidden_branch1'
   $ git log --graph --oneline --decorate
@@ -54,6 +55,7 @@
   $ josh-filter -s ::sub1/ master --update refs/heads/hidden_master
   [3] :prefix=sub1
   [4] :/sub1
+  [7] sequence_number
   $ git checkout hidden_master
   Switched to branch 'hidden_master'
   $ git log --graph --oneline --decorate
@@ -86,6 +88,7 @@
   $ josh-filter -s ::sub1/ --reverse master --update refs/heads/hidden_master
   [3] :prefix=sub1
   [4] :/sub1
+  [7] sequence_number
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/cmdline.t
+++ b/tests/filter/cmdline.t
@@ -36,6 +36,7 @@
   $ josh-filter -s c=:/sub1 --update refs/josh/filter/libs/master libs/master
   [2] :/sub1
   [2] :prefix=c
+  [4] sequence_number
   $ git log --graph --pretty=%s josh/filter/libs/master
   * add file2
   * add file1
@@ -45,6 +46,7 @@
   [2] :/sub1
   [2] :/sub2
   [2] :prefix=c
+  [7] sequence_number
   $ git log --graph --pretty=%s josh/filter/libs/foo
   * add file3
 
@@ -63,6 +65,13 @@
   |-- heads
   |   `-- master
   |-- josh
+  |   |-- 24
+  |   |   `-- 0
+  |   |       |-- 5a4a73be0065ab74681f8302fd032224a32ffaed
+  |   |       |-- c37f9b5c5d2022cce0acbae87682f3eb5cdf29fb
+  |   |       |-- d14715b1358e12e9fb4132036e06049fd1ddf88f
+  |   |       |-- d6fc41eeb18ee6e3acf23e9a49bd4f10136d1db0
+  |   |       `-- fcdb5e527e610ecf5ad7e25a5b388fffc2af7240
   |   `-- filter
   |       `-- libs
   |           |-- foo
@@ -74,7 +83,7 @@
   |       `-- master
   `-- tags
   
-  8 directories, 6 files
+  10 directories, 11 files
 
   $ git read-tree HEAD josh/filter/libs/master josh/filter/libs/foo
   $ git commit -m "sync"

--- a/tests/filter/commit_message_raw.t
+++ b/tests/filter/commit_message_raw.t
@@ -13,6 +13,7 @@
   $ josh-filter -s c=:prefix=pre master --update refs/josh/filter/master
   [1] :prefix=c
   [1] :prefix=pre
+  [2] sequence_number
   $ git cat-file commit master
   tree 2f407f8ecb16a66b85e2c84d3889720b7a0e3762
   author Josh <josh@example.com> 1112911993 +0000

--- a/tests/filter/compose_shadow_dir_same_name.t
+++ b/tests/filter/compose_shadow_dir_same_name.t
@@ -92,6 +92,7 @@
       :/xx
       :/sub/xx
   ]
+  [3] sequence_number
   $ git diff ${EMPTY_TREE}..FILTERED_HEAD
   diff --git a/file1 b/file1
   new file mode 100644

--- a/tests/filter/deleted_dir.t
+++ b/tests/filter/deleted_dir.t
@@ -19,6 +19,7 @@ in that subtree repo should have an empty tree
   $ josh-filter -s c=:/sub1 master --update refs/josh/filter/master
   [2] :/sub1
   [2] :prefix=c
+  [4] sequence_number
 
   $ git log refs/josh/filter/master --graph --pretty=%s
   * add file2
@@ -36,6 +37,7 @@ in that subtree repo should have an empty tree
   $ josh-filter -s c=:/sub1 master --update refs/josh/filter/master
   [3] :/sub1
   [3] :prefix=c
+  [6] sequence_number
 
   $ git log refs/josh/filter/master --graph --pretty=%s
   * rm sub1

--- a/tests/filter/empty_head.t
+++ b/tests/filter/empty_head.t
@@ -20,6 +20,7 @@
 
   $ josh-filter -s :/sub1 master --update refs/josh/filter/master
   [2] :/sub1
+  [3] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file2
   * add file1
@@ -27,6 +28,7 @@
   $ josh-filter -s :/sub2 master --update refs/josh/filter/master
   [2] :/sub1
   [2] :/sub2
+  [3] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file3
 
@@ -38,5 +40,6 @@
   Warning: reference refs/josh/filter/master wasn't updated
   [2] :/sub1
   [2] :/sub2
+  [4] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file3

--- a/tests/filter/empty_orphan.t
+++ b/tests/filter/empty_orphan.t
@@ -22,6 +22,7 @@ Empty root commits from unrelated parts of the tree should not be included
   $ josh-filter -s c=:/sub1 master --update refs/josh/filter/master
   [3] :/sub1
   [3] :prefix=c
+  [6] sequence_number
 
   $ git log refs/josh/filter/master --graph --pretty=%s
   * add file3
@@ -83,6 +84,7 @@ Empty root commits from unrelated parts of the tree should not be included
   $ josh-filter -s c=:/sub1 master
   [3] :prefix=c
   [5] :/sub1
+  [10] sequence_number
 
   $ git log FILTERED_HEAD --graph --pretty=%s
   * add file3
@@ -98,6 +100,7 @@ Empty root commits from unrelated parts of the tree should not be included
   [5] :/sub1
   [5] :exclude[::sub1/]
   [6] :prefix=c
+  [10] sequence_number
 
   $ git log FILTERED_HEAD --graph --pretty=%s
   * add some_other_file
@@ -113,6 +116,7 @@ Empty root commits from unrelated parts of the tree should not be included
   [5] :/sub1
   [5] :exclude[::sub1/]
   [6] :prefix=c
+  [12] sequence_number
 
   $ git ls-tree --name-only -r FILTERED_HEAD
   x/c/some_file

--- a/tests/filter/empty_reimport.t
+++ b/tests/filter/empty_reimport.t
@@ -40,6 +40,7 @@
   $ josh-filter -s c=:/pre master --update refs/josh/filter/master
   [2] :prefix=c
   [4] :/pre
+  [7] sequence_number
 
   $ git log josh/filter/master --graph --pretty=%s
   * change on other 2
@@ -82,6 +83,7 @@
   $ josh-filter -s c=:/pre master --update refs/josh/filter/master
   [5] :prefix=c
   [7] :/pre
+  [14] sequence_number
 
   $ git log josh/filter/master --graph --pretty=%s
   *   Merge branch 'other_branch'

--- a/tests/filter/exclude_compose.t
+++ b/tests/filter/exclude_compose.t
@@ -21,6 +21,7 @@
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   [2] :exclude[::sub2/]
+  [3] sequence_number
   $ git checkout -q hidden 1> /dev/null
   $ tree
   .
@@ -44,6 +45,7 @@
       ::sub2/
   ]
   [2] :exclude[::sub2/]
+  [3] sequence_number
 
   $ git checkout -q refs/josh/filtered
   $ tree
@@ -60,6 +62,7 @@
   ]
   [2] :exclude[::sub2/]
   [3] :exclude[:/sub3:prefix=sub1]
+  [3] sequence_number
 
   $ git checkout -q refs/josh/filtered
   $ tree

--- a/tests/filter/file.t
+++ b/tests/filter/file.t
@@ -33,6 +33,7 @@
       c = :/sub1
       a/b = :/sub2
   ]
+  [4] sequence_number
   $ git log --graph --pretty=%s FILTERED_HEAD
   * add file3
   * add file2
@@ -43,6 +44,7 @@
       c = :/sub1
       a/b = :/sub2
   ]
+  [5] sequence_number
   $ git log --graph --pretty=%s FILTERED_HEAD
   * initial
 
@@ -50,7 +52,11 @@
   .git/refs/
   |-- heads
   |   `-- master
+  |-- josh
+  |   `-- 24
+  |       `-- 0
+  |           `-- 8d28f139b3f76b91bc4e6146a5943eb1635bfb11
   `-- tags
   
-  3 directories, 1 file
+  6 directories, 2 files
 

--- a/tests/filter/gpgsig.t
+++ b/tests/filter/gpgsig.t
@@ -39,11 +39,13 @@ If 0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb shows up then the signature was lost
 Remove the signature, the shas are different.
   $ josh-filter :unsign refs/heads/master --update refs/heads/filtered -s
   [1] :unsign
+  [1] sequence_number
   $ git rev-parse master filtered
   cb22ebb8e47b109f7add68b1043e561e0db09802
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb
   $ josh-filter --reverse :unsign refs/heads/double-filtered --update refs/heads/filtered -s
   [1] :unsign
+  [1] sequence_number
   $ git rev-parse master double-filtered
   cb22ebb8e47b109f7add68b1043e561e0db09802
   cb22ebb8e47b109f7add68b1043e561e0db09802

--- a/tests/filter/hide_view.t
+++ b/tests/filter/hide_view.t
@@ -36,6 +36,7 @@
   $ josh-filter -s c=:exclude[::sub1/] master --update refs/josh/filter/master
   [1] :prefix=c
   [2] :exclude[::sub1/]
+  [4] sequence_number
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
   * add file3
@@ -51,6 +52,7 @@
   [2] :exclude[::sub1/]
   [2] :exclude[::sub1/file2]
   [3] :prefix=c
+  [5] sequence_number
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
   * add file3
@@ -70,6 +72,7 @@
   [2] :exclude[::sub1/file2]
   [2] :exclude[::sub2/file3]
   [4] :prefix=c
+  [5] sequence_number
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
   * add file2

--- a/tests/filter/hook_notes.t
+++ b/tests/filter/hook_notes.t
@@ -25,6 +25,7 @@
   $ josh-filter -s :hook=commits HEAD --update refs/josh/filtered
   [2] ::b
   [3] :hook="commits"
+  [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/filtered
   *   add f3

--- a/tests/filter/infofile.t
+++ b/tests/filter/infofile.t
@@ -25,6 +25,7 @@
   $ josh-filter -s c=:/sub1 master --update refs/josh/filter/master
   [2] :/sub1
   [2] :prefix=c
+  [6] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file2
   * add file1
@@ -33,6 +34,7 @@
   Warning: reference refs/josh/filter/master wasn't updated
   [2] :/sub1
   [2] :prefix=c
+  [6] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file2
   * add file1
@@ -41,6 +43,7 @@
   [2] :/sub1
   [2] :/sub2
   [3] :prefix=c
+  [7] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file3
 
@@ -53,5 +56,6 @@
   [2] :/sub1
   [2] :/sub2
   [3] :prefix=c
+  [8] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file3

--- a/tests/filter/join.t
+++ b/tests/filter/join.t
@@ -8,6 +8,7 @@ Initial commit
 Apply prefix filter
   $ josh-filter -s :prefix=subtree refs/heads/master --update refs/heads/filtered
   [1] :prefix=subtree
+  [1] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
   * add file1

--- a/tests/filter/linear.t
+++ b/tests/filter/linear.t
@@ -32,7 +32,8 @@
   * add file1
 
   $ josh-filter -s :linear refs/heads/master --update refs/heads/filtered
-  [3] :linear
+  [4] :linear
+  [4] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
   * Merge branch 'branch2'
@@ -57,7 +58,8 @@
   * add file1
 
   $ josh-filter -s :linear refs/heads/master --update refs/heads/filtered --reverse
-  [3] :linear
+  [4] :linear
+  [4] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/master
   * mod file2

--- a/tests/filter/moved_dir.t
+++ b/tests/filter/moved_dir.t
@@ -19,6 +19,7 @@ in that subtree repo should have an empty tree
   $ josh-filter -s c=:/sub1 master --update refs/josh/filter/master
   [2] :/sub1
   [2] :prefix=c
+  [4] sequence_number
 
   $ git log refs/josh/filter/master --graph --pretty=%s
   * add file2
@@ -38,6 +39,7 @@ in that subtree repo should have an empty tree
   $ josh-filter -s c=:/sub1 master --update refs/josh/filter/master
   [3] :/sub1
   [3] :prefix=c
+  [6] sequence_number
 
   $ git log refs/josh/filter/master --graph --pretty=%s
   * mv sub1
@@ -52,6 +54,7 @@ in that subtree repo should have an empty tree
   $ josh-filter -s c=:/sub1 master --update refs/josh/filter/master2
   [3] :/sub1
   [3] :prefix=c
+  [7] sequence_number
   $ git log refs/josh/filter/master2 --graph --pretty=%s
   * mv sub1
   * add file2

--- a/tests/filter/prefix.t
+++ b/tests/filter/prefix.t
@@ -8,6 +8,7 @@ Initial commit
 Apply prefix filter
   $ josh-filter -s :prefix=subtree refs/heads/master --update refs/heads/filtered
   [1] :prefix=subtree
+  [1] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
   * add file1

--- a/tests/filter/prune_trivial_merge.t
+++ b/tests/filter/prune_trivial_merge.t
@@ -35,6 +35,7 @@
 
   $ josh-filter -s ::file1
   [4] ::file1
+  [5] sequence_number
   $ git log --graph --pretty=%s FILTERED_HEAD
   *   Merge branch 'branch1'
   |\  
@@ -45,6 +46,7 @@
   $ josh-filter -s ::file1:prune=trivial-merge
   [3] :prune=trivial-merge
   [4] ::file1
+  [6] sequence_number
 
   $ git log --graph --pretty=%s FILTERED_HEAD
   * empty commit

--- a/tests/filter/rev.t
+++ b/tests/filter/rev.t
@@ -39,6 +39,7 @@
   $ josh-filter -s :prefix=x/y --update refs/heads/filtered
   [5] :prefix=x
   [5] :prefix=y
+  [10] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   *   37f8b29c9e892ea0eb7abac2759ddc6fb0337203:dcbbddf47649f8e73f59fae92896c0d2cd02b6ec
   |\  
@@ -51,6 +52,7 @@
   $ josh-filter -s ":rev(ffffffffffffffffffffffffffffffffffffffff:prefix=x/y)" --update refs/heads/filtered
   [5] :prefix=x
   [5] :prefix=y
+  [10] sequence_number
   ERROR: `:rev(...)` with nonexistent OID: ffffffffffffffffffffffffffffffffffffffff
   [1]
 
@@ -58,6 +60,7 @@
   [5] :prefix=x
   [5] :prefix=y
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/y)
+  [10] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   *   54651c29aa86e8512a7b9d39e3b8ea26da644247:5f47d9fdffdc726bb8ebcfea67531d2574243c5d
   |\  
@@ -73,6 +76,7 @@
   [5] :prefix=y
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/y)
   [5] :rev(e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
+  [10] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   *   5fe60a2d55b652822b3d3f25410714e9053ba72b:5f47d9fdffdc726bb8ebcfea67531d2574243c5d
   |\  
@@ -95,6 +99,7 @@
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/y)
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/y,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [5] :rev(e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
+  [10] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   *   63fea1234f375bd09019b676da8291f28d2ddb43:5f47d9fdffdc726bb8ebcfea67531d2574243c5d
   |\  
@@ -121,6 +126,7 @@
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/z,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [5] :rev(e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [6] :prefix=x
+  [11] sequence_number
   $ cat > filter.josh <<EOF
   > :rev(
   >   e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y
@@ -140,6 +146,7 @@
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/z,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [5] :rev(e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [6] :prefix=x
+  [11] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   *   1c4fe25dc386c77adaae12d6b1cd3abfa296fc3c:5f47d9fdffdc726bb8ebcfea67531d2574243c5d
   |\  
@@ -155,13 +162,14 @@
   [2] :rev(0000000000000000000000000000000000000000:prefix=x/y,975d4c4975912729482cc864d321c5196a969271:prefix=x/z)
   [2] :rev(0000000000000000000000000000000000000000:prefix=x/y,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [2] :rev(0000000000000000000000000000000000000000:prefix=x/z,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
-  [3] :linear
+  [5] :linear
   [5] :prefix=y
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/y)
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/y,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/z,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [5] :rev(e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [6] :prefix=x
+  [11] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   * f8e8bc9daf54340c9fce647be467d2577b623bbe:5f47d9fdffdc726bb8ebcfea67531d2574243c5d
   * e707f76bb6a1390f28b2162da5b5eb6933009070:5d8a699f74b48c9c595f4615dd3755244e11d176
@@ -195,14 +203,15 @@
   [2] :rev(0000000000000000000000000000000000000000:prefix=x/y,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [2] :rev(0000000000000000000000000000000000000000:prefix=x/z,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [2] :rev(0000000000000000000000000000000000000000:prefix=y,0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:prefix=z)
-  [3] :linear
   [3] :rev(0000000000000000000000000000000000000000:prefix=x,0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:prefix=z,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=y)
+  [5] :linear
   [5] :prefix=y
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/y)
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/y,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [5] :rev(975d4c4975912729482cc864d321c5196a969271:prefix=x/z,e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [5] :rev(e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [6] :prefix=x
+  [12] sequence_number
 
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   * 2944f04c33ea037f7696282bf20b2e570524552e:047b1b6f39e8d95b62ef7f136189005d0e3c80b3

--- a/tests/filter/reverse_hide.t
+++ b/tests/filter/reverse_hide.t
@@ -16,6 +16,7 @@
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   [1] :exclude[::sub2/]
+  [2] sequence_number
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
   $ tree
@@ -33,6 +34,7 @@
 
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   [1] :exclude[::sub2/]
+  [2] sequence_number
 
   $ git checkout master
   Switched to branch 'master'
@@ -67,6 +69,7 @@
 
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   [2] :exclude[::sub2/]
+  [3] sequence_number
   $ git log --graph --pretty=%s refs/heads/master
   * empty commit
   * add sub1/file3

--- a/tests/filter/reverse_hide_edit.t
+++ b/tests/filter/reverse_hide_edit.t
@@ -16,6 +16,7 @@
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   [1] :exclude[::sub2/]
+  [2] sequence_number
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
   $ tree
@@ -33,6 +34,7 @@
 
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   [1] :exclude[::sub2/]
+  [2] sequence_number
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/reverse_hide_edit_missing_change.t
+++ b/tests/filter/reverse_hide_edit_missing_change.t
@@ -29,6 +29,7 @@
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   [1] :exclude[::sub2/]
+  [2] sequence_number
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
   $ tree
@@ -48,6 +49,7 @@
 
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   [1] :exclude[::sub2/]
+  [2] sequence_number
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/reverse_merge.t
+++ b/tests/filter/reverse_merge.t
@@ -26,6 +26,7 @@
 
   $ josh-filter -s :exclude[::sub2/] branch1 --update refs/heads/hidden_branch1
   [2] :exclude[::sub2/]
+  [2] sequence_number
   $ git checkout hidden_branch1
   Switched to branch 'hidden_branch1'
   $ tree
@@ -40,6 +41,7 @@
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden_master
   [3] :exclude[::sub2/]
+  [3] sequence_number
   $ git checkout hidden_master
   Switched to branch 'hidden_master'
   $ tree
@@ -73,6 +75,7 @@
 
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden_master
   [3] :exclude[::sub2/]
+  [3] sequence_number
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/reverse_split.t
+++ b/tests/filter/reverse_split.t
@@ -18,6 +18,7 @@
       a = ::*.a
       :prefix=rest
   ]
+  [2] sequence_number
   $ git checkout filtered 1> /dev/null
   Switched to branch 'filtered'
   $ tree
@@ -42,6 +43,7 @@
       a = ::*.a
       :prefix=rest
   ]
+  [2] sequence_number
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/roundtrip_custom_header.t
+++ b/tests/filter/roundtrip_custom_header.t
@@ -130,3 +130,5 @@ Write a custom header into the commit (h/t https://github.com/Byron/gitoxide/blo
   f2fd7b2 (HEAD -> master, re-filtered) second
   73007fa initial
   7d7c929 initial
+  9340c45 Notes added by 'git_note_create' from libgit2
+  56a1fe0 Notes added by 'git_note_create' from libgit2

--- a/tests/filter/squash.t
+++ b/tests/filter/squash.t
@@ -30,6 +30,7 @@
 
   $ josh-filter -s --squash-pattern "refs/tags/*" --update refs/heads/filtered
   Warning: reference refs/heads/filtered wasn't updated
+  [5] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   fatal: ambiguous argument 'refs/heads/filtered': unknown revision or path not in the working tree.
@@ -45,6 +46,7 @@ This one tag is an annotated tag, to make sure those are handled as well
   [1] :squash(
       1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
   )
+  [7] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   * 977cc3ee14c0d6163ba63bd96f4aeedd43916ba7 (tag: filtered/tag_a, filtered) refs/tags/tag_a
@@ -73,6 +75,7 @@ This one tag is an annotated tag, to make sure those are handled as well
       977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a"
   )
   [4] :author="New Author";"new@e.mail"
+  [11] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   * be41caf35896090033cfd103e06aae721a3ce541 (tag: filtered/tag_a, filtered) refs/tags/tag_a
@@ -115,6 +118,7 @@ This one tag is an annotated tag, to make sure those are handled as well
       a68763bdf2f45a44304067954855749e366a5533:"refs/tags/filtered/filtered/tag_a"
       be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a"
   )
+  [16] sequence_number
   $ git log --graph --pretty=%an:%ae-%cn:%ce refs/heads/filtered
   * Josh:josh@example.com-New Author:new@e.mail
   |\
@@ -181,6 +185,7 @@ This one tag is an annotated tag, to make sure those are handled as well
       be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a"
   )
   [6] :author="New Author";"new@e.mail"
+  [19] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   *   2826b9a173c7a7d5c83d9ae2614de89c77205d83 (filtered) refs/tags/tag_a

--- a/tests/filter/squash_empty_initial.t
+++ b/tests/filter/squash_empty_initial.t
@@ -37,6 +37,7 @@
 
   $ josh-filter -s --squash-pattern "refs/tags/*" --update refs/heads/filtered
   Warning: reference refs/heads/filtered wasn't updated
+  [5] sequence_number
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   fatal: ambiguous argument 'refs/heads/filtered': unknown revision or path not in the working tree.
   Use '--' to separate paths from revisions, like this:
@@ -50,6 +51,7 @@
   [1] :squash(
       882f2656a5075936eb37bfefde740e0b453e4479:"refs/tags/tag_a"
   )
+  [7] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   * 977cc3ee14c0d6163ba63bd96f4aeedd43916ba7 (tag: filtered/tag_a, filtered) refs/tags/tag_a

--- a/tests/filter/submodule.t
+++ b/tests/filter/submodule.t
@@ -25,9 +25,11 @@
 
   $ josh-filter -s :/libs master --update refs/josh/filter/master
   [1] :/libs
+  [2] sequence_number
   $ git ls-tree --name-only -r refs/josh/filter/master 
   $ josh-filter -s c=:/libs master --update refs/josh/filter/master
   Warning: reference refs/josh/filter/master wasn't updated
   [1] :/libs
   [1] :prefix=c
+  [2] sequence_number
   $ git ls-tree --name-only -r refs/josh/filter/master 

--- a/tests/filter/subtree_prefix.t
+++ b/tests/filter/subtree_prefix.t
@@ -44,6 +44,7 @@ Rewrite the subtree part of the history
   $ josh-filter -s ":rev($SUBTREE_TIP:prefix=subtree)" refs/heads/master --update refs/heads/filtered
   [1] :prefix=subtree
   [4] :rev(c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
+  [4] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
   * subtree edit from main repo
@@ -70,6 +71,7 @@ Extract the subtree history
   [1] :prefix=subtree
   [4] :/subtree
   [4] :rev(c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
+  [7] sequence_number
   $ git checkout subtree
   Switched to branch 'subtree'
   $ cat file2
@@ -83,6 +85,7 @@ Work in the subtree, and sync that back.
   [1] :prefix=subtree
   [4] :/subtree
   [4] :rev(c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
+  [7] sequence_number
   $ git log --graph --pretty=%s  refs/heads/master
   * add even more content
   * subtree edit from main repo
@@ -105,6 +108,7 @@ And then re-extract, which should re-construct the same subtree.
   [1] :prefix=subtree
   [5] :/subtree
   [5] :rev(c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
+  [9] sequence_number
   $ test $(git rev-parse subtree) = $(git rev-parse subtree2)
 
 Simulate a feature branch on the main repo that crosses subtree changes
@@ -179,6 +183,7 @@ And finally, sync first from main to sub and then back.
   [1] :prefix=subtree
   [9] :/subtree
   [9] :rev(c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
+  [17] sequence_number
 
   $ git log --graph --pretty=%H:%s refs/heads/master
   *   6ac0ba56575859cfaacd5818084333e532ffc442:Merge branch 'subtree-sync' into subtree
@@ -225,6 +230,7 @@ taken back into the main history.
   [1] :prefix=subtree
   [13] :/subtree
   [13] :rev(c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
+  [25] sequence_number
   $ git ls-tree --name-only -r refs/heads/master
   feature1
   feature2

--- a/tests/filter/workspace_combine_filter.t
+++ b/tests/filter/workspace_combine_filter.t
@@ -56,6 +56,7 @@
   ]
   [2] :prefix=x
   [2] :workspace=ws
+  [4] sequence_number
 
   $ git log --graph --pretty=%s FILTERED_HEAD
   * add ws
@@ -92,6 +93,7 @@
       blub = :/sub1
   ]
   [3] :prefix=xyz
+  [7] sequence_number
 
   $ git log --graph --pretty=%s FILTERED_HEAD
   * add ws

--- a/tests/filter/workspace_discover.t
+++ b/tests/filter/workspace_discover.t
@@ -65,6 +65,7 @@
   ]
   [2] :workspace=ws
   [2] :workspace=ws2
+  [9] sequence_number
 
   $ cat > workspace.josh <<EOF
   > :/sub1::file1
@@ -101,3 +102,4 @@
   ]
   [2] :workspace=ws
   [2] :workspace=ws2
+  [10] sequence_number

--- a/tests/filter/workspace_exclude.t
+++ b/tests/filter/workspace_exclude.t
@@ -29,6 +29,7 @@
       ::sub2/subsub/
   ]
   [2] :workspace=ws
+  [3] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
   * add ws
@@ -59,6 +60,7 @@
       ::sub2/subsub/
   ]
   [2] :workspace=ws
+  [3] sequence_number
   $ git checkout master
   Switched to branch 'master'
 

--- a/tests/filter/workspace_implicit_filter.t
+++ b/tests/filter/workspace_implicit_filter.t
@@ -28,6 +28,7 @@
       ::sub2/subsub/
   ]
   [2] :workspace=ws
+  [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master
   * add ws

--- a/tests/filter/workspace_modify_chain.t
+++ b/tests/filter/workspace_modify_chain.t
@@ -29,6 +29,7 @@
   [1] :prefix=subsub
   [2] :workspace=ws
   [3] :/sub2
+  [7] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
   * add file2
@@ -53,6 +54,7 @@
   [1] :prefix=subsub
   [2] :workspace=ws
   [3] :/sub2
+  [7] sequence_number
   $ git checkout master
   Switched to branch 'master'
 

--- a/tests/filter/workspace_multiple_globs.t
+++ b/tests/filter/workspace_multiple_globs.t
@@ -33,6 +33,7 @@
       b = ::**/file1
   ]
   [2] :workspace=ws
+  [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master
   * add ws

--- a/tests/filter/workspace_redirect.t
+++ b/tests/filter/workspace_redirect.t
@@ -53,16 +53,18 @@
       ::sub2/subsub/
   ]
   [3] :workspace=ws
+  [7] sequence_number
   $ josh-filter -s :workspace=ws_new master --update refs/heads/filtered_new
   [1] :prefix=b
-  [1] :workspace=ws_new
   [2] :/sub3
   [2] :[
       a = :/sub1
       ::sub2/subsub/
   ]
+  [2] :workspace=ws_new
   [3] :workspace=ws
   [5] :exclude[::ws_new]
+  [7] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
   *   edit ws
@@ -188,3 +190,4 @@
   [4] :exclude[::ws]
   [4] :workspace=ws
   [6] :exclude[::ws_new]
+  [10] sequence_number

--- a/tests/filter/workspace_single_file.t
+++ b/tests/filter/workspace_single_file.t
@@ -46,6 +46,7 @@
       ::sub2/subsub/
   ]
   [2] :workspace=ws
+  [4] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master
   * add ws
@@ -86,6 +87,7 @@
   ]
   [2] :workspace=ws
   [2] :workspace=ws2
+  [4] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master
   * add ws2

--- a/tests/filter/workspace_trailing_slash.t
+++ b/tests/filter/workspace_trailing_slash.t
@@ -28,6 +28,7 @@
       a/b = :/sub2
   ]
   [2] :workspace=ws
+  [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master
   * add ws
@@ -48,6 +49,7 @@
       a/b = :/sub2
   ]
   [3] :workspace=ws
+  [4] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master
   * add trailing slash

--- a/tests/filter/workspace_unique.t
+++ b/tests/filter/workspace_unique.t
@@ -38,6 +38,7 @@ so the workspace.josh will still appear in the root of the workspace
       b = ::ws/workspace.josh
   ]
   [2] :workspace=ws
+  [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master
   * add ws


### PR DESCRIPTION
With the addition of a notes backed cache we will have the possibility of avoiding a "cold start" by transferring just the notes to another repo. To keep the amount of extra data small the notes cache is kept sparse: Not all commits have and entry and also in shards by sequence number, as old entries are unlikely to be relevant.
The old traversal logic did not perform very well with sparse cache. Especially "find_known" proved to be a bottleneck. So the traversal is revised now to work better in the sparse cache case.

Change: cache-sparse-shards