### PR TITLE
Clean up namespaces in a separate thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234655ec178edd82b891e262ea7cf71f6584bcd09eff94db786be23f1821825c"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "bpaf"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,6 +2190,7 @@ dependencies = [
  "axum-cgi",
  "axum-extra",
  "base64",
+ "bon",
  "clap",
  "futures",
  "git2",
@@ -2845,6 +2871,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]

--- a/josh-proxy/Cargo.toml
+++ b/josh-proxy/Cargo.toml
@@ -55,6 +55,7 @@ opentelemetry = "0.31.0"
 opentelemetry-semantic-conventions = "0.31.0"
 opentelemetry-otlp = { version = "0.31.0", features = ["grpc-tonic", "trace"] }
 opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio"] }
+bon = "3.8.2"
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -24,7 +24,7 @@ pub struct RepoUpdate {
     pub refs: std::collections::HashMap<String, (String, String)>,
     pub remote_url: String,
     pub remote_auth: RemoteAuth,
-    pub port: String,
+    pub port: u16,
     pub filter_spec: String,
     pub base_ns: String,
     pub git_ns: String,


### PR DESCRIPTION
Namespaces previously were cleaned up on drop, performing filesystem operations and lots of i/o calls from async context. For big repos with thousands of branches, this could mean blocking async runtime for hundreds of milliseconds or more. This creates an i/o thread that handles namespace cleanup.