### PR TITLE
Replace unindent dependency with indoc's formatdoc! macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,7 +1878,6 @@ dependencies = [
  "sled",
  "strfmt",
  "tracing",
- "unindent",
 ]
 
 [[package]]

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -35,4 +35,3 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sled = "0.34.7"
 tracing = { workspace = true }
-unindent = "0.2.3"

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -402,7 +402,7 @@ pub fn unapply_filter(
                     filtered_parent_ids.pop();
                 }
                 OrphansMode::Fail => {
-                    return Err(josh_error(&unindent::unindent(&format!(
+                    return Err(josh_error(&indoc::formatdoc!(
                         r###"
                         Rejecting new orphan branch at {:?} ({:?})
                         Specify one of these options:
@@ -412,7 +412,7 @@ pub fn unapply_filter(
                         "###,
                         module_commit.summary().unwrap_or_default(),
                         module_commit.id(),
-                    ))));
+                    )));
                 }
             }
         }

--- a/josh-proxy/Cargo.toml
+++ b/josh-proxy/Cargo.toml
@@ -41,7 +41,6 @@ tracing = { workspace = true }
 tracing-futures = "0.2.5"
 tracing-opentelemetry = "0.32.0"
 tracing-subscriber = { workspace = true }
-unindent = "0.2.3"
 url = "2.5.4"
 uuid = { version = "1.18.1", features = ["v4"] }
 josh-rpc = { path = "../josh-rpc" }

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -194,14 +194,14 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> josh_core::JoshResult<Str
                 "resolve_original_target"
             );
 
-            return Err(josh_core::josh_error(&unindent::unindent(&format!(
+            return Err(josh_core::josh_error(&indoc::formatdoc!(
                 r###"
                     Reference {:?} does not exist on remote.
                     If you want to create it, pass "-o base=<basebranch>" or "-o base=path/to/ref"
                     to specify a base branch/reference.
                     "###,
                 baseref
-            ))));
+            )));
         };
 
         let reparent_orphans = if push_options.create {


### PR DESCRIPTION
Remove the unindent dependency and use the existing indoc dependency's formatdoc! macro instead, which provides the same functionality.

Follows up on #1588

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/josh-project/josh/tree/claude/pr-1588-20251114-0643) | [View job run](https://github.com/josh-project/josh/actions/runs/19356649045