### PR TITLE
Stream git-http-backend CGI input and output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "http-body-util",
  "tokio",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2165,6 +2166,7 @@ dependencies = [
  "axum-extra",
  "base64",
  "clap",
+ "futures",
  "git2",
  "gix",
  "hex",
@@ -2181,6 +2183,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "percent-encoding",
+ "pin-project-lite",
  "regex",
  "reqwest",
  "serde",

--- a/axum-cgi/Cargo.toml
+++ b/axum-cgi/Cargo.toml
@@ -12,3 +12,4 @@ tokio-util = { workspace = true, features = ["io"] }
 axum = { workspace = true }
 http = "1.4.0"
 http-body-util = "0.1.0"
+tracing = { workspace = true }

--- a/axum-cgi/src/lib.rs
+++ b/axum-cgi/src/lib.rs
@@ -1,121 +1,132 @@
 use axum::body::Body;
-use axum::response::{IntoResponse, Response};
-use bytes::Bytes;
 use futures::TryStreamExt;
 use http::{Request, StatusCode};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio_util::io::ReaderStream;
 
 use std::io;
 use std::process::Stdio;
 use std::str::FromStr;
 
-pub async fn do_cgi(req: Request<Body>, cmd: tokio::process::Command) -> (Response, Vec<u8>) {
-    let mut cmd = cmd;
-    setup_cmd(&mut cmd, &req);
+pub type BodyStream = ReaderStream<BufReader<tokio::process::ChildStdout>>;
 
-    let mut child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(_e) => {
-            return (
-                error_response(),
-                std::vec::Vec::from("Unable to spawn child command"),
-            );
-        }
-    };
+async fn copy_request_body_to_stdin(
+    req: Request<Body>,
+    mut stdin: tokio::process::ChildStdin,
+) -> io::Result<()> {
+    // Convert axum body to async read
+    let data_stream = req.into_body().into_data_stream();
+    let stream_of_bytes = TryStreamExt::map_err(data_stream, io::Error::other);
+    let async_read = tokio_util::io::StreamReader::new(stream_of_bytes);
+
+    let mut req_body = std::pin::pin!(async_read);
+
+    tokio::io::copy(&mut req_body, &mut stdin).await?;
+    stdin.flush().await?;
+
+    Ok(())
+}
+
+async fn monitor_process_completion(
+    mut child: tokio::process::Child,
+    mut stderr: tokio::process::ChildStderr,
+) -> io::Result<()> {
+    let mut err_output = Vec::new();
+    stderr.read_to_end(&mut err_output).await?;
+
+    let status = child.wait().await?;
+
+    if !status.success() {
+        let stderr_str = String::from_utf8_lossy(&err_output);
+        tracing::error!(
+            "CGI process exited with non-zero status: {:?}, stderr: {}",
+            status,
+            stderr_str
+        );
+    }
+
+    Ok(())
+}
+
+pub async fn do_cgi(
+    req: Request<Body>,
+    cmd: tokio::process::Command,
+) -> io::Result<(http::response::Builder, BodyStream)> {
+    let mut cmd = cmd;
+
+    setup_cmd(&mut cmd, &req);
+    let mut child = cmd.spawn()?;
 
     let stdin = match child.stdin.take() {
         Some(i) => i,
         None => {
-            return (
-                error_response(),
-                std::vec::Vec::from("Unable to open stdin"),
-            );
+            return Err(io::Error::other("unable to open stdin"));
         }
     };
 
     let stdout = match child.stdout.take() {
         Some(o) => o,
         None => {
-            return (
-                error_response(),
-                std::vec::Vec::from("Unable to open stdout"),
-            );
+            return Err(io::Error::other("unable to open stdout"));
         }
     };
 
     let stderr = match child.stderr.take() {
         Some(e) => e,
         None => {
-            return (
-                error_response(),
-                std::vec::Vec::from("Unable to open stderr"),
-            );
+            return Err(io::Error::other("unable to open stderr"));
         }
     };
 
-    // Convert axum body to async read
-    let data_stream = req.into_body().into_data_stream();
-    let stream_of_bytes = TryStreamExt::map_err(data_stream, io::Error::other);
-    let async_read = tokio_util::io::StreamReader::new(stream_of_bytes);
-    let mut req_body = std::pin::pin!(async_read);
+    tokio::spawn(async move {
+        match copy_request_body_to_stdin(req, stdin).await {
+            Ok(()) => {}
+            Err(e) => {
+                tracing::error!("Failed to copy request body to CGI stdin: {}", e);
+            }
+        }
+    });
 
-    let mut err_output = vec![];
+    tokio::spawn(async move {
+        match monitor_process_completion(child, stderr).await {
+            Ok(()) => {}
+            Err(e) => {
+                tracing::error!("Failed to monitor CGI process: {}", e);
+            }
+        }
+    });
+
+    // Parse headers from stdout
     let mut stdout = BufReader::new(stdout);
-    let mut data = vec![];
+    let mut response = http::Response::builder();
+    let mut line = String::new();
 
-    let write_stdin = async {
-        let mut stdin = stdin;
-        let res = tokio::io::copy(&mut req_body, &mut stdin).await;
-        stdin.flush().await.unwrap();
-        res
-    };
+    while stdout.read_line(&mut line).await.unwrap_or(0) > 0 {
+        line = line
+            .trim_end_matches('\n')
+            .trim_end_matches('\r')
+            .to_owned();
 
-    let read_stderr = async {
-        let mut stderr = stderr;
-        stderr.read_to_end(&mut err_output).await
-    };
-
-    let read_stdout = async {
-        let mut response = http::Response::builder();
-        let mut line = String::new();
-
-        while stdout.read_line(&mut line).await.unwrap_or(0) > 0 {
-            line = line
-                .trim_end_matches('\n')
-                .trim_end_matches('\r')
-                .to_owned();
-
-            let l: Vec<&str> = line.splitn(2, ": ").collect();
-            if l.len() < 2 {
-                break;
-            }
-
-            if l[0] == "Status" {
-                response = response.status(
-                    StatusCode::from_u16(
-                        u16::from_str(l[1].split(' ').next().unwrap_or("500")).unwrap_or(500),
-                    )
-                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
-                );
-            } else {
-                response = response.header(l[0], l[1]);
-            }
-            line = String::new();
+        let l: Vec<&str> = line.splitn(2, ": ").collect();
+        if l.len() < 2 {
+            break;
         }
 
-        stdout.read_to_end(&mut data).await?;
-        convert_error_io_http(response.body(Body::from(Bytes::from(data))))
-    };
+        if l[0] == "Status" {
+            response = response.status(
+                StatusCode::from_u16(
+                    u16::from_str(l[1].split(' ').next().unwrap_or("500")).unwrap_or(500),
+                )
+                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+            );
+        } else {
+            response = response.header(l[0], l[1]);
+        }
 
-    let wait_process = async { child.wait().await };
-
-    if let Ok((_, _, response, _)) =
-        tokio::try_join!(write_stdin, read_stderr, read_stdout, wait_process)
-    {
-        return (response.into_response(), err_output);
+        line.clear();
     }
 
-    (error_response(), err_output)
+    Ok((response, ReaderStream::new(stdout)))
 }
 
 fn setup_cmd(cmd: &mut tokio::process::Command, req: &Request<Body>) {
@@ -156,21 +167,9 @@ fn setup_cmd(cmd: &mut tokio::process::Command, req: &Request<Body>) {
         );
 }
 
-fn error_response() -> Response {
-    (StatusCode::INTERNAL_SERVER_ERROR, Body::new(String::new())).into_response()
-}
-
-fn convert_error_io_http<T>(res: Result<T, http::Error>) -> Result<T, std::io::Error> {
-    match res {
-        Ok(res) => Ok(res),
-        Err(_) => Err(std::io::Error::other("Error!")),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
     use http_body_util::BodyExt;
 
     #[tokio::test]
@@ -187,20 +186,18 @@ mod tests {
             .header(http::header::ACCEPT_ENCODING, "deflate, gzip, br")
             .header(http::header::ACCEPT_LANGUAGE, "en-US, *;q=0.9")
             .header(http::header::PRAGMA, "no-cache")
-            .body(Body::from(Bytes::from("\r\na body")))
+            .body(Body::from("\r\na body"))
             .unwrap();
 
         let mut cmd = tokio::process::Command::new("cat");
         cmd.arg("-");
 
-        let (resp, stderr) = do_cgi(req, cmd).await;
-
+        let (response_builder, stream) = do_cgi(req, cmd).await.unwrap();
+        let resp = response_builder.body(Body::from_stream(stream)).unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
         let resp_string = String::from_utf8_lossy(&body_bytes);
-
-        assert_eq!("", std::str::from_utf8(&stderr).unwrap());
         assert_eq!(body_content, resp_string);
     }
 }

--- a/josh-proxy/Cargo.toml
+++ b/josh-proxy/Cargo.toml
@@ -33,6 +33,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true }
+futures = { workspace = true }
+pin-project-lite = "^0"
 toml = { workspace = true }
 tracing = { workspace = true }
 tracing-futures = "0.2.5"

--- a/josh-proxy/src/http.rs
+++ b/josh-proxy/src/http.rs
@@ -1,7 +1,13 @@
 use axum::body::Body;
 use axum::http::{Response, StatusCode};
 use axum::response::IntoResponse;
+use futures::Stream;
+use pin_project_lite::pin_project;
+
 use josh_core::JoshError;
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 // Wrapper to make JoshError work with axum's IntoResponse
 // while not running into coherence rules
@@ -23,5 +29,44 @@ where
 {
     fn from(err: E) -> Self {
         ProxyError(err.into())
+    }
+}
+
+pin_project! {
+    pub struct StreamWithGuard<S, G> {
+        #[pin]
+        stream: S,
+        _guard: G,
+    }
+}
+
+impl<S, G> StreamWithGuard<S, G> {
+    pub fn new(stream: S, guard: G) -> Self {
+        Self {
+            stream,
+            _guard: guard,
+        }
+    }
+}
+
+impl<S: Stream, G> Stream for StreamWithGuard<S, G> {
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().stream.poll_next(cx)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.stream.size_hint()
+    }
+}
+
+impl<S, G> IntoResponse for StreamWithGuard<S, G>
+where
+    S: Stream<Item = Result<axum::body::Bytes, std::io::Error>> + Send + 'static,
+    G: Send + 'static,
+{
+    fn into_response(self) -> Response<Body> {
+        Body::from_stream(self).into_response()
     }
 }


### PR DESCRIPTION
This provides performance benefits for large clones, as the packfile is no longer fully buffered in memory. Bonus: sideband is now correctly displayed as it's being streamed!

https://github.com/user-attachments/assets/f630a529-a910-48ac-858a-0064463a9eaf
