### PR TITLE
Add base refs to stacked pushes

### DIFF
--- a/tests/cli/push_stacked.t
+++ b/tests/cli/push_stacked.t
@@ -77,9 +77,17 @@ Push with stacked changes (should create multiple refs)
   
   Pushed c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
   To file://${TESTTMP}/remote
+   * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/1234
+  
+  Pushed 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/1234
+  To file://${TESTTMP}/remote
    * [new branch]      2cbfa8cb8d9a9f1de029fcba547a6e56c742733f -> @changes/master/josh@example.com/foo7
   
   Pushed 2cbfa8cb8d9a9f1de029fcba547a6e56c742733f to origin/refs/heads/@changes/master/josh@example.com/foo7
+  To file://${TESTTMP}/remote
+   * [new branch]      c61c37f4a3d5eb447f41dde15620eee1a181d60b -> @base/master/josh@example.com/foo7
+  
+  Pushed c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@base/master/josh@example.com/foo7
   To file://${TESTTMP}/remote
    * [new branch]      2cbfa8cb8d9a9f1de029fcba547a6e56c742733f -> @heads/master/josh@example.com
   
@@ -99,6 +107,8 @@ Verify the refs were created in the remote
   $ cd ${TESTTMP}/remote
   $ git ls-remote .
   6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d\tHEAD (esc)
+  6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d\trefs/heads/@base/master/josh@example.com/1234 (esc)
+  c61c37f4a3d5eb447f41dde15620eee1a181d60b\trefs/heads/@base/master/josh@example.com/foo7 (esc)
   c61c37f4a3d5eb447f41dde15620eee1a181d60b\trefs/heads/@changes/master/josh@example.com/1234 (esc)
   2cbfa8cb8d9a9f1de029fcba547a6e56c742733f\trefs/heads/@changes/master/josh@example.com/foo7 (esc)
   2cbfa8cb8d9a9f1de029fcba547a6e56c742733f\trefs/heads/@heads/master/josh@example.com (esc)

--- a/tests/cli/push_stacked_split.t
+++ b/tests/cli/push_stacked_split.t
@@ -72,13 +72,25 @@ Push with split mode (should create multiple refs for each change)
   
   Pushed c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
   To file://${TESTTMP}/remote
+   * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/1234
+  
+  Pushed 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/1234
+  To file://${TESTTMP}/remote
    * [new branch]      ba95dae3e5cf8fb0db28a931081e3a28f61fc94b -> @changes/master/josh@example.com/foo7
   
   Pushed ba95dae3e5cf8fb0db28a931081e3a28f61fc94b to origin/refs/heads/@changes/master/josh@example.com/foo7
   To file://${TESTTMP}/remote
+   * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/foo7
+  
+  Pushed 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/foo7
+  To file://${TESTTMP}/remote
    * [new branch]      ef7c3c85ad4c5875f308003d42a6e11d9b14aeb9 -> @changes/master/josh@example.com/1235
   
   Pushed ef7c3c85ad4c5875f308003d42a6e11d9b14aeb9 to origin/refs/heads/@changes/master/josh@example.com/1235
+  To file://${TESTTMP}/remote
+   * [new branch]      c61c37f4a3d5eb447f41dde15620eee1a181d60b -> @base/master/josh@example.com/1235
+  
+  Pushed c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@base/master/josh@example.com/1235
   To file://${TESTTMP}/remote
    * [new branch]      e8a69ac0518e72aec932b6f66f17670130cd1d0f -> @heads/master/josh@example.com
   
@@ -88,7 +100,10 @@ Verify the refs were created in the remote
 
   $ cd ${TESTTMP}/remote
   $ git ls-remote . | grep "@" | sort
+  6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d\trefs/heads/@base/master/josh@example.com/1234 (esc)
+  6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d\trefs/heads/@base/master/josh@example.com/foo7 (esc)
   ba95dae3e5cf8fb0db28a931081e3a28f61fc94b\trefs/heads/@changes/master/josh@example.com/foo7 (esc)
