### PR TITLE
Make link files location independent

### DIFF
--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -394,10 +394,8 @@ fn handle_link_push(
         .unwrap_or_else(|| "HEAD".to_string());
 
     // Build the export filter: subdir extracts the link path, :export strips .link.josh
-    let path_filter = josh_core::filter::Filter::new().subdir(normalized_path);
-    let combined_filter = path_filter
-        .export()?
-        .chain(josh_core::filter::invert(*link_file)?);
+    let path_filter = josh_core::filter::Filter::new();
+    let combined_filter = path_filter.chain(josh_core::filter::invert(*link_file)?);
 
     // Apply the filter to get the commit suitable for pushing
     let exported_commit = josh_core::filter_commit(transaction, combined_filter, head_commit.id())

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1033,13 +1033,10 @@ pub fn apply_to_commit2(
         }
         Op::Embed(path) => {
             check_experimental_features_enabled("embed filter")?;
-            let subdir = to_filter(Op::Subdir(path.clone()));
-            let unapply = to_filter(Op::Unapply(LazyRef::Resolved(commit.id()), subdir));
 
-            /* dbg!("embed"); */
-            /* dbg!(&path); */
             if let Some(link) = read_josh_link(repo, &commit.tree()?, &path, ".link.josh") {
-                /* dbg!(&link); */
+                let subdir = filter::invert(link.peel())?;
+                let unapply = to_filter(Op::Unapply(LazyRef::Resolved(commit.id()), subdir));
                 if let Some(commit_str) = link.get_meta("commit") {
                     if let Ok(commit_oid) = git2::Oid::from_str(&commit_str) {
                         let r = some_or!(transaction.get(unapply, commit_oid), {
@@ -1227,7 +1224,7 @@ pub fn apply<'a>(
 
                     // Process each submodule commit
                     for (submodule_path, (commit_oid, meta)) in submodule_commits {
-                        let prefix_filter = to_filter(Op::Nop);
+                        let prefix_filter = Filter::new().prefix(&submodule_path);
 
                         // Create a filter with metadata
                         let link_filter = prefix_filter
@@ -1312,13 +1309,9 @@ pub fn apply<'a>(
                 )
                 .unwrap();
 
-                result_tree = tree::insert(
-                    repo,
-                    &result_tree,
-                    &root,
-                    submodule_tree.tree().id(),
-                    0o0040000, // Tree mode
-                )?;
+                let result_tree_id =
+                    tree::overlay(transaction, result_tree.id(), submodule_tree.tree().id())?;
+                result_tree = repo.find_tree(result_tree_id)?;
                 let effective_mode = mode.clone().unwrap_or_else(|| {
                     link_file
                         .get_meta("mode")

--- a/josh-link/src/lib.rs
+++ b/josh-link/src/lib.rs
@@ -139,6 +139,8 @@ pub fn prepare_link_add(
     let filter_obj = josh_core::filter::parse(filter)
         .with_context(|| format!("Failed to parse filter '{}'", filter))?;
 
+    let filter_obj = filter_obj.prefix(&path);
+
     // Create a filter with metadata
     let link_filter = filter_obj
         .with_meta("remote", url.to_string())

--- a/tests/cq/track.t
+++ b/tests/cq/track.t
@@ -43,13 +43,13 @@
 
 # Verify the commit was created
   $ git log --oneline
-  4c107ca Track remote: myremote
+  6b261c7 Track remote: myremote
   51f2a63 Initial metarepo commit
 
 # Check the tree structure
   $ git ls-tree --format "${GIT_TREE_FMT}" -r HEAD
   100644 blob c937373cb4421598011a1a58ddab20d6227618e0 init.txt
-  100644 blob 95ae146ea76504b3b2e65265597f8c201ce88574 remotes/myremote/link/.link.josh
+  100644 blob 23d78eb1330c826590d75a067c9a5dc27f6a73ef remotes/myremote/link/.link.josh
   100644 blob 9225fc196ba1c36efea3fe89d89f3264f20e25c1 remotes/myremote/refs.json
 
 # Verify .link.josh content
@@ -60,7 +60,7 @@
       remote="../remote.git"
       target="HEAD"
   )[
-      :/
+      remotes = :prefix=link:prefix=myremote
   ]
 
   $ git show HEAD:remotes/myremote/refs.json

--- a/tests/experimental/link-add-push.t
+++ b/tests/experimental/link-add-push.t
@@ -52,12 +52,12 @@
       remote="../docs_repo.git"
       target="HEAD"
   )[
-      :/some_prefix
+      docs = :/some_prefix
   ]
 
   $ josh link push /docs
   To ../docs_repo.git
-   * [new branch]      49451f0ceb13b6e4130217b4db23e114b529e15b -> master
+   * [new branch]      cfb272114d10f61a88fbcd1976a0267ed7b55ebf -> master
   
 
   $ cd ${TESTTMP}
@@ -68,7 +68,24 @@
 
   $ cd docs_repo
 
+  $ git diff HEAD~1..HEAD
+  diff --git a/some_prefix/.link.josh b/some_prefix/.link.josh
+  new file mode 100644
+  index 0000000..e599191
+  --- /dev/null
+  +++ b/some_prefix/.link.josh
+  @@ -0,0 +1,8 @@
+  +:~(
+  +    commit="49451f0ceb13b6e4130217b4db23e114b529e15b"
+  +    mode="snapshot"
+  +    remote="../docs_repo.git"
+  +    target="HEAD"
+  +)[
+  +    docs = :/some_prefix
+  +]
+
   $ git log --graph --pretty=%s:%H
+  * Add link: docs:cfb272114d10f61a88fbcd1976a0267ed7b55ebf
   * update some docs:49451f0ceb13b6e4130217b4db23e114b529e15b
   * Initial commit:0d24cd27434a19674c17b21e47f176f7151a0260
 

--- a/tests/experimental/link-add.t
+++ b/tests/experimental/link-add.t
@@ -58,7 +58,7 @@
 
 # Verify the branch was created
   $ git show-ref | grep refs/heads/josh-link
-  20159bad8939bce913e384abe37f12fef436bbaa refs/heads/josh-link
+  225c0ed25b5de2330f138003f1213532c5415738 refs/heads/josh-link
 
 # Verify HEAD was not updated
   $ git log --oneline
@@ -83,11 +83,11 @@
   
   Turn off this advice by setting config variable advice.detachedHead to false
   
-  HEAD is now at 20159ba Add link: libs
+  HEAD is now at 225c0ed Add link: libs
 
   $ git ls-tree -r HEAD
   100644 blob f2376e2bab6c5194410bd8a55630f83f933d2f34\tREADME.md (esc)
-  100644 blob 0acb86f56c10bc4f5f4829b850009bf11a0bab9e\tlibs/.link.josh (esc)
+  100644 blob 21da4bdc8639a5a950cb07097735dfa764cc6716\tlibs/.link.josh (esc)
   $ cat libs/.link.josh
   :~(
       commit="d27fa3a10cc019e6aa55fc74c1f0893913380e2d"
@@ -95,11 +95,11 @@
       remote="../remote.git"
       target="HEAD"
   )[
-      :/
+      :prefix=libs
   ]
 
   $ git checkout master
-  Previous HEAD position was 20159ba Add link: libs
+  Previous HEAD position was 225c0ed Add link: libs
   Switched to branch 'master'
 
 # Test link add with custom filter and target
@@ -114,7 +114,7 @@
 
 # Verify the branch was created
   $ git show-ref | grep refs/heads/josh-link
-  18e1f2757e519eadfa53bf03e51fb55e5e579808 refs/heads/josh-link
+  80d468b2b322a0f881f911b8d9b2f5f80d520b74 refs/heads/josh-link
 
 # Check the content of the utils link branch
   $ git checkout refs/heads/josh-link
@@ -135,7 +135,7 @@
   
   Turn off this advice by setting config variable advice.detachedHead to false
   
-  HEAD is now at 18e1f27 Add link: utils
+  HEAD is now at 80d468b Add link: utils
   $ cat utils/.link.josh
   :~(
       commit="d27fa3a10cc019e6aa55fc74c1f0893913380e2d"
@@ -143,11 +143,11 @@
       remote="../remote.git"
       target="master"
   )[
-      :/utils
+      ::utils/
   ]
 
   $ git checkout master
-  Previous HEAD position was 18e1f27 Add link: utils
+  Previous HEAD position was 80d468b Add link: utils
   Switched to branch 'master'
 
 # Test path normalization (path with leading slash)
@@ -162,10 +162,10 @@
 
 # Verify path was normalized (no leading slash in branch name)
   $ git show-ref | grep refs/heads/josh-link
-  f185ec3e91d12287f1f12ac9421d09777fb279a3 refs/heads/josh-link
+  c945d1eaa0b8584d9c97d8ad6c5252078e9562ca refs/heads/josh-link
 
   $ git show refs/heads/josh-link
-  commit f185ec3e91d12287f1f12ac9421d09777fb279a3
+  commit c945d1eaa0b8584d9c97d8ad6c5252078e9562ca
   Author: JOSH <josh@josh-project.dev>
   Date:   Thu Jan 1 00:00:00 1970 +0000
   
@@ -173,7 +173,7 @@
   
   diff --git a/docs/.link.josh b/docs/.link.josh
   new file mode 100644
-  index 0000000..d1fd533
+  index 0000000..a93d950
   --- /dev/null
   +++ b/docs/.link.josh
   @@ -0,0 +1,8 @@
@@ -183,7 +183,7 @@
   +    remote="../remote.git"
   +    target="HEAD"
   +)[
-  +    :/docs
+  +    ::docs/
   +]
 
 

--- a/tests/experimental/link-push-force.t
+++ b/tests/experimental/link-push-force.t
@@ -43,23 +43,23 @@
 # Regular push is rejected: remote has unrelated history
   $ josh link push /docs
   To ../docs_repo.git
-   ! [rejected]        1d48cfeee0a6ac38edeef6f7c1d1449eaea9317c -> master (fetch first)
+   ! [rejected]        449200237526b58cb91be2743ee8fef1ac989a01 -> master (fetch first)
   error: failed to push some refs to '../docs_repo.git'
-  hint: * (glob)
-  hint: * (glob)
-  hint: * (glob)
-  hint: * (glob)
-  hint: * (glob)
+  hint: Updates were rejected because the remote contains work that you do not
+  hint: have locally. This is usually caused by another repository pushing to
+  hint: the same ref. If you want to integrate the remote changes, use
+  hint: 'git pull' before pushing again.
+  hint: See the 'Note about fast-forwards' in 'git push --help' for details.
   
   Error: Failed to push to '../docs_repo.git'
   Failed to push to '../docs_repo.git'
-  Command exited with code 1: git push ../docs_repo.git 1d48cfeee0a6ac38edeef6f7c1d1449eaea9317c:refs/heads/master
+  Command exited with code 1: git push ../docs_repo.git 449200237526b58cb91be2743ee8fef1ac989a01:refs/heads/master
   [1]
 
 # Force push overwrites the remote branch
   $ josh link push --force /docs
   To ../docs_repo.git
-   + 06358b5...1d48cfe 1d48cfeee0a6ac38edeef6f7c1d1449eaea9317c -> master (forced update)
+   + 06358b5...4492002 449200237526b58cb91be2743ee8fef1ac989a01 -> master (forced update)
   
 
 # Verify the remote now has our content

--- a/tests/experimental/link-submodules.t
+++ b/tests/experimental/link-submodules.t
@@ -61,10 +61,10 @@
 Test Adapt filter - should expand submodule into actual tree content
 
   $ josh-filter -s :adapt=submodules:link=embedded master --update refs/josh/filter/master
-  de1d866c061edd259d604b67b87e8f9bbb95a493
+  21b7f3ca0990df3f3bd6affb2d737f6f3b8f0ab2
   [1] :embed=libs
   [2] ::libs/.link.josh
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] :"{@}"
   [3] :adapt=submodules
   [3] :link=embedded
@@ -85,11 +85,11 @@ Test Adapt filter - should expand submodule into actual tree content
   main.txt
 
   $ git ls-tree refs/josh/filter/master
-  040000 tree c8039cb1eba006845979264c512b5b662a5e7d97\tlibs (esc)
+  040000 tree fae02e4d87ad32ac7f27862dac46f35f83b59692\tlibs (esc)
   100644 blob bcb9dcad21591bd9284afbb6c21e6d69eafe8f15\tmain.txt (esc)
 
   $ git ls-tree refs/josh/filter/master libs
-  040000 tree c8039cb1eba006845979264c512b5b662a5e7d97\tlibs (esc)
+  040000 tree fae02e4d87ad32ac7f27862dac46f35f83b59692\tlibs (esc)
 
   $ git ls-tree refs/josh/filter/master libs/foo
   040000 tree 81a0b9c71d7fac4f553b2a52b9d8d52d07dd8036\tlibs/foo (esc)
@@ -104,7 +104,7 @@ Test Adapt filter - should expand submodule into actual tree content
       remote="../submodule-repo"
       target="HEAD"
   )[
-      :/
+      :prefix=libs
   ]
   $ git show refs/josh/filter/master:libs/foo/file1.txt
   foo content
@@ -148,10 +148,10 @@ Test Adapt with multiple submodules
   	url = ../another-submodule
 
   $ josh-filter -s :adapt=submodules master --update refs/josh/filter/master
-  4e48d5817374b1950f15c4a8d135863594596dfe
+  36e64c35239749063d0ff71e5d67b6104a8ec8a4
   [1] :embed=libs
   [2] ::libs/.link.josh
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] :"{@}"
   [3] :link=embedded
   [4] :adapt=submodules
@@ -168,16 +168,16 @@ Test Adapt with multiple submodules
       remote="../submodule-repo"
       target="HEAD"
   )[
-      :/
+      :prefix=libs
   ]
   $ josh-filter -s :adapt=submodules:link=embedded master --update refs/josh/filter/master
-  c53a43b8e6335f332d28aac2b1aa5db511ef639e
+  ca7ee4a93815d05430f93898d9db88bda94c30a6
   [1] :embed=libs
   [1] :embed=modules/another
-  [1] :unapply(c6f07ba88c247cc089ba6729a95516729253e168:/modules/another)
+  [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
   [2] ::libs/.link.josh
   [2] ::modules/another/.link.josh
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [4] :"{@}"
   [4] :adapt=submodules
   [4] :link=embedded
@@ -203,7 +203,7 @@ Test Adapt with multiple submodules
   modules/another/another.txt
 
   $ git ls-tree refs/josh/filter/master modules
-  040000 tree 7b3cd056b887d0fee64b0752ce0bd983a5e05701\tmodules (esc)
+  040000 tree 7828c458c886668bae0b12f3b0d914298cee281b\tmodules (esc)
 
   $ git show refs/josh/filter/master:modules/another/another.txt
   another content
@@ -254,29 +254,29 @@ Test Adapt with submodule changes - add commits to submodule and update
 
 
   $ josh-filter -s :adapt=submodules:link=embedded master --update refs/josh/filter/master
-  e08fc8b154ffccae088368b570905d60f1262406
+  039bfc0995f10cd1bb1b3771b084c1acfca6949e
   [1] :embed=modules/another
-  [1] :unapply(c6f07ba88c247cc089ba6729a95516729253e168:/modules/another)
+  [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
   [2] ::modules/another/.link.josh
   [2] :embed=libs
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] ::libs/.link.josh
-  [4] :unapply(c84fadadb70fa40a33a61a03b334d2995b67b497:/libs)
+  [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
   [21] reachable_roots
   [21] sequence_number
   $ git log --graph --pretty=%s:%H refs/josh/filter/master
-  *   update libs submodule:e08fc8b154ffccae088368b570905d60f1262406
+  *   update libs submodule:039bfc0995f10cd1bb1b3771b084c1acfca6949e
   |\  
-  | * add file4.txt:7a5759d4b084f1e808874a44032a0b6446ddaaea
-  | * add file3.txt:c1b73bbd9c482eaca93ef84e9507e78fef85634d
-  * |   add another submodule:c53a43b8e6335f332d28aac2b1aa5db511ef639e
+  | * add file4.txt:16ee5600999ba1790afdbff89fcbf90c2ddde289
+  | * add file3.txt:6a5a648dc487e7006362c19a63c6d432c492cbfb
+  * |   add another submodule:ca7ee4a93815d05430f93898d9db88bda94c30a6
   |\ \  
-  | * | add another.txt:dfe454879200a2e8a9698c8b735f19afc246a5f4
+  | * | add another.txt:236993f40f766392481e54ca6cb6c47ed673b25e
   |  /  
-  * | add libs submodule:de1d866c061edd259d604b67b87e8f9bbb95a493
+  * | add libs submodule:21b7f3ca0990df3f3bd6affb2d737f6f3b8f0ab2
   |\| 
   | * add bar with file:2926fa3361cec2d5695a119fcc3592f4214af3ba
   | * add foo with files:e975fd8cd3f2d2de81884f5b761cc0ac150bdf47
@@ -306,14 +306,14 @@ Test Adapt with submodule changes - add commits to submodule and update
   another new content
 
   $ josh-filter -s :adapt=submodules:link=embedded:/libs master
-  b2e90aae4a2c0e7c2f9476d50300f92546cbc58f
+  c5ce38ecbae793a62ed4b46bb9f98e09eb71d78c
   [1] :embed=modules/another
-  [1] :unapply(c6f07ba88c247cc089ba6729a95516729253e168:/modules/another)
+  [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
   [2] ::modules/another/.link.josh
   [2] :embed=libs
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] ::libs/.link.josh
-  [4] :unapply(c84fadadb70fa40a33a61a03b334d2995b67b497:/libs)
+  [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
@@ -321,23 +321,23 @@ Test Adapt with submodule changes - add commits to submodule and update
   [29] reachable_roots
   [29] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
-  *   update libs submodule:b2e90aae4a2c0e7c2f9476d50300f92546cbc58f
+  *   update libs submodule:c5ce38ecbae793a62ed4b46bb9f98e09eb71d78c
   |\  
   | * add file4.txt:3061af908a0dc1417902fbd7208bb2b8dc354e6c
   | * add file3.txt:411907f127aa115588a614ec1dff6ee3c4696173
-  * | add libs submodule:24c4ad0143802f7d0cb1d76c5cfbc108f2f09e1e
+  * | add libs submodule:1eb3174f1a46b64ecb600d9e0626092e57497eae
   |/  
   * add bar with file:00c8fe9f1bb75a3f6280992ec7c3c893d858f5dd
   * add foo with files:4b63f3e50a3a34404541bc4519a3a1a0a8e6f738
   $ josh-filter -s :adapt=submodules:link=embedded:/libs:prune=trivial-merge master
-  b2e90aae4a2c0e7c2f9476d50300f92546cbc58f
+  c5ce38ecbae793a62ed4b46bb9f98e09eb71d78c
   [1] :embed=modules/another
-  [1] :unapply(c6f07ba88c247cc089ba6729a95516729253e168:/modules/another)
+  [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
   [2] ::modules/another/.link.josh
   [2] :embed=libs
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] ::libs/.link.josh
-  [4] :unapply(c84fadadb70fa40a33a61a03b334d2995b67b497:/libs)
+  [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
@@ -346,11 +346,11 @@ Test Adapt with submodule changes - add commits to submodule and update
   [31] reachable_roots
   [31] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
-  *   update libs submodule:b2e90aae4a2c0e7c2f9476d50300f92546cbc58f
+  *   update libs submodule:c5ce38ecbae793a62ed4b46bb9f98e09eb71d78c
   |\  
   | * add file4.txt:3061af908a0dc1417902fbd7208bb2b8dc354e6c
   | * add file3.txt:411907f127aa115588a614ec1dff6ee3c4696173
-  * | add libs submodule:24c4ad0143802f7d0cb1d76c5cfbc108f2f09e1e
+  * | add libs submodule:1eb3174f1a46b64ecb600d9e0626092e57497eae
   |/  
   * add bar with file:00c8fe9f1bb75a3f6280992ec7c3c893d858f5dd
   * add foo with files:4b63f3e50a3a34404541bc4519a3a1a0a8e6f738
@@ -359,12 +359,12 @@ Test Adapt with submodule changes - add commits to submodule and update
   $ josh-filter -s :adapt=submodules:link=embedded:/libs:export:prune=trivial-merge master
   3061af908a0dc1417902fbd7208bb2b8dc354e6c
   [1] :embed=modules/another
-  [1] :unapply(c6f07ba88c247cc089ba6729a95516729253e168:/modules/another)
+  [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
   [2] ::modules/another/.link.josh
   [2] :embed=libs
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] ::libs/.link.josh
-  [4] :unapply(c84fadadb70fa40a33a61a03b334d2995b67b497:/libs)
+  [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :export
@@ -381,12 +381,12 @@ Test Adapt with submodule changes - add commits to submodule and update
   $ josh-filter -s :adapt=submodules:link=embedded:/libs:export:prune=trivial-merge master
   3061af908a0dc1417902fbd7208bb2b8dc354e6c
   [1] :embed=modules/another
-  [1] :unapply(c6f07ba88c247cc089ba6729a95516729253e168:/modules/another)
+  [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
   [2] ::modules/another/.link.josh
   [2] :embed=libs
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] ::libs/.link.josh
-  [4] :unapply(c84fadadb70fa40a33a61a03b334d2995b67b497:/libs)
+  [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :export
@@ -401,15 +401,15 @@ Test Adapt with submodule changes - add commits to submodule and update
   * add bar with file:00c8fe9f1bb75a3f6280992ec7c3c893d858f5dd
   * add foo with files:4b63f3e50a3a34404541bc4519a3a1a0a8e6f738
   $ josh-filter -s :adapt=submodules:link=embedded:/modules/another master
-  b74da266394ae690a9b37b003779a1b59373bc65
+  a62789476855b6c89d1f15ba935d1a937e3ccd67
   [1] :embed=modules/another
-  [1] :unapply(c6f07ba88c247cc089ba6729a95516729253e168:/modules/another)
+  [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
   [2] :/another
   [2] ::modules/another/.link.josh
   [2] :embed=libs
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] ::libs/.link.josh
-  [4] :unapply(c84fadadb70fa40a33a61a03b334d2995b67b497:/libs)
+  [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :export
@@ -420,19 +420,19 @@ Test Adapt with submodule changes - add commits to submodule and update
   [33] reachable_roots
   [33] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
-  * add another submodule:b74da266394ae690a9b37b003779a1b59373bc65
+  * add another submodule:a62789476855b6c89d1f15ba935d1a937e3ccd67
   * add another.txt:8fbd01fa31551a059e280f68ac37397712feb59e
 
   $ josh-filter -s :adapt=submodules:link=embedded master --update refs/heads/testsubexport
-  e08fc8b154ffccae088368b570905d60f1262406
+  039bfc0995f10cd1bb1b3771b084c1acfca6949e
   [1] :embed=modules/another
-  [1] :unapply(c6f07ba88c247cc089ba6729a95516729253e168:/modules/another)
+  [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
   [2] :/another
   [2] ::modules/another/.link.josh
   [2] :embed=libs
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] ::libs/.link.josh
-  [4] :unapply(c84fadadb70fa40a33a61a03b334d2995b67b497:/libs)
+  [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :export
@@ -450,16 +450,16 @@ Test Adapt with submodule changes - add commits to submodule and update
   $ git add .
   $ git commit -m "mod libs submodule" 1> /dev/null
   $ git log --graph --pretty=%s:%H
-  * mod libs submodule:36043860d4b2efb245881c8bcb6e03e1b955c207
-  *   update libs submodule:e08fc8b154ffccae088368b570905d60f1262406
+  * mod libs submodule:e056e2408e26e7970cdfae049b66c302f3bebbbc
+  *   update libs submodule:039bfc0995f10cd1bb1b3771b084c1acfca6949e
   |\  
-  | * add file4.txt:7a5759d4b084f1e808874a44032a0b6446ddaaea
-  | * add file3.txt:c1b73bbd9c482eaca93ef84e9507e78fef85634d
-  * |   add another submodule:c53a43b8e6335f332d28aac2b1aa5db511ef639e
+  | * add file4.txt:16ee5600999ba1790afdbff89fcbf90c2ddde289
+  | * add file3.txt:6a5a648dc487e7006362c19a63c6d432c492cbfb
+  * |   add another submodule:ca7ee4a93815d05430f93898d9db88bda94c30a6
   |\ \  
-  | * | add another.txt:dfe454879200a2e8a9698c8b735f19afc246a5f4
+  | * | add another.txt:236993f40f766392481e54ca6cb6c47ed673b25e
   |  /  
-  * | add libs submodule:de1d866c061edd259d604b67b87e8f9bbb95a493
+  * | add libs submodule:21b7f3ca0990df3f3bd6affb2d737f6f3b8f0ab2
   |\| 
   | * add bar with file:2926fa3361cec2d5695a119fcc3592f4214af3ba
   | * add foo with files:e975fd8cd3f2d2de81884f5b761cc0ac150bdf47
@@ -468,13 +468,13 @@ Test Adapt with submodule changes - add commits to submodule and update
   $ josh-filter -s ":/libs:export:prune=trivial-merge" --update refs/heads/testsubexported
   005cde5c84fbcf17526a0e2fec0a2932c4ce8f24
   [1] :embed=modules/another
-  [1] :unapply(c6f07ba88c247cc089ba6729a95516729253e168:/modules/another)
+  [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
   [2] :/another
   [2] ::modules/another/.link.josh
   [2] :embed=libs
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] ::libs/.link.josh
-  [4] :unapply(c84fadadb70fa40a33a61a03b334d2995b67b497:/libs)
+  [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
@@ -504,17 +504,17 @@ Test Adapt with submodule changes - add commits to submodule and update
   * add foo with files:4b63f3e50a3a34404541bc4519a3a1a0a8e6f738
 
   $ josh-filter -s ":adapt=submodules:link=embedded:unlink" refs/heads/master --update refs/heads/unlinked_master
-  765042a09b160bb584461699a555d7d0dc812ec0
+  3d95fb6ef91b355b85f191cc16ac494a2c9651b3
   [1] :embed=modules/another
   [1] :prefix=modules/another
-  [1] :unapply(c6f07ba88c247cc089ba6729a95516729253e168:/modules/another)
+  [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
   [2] :/another
   [2] ::modules/another/.link.josh
   [2] :embed=libs
-  [2] :unapply(1f0a2b6933f2c095b7e3b6e958cf3695538b9f42:/libs)
+  [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] ::libs/.link.josh
   [4] :prefix=libs
-  [4] :unapply(c84fadadb70fa40a33a61a03b334d2995b67b497:/libs)
+  [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
@@ -527,15 +527,15 @@ Test Adapt with submodule changes - add commits to submodule and update
   [36] sequence_number
 
   $ git log --graph --pretty=%s:%H:%T refs/heads/unlinked_master
-  *   update libs submodule:765042a09b160bb584461699a555d7d0dc812ec0:7ff0acd41cae0c10ec166888f075e3f22ad8b299
+  *   update libs submodule:3d95fb6ef91b355b85f191cc16ac494a2c9651b3:0dff040bb48e18b3a89c345d5209fe73b3ca6ed1
   |\  
-  | * add file4.txt:7a5759d4b084f1e808874a44032a0b6446ddaaea:81be2dc8fa07e51134c28c4570c4333c0db0dec7
-  | * add file3.txt:c1b73bbd9c482eaca93ef84e9507e78fef85634d:213a615bad5b0a49101dab6b84faea148c41b378
-  * |   add another submodule:e50aafacef8f49c22bb6569952c060dfb82b8fe0:7615aa4b11b195001ea4befbe65a098cf51fe992
+  | * add file4.txt:16ee5600999ba1790afdbff89fcbf90c2ddde289:368005e9b692ddaf0ca9405d6fbda2b3bb20c8fc
+  | * add file3.txt:6a5a648dc487e7006362c19a63c6d432c492cbfb:b152c21838fd1d93f7899907bad5cc9aa245040b
+  * |   add another submodule:46aa06004c8da6f31223ac964fb7e4bf36858b98:60bd97919baa32a50192344481784299b405b19a
   |\ \  
-  | * | add another.txt:dfe454879200a2e8a9698c8b735f19afc246a5f4:d469e2eb543c1ea2388eb37085326e64606183a9
+  | * | add another.txt:236993f40f766392481e54ca6cb6c47ed673b25e:37e80d7bb93feef02524470d621167dbd5bee9c4
   |  /  
-  * | add libs submodule:07cd9b8b539e998af1ceceb1e0082f4c15c147e5:6e719f77f0079c314bf25ee0267e5c740a43e0b2
+  * | add libs submodule:a4d3b6f7b147345bc19ecfb958fc8dcdcc043b6e:25540e8fa5e62f7524ca3b84396d5ac97abba9d6
   |\| 
   | * add bar with file:2926fa3361cec2d5695a119fcc3592f4214af3ba:0b7130f9c4103e0b89fd511f432114ef2ebd33e9
   | * add foo with files:e975fd8cd3f2d2de81884f5b761cc0ac150bdf47:1fbe431508b38e48268466d9bb922b979e173ca9

--- a/tests/experimental/link.t
+++ b/tests/experimental/link.t
@@ -31,9 +31,9 @@ Test Link filter (identical to Adapt)
    * branch            HEAD       -> FETCH_HEAD
 
   $ josh-filter -s :adapt=submodules:link=embedded master --update refs/josh/filter/master
-  27814d162ba765274145a42ae41d327137422c1b
+  92633928cfadfc6a62a6e9b6d5f2a1e133b24877
   [1] :embed=libs
-  [1] :unapply(48c826999e0af24d18b3427ef57120c7077e318d:/libs)
+  [1] :unapply(547cadac76e234f77d5b363a4c517bf7a85cd4ee:/libs)
   [2] :"{@}"
   [2] ::libs/.link.josh
   [2] :adapt=submodules

--- a/tests/experimental/unsubmodule.t
+++ b/tests/experimental/unsubmodule.t
@@ -57,7 +57,7 @@
 Test Adapt filter - should expand submodule into actual tree content
 
   $ josh-filter -s :adapt=submodules master --update refs/josh/filter/master
-  71cd16ff3e379f18440c941c375ddacae56e4a8d
+  3db71ffd192bbef93c12795799f5dca34165fa96
   [3] :adapt=submodules
   [3] reachable_roots
   [3] sequence_number
@@ -70,11 +70,11 @@ Test Adapt filter - should expand submodule into actual tree content
   main.txt
 
   $ git ls-tree refs/josh/filter/master
-  040000 tree 00f86aede4e175a087264f1274397ba16334ea4a\tlibs (esc)
+  040000 tree 7b8647048d1914e07859a6e953cd6de50193bdce\tlibs (esc)
   100644 blob bcb9dcad21591bd9284afbb6c21e6d69eafe8f15\tmain.txt (esc)
 
   $ git ls-tree refs/josh/filter/master libs
-  040000 tree 00f86aede4e175a087264f1274397ba16334ea4a\tlibs (esc)
+  040000 tree 7b8647048d1914e07859a6e953cd6de50193bdce\tlibs (esc)
 
   $ git ls-tree refs/josh/filter/master libs/foo
 
@@ -123,7 +123,7 @@ Test Adapt with multiple submodules
   	url = ../another-submodule
 
   $ josh-filter -s :adapt=submodules master --update refs/josh/filter/master
-  4e48d5817374b1950f15c4a8d135863594596dfe
+  36e64c35239749063d0ff71e5d67b6104a8ec8a4
   [4] :adapt=submodules
   [4] reachable_roots
   [4] sequence_number
@@ -138,7 +138,7 @@ Test Adapt with multiple submodules
   modules/another/.link.josh
 
   $ git ls-tree refs/josh/filter/master modules
-  040000 tree 87e00852815f55431ea15f898ed31248c24217ca\tmodules (esc)
+  040000 tree ef28d03b997b5ca759e55df4879d22855f99fbf4\tmodules (esc)
 
   $ git show refs/josh/filter/master:modules/another/another.txt
   fatal: path 'modules/another/another.txt' exists on disk, but not in 'refs/josh/filter/master'
@@ -168,7 +168,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   $ git commit -m "update libs submodule" 1> /dev/null
 
   $ josh-filter -s :adapt=submodules master --update refs/josh/filter/master
-  814db71a8c61b7ee00b175cc9aa64b73aaef37b9
+  f1ab4cf4e933902ce8fa669d7f5eb90061aa1ad7
   [5] :adapt=submodules
   [5] reachable_roots
   [5] sequence_number


### PR DESCRIPTION
Make link files location independent

Before the path to the .link.josh file would imply
part of the filter (the prefix) but with this change
link files contain the full filter and their location
does not matter anymore.

Change: link-any-place