### PR TITLE
Add "pin" filter [2]

### DIFF
--- a/docs/src/reference/filters.md
+++ b/docs/src/reference/filters.md
@@ -121,6 +121,22 @@ tree.
 Normally Josh will keep all commits in the filtered history whose tree differs from any of it's
 parents.
 
+### Pin tree contents
+
+Pin revision of a subtree to revision of the parent commit.
+
+In practical terms, it means that file and folder updates are "held off", and revisions are "pinned".
+If a tree entry already existed in the parent revision, that version will be chosen.
+Otherwise, the tree entry will not appear in the filtered commit.
+
+The source of the parent revision is always the first commit parent.
+
+Note that this filter is only practical when used with `:hook` or `workspace.josh`,
+as it should apply per-revision only. Applying `:pin` for the whole history
+will result in the subtree being excluded from all revisions.
+
+Refer to `pin_filter_workspace.t` and `pin_filter_hook.t` for reference.
+
 Filter order matters
 --------------------
 

--- a/josh-core/src/filter/opt.rs
+++ b/josh-core/src/filter/opt.rs
@@ -82,6 +82,7 @@ pub fn simplify(filter: Filter) -> Filter {
             Op::Subtract(simplify(to_filter(a)), simplify(to_filter(b)))
         }
         Op::Exclude(b) => Op::Exclude(simplify(b)),
+        Op::Pin(b) => Op::Pin(simplify(b)),
         _ => to_op(filter),
     });
 
@@ -137,6 +138,7 @@ pub fn flatten(filter: Filter) -> Filter {
             Op::Subtract(flatten(to_filter(a)), flatten(to_filter(b)))
         }
         Op::Exclude(b) => Op::Exclude(flatten(b)),
+        Op::Pin(b) => Op::Pin(flatten(b)),
         _ => to_op(filter),
     });
 
@@ -440,8 +442,9 @@ fn step(filter: Filter) -> Filter {
             (a, b) => Op::Chain(step(to_filter(a)), step(to_filter(b))),
         },
         Op::Exclude(b) if b == to_filter(Op::Nop) => Op::Empty,
-        Op::Exclude(b) if b == to_filter(Op::Empty) => Op::Nop,
+        Op::Exclude(b) | Op::Pin(b) if b == to_filter(Op::Empty) => Op::Nop,
         Op::Exclude(b) => Op::Exclude(step(b)),
