### PR TITLE
Avoid git2 OID type inside core::Oid; update bench

### DIFF
--- a/josh-core/benches/ultrawide.rs
+++ b/josh-core/benches/ultrawide.rs
@@ -5,7 +5,7 @@ use rand::distr::{Alphabetic, Distribution};
 use rand::rngs::ThreadRng;
 use std::path::PathBuf;
 
-const N_PATHS: usize = 30;
+const N_PATHS: usize = 1000;
 
 fn generate_paths() -> Vec<PathBuf> {
     const PATH_COMPONENTS_MAX: usize = 10;


### PR DESCRIPTION
* Use a plain array for inner OID type:
    * this removes some calls over FFI, especially for comparison, making the type fully inspectable by the rust compiler
    * also uses optimized implementations of hex ser/de from gix

* Update benchmark to use a bigger filter since it's now too fast for the size of filter 30