### PR TITLE
Upgrade Rust toolchain to 1.92.0

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
-          toolchain: "1.89.0"
+          toolchain: "1.92.0"
           components: rustfmt
 
       - name: Setup BuildX

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG ARCH
 ARG RUSTUP_VERSION=1.28.2
 
 # Update check: https://github.com/rust-lang/rust/tags
-ARG RUST_VERSION=1.89.0
+ARG RUST_VERSION=1.92.0
 
 # https://github.com/sfackler/rust-openssl/issues/1462
 ENV RUSTFLAGS="-Ctarget-feature=-crt-static"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.92.0"
 components = ["rustfmt"]


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Summary
- Upgrades Rust toolchain from version 1.89.0 to 1.92.0 (latest stable)
- Updates rust-toolchain.toml, GitHub Actions workflow, and Dockerfile