### PR TITLE
Clean up debug output and add label support

### DIFF
--- a/josh-run/bin/josh-run
+++ b/josh-run/bin/josh-run
@@ -38,14 +38,15 @@ fi
 # Derive filtered tree SHAs for the workspace: build context (:image),
 # runtime files (:run), and the combined workspace tree (for output vol naming).
 WS_TREE=$(git rev-parse $(josh-filter "$FILTER" "$SNAPSHOT_INPUT")^{tree})
-
-echo "WS_TREE: $WS_TREE"
-
 SAFE_NAME=$(josh-filter -i "$FILTER")
+LABEL=$(git show "$WS_TREE:label" 2>/dev/null || echo "$SAFE_NAME")
 OUTPUT_MODE=$(git show "$WS_TREE:output" 2>/dev/null || echo "volume")
+
+echo "Running: $LABEL ($WS_TREE)"
+
 $(dirname "$0")/josh-run-container "$SAFE_NAME" "$WS_TREE" || true
 
 # Pull generated artifacts from the output volume back to the host when enabled.
 if [[ "$OUTPUT_MODE" != "none" ]]; then
-    podman volume export "out_$WS_TREE" | tar -xvf -
+    podman volume export "out_$WS_TREE" | tar -xf -
 fi

--- a/josh-run/bin/josh-run-build-image
+++ b/josh-run/bin/josh-run-build-image
@@ -12,9 +12,9 @@ CONTEXT_TREE=$(git rev-parse $BUILD_TREE:context)
 
 IMAGE_NAME=ws_image_$BUILD_TREE
 if podman image inspect $IMAGE_NAME >/dev/null 2>&1; then
-    echo "Image exists locally"
+    echo "[image:${BUILD_TREE:0:12}] Already built"
 else
-    echo "Image does not exist locally"
+    echo "[image:${BUILD_TREE:0:12}] Building..."
     ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
     BUILD_ARGS=(--build-arg "USER_UID=$(id -u)" --build-arg "USER_GID=$(id -g)" --build-arg "ARCH=$ARCH")
     if [ -d ".git" ]; then

