### PR TITLE
Rename notes cache to distributed cache

### DIFF
--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -87,10 +87,10 @@ fn make_app() -> clap::Command {
                 .short('n'),
         )
         .arg(
-            clap::Arg::new("notes-cache")
+            clap::Arg::new("distributed-cache")
                 .action(clap::ArgAction::SetTrue)
-                .help("Enables notes based cache")
-                .long("notes-cache"),
+                .help("Enables distributed cache")
+                .long("distributed-cache"),
         )
         .arg(
             clap::Arg::new("pack")
@@ -200,8 +200,8 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         let cache = josh_core::cache::CacheStack::new()
             .with_backend(josh_core::cache::SledCacheBackend::default());
 
-        if args.get_flag("notes-cache") {
-            cache.with_backend(josh_core::cache::NotesCacheBackend::new(&repo_path)?)
+        if args.get_flag("distributed-cache") {
+            cache.with_backend(josh_core::cache::DistributedCacheBackend::new(&repo_path)?)
         } else {
             cache
         }

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -209,8 +209,8 @@ fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
         josh_core::cache::CacheStack::new()
             .with_backend(josh_core::cache::SledCacheBackend::default())
             .with_backend(
-                josh_core::cache::NotesCacheBackend::new(&repo_path)
-                    .context("Failed to create NotesCacheBackend")?,
+                josh_core::cache::DistributedCacheBackend::new(&repo_path)
+                    .context("Failed to create DistributedCacheBackend")?,
             ),
     );
 

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -6,20 +6,20 @@ use std::collections::HashMap;
 // Only flush shards after they gained enough new entries
 const FLUSH_AFTER: usize = 1000;
 
-pub struct NotesCacheBackend {
+pub struct DistributedCacheBackend {
     new_entries: std::sync::Mutex<HashMap<String, HashMap<git2::Oid, git2::Oid>>>,
     repo: std::sync::Mutex<git2::Repository>,
 }
 
-impl Drop for NotesCacheBackend {
+impl Drop for DistributedCacheBackend {
     fn drop(&mut self) {
         if !self.flush(true).is_ok() {
-            log::warn!("NotesCacheBackend: flush failed");
+            log::warn!("DistributedCacheBackend: flush failed");
         }
     }
 }
 
-impl NotesCacheBackend {
+impl DistributedCacheBackend {
     pub fn new(repo_path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
         let repo = git2::Repository::open(repo_path.as_ref())?;
         Ok(Self {
@@ -109,7 +109,7 @@ fn fanout(commit: git2::Oid) -> std::path::PathBuf {
         .join(commit)
 }
 
-impl CacheBackend for NotesCacheBackend {
+impl CacheBackend for DistributedCacheBackend {
     fn read(
         &self,
         filter: Filter,

--- a/josh-core/src/cache/mod.rs
+++ b/josh-core/src/cache/mod.rs
@@ -1,9 +1,9 @@
-pub mod notes;
+pub mod distributed;
 pub mod sled;
 pub mod stack;
 mod transaction;
 
-pub use notes::NotesCacheBackend;
+pub use distributed::DistributedCacheBackend;
 pub use sled::{SledCacheBackend, sled_load, sled_open_josh_trees, sled_print_stats};
 pub use stack::CacheStack;
 pub use transaction::*;

--- a/tests/filter/cmdline.t
+++ b/tests/filter/cmdline.t
@@ -33,7 +33,7 @@
 
   $ git commit -m "initial" --allow-empty 1> /dev/null
 
-  $ josh-filter --notes-cache -s c=:/sub1 --update refs/josh/filter/libs/master libs/master
+  $ josh-filter --distributed-cache -s c=:/sub1 --update refs/josh/filter/libs/master libs/master
   21a904a6f350cb1f8ea4dc6fe9bd4e3b4cc4840b
   [2] :/sub1
   [2] :prefix=c
@@ -41,7 +41,7 @@
   $ git log --graph --pretty=%s josh/filter/libs/master
   * add file2
   * add file1
-  $ josh-filter --notes-cache -s a/b=:/sub2 --update refs/josh/filter/libs/foo libs/foo
+  $ josh-filter --distributed-cache -s a/b=:/sub2 --update refs/josh/filter/libs/foo libs/foo
   933f26e096e3452793bcbb82e8d927d7820340fb
   [1] :prefix=a
   [1] :prefix=b


### PR DESCRIPTION
This change is not actually using git-notes anymore so keeping the name would be misleading.