+  c61c37f4a3d5eb447f41dde15620eee1a181d60b\trefs/heads/@base/master/josh@example.com/1235 (esc)
   c61c37f4a3d5eb447f41dde15620eee1a181d60b\trefs/heads/@changes/master/josh@example.com/1234 (esc)
   e8a69ac0518e72aec932b6f66f17670130cd1d0f\trefs/heads/@heads/master/josh@example.com (esc)
   ef7c3c85ad4c5875f308003d42a6e11d9b14aeb9\trefs/heads/@changes/master/josh@example.com/1235 (esc)
@@ -100,21 +115,27 @@ Verify the refs were created in the remote
   | | *   115911beff2c43af69fb8b00efc50b6057b4174d
   | |/  
   |/|   
-  * | Change-Id: 1234  (@changes/master/josh@example.com/1234) c61c37f4a3d5eb447f41dde15620eee1a181d60b
+  * | Change-Id: 1234  (@changes/master/josh@example.com/1234, @base/master/josh@example.com/1235) c61c37f4a3d5eb447f41dde15620eee1a181d60b
   |/  
-  * add file1  (HEAD -> master) 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d
+  * add file1  (HEAD -> master, @base/master/josh@example.com/foo7, @base/master/josh@example.com/1234) 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d
 
 Test that we can fetch the split refs back
 
   $ cd ${TESTTMP}/filtered
   $ josh fetch
   From file://${TESTTMP}/remote
+   * [new branch]      @base/master/josh@example.com/1234 -> refs/josh/remotes/origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/1235 -> refs/josh/remotes/origin/@base/master/josh@example.com/1235
+   * [new branch]      @base/master/josh@example.com/foo7 -> refs/josh/remotes/origin/@base/master/josh@example.com/foo7
    * [new branch]      @changes/master/josh@example.com/1234 -> refs/josh/remotes/origin/@changes/master/josh@example.com/1234
    * [new branch]      @changes/master/josh@example.com/1235 -> refs/josh/remotes/origin/@changes/master/josh@example.com/1235
    * [new branch]      @changes/master/josh@example.com/foo7 -> refs/josh/remotes/origin/@changes/master/josh@example.com/foo7
    * [new branch]      @heads/master/josh@example.com -> refs/josh/remotes/origin/@heads/master/josh@example.com
   
   From file://${TESTTMP}/filtered
+   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/1235 -> origin/@base/master/josh@example.com/1235
+   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
    * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
    * [new branch]      @changes/master/josh@example.com/1235 -> origin/@changes/master/josh@example.com/1235
    * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
@@ -141,9 +162,9 @@ Test that we can fetch the split refs back
   | | *   51310e834ba7c7f2f034352a39a308bd86e5dd70
   | |/  
   |/|   
-  * | Change-Id: 1234  (origin/@changes/master/josh@example.com/1234) 43d6fcc9e7a81452d7343c78c0102f76027717fb
+  * | Change-Id: 1234  (origin/@changes/master/josh@example.com/1234, origin/@base/master/josh@example.com/1235) 43d6fcc9e7a81452d7343c78c0102f76027717fb
   |/  
-  * add file1  (origin/master, origin/HEAD) 5f2928c89c4dcc7f5a8c59ef65734a83620cefee
+  * add file1  (origin/master, origin/HEAD, origin/@base/master/josh@example.com/foo7, origin/@base/master/josh@example.com/1234) 5f2928c89c4dcc7f5a8c59ef65734a83620cefee
   * cache  3c2c2237ae79b148f5a4ca12279f75ab6029fe2b
 
 Test normal push still works

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -46,7 +46,11 @@
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1234 -> @changes/master/josh@example.com/1234        
   remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      1234 -> @base/master/josh@example.com/1234        
