### PR TITLE
Fix Claude Code write permissions in workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,8 +19,8 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
       issues: read
       actions: read
       id-token: write


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Summary

- Fix job-level permissions in Claude Code workflow to allow pushing commits
- Changes `contents: read` → `contents: write` 
- Changes `pull-requests: read` → `pull-requests: write`

## Problem

The Claude Code action was failing to push commits back to the repository with a 403 error:

```
remote: Permission to josh-project/josh.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/josh-project/josh.git/': The requested URL returned error: 403
```

**Failed run example:** https://github.com/josh-project/josh/actions/runs/20410794307

## Root Cause

The `additional_permissions` parameter in the Claude Code action step (.github/workflows/claude.yml:49-52) is **just configuration metadata** - it tells Claude what it should be able to do, but **cannot grant actual permissions beyond what's defined at the job level**.

GitHub Actions permissions work hierarchically:

1. **Job-level permissions** (lines 21-26) = the actual permissions granted to the GitHub token
2. **`additional_permissions`** = configuration passed to the action (documentation only)

Even though `additional_permissions` specified `contents: write` and `pull-requests: write`, the job level only granted `contents: read` and `pull-requests: read`, which prevented Claude from pushing changes.

## Solution

Update the job-level permissions to match what Claude needs:
- `contents: write` - allows pushing commits to branches
- `pull-requests: write` - allows creating and updating pull requests

Now the job-level permissions align with the `additional_permissions` configuration, allowing Claude to complete its workflow.