### PR TITLE
Use "populate" instead of "transpose" for pin filter

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1543,12 +1543,14 @@ fn per_rev_filter(
             )?;
 
             let parent = transaction.repo().find_commit(parent)?;
-            let parent = parent.tree()?;
 
-            let pin_subtract = pin_subtract.tree();
-            let pin_overlay = tree::transpose(transaction, pin_subtract, &parent)?;
+            let pin_overlay = tree::populate(
+                transaction,
+                tree::pathstree("", pin_subtract.tree.id(), transaction)?.id(),
+                parent.tree_id(),
+            )?;
 
-            Some((pin_subtract.id(), pin_overlay.id()))
+            Some((pin_subtract.tree.id(), pin_overlay))
         } else {
             None
         }

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::path::PathBuf;
 
 use crate::cache::TransactionContext;
 use crate::cache_stack::CacheStack;
@@ -890,7 +889,7 @@ pub fn repopulated_tree(
     populate(transaction, ipaths.id(), partial_tree.id())
 }
 
-fn populate(
+pub fn populate(
     transaction: &cache::Transaction,
     paths: git2::Oid,
     content: git2::Oid,
@@ -1000,41 +999,6 @@ pub fn get_blob(repo: &git2::Repository, tree: &git2::Tree, path: &Path) -> Stri
     });
 
     content.to_owned()
-}
-
-/// Compose a new tree by taking paths out of `paths`,
-/// and actual blobs out of `blobs`.
-pub fn transpose<'a>(
-    transaction: &'a cache::Transaction,
-    paths: &'a git2::Tree,
-    blobs: &'a git2::Tree,
-) -> JoshResult<git2::Tree<'a>> {
-    use git2::build::TreeUpdateBuilder;
-    use git2::{TreeWalkMode, TreeWalkResult};
-
-    let mut builder = TreeUpdateBuilder::new();
-
-    paths.walk(TreeWalkMode::PostOrder, |path, entry| {
-        let path = PathBuf::from(path).join(entry.name().unwrap_or(""));
-
-        let entry = match blobs.get_path(&path) {
-            Ok(entry) => entry,
-            Err(e) if e.code() == git2::ErrorCode::NotFound => return TreeWalkResult::Ok,
-            Err(_) => return TreeWalkResult::Abort,
-        };
-
-        if entry.kind() != Some(git2::ObjectType::Blob) {
-            return TreeWalkResult::Ok;
-        }
-
-        builder.upsert(path, entry.id(), git2::FileMode::Blob);
-        TreeWalkResult::Ok
-    })?;
-
-    let repo = transaction.repo();
-    let tree = builder.create_updated(repo, &empty(repo))?;
-
-    Ok(repo.find_tree(tree)?)
 }
 
 pub fn empty_id() -> git2::Oid {


### PR DESCRIPTION
We didn't realize that we can use those existing functions instead
of creating a new one.
Going via pathstree() and populate() might not be the absolute best possible
route, but those use memoization and should be much faster for repeated
application that the transpose() which always needs to look at all paths.