+  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      foo7 -> @changes/master/josh@example.com/foo7        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      foo7 -> @base/master/josh@example.com/foo7        
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      master -> @heads/master/josh@example.com        
   To http://localhost:8002/real_repo.git
@@ -59,6 +63,8 @@
   remote: upstream: response status: 200 OK        
   remote: upstream: response body:        
   remote: 
+  remote: Everything up-to-date        
+  remote: Everything up-to-date        
   remote: Everything up-to-date        
   remote: Everything up-to-date        
   remote: To http://localhost:8001/real_repo.git        
@@ -79,6 +85,8 @@
   Flushed credential cache (no-eol)
   $ git fetch origin
   From http://localhost:8002/real_repo
+   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
    * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
    * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
    * [new branch]      @heads/master/foo@example.com -> origin/@heads/master/foo@example.com
@@ -87,12 +95,14 @@
   $ git log --decorate --graph --pretty="%s %d"
   * add file3  (HEAD -> master, origin/@heads/master/josh@example.com, origin/@heads/master/foo@example.com)
   * Change-Id: foo7  (origin/@changes/master/josh@example.com/foo7)
-  * Change-Id: 1234  (origin/@changes/master/josh@example.com/1234)
-  * add file1  (origin/master, origin/HEAD)
+  * Change-Id: 1234  (origin/@changes/master/josh@example.com/1234, origin/@base/master/josh@example.com/foo7)
+  * add file1  (origin/master, origin/HEAD, origin/@base/master/josh@example.com/1234)
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin
   From http://localhost:8001/real_repo
+   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
    * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
    * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
    * [new branch]      @heads/master/foo@example.com -> origin/@heads/master/foo@example.com
@@ -101,7 +111,7 @@
   error: pathspec 'heads/master/foo@example.com' did not match any file(s) known to git
   [1]
   $ git log --decorate --graph --pretty="%s %d"
-  * add file1  (HEAD -> master, origin/master, origin/HEAD)
+  * add file1  (HEAD -> master, origin/master, origin/HEAD, origin/@base/master/josh@example.com/1234)
 
   $ tree
   .
@@ -116,6 +126,8 @@ get listed if they differ from HEAD
 
   $ git ls-remote http://localhost:8002/real_repo.git
   4950fa502f51b7bfda0d7975dbff9b0f9a9481ca\tHEAD (esc)
+  4950fa502f51b7bfda0d7975dbff9b0f9a9481ca\trefs/heads/@base/master/josh@example.com/1234 (esc)
+  3b0e3dbefd779ec54d92286047f32d3129161c0d\trefs/heads/@base/master/josh@example.com/foo7 (esc)
   3b0e3dbefd779ec54d92286047f32d3129161c0d\trefs/heads/@changes/master/josh@example.com/1234 (esc)
   ec41aad70b4b898baf48efeb795a7753d9674152\trefs/heads/@changes/master/josh@example.com/foo7 (esc)
   3ad32b3bd3bb778441e7eae43930d8dc6293eddc\trefs/heads/@heads/master/foo@example.com (esc)
@@ -124,6 +136,8 @@ get listed if they differ from HEAD
 
   $ git ls-remote http://localhost:8002/real_repo.git:/sub1.git
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb\tHEAD (esc)
+  0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb\trefs/heads/@base/master/josh@example.com/1234 (esc)
+  0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb\trefs/heads/@base/master/josh@example.com/foo7 (esc)
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb\trefs/heads/@changes/master/josh@example.com/1234 (esc)
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb\trefs/heads/@changes/master/josh@example.com/foo7 (esc)
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb\trefs/heads/@heads/master/foo@example.com (esc)
@@ -132,6 +146,8 @@ get listed if they differ from HEAD
   $ git ls-remote http://localhost:8002/real_repo.git::file2.git
   $ git ls-remote http://localhost:8002/real_repo.git::file7.git
   23b2396b6521abcd906f16d8492c5aeacaee06ed\tHEAD (esc)
