### PR TITLE
Remove outdated container run action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,64 +51,16 @@ jobs:
         push: false
         load: true
     - name: Run tests
-      uses: addnab/docker-run-action@v3
-      with:
-        image: josh-ci-dev:latest
-        options: -v ${{ github.workspace }}:/github/workspace -w /github/workspace
-        shell: bash
-        run: |
-          set -e -x
-          shopt -s extglob
-
-          # Formatting
-          cargo fmt -- --check
-
-          # Guard against cargo feature unification silently enabling "incubating" on josh-core.
-          # When building the whole workspace, any crate that depends on josh-core with
-          # features=["incubating"] causes ALL crates to see josh-core with that feature on.
-          # This check ensures the non-incubating build genuinely compiles without it.
-          declare incubating_enabled
-          declare cargo_tree_output
-
-          cargo_tree_output=$(cargo tree -p josh-core -e features --workspace \
-            --exclude josh-link --exclude josh-cq --exclude josh-starlark --prefix none)
-          incubating_enabled=$(echo "$cargo_tree_output" | grep 'josh-core feature "incubating"' | wc -l)
-
-          if [ "$incubating_enabled" -ne 0 ]; then
-            echo "ERROR: incubating feature is leaking into the non-incubating workspace build"
-            exit 1
-          fi
-
-          # Unit tests
-          cargo test --workspace --all --exclude josh-link --exclude josh-cq --exclude josh-starlark
-
-          # Integration tests
-          cargo build --workspace --all-targets --exclude josh-link --exclude josh-cq --exclude josh-starlark
-          ( cd josh-ssh-dev-server ; go build -o "${CARGO_TARGET_DIR}/josh-ssh-dev-server" )
-          sh run-tests.sh --verbose tests/filter/!(incubating_*).t
-          sh run-tests.sh --verbose tests/proxy/**.t
-          sh run-tests.sh --verbose tests/cli/**.t
-
+      run: >-
+        docker run --rm
+        -v ${{ github.workspace }}:/github/workspace
+        -w /github/workspace
+        josh-ci-dev:latest
+        bash /github/workspace/.github/workflows/scripts/run-tests.sh
     - name: Run tests (incubating)
-      uses: addnab/docker-run-action@v3
-      with:
-        image: josh-ci-dev:latest
-        options: -v ${{ github.workspace }}:/github/workspace -w /github/workspace
-        shell: bash
-        run: |
-          set -e -x
-
-          # Formatting
-          cargo fmt -- --check
-
-          # Unit tests
-          cargo test --workspace --all --features incubating
-
-          # Integration tests
-          cargo build --workspace --all-targets --features incubating
-          ( cd josh-ssh-dev-server ; go build -o "${CARGO_TARGET_DIR}/josh-ssh-dev-server" )
-          sh run-tests.sh --verbose tests/experimental/**.t
-          sh run-tests.sh --verbose tests/filter/**.t
-          sh run-tests.sh --verbose tests/proxy/**.t
-          sh run-tests.sh --verbose tests/cli/**.t
-          sh run-tests.sh --verbose tests/cq/**.t
+      run: >-
+        docker run --rm
+        -v ${{ github.workspace }}:/github/workspace
+        -w /github/workspace
+        josh-ci-dev:latest
+        bash /github/workspace/.github/workflows/scripts/run-tests-incubating.sh

--- a/.github/workflows/scripts/run-tests-incubating.sh
+++ b/.github/workflows/scripts/run-tests-incubating.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e -x
+
+# Formatting
+cargo fmt -- --check
+
+# Unit tests
+cargo test --workspace --all --features incubating
+
+# Integration tests
+cargo build --workspace --all-targets --features incubating
+( cd josh-ssh-dev-server ; go build -o "${CARGO_TARGET_DIR}/josh-ssh-dev-server" )
+sh run-tests.sh --verbose tests/experimental/**.t
+sh run-tests.sh --verbose tests/filter/**.t
+sh run-tests.sh --verbose tests/proxy/**.t
+sh run-tests.sh --verbose tests/cli/**.t
+sh run-tests.sh --verbose tests/cq/**.t

--- a/.github/workflows/scripts/run-tests.sh
+++ b/.github/workflows/scripts/run-tests.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e -x
+shopt -s extglob
+
+# Formatting
+cargo fmt -- --check
+
+# Guard against cargo feature unification silently enabling "incubating" on josh-core.
+# When building the whole workspace, any crate that depends on josh-core with
+# features=["incubating"] causes ALL crates to see josh-core with that feature on.
+# This check ensures the non-incubating build genuinely compiles without it.
+declare incubating_enabled
+declare cargo_tree_output
+
+cargo_tree_output=$(cargo tree -p josh-core -e features --workspace \
+  --exclude josh-link --exclude josh-cq --exclude josh-starlark --prefix none)
+incubating_enabled=$(echo "$cargo_tree_output" | grep 'josh-core feature "incubating"' | wc -l)
+
+if [ "$incubating_enabled" -ne 0 ]; then
+  echo "ERROR: incubating feature is leaking into the non-incubating workspace build"
+  exit 1
+fi
+
+# Unit tests
+cargo test --workspace --all --exclude josh-link --exclude josh-cq --exclude josh-starlark
+
+# Integration tests
+cargo build --workspace --all-targets --exclude josh-link --exclude josh-cq --exclude josh-starlark
+( cd josh-ssh-dev-server ; go build -o "${CARGO_TARGET_DIR}/josh-ssh-dev-server" )
+sh run-tests.sh --verbose tests/filter/!(incubating_*).t
+sh run-tests.sh --verbose tests/proxy/**.t
+sh run-tests.sh --verbose tests/cli/**.t


### PR DESCRIPTION
We can't pin runner images without having our own runners
or paying for custom runners. Github updated their runner image
and the docker client used in docker-run-action was no longer compatible.
