### PR TITLE
Use axum extractors for FilteredRepoUrl and other request args

### DIFF
--- a/tests/proxy/ui.t
+++ b/tests/proxy/ui.t
@@ -1,7 +1,7 @@
   $ . ${TESTDIR}/setup_test_env.sh
   $ cd ${TESTTMP}
   $ curl -s -I http://127.0.0.1:8002/
-  HTTP/1.1 302 Found\r (esc)
+  HTTP/1.1 303 See Other\r (esc)
   location: /~/ui/\r (esc)
   content-length: 0\r (esc)
   date: *\r (esc) (glob)


### PR DESCRIPTION
This isn't yet a complete solution, but an intermediate step towards making it easier to split handlers. The extractor is not used for serve_namespace yet because of some routing complexities it involves that will be solved later.