+  23b2396b6521abcd906f16d8492c5aeacaee06ed\trefs/heads/@base/master/josh@example.com/1234 (esc)
+  23b2396b6521abcd906f16d8492c5aeacaee06ed\trefs/heads/@base/master/josh@example.com/foo7 (esc)
   23b2396b6521abcd906f16d8492c5aeacaee06ed\trefs/heads/@changes/master/josh@example.com/1234 (esc)
   08c82a20e92d548ff32f86d634b82da6756e1f5f\trefs/heads/@changes/master/josh@example.com/foo7 (esc)
   08c82a20e92d548ff32f86d634b82da6756e1f5f\trefs/heads/@heads/master/foo@example.com (esc)
@@ -199,6 +215,11 @@ Make sure all temporary namespace got removed
   |       |           |-- HEAD
   |       |           `-- refs
   |       |               `-- heads
+  |       |                   |-- @base
+  |       |                   |   `-- master
+  |       |                   |       `-- josh@example.com
+  |       |                   |           |-- 1234
+  |       |                   |           `-- foo7
   |       |                   |-- @changes
   |       |                   |   `-- master
   |       |                   |       `-- josh@example.com
@@ -254,7 +275,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  60 directories, 44 files
+  63 directories, 46 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_gerrit.t
+++ b/tests/proxy/push_stacked_gerrit.t
@@ -51,7 +51,11 @@
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1234 -> @changes/master/josh@example.com/1234        
   remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      1234 -> @base/master/josh@example.com/1234        
+  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      foo7 -> @changes/master/josh@example.com/foo7        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      foo7 -> @base/master/josh@example.com/foo7        
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new reference]   JOSH_PUSH -> refs/for/master        
   remote: To http://localhost:8001/real_repo.git        
@@ -66,6 +70,8 @@
   remote: upstream: response status: 200 OK        
   remote: upstream: response body:        
   remote: 
+  remote: Everything up-to-date        
+  remote: Everything up-to-date        
   remote: Everything up-to-date        
   remote: Everything up-to-date        
   remote: To http://localhost:8001/real_repo.git        
@@ -93,6 +99,8 @@
   Flushed credential cache (no-eol)
   $ git fetch origin
   From http://localhost:8002/real_repo
+   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
    * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
    * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
    * [new branch]      @heads/master/foo@example.com -> origin/@heads/master/foo@example.com
@@ -101,12 +109,14 @@
   $ git log --decorate --graph --pretty="%s %d"
   * add file3  (HEAD -> master, origin/@heads/master/josh@example.com, origin/@heads/master/foo@example.com)
   * Change-Id: foo7  (origin/@changes/master/josh@example.com/foo7)
-  * Change-Id: 1234  (origin/@changes/master/josh@example.com/1234)
-  * add file1  (origin/master, origin/HEAD)
+  * Change-Id: 1234  (origin/@changes/master/josh@example.com/1234, origin/@base/master/josh@example.com/foo7)
+  * add file1  (origin/master, origin/HEAD, origin/@base/master/josh@example.com/1234)
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin
   From http://localhost:8001/real_repo
+   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
    * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
    * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
    * [new branch]      @heads/master/foo@example.com -> origin/@heads/master/foo@example.com
@@ -115,8 +125,8 @@
   $ git log --decorate --graph --pretty="%s %d"
   * add file3  (HEAD -> @heads/master/foo@example.com, origin/@heads/master/josh@example.com, origin/@heads/master/foo@example.com)
   * Change-Id: foo7  (origin/@changes/master/josh@example.com/foo7)
-  * Change-Id: 1234  (origin/@changes/master/josh@example.com/1234)
-  * add file1  (origin/master, origin/HEAD, master)
+  * Change-Id: 1234  (origin/@changes/master/josh@example.com/1234, origin/@base/master/josh@example.com/foo7)
+  * add file1  (origin/master, origin/HEAD, origin/@base/master/josh@example.com/1234, master)
 
   $ tree
   .
@@ -184,6 +194,11 @@ Make sure all temporary namespace got removed
   |       |           |-- HEAD
   |       |           `-- refs
   |       |               `-- heads
+  |       |                   |-- @base
+  |       |                   |   `-- master
+  |       |                   |       `-- josh@example.com
+  |       |                   |           |-- 1234
+  |       |                   |           `-- foo7
   |       |                   |-- @changes
   |       |                   |   `-- master
   |       |                   |       `-- josh@example.com
