### PR TITLE
Change stored filter to always append extension

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -369,7 +369,7 @@ fn get_stored<'a>(
     tree: &'a git2::Tree<'a>,
     path: &Path,
 ) -> Filter {
-    let stored_path = path.with_extension("josh");
+    let stored_path = path.with_added_extension("josh");
     let sj_file = Filter::new().file(stored_path.clone());
     compose(&[sj_file, get_filter(transaction, tree, &stored_path)])
 }
@@ -1515,7 +1515,7 @@ fn unapply_workspace<'a>(
             Ok(Some(result))
         }
         Op::Stored(path) => {
-            let stored_path = path.with_extension("josh");
+            let stored_path = path.with_added_extension("josh");
             let stored = get_filter(transaction, &tree, &stored_path);
             let original_stored = get_filter(transaction, &parent_tree, &stored_path);
 
@@ -1619,7 +1619,7 @@ pub fn compute_warnings<'a>(
     }
 
     if let Op::Stored(path) = to_op(filter) {
-        let stored_path = path.with_extension("josh");
+        let stored_path = path.with_added_extension("josh");
         let stored_filter = &tree::get_blob(transaction.repo(), &tree, &stored_path);
         if let Ok(res) = parse(stored_filter) {
             filter = res;

--- a/tests/filter/stored_single_file.t
+++ b/tests/filter/stored_single_file.t
@@ -20,7 +20,10 @@
   $ git commit -m "add file2" 1> /dev/null
 
   $ mkdir st
-  $ cat > st/config.josh <<EOF
+
+Use a filename with an extension here to check that the extension does not get replaced
+by ".josh" but rather kept and extended
+  $ cat > st/config.filter.josh <<EOF
   > :/sub1::file1
   > :/sub1::file2
   > ::sub2/subsub/
@@ -28,9 +31,9 @@
   $ git add st
   $ git commit -m "add st" 1> /dev/null
 
-  $ josh-filter -s :+st/config master --update refs/josh/master
-  4151198c71b2a1ecc2ff632ecf335c3f1604926b
-  [2] :+st/config
+  $ josh-filter -s :+st/config.filter master --update refs/josh/master
+  3397ec2c69d5c8f67ad39cf477b3711683022d84
+  [2] :+st/config.filter
   [2] :[
       :/sub1:[
           ::file1
@@ -49,14 +52,14 @@
   $ git ls-tree HEAD
   100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile1 (esc)
   100755 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile2 (esc)
-  040000 tree 39ba55859ffd8fca4931d1426510f486b3285e07\tst (esc)
+  040000 tree 708c21a7d31d142c2d1030810e573154134f32e6\tst (esc)
   040000 tree 81b2a24c53f9090c6f6a23176a2a5660e6f48317\tsub2 (esc)
   $ tree
   .
   |-- file1
   |-- file2
   |-- st
-  |   `-- config.josh
+  |   `-- config.filter.josh
   `-- sub2
       `-- subsub
           `-- file2


### PR DESCRIPTION
This was the intended (and tested) behaviour all along. Just misunderstood the with_extension
function.