### PR TITLE
Get rid of HashSet in prefix_sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,6 +2232,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sled",
+ "smallvec",
  "strfmt",
  "toml",
  "tracing",

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -41,6 +41,7 @@ sled = "0.34.7"
 tracing = { workspace = true }
 toml = { workspace = true }
 rustc-hash = "2.1.1"
+smallvec = "1.15.1"
 
 [dev-dependencies]
 rand = "0.9.2"

--- a/josh-core/benches/ultrawide.rs
+++ b/josh-core/benches/ultrawide.rs
@@ -5,7 +5,7 @@ use rand::distr::{Alphabetic, Distribution};
 use rand::rngs::ThreadRng;
 use std::path::PathBuf;
 
-const N_PATHS: usize = 1000;
+const N_PATHS: usize = 3000;
 
 fn generate_paths() -> Vec<PathBuf> {
     const PATH_COMPONENTS_MAX: usize = 10;


### PR DESCRIPTION
HashSet is actually not needed; it's enough to have vectors. SmallVec is used to reduce vector reallocs

<img width="718" height="65" alt="image" src="https://github.com/user-attachments/assets/ca79923d-1178-4f28-aa3c-0dc2e62cbed3" />

ℹ️ at this point, the total share of prefix_sort is starting to get smaller, so next step would be to remove string parsing from benchmark and use builder API.