@@ -223,7 +238,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  52 directories, 36 files
+  55 directories, 38 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_split.t
+++ b/tests/proxy/push_stacked_split.t
@@ -41,9 +41,15 @@
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1234 -> @changes/master/josh@example.com/1234        
   remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      1234 -> @base/master/josh@example.com/1234        
+  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      foo7 -> @changes/master/josh@example.com/foo7        
   remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      foo7 -> @base/master/josh@example.com/foo7        
+  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1235 -> @changes/master/josh@example.com/1235        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      1235 -> @base/master/josh@example.com/1235        
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      master -> @heads/master/josh@example.com        
   To http://localhost:8002/real_repo.git
@@ -53,6 +59,9 @@
   Flushed credential cache (no-eol)
   $ git fetch origin
   From http://localhost:8002/real_repo
+   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/1235 -> origin/@base/master/josh@example.com/1235
+   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
    * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
    * [new branch]      @changes/master/josh@example.com/1235 -> origin/@changes/master/josh@example.com/1235
    * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
@@ -63,10 +72,10 @@
   * Change-Id: foo7 
   | * Change-Id: 1235  (origin/@changes/master/josh@example.com/1235)
   |/  
-  * Change-Id: 1234  (origin/@changes/master/josh@example.com/1234)
+  * Change-Id: 1234  (origin/@changes/master/josh@example.com/1234, origin/@base/master/josh@example.com/1235)
   | * Change-Id: foo7  (origin/@changes/master/josh@example.com/foo7)
   |/  
-  * add file1  (origin/master, origin/HEAD)
+  * add file1  (origin/master, origin/HEAD, origin/@base/master/josh@example.com/foo7, origin/@base/master/josh@example.com/1234)
 
 Make sure all temporary namespace got removed
   $ tree ${TESTTMP}/remote/scratch/real_repo.git/refs/ | grep request_
@@ -134,6 +143,12 @@ Make sure all temporary namespace got removed
   |       |           |-- HEAD
   |       |           `-- refs
   |       |               `-- heads
