### PR TITLE
build: update and fix nixpkgs pin

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,9 @@
 let
   pkgs = import (fetchTarball {
-    name = "nixos-24.11";
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.11.tar.gz";
+    name = "nixpkgs-release-25.11";
+    url = "https://github.com/NixOS/nixpkgs/archive/871b9fd269ff6246794583ce4ee1031e1da71895.tar.gz";
     # Hash obtained using `nix-prefetch-url --unpack <url>`
-    sha256 = "1250a3g9g4id46h9ysy5xfqnjf0yb2mfai366pyj5y2bzb8x0i2l";
+    sha256 = "1zn1lsafn62sz6azx6j735fh4vwwghj8cc9x91g5sx2nrg23ap9k";
   }) {};
   
   # Handle darwin-specific dependencies properly


### PR DESCRIPTION
While fetching the tarball by tag is *valid*, it's not necessarily a good idea. One reason for this is because new commits in nixpkgs, for example backports, can change the value of tags. Release 24.11, for example, was last tagged on March 7th 2025 (substantially after it's inital release at the end of 2024-11).

I believe this is a fault on the part of nixpkgs (git doesn't change tags for you after you initially fetch them, so changing tags causes inconsistent tagging), but it's still a bug in the shell that causes errors like so:

    error: hash mismatch in file downloaded from 'https://github.com/NixOS/nixpkgs/archive/refs/tags/24.11.tar.gz':
      specified: sha256-VETQ0fpL+CL9NWZE5apYHjhpsevFa5+gIS2Sl95QoIg=
      got:       sha256-CqCX4JG7UiHvkrBTpYC3wcEurvbtTADLbo3Ns2CEoL8=

It would be better to specify this by commit, which I have done.

Finally, commit 50481f5d3473620c485134d9115c2fb26deedea7, which is the previous commit, appears erroneous to me. It reads:

> - Update from NixOS 25.05 (non-existent) to stable NixOS 24.11

But this is untrue, 25.05 was a valid nixpkgs tag available here:

<https://github.com/NixOS/nixpkgs/releases/tag/25.05>

Additionally, 24.11 is too far back, as we get the following cargo error when trying to use any cargo command

    error: failed to load manifest for workspace member `/home/minion/Code/freshly/josh/hyper_cgi`
    referenced by workspace at `/home/minion/Code/freshly/josh/Cargo.toml`

    Caused by:
      failed to parse manifest at `/home/minion/Code/freshly/josh/hyper_cgi/Cargo.toml`

    Caused by:
      feature `edition2024` is required

      The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.82.0 (8f40fc59f 2024-08-21)).

We need to update cargo to a later version and, since as your cargo version is pinned to your nixpkgs version when installed like this, you can't downgrade all the way to 24.11 and have a working shell.

I have upgraded us to 25.11 instead, which is the most recent stable release of nixpkgs - released at the end of this November. I have done this by taking the hash that the nixpkgs 25.11 tag points to as of 2025-12-23 and downloading the tarball for that hash directly. In future, it may be wise to look into a tool like npins to ease keeping the nixpkgs version up-to-date (<https://github.com/andir/npins>)