### PR TITLE
Refactor chain to use a vec

### DIFF
--- a/josh-core/src/build.rs
+++ b/josh-core/src/build.rs
@@ -44,7 +44,7 @@ pub fn squash(ids: Option<&[(git2::Oid, Filter)]>) -> Filter {
 
 /// Create a filter that is the result of feeding the output of `first` into `second`
 pub fn chain(first: Filter, second: Filter) -> Filter {
-    opt::optimize(to_filter(Op::Chain(first, second)))
+    opt::optimize(to_filter(Op::Chain(vec![first, second])))
 }
 
 /// Create a filter that is the result of overlaying the output of `first` onto `second`

--- a/josh-core/src/filter/op.rs
+++ b/josh-core/src/filter/op.rs
@@ -83,7 +83,7 @@ pub enum Op {
     Unapply(LazyRef, Filter),
 
     Compose(Vec<Filter>),
-    Chain(Filter, Filter),
+    Chain(Vec<Filter>),
     Subtract(Filter, Filter),
     Exclude(Filter),
     Pin(Filter),

--- a/tests/filter/file.t
+++ b/tests/filter/file.t
@@ -57,7 +57,7 @@
   |-- josh
   |   `-- 24
   |       `-- 0
-  |           `-- b3521f07f4c095a5b2142766269603c039a39271
+  |           `-- fc16bb70cbbc24982dac74e19c853a8fc91a2aed
   `-- tags
   
   6 directories, 2 files

--- a/tests/filter/filter_id.t
+++ b/tests/filter/filter_id.t
@@ -76,29 +76,25 @@
               |       |-- 0
               |       |   `-- subdir
               |       |       `-- 0
-              |       `-- 1
-              |           `-- chain
-              |               |-- 0
-              |               |   `-- subdir
-              |               |       `-- 0
-              |               `-- 1
-              |                   `-- prefix
-              |                       `-- 0
+              |       |-- 1
+              |       |   `-- subdir
+              |       |       `-- 0
+              |       `-- 2
+              |           `-- prefix
+              |               `-- 0
               `-- 1
                   `-- chain
                       |-- 0
                       |   `-- subdir
                       |       `-- 0
-                      `-- 1
-                          `-- chain
-                              |-- 0
-                              |   `-- subdir
-                              |       `-- 0
-                              `-- 1
-                                  `-- prefix
-                                      `-- 0
+                      |-- 1
+                      |   `-- subdir
+                      |       `-- 0
+                      `-- 2
+                          `-- prefix
+                              `-- 0
   
-  26 directories, 7 files
+  22 directories, 7 files
   $ git diff ${EMPTY_TREE}..${FILTER_HASH}
   diff --git a/chain/0/subdir/0 b/chain/0/subdir/0
   new file mode 100644
@@ -116,19 +112,19 @@
   @@ -0,0 +1 @@
   +b
   \ No newline at end of file
-  diff --git a/chain/1/compose/0/chain/1/chain/0/subdir/0 b/chain/1/compose/0/chain/1/chain/0/subdir/0
+  diff --git a/chain/1/compose/0/chain/1/subdir/0 b/chain/1/compose/0/chain/1/subdir/0
   new file mode 100644
   index 0000000..c59d9b6
   --- /dev/null
-  +++ b/chain/1/compose/0/chain/1/chain/0/subdir/0
+  +++ b/chain/1/compose/0/chain/1/subdir/0
   @@ -0,0 +1 @@
   +d
   \ No newline at end of file
-  diff --git a/chain/1/compose/0/chain/1/chain/1/prefix/0 b/chain/1/compose/0/chain/1/chain/1/prefix/0
+  diff --git a/chain/1/compose/0/chain/2/prefix/0 b/chain/1/compose/0/chain/2/prefix/0
   new file mode 100644
   index 0000000..c1b0730
   --- /dev/null
-  +++ b/chain/1/compose/0/chain/1/chain/1/prefix/0
+  +++ b/chain/1/compose/0/chain/2/prefix/0
   @@ -0,0 +1 @@
   +x
   \ No newline at end of file
@@ -140,19 +136,19 @@
   @@ -0,0 +1 @@
   +c
   \ No newline at end of file
-  diff --git a/chain/1/compose/1/chain/1/chain/0/subdir/0 b/chain/1/compose/1/chain/1/chain/0/subdir/0
+  diff --git a/chain/1/compose/1/chain/1/subdir/0 b/chain/1/compose/1/chain/1/subdir/0
   new file mode 100644
   index 0000000..c59d9b6
   --- /dev/null
-  +++ b/chain/1/compose/1/chain/1/chain/0/subdir/0
+  +++ b/chain/1/compose/1/chain/1/subdir/0
   @@ -0,0 +1 @@
   +d
   \ No newline at end of file
-  diff --git a/chain/1/compose/1/chain/1/chain/1/prefix/0 b/chain/1/compose/1/chain/1/chain/1/prefix/0
+  diff --git a/chain/1/compose/1/chain/2/prefix/0 b/chain/1/compose/1/chain/2/prefix/0
   new file mode 100644
   index 0000000..e25f181
   --- /dev/null
-  +++ b/chain/1/compose/1/chain/1/chain/1/prefix/0
+  +++ b/chain/1/compose/1/chain/2/prefix/0
   @@ -0,0 +1 @@
   +y
   \ No newline at end of file
@@ -545,31 +541,23 @@ Test ::a/b/c/ (nested directory path with trailing slash)
       |-- 0
       |   `-- subdir
       |       `-- 0
-      `-- 1
-          `-- chain
-              |-- 0
-              |   `-- subdir
-              |       `-- 0
-              `-- 1
-                  `-- chain
-                      |-- 0
-                      |   `-- subdir
-                      |       `-- 0
-                      `-- 1
-                          `-- chain
-                              |-- 0
-                              |   `-- prefix
-                              |       `-- 0
-                              `-- 1
-                                  `-- chain
-                                      |-- 0
-                                      |   `-- prefix
-                                      |       `-- 0
-                                      `-- 1
-                                          `-- prefix
-                                              `-- 0
+      |-- 1
+      |   `-- subdir
+      |       `-- 0
+      |-- 2
+      |   `-- subdir
+      |       `-- 0
+      |-- 3
+      |   `-- prefix
+      |       `-- 0
+      |-- 4
+      |   `-- prefix
+      |       `-- 0
+      `-- 5
+          `-- prefix
+              `-- 0
   
-  22 directories, 6 files
+  14 directories, 6 files
   $ git diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904..${FILTER_HASH}
   diff --git a/chain/0/subdir/0 b/chain/0/subdir/0
   new file mode 100644
@@ -579,43 +567,43 @@ Test ::a/b/c/ (nested directory path with trailing slash)
   @@ -0,0 +1 @@
   +a
   \ No newline at end of file
-  diff --git a/chain/1/chain/0/subdir/0 b/chain/1/chain/0/subdir/0
+  diff --git a/chain/1/subdir/0 b/chain/1/subdir/0
   new file mode 100644
   index 0000000..63d8dbd
   --- /dev/null
-  +++ b/chain/1/chain/0/subdir/0
+  +++ b/chain/1/subdir/0
   @@ -0,0 +1 @@
   +b
   \ No newline at end of file
-  diff --git a/chain/1/chain/1/chain/0/subdir/0 b/chain/1/chain/1/chain/0/subdir/0
+  diff --git a/chain/2/subdir/0 b/chain/2/subdir/0
   new file mode 100644
   index 0000000..3410062
   --- /dev/null
-  +++ b/chain/1/chain/1/chain/0/subdir/0
+  +++ b/chain/2/subdir/0
   @@ -0,0 +1 @@
   +c
   \ No newline at end of file
-  diff --git a/chain/1/chain/1/chain/1/chain/0/prefix/0 b/chain/1/chain/1/chain/1/chain/0/prefix/0
+  diff --git a/chain/3/prefix/0 b/chain/3/prefix/0
   new file mode 100644
   index 0000000..3410062
   --- /dev/null
-  +++ b/chain/1/chain/1/chain/1/chain/0/prefix/0
+  +++ b/chain/3/prefix/0
   @@ -0,0 +1 @@
   +c
   \ No newline at end of file
-  diff --git a/chain/1/chain/1/chain/1/chain/1/chain/0/prefix/0 b/chain/1/chain/1/chain/1/chain/1/chain/0/prefix/0
+  diff --git a/chain/4/prefix/0 b/chain/4/prefix/0
   new file mode 100644
   index 0000000..63d8dbd
   --- /dev/null
-  +++ b/chain/1/chain/1/chain/1/chain/1/chain/0/prefix/0
+  +++ b/chain/4/prefix/0
   @@ -0,0 +1 @@
   +b
   \ No newline at end of file
-  diff --git a/chain/1/chain/1/chain/1/chain/1/chain/1/prefix/0 b/chain/1/chain/1/chain/1/chain/1/chain/1/prefix/0
+  diff --git a/chain/5/prefix/0 b/chain/5/prefix/0
   new file mode 100644
   index 0000000..2e65efe
   --- /dev/null
-  +++ b/chain/1/chain/1/chain/1/chain/1/chain/1/prefix/0
+  +++ b/chain/5/prefix/0
   @@ -0,0 +1 @@
   +a
   \ No newline at end of file

--- a/tests/filter/scope_filter.t
+++ b/tests/filter/scope_filter.t
@@ -24,16 +24,14 @@ Test basic scope filter syntax :<X>[Y]
       |-- 0
       |   `-- subdir
       |       `-- 0
-      `-- 1
-          `-- chain
-              |-- 0
-              |   `-- subdir
-              |       `-- 0
-              `-- 1
-                  `-- prefix
-                      `-- 0
+      |-- 1
+      |   `-- subdir
+      |       `-- 0
+      `-- 2
+          `-- prefix
+              `-- 0
   
-  10 directories, 3 files
+  8 directories, 3 files
   $ cat sub1/file1
   cat: sub1/file1: No such file or directory
   [1]
@@ -52,26 +50,24 @@ Test scope filter with multiple filters in compose
       |-- 0
       |   `-- subdir
       |       `-- 0
-      `-- 1
-          `-- chain
-              |-- 0
-              |   `-- compose
-              |       |-- 0
-              |       |   `-- subdir
-              |       |       `-- 0
-              |       `-- 1
-              |           `-- chain
-              |               |-- 0
-              |               |   `-- subdir
-              |               |       `-- 0
-              |               `-- 1
-              |                   `-- subdir
-              |                       `-- 0
-              `-- 1
-                  `-- prefix
-                      `-- 0
+      |-- 1
+      |   `-- compose
+      |       |-- 0
+      |       |   `-- subdir
+      |       |       `-- 0
+      |       `-- 1
+      |           `-- chain
+      |               |-- 0
+      |               |   `-- subdir
+      |               |       `-- 0
+      |               `-- 1
+      |                   `-- subdir
+      |                       `-- 0
+      `-- 2
+          `-- prefix
+              `-- 0
   
-  18 directories, 5 files
+  16 directories, 5 files
 
 Test scope filter with prefix filter
   $ FILTER_HASH=$(josh-filter -i ':<:prefix=sub1>[:prefix=file1]')
@@ -95,19 +91,17 @@ Test scope filter with subdir and exclude
       |-- 0
       |   `-- subdir
       |       `-- 0
-      `-- 1
-          `-- chain
-              |-- 0
-              |   `-- exclude
-              |       `-- 0
-              |           `-- file
-              |               |-- 0
-              |               `-- 1
-              `-- 1
-                  `-- prefix
-                      `-- 0
+      |-- 1
+      |   `-- exclude
+      |       `-- 0
+      |           `-- file
+      |               |-- 0
+      |               `-- 1
+      `-- 2
+          `-- prefix
+              `-- 0
   
-  12 directories, 4 files
+  10 directories, 4 files
 
 Test scope filter verifies it expands to chain(X, chain(Y, invert(X)))
   $ FILTER_HASH=$(josh-filter -i ':<:/sub1>[:/file1]')
@@ -129,24 +123,22 @@ Test scope filter with nested filters
       |-- 0
       |   `-- subdir
       |       `-- 0
-      `-- 1
-          `-- chain
-              |-- 0
-              |   `-- compose
-              |       |-- 0
-              |       |   `-- subdir
-              |       |       `-- 0
-              |       `-- 1
-              |           `-- chain
-              |               |-- 0
-              |               |   `-- subdir
-              |               |       `-- 0
-              |               `-- 1
-              |                   `-- subdir
-              |                       `-- 0
-              `-- 1
-                  `-- prefix
-                      `-- 0
+      |-- 1
+      |   `-- compose
+      |       |-- 0
+      |       |   `-- subdir
+      |       |       `-- 0
+      |       `-- 1
+      |           `-- chain
+      |               |-- 0
+      |               |   `-- subdir
+      |               |       `-- 0
+      |               `-- 1
+      |                   `-- subdir
+      |                       `-- 0
+      `-- 2
+          `-- prefix
+              `-- 0
   
-  18 directories, 5 files
+  16 directories, 5 files
 

--- a/tests/proxy/clone_with_meta.t
+++ b/tests/proxy/clone_with_meta.t
@@ -122,10 +122,10 @@
       "::with_prefix.git/",
   ]
   "real_repo.git" = [
+      ":/sub1",
       "::sub1/",
       "::sub2/",
       ":prefix=my_prefix",
-      ":prefix=my_prefix:/my_prefix:/sub1",
   ]
   .
   |-- josh

--- a/tests/proxy/workspace_errors.t
+++ b/tests/proxy/workspace_errors.t
@@ -141,7 +141,7 @@ No match for filters
   remote: upstream: response body:        
   remote: 
   remote: To http://localhost:8001/real_repo.git        
-  remote:    5119a73..25943be  JOSH_PUSH -> master        
+  remote:    5119a73..25c566d  JOSH_PUSH -> master        
   remote: warnings:        
   remote: No match for "::abc"        
   remote: No match for "a/b = :/b/c/*"        
@@ -150,7 +150,7 @@ No match for filters
   remote: No match for "test = ::test"        
   remote: No match for "test/test = :/test:/"        
   remote: No match for "::test/test/"        
-  remote: REWRITE(064643c5fdf5295695d383a511e4335ea3262fce -> 9cbc5874da793480ee59207ca72d9f0523b8b127)        
+  remote: REWRITE(064643c5fdf5295695d383a511e4335ea3262fce -> e972e5448a9595045a092fb5f7d82dc6797b4d23)        
   To http://localhost:8002/real_repo.git:workspace=ws.git
      66a8b5e..064643c  HEAD -> master
 


### PR DESCRIPTION
It was discovered during profiling that filter optimisation spends lots of time rearranging chains.
Using a vec will make operations like finding the last element in a chain much faster.