### PR TITLE
Extend file filter to support renames

### DIFF
--- a/docs/src/reference/filters.md
+++ b/docs/src/reference/filters.md
@@ -33,9 +33,20 @@ Note that ``:/a/b`` and ``:/a:/b`` are equivalent ways to get the same result.
 ### Directory **`::a/`**
 A shorthand for the commonly occurring filter combination ``:/a:prefix=a``.
 
-### File **`::a`**
-Produces a tree with only the specified file in it's root.
+### File **`::a`** or **`::destination=source`**
+Produces a tree with only the specified file.
+
+When using a single argument (`::a`), the file is placed at the same full path as in the source tree.
+When using the `destination=source` syntax (`::destination=source`), the file is renamed from `source` to `destination` in the filtered tree.
+
+Examples:
+- `::file.txt` - Selects `file.txt` and places it at `file.txt`
+- `::src/file.txt` - Selects `src/file.txt` and places it at `src/file.txt`
+- `::renamed.txt=src/original.txt` - Selects `src/original.txt` and places it at `renamed.txt`
+- `::subdir/file.txt=src/file.txt` - Selects `src/file.txt` and places it at `subdir/file.txt`
+
 Note that `::a/b` is equivalent to `::a/::b`.
+Pattern filters (with `*`) cannot be combined with the `destination=source` syntax.
 
 ### Prefix **`:prefix=a`**
 Take the input tree and place it into subdirectory ``a``.

