### PR TITLE
Fix missing list performance regression

### DIFF
--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -400,9 +400,7 @@ impl Transaction {
         } else {
             let mut t2 = self.t2.borrow_mut();
             t2.misses += 1;
-            if !t2.missing.contains(&(filter, from)) {
-                t2.missing.insert(0, (filter, from));
-            }
+            t2.missing.push((filter, from));
             None
         }
     }

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -566,7 +566,7 @@ pub fn apply_to_commit(
 
         let missing = transaction.get_missing();
 
-        for (f, i) in missing {
+        for (f, i) in missing.into_iter().rev() {
             history::walk2(f, i, transaction)?;
         }
     }


### PR DESCRIPTION
Inserting at the beginning of the Vec caused a lot of memmoves, so it's much better to insert at the end and reverse the iterator at the end.

Checking for duplicates was expensive and also not necessary since duplicates are not common and keeping them does not have a big impact.