### PR TITLE
Fix Docker build cache scope for PR branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,8 +44,10 @@ jobs:
       with:
         context: .
         file: Dockerfile
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: |
+          type=gha
+          type=gha,scope=main
+        cache-to: type=gha,mode=max,scope=${{ github.ref_name }}
         target: dev-ci
         tags: josh-ci-dev:latest
         push: false


### PR DESCRIPTION
LLM generated

---

Configure GHA cache to read from both current branch and main branch, allowing PRs to get cache hits from master builds.