### PR TITLE
Fix clippy warnings

### DIFF
--- a/hyper-reverse-proxy/src/lib.rs
+++ b/hyper-reverse-proxy/src/lib.rs
@@ -145,7 +145,7 @@ async fn create_proxied_response(
     let (mut parts, body) = response.into_parts();
     parts.headers = remove_hop_headers(&parts.headers);
 
-    if method == &Method::HEAD || parts.status == StatusCode::NO_CONTENT {
+    if method == Method::HEAD || parts.status == StatusCode::NO_CONTENT {
         let response = Response::from_parts(parts, Full::new(Bytes::new()));
         return Ok(response);
     }

--- a/hyper_cgi/src/hyper_cgi.rs
+++ b/hyper_cgi/src/hyper_cgi.rs
@@ -66,7 +66,7 @@ where
     let stream_of_frames = BodyStream::new(req.into_body());
     let stream_of_bytes = stream_of_frames
         .try_filter_map(|frame| async move { Ok(frame.into_data().ok()) })
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err));
+        .map_err(|err| io::Error::other(err));
     let async_read = tokio_util::io::StreamReader::new(stream_of_bytes);
     let mut req_body = std::pin::pin!(async_read);
 
@@ -175,7 +175,7 @@ fn error_response() -> hyper::Response<Full<Bytes>> {
 fn convert_error_io_hyper<T>(res: Result<T, hyper::http::Error>) -> Result<T, std::io::Error> {
     match res {
         Ok(res) => Ok(res),
-        Err(_) => Err(std::io::Error::new(std::io::ErrorKind::Other, "Error!")),
+        Err(_) => Err(std::io::Error::other("Error!")),
     }
 }
 

--- a/josh-core/src/cache/mod.rs
+++ b/josh-core/src/cache/mod.rs
@@ -1,9 +1,9 @@
-mod cache;
 pub mod notes;
 pub mod sled;
 pub mod stack;
+mod transaction;
 
-pub use cache::*;
 pub use notes::NotesCacheBackend;
 pub use sled::{SledCacheBackend, sled_load, sled_open_josh_trees, sled_print_stats};
 pub use stack::CacheStack;
+pub use transaction::*;

--- a/josh-core/src/cache/notes.rs
+++ b/josh-core/src/cache/notes.rs
@@ -1,4 +1,4 @@
-use super::cache::{CACHE_VERSION, CacheBackend};
+use super::transaction::{CACHE_VERSION, CacheBackend};
 use crate::JoshResult;
 use crate::filter;
 use crate::filter::Filter;
@@ -84,12 +84,12 @@ impl CacheBackend for NotesCacheBackend {
         }
 
         let repo = self.repo.lock()?;
-        if !is_note_eligible(&*repo, from, sequence_number) {
+        if !is_note_eligible(&repo, from, sequence_number) {
             return Ok(());
         }
 
         let key = filter.id();
-        let signature = super::cache::josh_commit_signature()?;
+        let signature = super::transaction::josh_commit_signature()?;
 
         repo.note(
             &signature,

--- a/josh-core/src/cache/sled.rs
+++ b/josh-core/src/cache/sled.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use super::cache::{CACHE_VERSION, CacheBackend};
+use super::transaction::{CACHE_VERSION, CacheBackend};
 use crate::filter::Filter;
 use crate::{JoshResult, filter, josh_error};
 

--- a/josh-core/src/cache/stack.rs
+++ b/josh-core/src/cache/stack.rs
@@ -1,5 +1,5 @@
-use super::cache::CacheBackend;
 use super::sled::SledCacheBackend;
+use super::transaction::CacheBackend;
 use crate::{JoshResult, filter};
 
 pub struct CacheStack {

--- a/josh-core/src/changes.rs
+++ b/josh-core/src/changes.rs
@@ -42,7 +42,7 @@ pub fn baseref_and_options(refname: &str) -> JoshResult<(String, String, Vec<Str
 
 fn split_changes(
     repo: &git2::Repository,
-    changes: &mut Vec<(String, git2::Oid, String)>,
+    changes: &mut [(String, git2::Oid, String)],
     base: git2::Oid,
 ) -> JoshResult<()> {
     if base == git2::Oid::zero() {
@@ -153,6 +153,7 @@ pub fn changes_to_refs(
         .collect())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn build_to_push(
     repo: &git2::Repository,
     changes: Option<Vec<Change>>,

--- a/josh-core/src/filter/hash.rs
+++ b/josh-core/src/filter/hash.rs
@@ -71,8 +71,8 @@ mod tests {
         let filter2 = Filter::new().subdir("b");
         let filter3 = Filter::new().subdir("a"); // same as filter1
 
-        map.insert(filter1.clone(), "value1".to_string());
-        map.insert(filter2.clone(), "value2".to_string());
+        map.insert(filter1, "value1".to_string());
+        map.insert(filter2, "value2".to_string());
 
         assert_eq!(map.get(&filter1), Some(&"value1".to_string()));
         assert_eq!(map.get(&filter2), Some(&"value2".to_string()));

--- a/josh-core/src/filter/op.rs
+++ b/josh-core/src/filter/op.rs
@@ -8,13 +8,16 @@ pub enum LazyRef {
     Lazy(String),
 }
 
-impl LazyRef {
-    pub fn to_string(&self) -> String {
+impl std::fmt::Display for LazyRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LazyRef::Resolved(id) => format!("{}", id),
-            LazyRef::Lazy(lazy) => format!("\"{}\"", lazy),
+            LazyRef::Resolved(id) => write!(f, "{}", id),
+            LazyRef::Lazy(lazy) => write!(f, "\"{}\"", lazy),
         }
     }
+}
+
+impl LazyRef {
     pub fn parse(s: &str) -> JoshResult<LazyRef> {
         let s = s.replace("'", "\"");
         if let Ok(serde_json::Value::String(s)) = serde_json::from_str(&s) {

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -636,12 +636,14 @@ pub fn search_candidates(
     Ok(results)
 }
 
+type SearchMatchesResult = Vec<(String, Vec<(usize, String)>)>;
+
 pub fn search_matches(
     transaction: &cache::Transaction,
     tree: &git2::Tree,
     searchstring: &str,
     candidates: &Vec<String>,
-) -> JoshResult<Vec<(String, Vec<(usize, String)>)>> {
+) -> JoshResult<SearchMatchesResult> {
     let mut results = vec![];
 
     for c in candidates {
@@ -728,16 +730,14 @@ pub fn trigram_search<'a>(
                     }
                 }
 
-                if fmatch {
-                    if let Some(filename) = filename {
-                        results.push(format!(
-                            "{}{}{}",
-                            root,
-                            if root.is_empty() { "" } else { "/" },
-                            filename
-                        ));
-                        skip = true;
-                    }
+                if fmatch && let Some(filename) = filename {
+                    results.push(format!(
+                        "{}{}{}",
+                        root,
+                        if root.is_empty() { "" } else { "/" },
+                        filename
+                    ));
+                    skip = true;
                 }
             }
         }

--- a/josh-core/src/flang/mod.rs
+++ b/josh-core/src/flang/mod.rs
@@ -13,15 +13,15 @@ use crate::filter::{self, Filter};
 pub fn pretty(filter: Filter, indent: usize) -> String {
     let filter = opt::simplify(filter);
 
-    if let Op::Compose(filters) = to_op(filter) {
-        if indent == 0 {
-            let i = format!("\n{}", " ".repeat(indent));
-            return filters
-                .iter()
-                .map(|x| pretty2(&to_op(*x), indent + 4, true))
-                .collect::<Vec<_>>()
-                .join(&i);
-        }
+    if let Op::Compose(filters) = to_op(filter)
+        && indent == 0
+    {
+        let i = format!("\n{}", " ".repeat(indent));
+        return filters
+            .iter()
+            .map(|x| pretty2(&to_op(*x), indent + 4, true))
+            .collect::<Vec<_>>()
+            .join(&i);
     }
     pretty2(&to_op(filter), indent, true)
 }
@@ -63,7 +63,7 @@ fn pretty2(op: &Op, indent: usize, compose: bool) -> String {
                 return pretty2(&to_op(filters[0]), indent, compose);
             }
             // Check for special case: Subdir + Prefix that cancel
-            match &to_ops(&filters)[..] {
+            match &to_ops(filters)[..] {
                 [Op::Subdir(p1), Op::Prefix(p2)] if p1 == p2 => {
                     return format!("::{}/", parse::quote_if(&p1.to_string_lossy()));
                 }
@@ -158,7 +158,7 @@ pub(crate) fn spec2(op: &Op) -> String {
         Op::Rev(filters) => {
             let mut v = filters
                 .iter()
-                .map(|(k, v)| format!("{}{}", k.to_string(), spec(*v)))
+                .map(|(k, v)| format!("{}{}", k, spec(*v)))
                 .collect::<Vec<_>>();
             v.sort();
             format!(":rev({})", v.join(","))
@@ -208,7 +208,7 @@ pub(crate) fn spec2(op: &Op) -> String {
         Op::Squash(Some(ids)) => {
             let mut v = ids
                 .iter()
-                .map(|(oid, f)| format!("{}{}", oid.to_string(), spec(*f)))
+                .map(|(oid, f)| format!("{}{}", oid, spec(*f)))
                 .collect::<Vec<_>>();
             v.sort();
             format!(":squash({})", v.join(","))
@@ -259,11 +259,11 @@ pub(crate) fn spec2(op: &Op) -> String {
             format!(":{};{}", parse::quote(m), parse::quote(r.as_str()))
         }
         Op::HistoryConcat(r, filter) => {
-            format!(":concat({}{})", r.to_string(), spec(*filter))
+            format!(":concat({}{})", r, spec(*filter))
         }
         #[cfg(feature = "incubating")]
         Op::Unapply(r, filter) => {
-            format!(":unapply({}{})", r.to_string(), spec(*filter))
+            format!(":unapply({}{})", r, spec(*filter))
         }
         Op::Hook(hook) => {
             format!(":hook={}", parse::quote(hook))

--- a/josh-core/src/flang/parse.rs
+++ b/josh-core/src/flang/parse.rs
@@ -244,13 +244,13 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> JoshResult<Filter> {
             Ok(to_filter(Op::Squash(Some(ids))))
         }
         Rule::filter_meta => {
-            let mut inner = pair.into_inner();
+            let inner = pair.into_inner();
             let mut meta = std::collections::BTreeMap::new();
             let mut compose_item = None;
 
             // Collect all items - filter_path (keys) and string (values) come in pairs, then compose
             let mut items = Vec::new();
-            while let Some(item) = inner.next() {
+            for item in inner {
                 match item.as_rule() {
                     Rule::filter_path => items.push(item),
                     Rule::string => items.push(item),
@@ -391,10 +391,10 @@ fn unquote(s: &str) -> String {
 // Encode string as json if it contains any chars reserved
 // by the filter language
 pub fn quote_if(s: &str) -> String {
-    if let Ok(r) = Grammar::parse(Rule::filter_path, s) {
-        if r.as_str() == s {
-            return s.to_string();
-        }
+    if let Ok(r) = Grammar::parse(Rule::filter_path, s)
+        && r.as_str() == s
+    {
+        return s.to_string();
     }
     quote(s)
 }

--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -46,14 +46,14 @@ pub fn list_refs(
 pub fn remember_filter(upstream_repo: &str, filter_spec: &str) {
     // no need to remember the nop filter since we already keep a reference to
     // the unfiltered branch in refs/josh/upstream
-    if filter_spec != ":/" {
-        if let Ok(mut known_filters) = KNOWN_FILTERS.try_lock() {
-            let known_f = &mut known_filters
-                .entry(upstream_repo.trim_start_matches('/').to_string())
-                .or_insert_with(|| (git2::Oid::zero(), BTreeSet::new()));
+    if filter_spec != ":/"
+        && let Ok(mut known_filters) = KNOWN_FILTERS.try_lock()
+    {
+        let known_f = &mut known_filters
+            .entry(upstream_repo.trim_start_matches('/').to_string())
+            .or_insert_with(|| (git2::Oid::zero(), BTreeSet::new()));
 
-            known_f.1.insert(filter_spec.to_string());
-        }
+        known_f.1.insert(filter_spec.to_string());
     }
 }
 
@@ -91,14 +91,14 @@ pub fn default_from_to(
 
     // no need to remember the nop filter since we already keep a reference to
     // the unfiltered branch in refs/josh/upstream
-    if filter_spec != ":/" {
-        if let Ok(mut known_filters) = KNOWN_FILTERS.try_lock() {
-            let known_f = &mut known_filters
-                .entry(upstream_repo.trim_start_matches('/').to_string())
-                .or_insert_with(|| (git2::Oid::zero(), BTreeSet::new()));
+    if filter_spec != ":/"
+        && let Ok(mut known_filters) = KNOWN_FILTERS.try_lock()
+    {
+        let known_f = &mut known_filters
+            .entry(upstream_repo.trim_start_matches('/').to_string())
+            .or_insert_with(|| (git2::Oid::zero(), BTreeSet::new()));
 
-            known_f.1.insert(filter_spec.to_string());
-        }
+        known_f.1.insert(filter_spec.to_string());
     }
 
     refs
@@ -152,13 +152,13 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> JoshResul
             .entry(name.clone())
             .or_insert_with(|| (git2::Oid::zero(), BTreeSet::new()));
 
-        if let Some(target) = r.target() {
-            if known_f.0 != target {
-                let hs = find_all_workspaces_and_subdirectories(&r.peel_to_tree()?)?;
-                known_f.0 = target;
-                for i in hs {
-                    known_f.1.insert(i);
-                }
+        if let Some(target) = r.target()
+            && known_f.0 != target
+        {
+            let hs = find_all_workspaces_and_subdirectories(&r.peel_to_tree()?)?;
+            known_f.0 = target;
+            for i in hs {
+                known_f.1.insert(i);
             }
         }
     }

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -251,12 +251,14 @@ pub fn filter_commit(
     Ok(filter_commit)
 }
 
+type FilterRefsResult = (Vec<(String, git2::Oid)>, Vec<(String, JoshError)>);
+
 pub fn filter_refs(
     transaction: &cache::Transaction,
     filterobj: filter::Filter,
     refs: &[(String, git2::Oid)],
     permissions: filter::Filter,
-) -> (Vec<(String, git2::Oid)>, Vec<(String, JoshError)>) {
+) -> FilterRefsResult {
     rs_tracing::trace_scoped!("filter_refs", "spec": filter::spec(filterobj));
     let s = tracing::Span::current();
     let _e = s.enter();

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -282,25 +282,25 @@ fn main() {
     // The update hook will then make a http request back to the main
     // process to do the actual computation while taking advantage of the
     // cached data already loaded into the main process's memory.
-    if let [a0, a1, a2, a3, ..] = &std::env::args().collect::<Vec<_>>().as_slice() {
-        if a0.ends_with("/update") {
-            std::process::exit(update_hook(a1, a2, a3).unwrap_or(1));
-        }
+    if let [a0, a1, a2, a3, ..] = &std::env::args().collect::<Vec<_>>().as_slice()
+        && a0.ends_with("/update")
+    {
+        std::process::exit(update_hook(a1, a2, a3).unwrap_or(1));
     }
 
-    if let [a0, ..] = &std::env::args().collect::<Vec<_>>().as_slice() {
-        if a0.ends_with("/pre-receive") {
-            eprintln!("josh-proxy: pre-receive hook");
-            let code = match pre_receive_hook() {
-                Ok(code) => code,
-                Err(e) => {
-                    eprintln!("josh-proxy: pre-receive hook failed: {}", e);
-                    std::process::exit(1);
-                }
-            };
+    if let [a0, ..] = &std::env::args().collect::<Vec<_>>().as_slice()
+        && a0.ends_with("/pre-receive")
+    {
+        eprintln!("josh-proxy: pre-receive hook");
+        let code = match pre_receive_hook() {
+            Ok(code) => code,
+            Err(e) => {
+                eprintln!("josh-proxy: pre-receive hook failed: {}", e);
+                std::process::exit(1);
+            }
+        };
 
-            std::process::exit(code);
-        }
+        std::process::exit(code);
     }
 
     let args = josh_proxy::cli::Args::parse();

--- a/josh-proxy/src/housekeeping.rs
+++ b/josh-proxy/src/housekeeping.rs
@@ -85,11 +85,7 @@ fn try_parse_count_objects_output(value: &str) -> Option<CountObjectsOutput> {
     let map = value
         .lines()
         .filter(|line| !line.trim().is_empty())
-        .map(|value| {
-            value
-                .split_once(':')
-                .and_then(|(k, v)| Some((k.trim(), v.trim())))
-        })
+        .map(|value| value.split_once(':').map(|(k, v)| (k.trim(), v.trim())))
         .collect::<Option<std::collections::HashMap<_, _>>>()?;
 
     let try_get =

--- a/josh-ssh-shell/src/bin/josh-ssh-shell.rs
+++ b/josh-ssh-shell/src/bin/josh-ssh-shell.rs
@@ -34,6 +34,7 @@ fn die(message: &str) -> ! {
 }
 
 #[derive(thiserror::Error, Debug)]
+#[allow(clippy::enum_variant_names)]
 enum CallError {
     FifoError(#[from] std::io::Error),
     RequestError(#[from] reqwest::Error),


### PR DESCRIPTION
Since the current batch of PRs moves a lot of code around, i thought it might make sense to also get rid of clippy warnings to avoid doing this separately and complicating rebase at another point in time.