+  |       |                   |-- @base
+  |       |                   |   `-- master
+  |       |                   |       `-- josh@example.com
+  |       |                   |           |-- 1234
+  |       |                   |           |-- 1235
+  |       |                   |           `-- foo7
   |       |                   |-- @changes
   |       |                   |   `-- master
   |       |                   |       `-- josh@example.com
@@ -183,7 +198,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  62 directories, 46 files
+  65 directories, 49 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -36,7 +36,11 @@
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1234 -> @changes/master/josh@example.com/1234        
   remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      1234 -> @base/master/josh@example.com/1234        
+  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      foo7 -> @changes/master/josh@example.com/foo7        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      foo7 -> @base/master/josh@example.com/foo7        
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      master -> @heads/master/josh@example.com        
   To http://localhost:8002/real_repo.git:/sub1.git
@@ -63,7 +67,11 @@
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1234 -> @changes/other_branch/josh@example.com/1234        
   remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      1234 -> @base/other_branch/josh@example.com/1234        
+  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      foo7 -> @changes/other_branch/josh@example.com/foo7        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      foo7 -> @base/other_branch/josh@example.com/foo7        
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      other_branch -> @heads/other_branch/josh@example.com        
   To http://localhost:8002/real_repo.git:/sub1.git
@@ -78,6 +86,8 @@
   remote: 
   remote: Everything up-to-date        
   remote: Everything up-to-date        
+  remote: Everything up-to-date        
+  remote: Everything up-to-date        
   remote: To http://localhost:8001/real_repo.git        
   remote:    2bb9471..a306516  master -> @heads/master/josh@example.com        
   To http://localhost:8002/real_repo.git:/sub1.git
@@ -87,6 +97,10 @@
   Flushed credential cache (no-eol)
   $ git fetch origin
   From http://localhost:8002/real_repo.git:/sub1
+   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
+   * [new branch]      @base/other_branch/josh@example.com/1234 -> origin/@base/other_branch/josh@example.com/1234
+   * [new branch]      @base/other_branch/josh@example.com/foo7 -> origin/@base/other_branch/josh@example.com/foo7
    * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
    * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
    * [new branch]      @changes/other_branch/josh@example.com/1234 -> origin/@changes/other_branch/josh@example.com/1234
@@ -96,12 +110,16 @@
   $ git log --decorate --graph --pretty="%s %d"
   * add file3  (HEAD -> master, origin/@heads/master/josh@example.com)
   * Change-Id: foo7  (origin/@heads/other_branch/josh@example.com, origin/@changes/other_branch/josh@example.com/foo7, origin/@changes/master/josh@example.com/foo7)
-  * Change-Id: 1234  (origin/@changes/other_branch/josh@example.com/1234, origin/@changes/master/josh@example.com/1234)
-  * add file1  (origin/master, origin/HEAD)
+  * Change-Id: 1234  (origin/@changes/other_branch/josh@example.com/1234, origin/@changes/master/josh@example.com/1234, origin/@base/other_branch/josh@example.com/foo7, origin/@base/master/josh@example.com/foo7)
+  * add file1  (origin/master, origin/HEAD, origin/@base/other_branch/josh@example.com/1234, origin/@base/master/josh@example.com/1234)
 
   $ cd ${TESTTMP}/real_repo
   $ git fetch origin
   From http://localhost:8001/real_repo
+   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
+   * [new branch]      @base/other_branch/josh@example.com/1234 -> origin/@base/other_branch/josh@example.com/1234
+   * [new branch]      @base/other_branch/josh@example.com/foo7 -> origin/@base/other_branch/josh@example.com/foo7
    * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
    * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
    * [new branch]      @changes/other_branch/josh@example.com/1234 -> origin/@changes/other_branch/josh@example.com/1234
@@ -112,7 +130,7 @@
   error: pathspec 'heads/master/josh@example.com' did not match any file(s) known to git
   [1]
   $ git log --decorate --graph --pretty="%s %d"
-  * add file1  (HEAD -> master, origin/master, origin/HEAD)
+  * add file1  (HEAD -> master, origin/master, origin/HEAD, origin/@base/other_branch/josh@example.com/1234, origin/@base/master/josh@example.com/1234)
 
   $ tree
   .
@@ -183,6 +201,15 @@ Make sure all temporary namespace got removed
   |       |           |-- HEAD
   |       |           `-- refs
   |       |               `-- heads
+  |       |                   |-- @base
+  |       |                   |   |-- master
+  |       |                   |   |   `-- josh@example.com
+  |       |                   |   |       |-- 1234
+  |       |                   |   |       `-- foo7
+  |       |                   |   `-- other_branch
+  |       |                   |       `-- josh@example.com
+  |       |                   |           |-- 1234
+  |       |                   |           `-- foo7
   |       |                   |-- @changes
   |       |                   |   |-- master
   |       |                   |   |   `-- josh@example.com
@@ -240,7 +267,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  62 directories, 47 files
+  67 directories, 51 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE


### PR DESCRIPTION
Add base refs to stacked pushes

In addition to branches for the changes themselves, this creates
branches to be used as the base for PRs so they have clean single
commits diffs.