+        Op::Pin(b) => Op::Pin(step(b)),
         Op::Subtract(a, b) if a == b => Op::Empty,
         Op::Subtract(af, bf) => match (to_op(af), to_op(bf)) {
             (Op::Empty, _) => Op::Empty,
@@ -504,6 +507,7 @@ pub fn invert(filter: Filter) -> JoshResult<Filter> {
         Op::Pattern(pattern) => Some(Op::Pattern(pattern)),
         Op::Rev(_) => Some(Op::Nop),
         Op::RegexReplace(_) => Some(Op::Nop),
+        Op::Pin(_) => Some(Op::Nop),
         _ => None,
     };
 

--- a/josh-core/src/filter/parse.rs
+++ b/josh-core/src/filter/parse.rs
@@ -115,6 +115,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> JoshResult<Op> {
                 [cmd, args] => {
                     let g = parse_group(args)?;
                     match *cmd {
+                        "pin" => Ok(Op::Pin(to_filter(Op::Compose(g)))),
                         "exclude" => Ok(Op::Exclude(to_filter(Op::Compose(g)))),
                         "subtract" if g.len() == 2 => Ok(Op::Subtract(g[0], g[1])),
                         _ => Err(josh_error(&format!("parse_item: no match {:?}", cmd))),

--- a/tests/filter/pin_compose.t
+++ b/tests/filter/pin_compose.t
@@ -1,0 +1,117 @@
+  $ export GIT_TREE_FMT='%(objectmode) %(objecttype) %(objectname) %(path)'
+
+  $ export TESTTMP=${PWD}
+  $ cd ${TESTTMP}
+
+  $ git init -q repo
+  $ cd repo
+  $ mkdir -p josh/overlay
+  $ mkdir -p code
+
+Populate repo contents for the first commit
+
+  $ cat << EOF > code/app.js
+  > async fn main() {
+  >   await fetch("http://127.0.0.1");
+  > }
+  > EOF
+
+  $ cat << EOF > code/lib.js
+  > fn log() {
+  >   console.log("logged!");
+  > }
+  > EOF
+
+Also create a workspace with the tree overlay filter
+
+We first select files in josh/overlay, whatever is in there
+will take priority over the next tree in the composition filter
+
+  $ mkdir -p workspaces/overlay
+  $ cat << EOF > workspaces/overlay/workspace.josh
+  > :[
+  >   :/code
+  >   :/josh/overlay
+  > ]
+  > EOF
+
+Here's the repo layout at this point:
+
+  $ tree .
+  .
+  |-- code
+  |   |-- app.js
+  |   `-- lib.js
+  |-- josh
+  |   `-- overlay
+  `-- workspaces
+      `-- overlay
+          `-- workspace.josh
+  
+  6 directories, 3 files
+
+Commit this:
+
+  $ git add .
+  $ git commit -q -m "first commit"
+
+Now, filter the ws and check the result
+
+  $ josh-filter ':workspace=workspaces/overlay'
+  $ git ls-tree --format="${GIT_TREE_FMT}" -r FILTERED_HEAD
+  100644 blob 0747fcb9cd688a7876932dcc30006e6ffa9106d6 app.js
+  100644 blob 5910ad90fda519a6cc9299d4688679d56dc8d6dd lib.js
+  100644 blob 39dc0f50ad353a5ee880b4a87ecc06dee7b48c92 workspace.josh
+
+Save the OID of app.js before making changes:
+
+  $ export ORIGINAL_APP_OID=$(git ls-tree --format="%(objectname)" FILTERED_HEAD app.js)
+  $ echo "${ORIGINAL_APP_OID}"
+  0747fcb9cd688a7876932dcc30006e6ffa9106d6
+
+Make next commit: both files will change
+
+  $ cat << EOF > code/app.js
+  > async fn main() {
+  >   await fetch("http://internal-secret-portal.company.com");
+  > }
+  > EOF
+
+  $ cat << EOF > code/lib.js
+  > fn log() {
+  >   console.log("INFO: logged!");
+  > }
+  > EOF
+
+  $ git add code/app.js code/lib.js
+
+Insert the old app.js OID into the overlay.
+Note that we aren't copying the file -- we are directly referencing the OID.
+This ensures it's the same entry in git ODB.
+
+  $ git update-index --add --cacheinfo 100644,"${ORIGINAL_APP_OID}","josh/overlay/app.js"
+  $ git commit -q -m "second commit"
+
+Verify commit tree looks right:
+
+  $ git ls-tree -r --format="${GIT_TREE_FMT}" HEAD
+  100644 blob 1540d15e1bdc499e31ea05703a0daaf520774a85 code/app.js
+  100644 blob 627cdb2ef7a3eb1a2b4537ce17fea1d93bfecdd2 code/lib.js
+  100644 blob 0747fcb9cd688a7876932dcc30006e6ffa9106d6 josh/overlay/app.js
+  100644 blob 39dc0f50ad353a5ee880b4a87ecc06dee7b48c92 workspaces/overlay/workspace.josh
+
+Filter the workspace and check the result:
+
+  $ josh-filter ':workspace=workspaces/overlay'
+
+We can see now that the app.js file was held at the previous version:
+
+  $ git ls-tree --format="${GIT_TREE_FMT}" -r FILTERED_HEAD
+  100644 blob 0747fcb9cd688a7876932dcc30006e6ffa9106d6 app.js
+  100644 blob 627cdb2ef7a3eb1a2b4537ce17fea1d93bfecdd2 lib.js
+  100644 blob 39dc0f50ad353a5ee880b4a87ecc06dee7b48c92 workspace.josh
+
+  $ git show FILTERED_HEAD:app.js
+  async fn main() {
+    await fetch("http://127.0.0.1");
+  }

--- a/tests/filter/pin_filter_hook.t
+++ b/tests/filter/pin_filter_hook.t
@@ -1,0 +1,134 @@
+  $ export GIT_TREE_FMT='%(objectmode) %(objecttype) %(objectname) %(path)'
+
+  $ export TESTTMP=${PWD}
+  $ cd ${TESTTMP}
+
+Similar scenario to pin_filter_workspace.t, except here it's using
+filter hooks as opposed to workspace.josh
+
+  $ git init -q repo
+  $ cd repo
+  $ mkdir -p code
+
+Populate repo contents for the first commit
+
+  $ cat << EOF > code/app.js
+  > async fn main() {
+  >   await fetch("http://127.0.0.1");
+  > }
+  > EOF
+
+  $ cat << EOF > code/lib.js
+  > fn log() {
+  >   console.log("logged!");
+  > }
+  > EOF
+
+  $ git add .
+  $ git commit -q -m "first commit"
+
+Add note with basic filter - no pin yet
+
+  $ git notes add -m ':/code' -f
+
+Update files, but pin one file using git notes
+
+  $ cat << EOF > code/app.js
+  > async fn main() {
+  >   await fetch("https://secret-internal-resource.contoso.com");
+  > }
+  > EOF
+
+  $ cat << EOF > code/lib2.js
+  > fn foo() {}
+  > EOF
+
+  $ git add .
+  $ git commit -q -m "secret update"
+
+Add note with pin filter for this commit
+
+  $ git notes add -m ':/code:pin[::app.js]' -f
+
+Filter using the hook
+
+  $ josh-filter ':hook=commits'
+
+Check the filtered history
+
+  $ git log --oneline FILTERED_HEAD
+  e22b4d0 secret update
+  71f53f9 first commit
+
+Verify that the secret update commit doesn't show app.js changes
+
+  $ git show FILTERED_HEAD
+  commit e22b4d031f61b2d443a11700627fa73011bfd95f
+  Author: Josh <josh@example.com>
+  Date:   Thu Apr 7 22:13:13 2005 +0000
+  
+      secret update
+  
+  diff --git a/lib2.js b/lib2.js
+  new file mode 100644
+  index 0000000..8f3b7ef
+  --- /dev/null
+  +++ b/lib2.js
+  @@ -0,0 +1 @@
+  +fn foo() {}
+
+Add another file and use hook to hold it
+
+  $ cat << EOF > code/lib3.js
+  > fn bar() {}
+  > EOF
+
+Also update app.js to remove the secret - remove pin from it
+
+  $ cat << EOF > code/app.js
+  > async fn main() {
+  >   const host = process.env.REMOTE_HOST;
+  >   await fetch(host);
+  > }
+  > EOF
+
+  $ git add .
+  $ git commit -q -m "read env variable"
+
+Add note to pin the new file and allow app.js changes
+
+  $ git notes add -m ':/code:pin[::lib3.js]' -f
+
+  $ josh-filter ':hook=commits'
+
+Check the resulting history
+
+  $ git log --oneline FILTERED_HEAD
+  6b712b2 read env variable
+  e22b4d0 secret update
+  71f53f9 first commit
+
+Verify that app.js changes are now visible but lib3.js is pinned
+
+  $ git show FILTERED_HEAD -- app.js
+  commit 6b712b21b99511e8b40334a96ef266d2a38f2e94
+  Author: Josh <josh@example.com>
+  Date:   Thu Apr 7 22:13:13 2005 +0000
+  
+      read env variable
+  
+  diff --git a/app.js b/app.js
+  index 0747fcb..990514f 100644
+  --- a/app.js
+  +++ b/app.js
+  @@ -1,3 +1,4 @@
+   async fn main() {
+  -  await fetch("http://127.0.0.1");
+  +  const host = process.env.REMOTE_HOST;
+  +  await fetch(host);
+   }
+
+  $ git ls-tree --format="${GIT_TREE_FMT}" -r FILTERED_HEAD
+  100644 blob 990514fe4034b4d8dac7ffa05d4a74331b57cb21 app.js
+  100644 blob 5910ad90fda519a6cc9299d4688679d56dc8d6dd lib.js
+  100644 blob 8f3b7ef112a0f4951016967f520b9399c02f902d lib2.js

--- a/tests/filter/pin_filter_workspace.t
+++ b/tests/filter/pin_filter_workspace.t
@@ -1,0 +1,163 @@
+  $ export GIT_TREE_FMT='%(objectmode) %(objecttype) %(objectname) %(path)'
+
+  $ export TESTTMP=${PWD}
+  $ cd ${TESTTMP}
+
+  $ git init -q repo
+  $ cd repo
+  $ mkdir -p code
+
+Populate repo contents for the first commit
+
+  $ cat << EOF > code/app.js
+  > async fn main() {
+  >   await fetch("http://127.0.0.1");
+  > }
+  > EOF
+
+  $ cat << EOF > code/lib.js
+  > fn log() {
+  >   console.log("logged!");
+  > }
+  > EOF
+
+Create a workspace: the :pin filter must be applicable per-commit, so it should
+be tied to commit sha1 either via workspace or via hook. Otherwise we are going
+to pin a file in every commit, resulting in no versions of the file appearing at all.
+Don't pin anything yet.
+
+  $ mkdir -p workspaces/code
+  $ cat << EOF > workspaces/code/workspace.josh
+  > :/code
+  > EOF
+
+  $ git add .
+  $ git commit -q -m "first commit"
+
+  $ josh-filter ':workspace=workspaces/code'
+  $ git ls-tree --format="${GIT_TREE_FMT}" -r FILTERED_HEAD
+  100644 blob 0747fcb9cd688a7876932dcc30006e6ffa9106d6 app.js
+  100644 blob 5910ad90fda519a6cc9299d4688679d56dc8d6dd lib.js
+  100644 blob 035bf7abf8a572ccf122f71984ed0e9680e8a01d workspace.josh
+
+Update a file, but put it on pin in workspace
+
+  $ cat << EOF > code/app.js
+  > async fn main() {
+  >   await fetch("https://secret-internal-resource.contoso.com");
+  > }
+  > EOF
+
+  $ cat << EOF > workspaces/code/workspace.josh
+  > :/code:pin[::app.js]
+  > EOF
+
+  $ git add .
+  $ git commit -q -m "secret update"
+
+Filter and check history
+
+  $ josh-filter ':workspace=workspaces/code'
+  $ git log --oneline FILTERED_HEAD
+  4f83a36 secret update
+  6620984 first commit
+
+We only see workspace.josh update
+
+  $ git show FILTERED_HEAD
+  commit 4f83a362554fde79389596222637db9084e028bc
+  Author: Josh <josh@example.com>
+  Date:   Thu Apr 7 22:13:13 2005 +0000
+  
+      secret update
+  
+  diff --git a/workspace.josh b/workspace.josh
+  index 035bf7a..801a6f7 100644
+  --- a/workspace.josh
+  +++ b/workspace.josh
+  @@ -1 +1 @@
+  -:/code
+  +:/code:pin[::app.js]
+
+We can also exclude workspace.josh itself
+
+  $ josh-filter ':workspace=workspaces/code:exclude[::workspace.josh]'
+
+This makes the commit disappear completely
+
+  $ git log --oneline FILTERED_HEAD
+  71f53f9 first commit
+
+Now, let's add another file, but prevent it from appearing
+
+  $ cat << EOF > code/lib2.js
+  > fn bar() {}
+  > EOF
+
+Also, update app.js and remove pin from it
+
+  $ cat << EOF > code/app.js
+  > async fn main() {
+  >   const host = process.env.REMOTE_HOST;
+  >   await fetch(host);
+  > }
+  > EOF
+
+  $ cat << EOF > workspaces/code/workspace.josh
+  > :/code:pin[::lib2.js]
+  > EOF
+
+  $ git add .
+  $ git commit -q -m "read env variable"
+
+  $ josh-filter ':workspace=workspaces/code'
+
+Check the resulting history
+
+  $ git log --oneline FILTERED_HEAD
+  824fe83 read env variable
+  4f83a36 secret update
+  6620984 first commit
+
+Check that files changed in commits are as expected
+
+  $ git show --stat FILTERED_HEAD~1
+  commit 4f83a362554fde79389596222637db9084e028bc
+  Author: Josh <josh@example.com>
+  Date:   Thu Apr 7 22:13:13 2005 +0000
+  
+      secret update
+  
+   workspace.josh | 2 +-
+   1 file changed, 1 insertion(+), 1 deletion(-)
+
+  $ git show --stat FILTERED_HEAD
+  commit 824fe83d4a74a71fd7bec25756166863e063b932
+  Author: Josh <josh@example.com>
+  Date:   Thu Apr 7 22:13:13 2005 +0000
+  
+      read env variable
+  
+   app.js         | 3 ++-
+   workspace.josh | 2 +-
+   2 files changed, 3 insertions(+), 2 deletions(-)
+
+We can also verify that the "offending" version was skipped in filtered history
+
+  $ git show FILTERED_HEAD -- app.js
+  commit 824fe83d4a74a71fd7bec25756166863e063b932
+  Author: Josh <josh@example.com>
+  Date:   Thu Apr 7 22:13:13 2005 +0000
+  
+      read env variable
+  
+  diff --git a/app.js b/app.js
+  index 0747fcb..990514f 100644
+  --- a/app.js
+  +++ b/app.js
+  @@ -1,3 +1,4 @@
+   async fn main() {
+  -  await fetch("http://127.0.0.1");
+  +  const host = process.env.REMOTE_HOST;
+  +  await fetch(host);
+   }


### PR DESCRIPTION
"pin" filter holds off updates to the tree, choosing versions from parent, or preventing versions from appearing.

this version has less restrictions than the first iteration, allowing the pin filter to be used in more positions