### PR TITLE
josh-cq admit

### DIFF
--- a/josh-cq/src/bin/josh-cq.rs
+++ b/josh-cq/src/bin/josh-cq.rs
@@ -1,4 +1,4 @@
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use clap::Parser;
 
 use josh_core::filter::tree;
@@ -28,6 +28,9 @@ enum ActionCommands {
     Track(TrackArgs),
     /// Fetch remotes, collect and record state of conditions
     Fetch,
+    /// Manually mark a change as admissible, allowing it to participate
+    /// in speculative history
+    Admit(AdmitArgs),
     /// Single step through the queue, updating the state
     Step,
     /// Push updated metarepo state to remotes
@@ -45,8 +48,104 @@ struct TrackArgs {
     vendor: josh_cq::vendor::Vendor,
 }
 
+#[derive(clap::Parser)]
+struct AdmitArgs {
+    /// Change ID to admit
+    change_id: String,
+}
+
 // TODO: make it configurable/read git config
 const METAREPO_MAIN_REF: &'static str = "refs/heads/master";
+
+fn make_changes_path(remote_id: &str) -> std::path::PathBuf {
+    std::path::Path::new("remotes")
+        .join(remote_id)
+        .join("changes.json")
+}
+
+fn list_remotes(repo: &git2::Repository) -> anyhow::Result<Vec<String>> {
+    let metarepo_main = repo.find_reference(METAREPO_MAIN_REF)?.peel_to_commit()?;
+    let metarepo_tree = metarepo_main.tree()?;
+
+    let Some(remotes_entry) = metarepo_tree.get_name("remotes") else {
+        return Ok(vec![]);
+    };
+
+    let remotes_tree = repo.find_tree(remotes_entry.id())?;
+
+    remotes_tree
+        .iter()
+        .map(|entry| {
+            entry
+                .name()
+                .map(|s| s.to_string())
+                .context("Invalid remote entry name")
+        })
+        .collect()
+}
+
+fn read_changes(
+    repo: &git2::Repository,
+    tree: &git2::Tree,
+    remote_id: &str,
+) -> anyhow::Result<Option<josh_cq::change::ChangeGraph>> {
+    let changes_path = make_changes_path(remote_id);
+
+    let Ok(entry) = tree.get_path(&changes_path) else {
+        return Ok(None);
+    };
+
+    let blob = repo.find_blob(entry.id())?;
+    let graph = serde_json::from_slice(blob.content()).context("Failed to parse changes.json")?;
+
+    Ok(Some(graph))
+}
+
+fn write_changes<'a>(
+    repo: &'a git2::Repository,
+    tree: &git2::Tree,
+    remote_id: &str,
+    changes: &josh_cq::change::ChangeGraph,
+) -> anyhow::Result<git2::Tree<'a>> {
+    let changes_json =
+        serde_json::to_string_pretty(changes).context("Failed to serialize changes")?;
+    let blob_oid = repo
+        .blob(changes_json.as_bytes())
+        .context("Failed to create changes.json blob")?;
+
+    let changes_path = make_changes_path(remote_id);
+
+    tree::insert(
+        repo,
+        tree,
+        &changes_path,
+        blob_oid,
+        git2::FileMode::Blob.into(),
+    )
+    .context("Failed to insert changes.json into tree")
+}
+
+fn commit_metarepo_main(
+    repo: &git2::Repository,
+    tree: &git2::Tree,
+    message: &str,
+) -> anyhow::Result<git2::Oid> {
+    let metarepo_main = repo.find_reference(METAREPO_MAIN_REF)?.peel_to_commit()?;
+    let signature = make_signature(repo)?;
+
+    let commit_oid = repo.commit(
+        None,
+        &signature,
+        &signature,
+        message,
+        tree,
+        &[&metarepo_main],
+    )?;
+
+    repo.head()?.set_target(commit_oid, message)?;
+
+    Ok(commit_oid)
+}
 
 fn handle_track(
     args: &TrackArgs,
@@ -65,10 +164,11 @@ fn handle_track(
         )
     })?;
 