--- a/josh-run/bin/josh-run-container
+++ b/josh-run/bin/josh-run-container
@@ -10,22 +10,19 @@ usage() {
 SAFE_NAME=$1
 WS_TREE=$2
 
-echo "ls $WS_TREE"
-git ls-tree $WS_TREE
-echo "/ls $WS_TREE"
+LABEL=$(git show "$WS_TREE:label" 2>/dev/null || echo "$SAFE_NAME")
 
 OUTPUT_MODE=$(git show "$WS_TREE:output" 2>/dev/null || echo "volume")
 out_vol="out_${WS_TREE}"
 if [[ "$OUTPUT_MODE" != "none" ]] && podman volume inspect "$out_vol" >/dev/null 2>&1; then
-    echo "Cached output found, skipping build ($out_vol)"
+    echo "[$LABEL] Using cached output"
 else
     BUILD_ARGS=(--device /dev/net/tun --net host --cap-add=SYS_MODULE --cap-add=NET_ADMIN)
     if git rev-parse --verify "$WS_TREE:deps" >/dev/null 2>&1; then
-        git ls-tree "$WS_TREE:deps"
         while IFS= read -r filename <&3; do
             sha=$(git show "$WS_TREE:deps/$filename")
             ws="${SAFE_NAME}-${filename}"
-            echo "DEP: $0 $ws $sha"
+            echo "[$LABEL] Resolving dependency: $filename"
             "$0" "$ws" "$sha"
             dep_output_mode=$(git show "$sha:output" 2>/dev/null || echo "volume")
             if [[ "$dep_output_mode" == "none" ]]; then
@@ -45,7 +42,7 @@ else
         if git rev-parse --verify "$WS_TREE:cache" >/dev/null 2>&1; then
             cache_content=$(git show "$WS_TREE:cache")
             cache_vol="${cache_content}_cache"
-            podman volume create "$cache_vol" 2>/dev/null || true
+            podman volume create "$cache_vol" >/dev/null 2>&1 || true
             CACHE_MOUNT=(-v "$cache_vol":/opt/cache)
         else
             CACHE_MOUNT=()
@@ -59,15 +56,15 @@ else
             done 3< <(git ls-tree --name-only "$WS_TREE:env")
         fi
 
-        vol="snapshot_${RUN_TREE}_$(openssl rand -hex 4)"
-        podman volume create "$vol"
+        vol=$(podman volume create "snapshot_${RUN_TREE}_$(openssl rand -hex 4)")
+        echo "[$LABEL] Snapshot: $vol"
         if [[ "$OUTPUT_MODE" != "none" ]]; then
-            podman volume create "$out_vol"
+            echo "[$LABEL] Output volume: $(podman volume create "$out_vol")"
         elif podman volume inspect "$out_vol" >/dev/null 2>&1; then
-            podman volume rm "$out_vol"
+            echo "[$LABEL] Removed stale output: $(podman volume rm "$out_vol")"
         fi
 
-        git archive $RUN_TREE | podman volume import "$vol" -
+        echo "[$LABEL] Importing snapshot: $(git archive $RUN_TREE | podman volume import "$vol" -)"
 
         owner_paths=(/data)
         if [[ "$OUTPUT_MODE" != "none" ]]; then
@@ -88,14 +85,14 @@ else
             --entrypoint sh \
             --user $(id -u):$(id -g) ws_image_$IMAGE_TREE -c "bash run.sh" || RUN_STATUS=$?
 
-        podman volume rm "$vol"
+        podman volume rm "$vol" >/dev/null
     fi
 fi
 
 if [[ ${RUN_STATUS:-0} -ne 0 ]]; then
-    echo "FAILED: $SAFE_NAME"
+    echo "[$LABEL] FAILED"
 else
-    echo "SUCCESS: $SAFE_NAME"
+    echo "[$LABEL] SUCCESS"
 fi
 
 exit ${RUN_STATUS:-0}

--- a/ws/build.josh
+++ b/ws/build.josh
@@ -1,3 +1,4 @@
+:$label="cargo build"
 :#image[:+images/dev-local/image]
 :$cache="cargo"
 

--- a/ws/fetch.josh
+++ b/ws/fetch.josh
@@ -1,3 +1,4 @@
+:$label="cargo fetch"
 :#image[:+images/dev-local/image]
 :$cache="cargo"
 

--- a/ws/josh.josh
+++ b/ws/josh.josh
@@ -1,3 +1,4 @@
+:$label="josh proxy"
 :#image[:+images/run/image]
 :$cache="josh-data"
 :$output="none"

--- a/ws/test.josh
+++ b/ws/test.josh
@@ -1,6 +1,8 @@
+:$label="test suite"
 :$output="none"
 deps = :[
     :#cargo-test[
+        :$label="cargo test"
         :#image[:+images/dev-local/image]
         :$cache="cargo"
 
@@ -21,6 +23,7 @@ deps = :[
         ]
     ]
     :#fmt[
+        :$label="cargo fmt"
         :#image[:+images/dev-local/image]
 
         run = :[
@@ -32,6 +35,7 @@ deps = :[
         ]
     ]
     :#stable[
+        :$label="stable tests"
         :#image[:+images/dev-local/image]
 
         deps = :[
@@ -46,6 +50,7 @@ deps = :[
         ]
     ]
     :#incubating[
+        :$label="incubating tests"
         :#image[:+images/dev-local/image]
 
         deps = :[


### PR DESCRIPTION
Clean up debug output and add label support

- Remove debug git ls-tree dumps and DEP: prefix prints from josh-run-container
- Remove -v (verbose file listing) from tar extraction in josh-run
- Add :="..." blob reading in josh-run and josh-run-container; fall
  back to SAFE_NAME when no label is present
- Use [] prefix on all runtime messages for clear attribution
- Replace bare "Image exists/does not exist locally" in josh-run-build-image
  with [image:<short-sha>] prefixed messages
- Add :$$label entries to all workspace definitions

Change: josh-run-labels