### PR TITLE
Enable grouped dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,23 +16,43 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    rust-deps:
+      patterns:
+        - "*"
 - package-ecosystem: npm
   directory: "josh-ui"
   schedule:
     interval: weekly
+  groups:
+    npm-deps:
+      patterns:
+        - "*"
 - package-ecosystem: gomod
   directories:
     - "josh-ssh-dev-server"
     - "lfs-test-server"
   schedule:
     interval: weekly
+  groups:
+    go-deps:
+      patterns:
+        - "*"
 - package-ecosystem: docker
   directories:
     - "/"
     - "lfs-test-server"
   schedule:
     interval: weekly
+  groups:
+    docker-deps:
+      patterns:
+        - "*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
+  groups:
+    actions-deps:
+      patterns:
+        - "*"


### PR DESCRIPTION
Generated with [Claude Code](https://claude.ai/code)

---

Add dependency groups for all package ecosystems:
- rust-deps: Groups all Rust/Cargo dependencies
- npm-deps: Groups all npm dependencies
- go-deps: Groups all Go module dependencies
- docker-deps: Groups all Docker dependencies
- actions-deps: Groups all GitHub Actions dependencies

This will reduce the number of individual dependency update PRs by grouping them by language/ecosystem.

Closes #1756