### PR TITLE
Store forge metadata when adding remotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2717,6 +2717,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "url",
 ]
 
 [[package]]

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -22,6 +22,7 @@ git2.workspace = true
 toml.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 serde.workspace = true
+url.workspace = true
 
 keyring = "^3.6"
 arboard = { version = "^3.6", default-features = false }

--- a/josh-cli/src/commands/auth.rs
+++ b/josh-cli/src/commands/auth.rs
@@ -1,9 +1,9 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
-use clap::{Subcommand, ValueEnum};
+use clap::Subcommand;
 
-use crate::forge::GITHUB_APP_CLIENT_ID;
+use crate::forge::{Forge, GITHUB_APP_CLIENT_ID};
 
 const KEYRING_SERVICE: &str = "josh-cli";
 const KEYRING_GITHUB_ACCESS_TOKEN: &str = "github:access_token";
@@ -30,12 +30,6 @@ pub struct ForgeArgs {
     /// Forge to authenticate with
     #[arg()]
     pub forge: Forge,
-}
-
-#[derive(Debug, Clone, ValueEnum)]
-pub enum Forge {
-    /// GitHub
-    Github,
 }
 
 pub fn handle_auth(args: &AuthArgs) -> anyhow::Result<()> {

--- a/josh-cli/src/forge.rs
+++ b/josh-cli/src/forge.rs
@@ -1,2 +1,44 @@
+use std::fmt::{Display, Formatter};
+
+use clap::ValueEnum;
+
 pub const GITHUB_APP_CLIENT_ID: &str = "Iv23liK2qIIUHy5iILiz";
 pub const GITHUB_APP_ID: &str = "2871336";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Forge {
+    /// GitHub
+    Github,
+}
+
+impl Display for Forge {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Forge::Github => f.write_str("github"),
+        }
+    }
+}
+
+pub fn guess_forge(url: &str) -> Option<Forge> {
+    let url = url::Url::parse(url).ok()?;
+    let host = url.host_str()?;
+
+    if host == "github.com" || host.ends_with(".github.com") {
+        return Some(Forge::Github);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::forge::{Forge, guess_forge};
+
+    #[test]
+    fn test_guess_forge() {
+        assert_eq!(
+            guess_forge("https://github.com/josh-project/josh.git"),
+            Some(Forge::Github)
+        )
+    }
+}


### PR DESCRIPTION
* Let users specify the forge or lack thereof
* Try to guess forge by default from remote URL