--- a/josh-core/src/filter/grammar.pest
+++ b/josh-core/src/filter/grammar.pest
@@ -37,7 +37,7 @@ filter_spec = { (
 filter_group = { CMD_START ~ cmd? ~ GROUP_START ~ compose ~ GROUP_END }
 filter_subdir = { CMD_START ~ "/" ~ argument }
 filter_nop = { CMD_START ~ "/" }
-filter_presub = { CMD_START ~ ":" ~ argument }
+filter_presub = { CMD_START ~ ":" ~ argument ~ ("=" ~ argument)? }
 filter = { CMD_START ~ cmd ~ "=" ~ (argument ~ (";" ~ argument)*)? }
 filter_noarg = { CMD_START ~ cmd }
 filter_message = { CMD_START ~ string ~ (";" ~ string)? }

--- a/josh-core/src/filter/opt.rs
+++ b/josh-core/src/filter/opt.rs
@@ -501,7 +501,7 @@ pub fn invert(filter: Filter) -> JoshResult<Filter> {
         Op::Unsign => Some(Op::Unsign),
         Op::Empty => Some(Op::Empty),
         Op::Subdir(path) => Some(Op::Prefix(path)),
-        Op::File(path) => Some(Op::File(path)),
+        Op::File(dest_path, source_path) => Some(Op::File(source_path, dest_path)),
         Op::Prefix(path) => Some(Op::Subdir(path)),
         Op::Pattern(pattern) => Some(Op::Pattern(pattern)),
         Op::Rev(_) => Some(Op::Nop),

--- a/tests/filter/file_destination.t
+++ b/tests/filter/file_destination.t
@@ -1,0 +1,172 @@
+  $ export TESTTMP=${PWD}
+
+Test File filter with destination path
+  $ cd ${TESTTMP}
+  $ git init -q test_dest 1> /dev/null
+  $ cd test_dest
+
+  $ mkdir -p src/subdir
+  $ echo "source content" > src/subdir/original.txt
+  $ echo "other file" > src/subdir/other.txt
+  $ echo "root file" > src/root.txt
+  $ echo "another" > another.txt
+  $ git add .
+  $ git commit -m "add files" 1> /dev/null
+
+  $ josh-filter -s ::renamed.txt=src/subdir/original.txt master --update refs/josh/master
+  [1] ::renamed.txt=src/subdir/original.txt
+  [1] sequence_number
+
+  $ git checkout refs/josh/master 2> /dev/null
+  $ tree
+  .
+  `-- renamed.txt
+  
+  1 directory, 1 file
+  $ cat renamed.txt
+  source content
+
+Test File filter with destination path in subdirectory
+  $ cd ${TESTTMP}
+  $ git init -q test_dest_subdir 1> /dev/null
+  $ cd test_dest_subdir
+
+  $ mkdir -p src/subdir
+  $ echo "source content" > src/subdir/original.txt
+  $ echo "other file" > src/subdir/other.txt
+  $ echo "root file" > src/root.txt
+  $ echo "another" > another.txt
+  $ git add .
+  $ git commit -m "add files" 1> /dev/null
+
+  $ josh-filter -s ::dest/subdir/renamed.txt=src/subdir/original.txt master --update refs/josh/master
+  [1] ::dest/subdir/renamed.txt=src/subdir/original.txt
+  [1] sequence_number
+
+  $ git checkout refs/josh/master 2> /dev/null
+  $ tree
+  .
+  `-- dest
+      `-- subdir
+          `-- renamed.txt
+  
+  3 directories, 1 file
+  $ cat dest/subdir/renamed.txt
+  source content
+
+Test File filter spec formatting with destination path
+  $ josh-filter -p ::dest/renamed.txt=src/file.txt
+  ::dest/renamed.txt=src/file.txt
+
+Test File filter backward compatibility (no destination path - keeps same path)
+  $ cd ${TESTTMP}
+  $ git init -q test_backward 1> /dev/null
+  $ cd test_backward
+
+  $ mkdir -p src/subdir
+  $ echo "content" > src/subdir/file.txt
+  $ echo "other file" > src/subdir/other.txt
+  $ echo "root file" > src/root.txt
+  $ echo "another" > another.txt
+  $ git add .
+  $ git commit -m "add files" 1> /dev/null
+
+  $ josh-filter -s ::src/subdir/file.txt master --update refs/josh/master
+  [1] ::src/subdir/file.txt
+  [1] sequence_number
+
+  $ git checkout refs/josh/master 2> /dev/null
+  $ tree
+  .
+  `-- src
+      `-- subdir
+          `-- file.txt
+  
+  3 directories, 1 file
+  $ cat src/subdir/file.txt
+  content
+
+Test File filter with destination path --reverse
+  $ cd ${TESTTMP}
+  $ git init -q test_reverse 1> /dev/null
+  $ cd test_reverse
+
+  $ mkdir -p src/subdir
+  $ echo "source content" > src/subdir/original.txt
+  $ echo "other file" > src/subdir/other.txt
+  $ echo "root file" > src/root.txt
+  $ echo "another" > another.txt
+  $ git add .
+  $ git commit -m "add files" 1> /dev/null
+
+  $ josh-filter -s ::renamed.txt=src/subdir/original.txt master --update refs/josh/master
+  [1] ::renamed.txt=src/subdir/original.txt
+  [1] sequence_number
+
+  $ git checkout refs/josh/master 2> /dev/null
+  $ echo "modified content" > renamed.txt
+  $ git add renamed.txt
+  $ git commit -m "modify file" 1> /dev/null
+
+  $ josh-filter -s ::renamed.txt=src/subdir/original.txt --reverse master --update refs/josh/master
+  [1] ::renamed.txt=src/subdir/original.txt
+  [1] sequence_number
+
+  $ git checkout master 2> /dev/null
+  $ cat src/subdir/original.txt
+  source content
+  $ cat src/subdir/other.txt
+  other file
+  $ tree
+  .
+  |-- another.txt
+  `-- src
+      |-- root.txt
+      `-- subdir
+          |-- original.txt
+          `-- other.txt
+  
+  3 directories, 4 files
+
+Test File filter backward compatibility --reverse
+  $ cd ${TESTTMP}
+  $ git init -q test_reverse_backward 1> /dev/null
+  $ cd test_reverse_backward
+
+  $ mkdir -p src/subdir
+  $ echo "content" > src/subdir/file.txt
+  $ echo "other file" > src/subdir/other.txt
+  $ echo "root file" > src/root.txt
+  $ echo "another" > another.txt
+  $ git add .
+  $ git commit -m "add files" 1> /dev/null
+
+  $ josh-filter -s ::src/subdir/file.txt master --update refs/josh/master
+  [1] ::src/subdir/file.txt
+  [1] sequence_number
+
+  $ git checkout refs/josh/master 2> /dev/null
+  $ echo "modified content" > src/subdir/file.txt
+  $ git add src/subdir/file.txt
+  $ git commit -m "modify file" 1> /dev/null
+
+  $ josh-filter -s ::src/subdir/file.txt --reverse master --update refs/josh/master
+  [1] ::src/subdir/file.txt
+  [1] sequence_number
+
+  $ git checkout master 2> /dev/null
+  $ cat src/subdir/file.txt
+  content
+  $ cat src/subdir/other.txt
+  other file
+  $ tree
+  .
+  |-- another.txt
+  `-- src
+      |-- root.txt
+      `-- subdir
+          |-- file.txt
+          `-- other.txt
+  
+  3 directories, 4 files
+


### PR DESCRIPTION
This required quite a tricky extension of the syntax, so it's also adding quite a lot of new test cases for parsing the file filter variants.