### PR TITLE
Remove parents from Apply struct

### DIFF
--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -277,6 +277,8 @@ Flushed credential cache
       |   |   `-- 8233465e92d353e2ef47c02dc568ea44a32339
       |   |-- 70
       |   |   `-- 5dcb4e33bd0dd3f95d5831fc8dc8a41ca3e566
+      |   |-- 7b
+      |   |   `-- 418ed7c356797b1a8eef3ff949632495d273c6
       |   |-- 7d
       |   |   `-- 5816334652b9738e33e4ceaf925573c3414e0c
       |   |-- 85
@@ -295,6 +297,8 @@ Flushed credential cache
       |   |   `-- 613be55337cdfab189935d8dbd1d4f427ef75e
       |   |-- b7
       |   |   `-- 8eb888451be077531b50794384c2faec025765
+      |   |-- cd
+      |   |   `-- 9ae8cb61e7d1aaa7b90766ff9aa9b3dc78c856
       |   |-- db
       |   |   `-- 9120ba624b0afe79d37a5a262d8deb14e13707
       |   |-- f0
@@ -308,4 +312,4 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  69 directories, 56 files
+  71 directories, 58 files

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -343,6 +343,8 @@
       |   |   `-- 2a35c53f4e5901c9cc083a94b417c15837cad8
       |   |-- 22
       |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
+      |   |-- 23
+      |   |   `-- f7e90462b3fc5db0a26335139e1fe83d04d2cd
       |   |-- 26
       |   |   `-- 6864a895cac573b04a44bd40ee3bd8fe458a5f
       |   |-- 2c
@@ -377,18 +379,25 @@
       |   |   `-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
       |   |-- 83
       |   |   `-- 3812f1557e561166754add564fe32228dd1703
+      |   |-- 96
+      |   |   `-- f5351b972284f81d7246836f82f6be06c6631f
       |   |-- 98
       |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
       |   |-- 9c
       |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
       |   |-- 9f
       |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- a0
+      |   |   `-- 28e4ad33176e7db6f3d4a5fc7e92257cfe213e
       |   |-- a3
       |   |   `-- d19dcb2f51fa1efd55250f60df559c2b8270b8
       |   |-- a4
-      |   |   `-- 1772e0c7cdad1a13b7a7bc38c0d382a5a827ce
+      |   |   |-- 1772e0c7cdad1a13b7a7bc38c0d382a5a827ce
+      |   |   `-- 8223bf4fc7801a0322b4ecaa5ed6a2c5dce7f1
       |   |-- b0
       |   |   `-- fdeb65d9b9069015ef9c0f735a4f6f2f28fe77
+      |   |-- b1
+      |   |   `-- c1b15558aebbce0682f25933cb729e9acd209c
       |   |-- b6
       |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
       |   |-- b8
@@ -407,8 +416,12 @@
       |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+      |   |-- e2
+      |   |   `-- 5d071c2db414f24473e3768c063dbcf8c55d04
       |   |-- ea
       |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
+      |   |-- ed
+      |   |   `-- 8ae0c02d30bd34d7a8584cb0930d0d7a58df26
       |   |-- f2
       |   |   |-- 257977b96d2272be155d6699046148e477e9fb
       |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
@@ -423,6 +436,6 @@
           |-- namespaces
           `-- tags
   
-  101 directories, 92 files
+  107 directories, 99 files
 
 $ cat ${TESTTMP}/josh-proxy.out


### PR DESCRIPTION
With the new per_rev_filter function, we no longer need parents in Apply