-    let metarepo_main = repo.find_reference(METAREPO_MAIN_REF)?.peel_to_commit()?;
-    let metarepo_tree = metarepo_main.tree().context("Failed to get main tree")?;
-
-    let signature = make_signature(repo)?;
+    let metarepo_tree = repo
+        .find_reference(METAREPO_MAIN_REF)?
+        .peel_to_commit()?
+        .tree()
+        .context("Failed to get main tree")?;
 
     let link_path = std::path::Path::new("remotes").join(&args.id).join("link");
     let tree_with_link_oid = josh_link::prepare_link_add(
@@ -94,48 +194,66 @@ fn handle_track(
     )?;
     let changes = vendor.list_changes()?;
 
-    // Create changes.json blob
-    let changes_blob = {
-        let changes_json =
-            serde_json::to_string_pretty(&changes).context("Failed to serialize refs to JSON")?;
+    let final_tree = write_changes(repo, &tree_with_link, &args.id, &changes)?;
 
-        repo.blob(changes_json.as_bytes())
-            .context("Failed to create changes.json blob")?
-    };
-
-    // Insert changes.json into the tree
-    let changes_path = std::path::Path::new("remotes")
-        .join(&args.id)
-        .join("changes.json");
-
-    let final_tree = tree::insert(
-        repo,
-        &tree_with_link,
-        &changes_path,
-        changes_blob,
-        git2::FileMode::Blob.into(),
-    )
-    .context("Failed to insert refs.json into tree")?;
-
-    // Create final commit with both files
-    let final_commit = repo
-        .commit(
-            None,
-            &signature,
-            &signature,
-            &format!("Track remote: {}", args.id),
-            &final_tree,
-            &[&metarepo_main],
-        )
-        .context("Failed to create final commit")?;
-
-    // Update HEAD to point to the new commit
-    repo.head()?
-        .set_target(final_commit, "josh-cq track")
-        .context("Failed to update HEAD")?;
+    commit_metarepo_main(repo, &final_tree, &format!("Track remote: {}", args.id))?;
 
     println!("Tracked remote '{}' at {}", args.id, args.url);
     println!("Found {} changes", changes.graph.node_count());
+
+    Ok(())
+}
+
+fn handle_admit(
+    args: &AdmitArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+
+    let metarepo_tree = repo
+        .find_reference(METAREPO_MAIN_REF)?
+        .peel_to_commit()?
+        .tree()
+        .context("Failed to get main tree")?;
+
+    let remotes = list_remotes(repo)?;
+    let mut found = false;
+    let mut current_tree_oid = metarepo_tree.id();
+
+    for remote_id in &remotes {
+        let current_tree = repo.find_tree(current_tree_oid)?;
+
+        let Some(mut change_graph) = read_changes(repo, &current_tree, remote_id)? else {
+            continue;
+        };
+
+        let Some(&node_idx) = change_graph.nodes.get(&args.change_id) else {
+            continue;
+        };
+
+        change_graph.graph[node_idx].admit = true;
+        found = true;
+
+        let updated_tree = write_changes(repo, &current_tree, remote_id, &change_graph)?;
+        current_tree_oid = updated_tree.id();
+    }
+
+    if !found {
+        return Err(anyhow!(
+            "Change '{}' not found in any tracked remote",
+            args.change_id
+        ));
+    }
+
+    let final_tree = repo.find_tree(current_tree_oid)?;
+
+    commit_metarepo_main(
+        repo,
+        &final_tree,
+        &format!("Admit change: {}", args.change_id),
+    )?;
+
+    println!("Admitted change '{}'", args.change_id);
 
     Ok(())
 }
@@ -177,5 +295,6 @@ async fn main() -> anyhow::Result<()> {
         ActionCommands::Push => {
             todo!()
         }
+        ActionCommands::Admit(ref args) => handle_admit(args, &transaction),
     }
 }

--- a/josh-cq/src/change.rs
+++ b/josh-cq/src/change.rs
@@ -9,6 +9,7 @@ pub type ChangeId = String;
 pub struct Change {
     pub id: ChangeId,
     pub head: git2::Oid,
+    pub admit: bool,
 }
 
 /// DAG (forest) of changes where edges point from child to parent.
@@ -34,6 +35,9 @@ pub struct ChangeGraph {
 struct SerializedChange {
     id: ChangeId,
     head: String,
+
+    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    admit: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -59,6 +63,7 @@ impl Serialize for ChangeGraph {
                 SerializedChange {
                     id: change.id.clone(),
                     head: change.head.to_string(),
+                    admit: change.admit,
                 }
             })
             .collect();
@@ -93,6 +98,7 @@ impl<'de> Deserialize<'de> for ChangeGraph {
             let idx = graph.add_node(Change {
                 id: change.id.clone(),
                 head: oid,
+                admit: change.admit,
             });
             nodes.insert(change.id, idx);
         }

--- a/josh-cq/src/vendor/generic.rs
+++ b/josh-cq/src/vendor/generic.rs
@@ -135,6 +135,7 @@ impl ChangeVendor for GenericRemote {
                     let node_idx = graph.add_node(Change {
                         id: change_id.clone(),
                         head: *oid,
+                        admit: false,
                     });
                     nodes.insert(change_id.clone(), node_idx);
                 }

--- a/tests/cq/help.t
+++ b/tests/cq/help.t
@@ -7,6 +7,7 @@
     init   Initialize metarepo
     track  Track a remote repository
     fetch  Fetch remotes, collect and record state of conditions
+    admit  Manually mark a change as admissible, allowing it to participate in speculative history
     step   Single step through the queue, updating the state
     push   Push updated metarepo state to remotes
     help   Print this message or the help of the given subcommand(s)

--- a/tests/cq/track.t
+++ b/tests/cq/track.t
@@ -84,3 +84,29 @@
       }
     ]
   } (no-eol)
+
+# Admit a change
+  $ josh-cq admit change-1
+  Admitted change 'change-1'
+
+  $ git show HEAD:remotes/myremote/changes.json
+  {
+    "changes": [
+      {
+        "id": "change-1",
+        "head": "28d9779d81e6ccdd85e9145e5b1dae3a6ffd61f4",
+        "admit": true
+      },
+      {
+        "id": "change-2",
+        "head": "ddd79153049e608636bccd727396380ebf0e16de"
+      }
+    ],
+    "edges": [
+      {
+        "from": "change-2",
+        "to": "change-1",
+        "base": "28d9779d81e6ccdd85e9145e5b1dae3a6ffd61f4"
+      }
+    ]
+  } (no-eol)


### PR DESCRIPTION
Some parts of this commit have been generated by an LLM and reviewed.

Since a "generic" remote doesn't have any notification mechanism, for now just add a command that admits a change and enables it to be merged by the queue.