### PR TITLE
Remove SSH max startups option

### DIFF
--- a/docker/etc/ssh/sshd_config.template
+++ b/docker/etc/ssh/sshd_config.template
@@ -24,11 +24,6 @@ PrintMotd no
 
 AcceptEnv GIT_PROTOCOL
 
-# fail2ban-like features
-
-PerSourceMaxStartups ${JOSH_SSH_MAX_STARTUPS}
-PerSourceNetBlockSize 32:128
-
 # Client management
 
 ClientAliveInterval 360

--- a/docker/s6-rc.d/sshd-generate-config/up
+++ b/docker/s6-rc.d/sshd-generate-config/up
@@ -1,10 +1,8 @@
 #!/command/execlineb -P
 
 importas -D 8022 josh_ssh_port JOSH_SSH_PORT
-importas -D 16 josh_ssh_max_startups JOSH_SSH_MAX_STARTUPS
 emptyenv -p
 backtick JOSH_SSH_PORT { echo ${josh_ssh_port} }
-backtick JOSH_SSH_MAX_STARTUPS { echo ${josh_ssh_max_startups} }
 foreground
 {
   redirfd -r 0 /etc/ssh/sshd_config.template

--- a/docs/src/reference/container.md
+++ b/docs/src/reference/container.md
@@ -49,14 +49,6 @@
     </tr>
     <tr>
         <td>
-            <code>JOSH_SSH_MAX_STARTUPS</code>
-        </td>
-        <td>
-            Maximum number of concurrent SSH authentication attempts. Default: 16
-        </td>
-    </tr>
-    <tr>
-        <td>
             <code>JOSH_SSH_TIMEOUT</code>
         </td>
         <td>


### PR DESCRIPTION
sshd changed behaviour some time ago and max startups per source option doesn't seem to account for clients disconnecting, or at least not in our case. this means after e.g. 16 clones by default SSH doesn't work anymore as it doesn't accept connections.

I think it's better to just remove the option instead of trying to figure out what went wrong in sshd -- security options like that are anyway better handled in a separate service, like an SSH proxy or bastion host.