### PR TITLE
feat: use reqwest for josh-proxy auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3170,16 +3170,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tower",
  "tower-http",
  "tower-service",
@@ -3222,6 +3226,15 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -4300,6 +4313,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ features = ["compat"]
 [workspace.dependencies.reqwest]
 version = "0.12.26"
 default-features = false
-features = ["blocking", "json"]
+features = ["blocking", "default-tls", "json"]
 
 [workspace.dependencies.tracing]
 version = "0.1.43"


### PR DESCRIPTION
There are various benefits to using reqwest rather than directly using hyper comprising:

- A simpler and, in my opinion, easier-to-read interface
- We already use reqwest elsewhere in the code (in juniper_hyper tests and josh-ssh-shell)
- Reqwest handles http responses better. For example, it follows redirects which are used by forges such at tangled extensively (<https://tangled.org/>). Tangled in particular has repositories ending in `.git` redirected to URLs that do not end in `.git`, which breaks Josh

(N.B. It was previously possible to workaround this with a git config providing `insteadOf` URLs like so:

    [url "https://tangled.org/freshlybakedca.ke/patisserie"]
      insteadOf = "https://tangled.org/freshlybakedca.ke/patisserie.git"

, but an update to either Josh or
Tangled broke this again. I'm not quite sure which...)