### PR TITLE
Remove cargo-test.sh, pass RUSTFLAGS via env

### DIFF
--- a/ws/cargo-test.sh
+++ b/ws/cargo-test.sh
@@ -1,4 +1,0 @@
-set -e
-
-export RUSTFLAGS="-D warnings"
-cargo test --workspace --offline --locked

--- a/ws/test.josh
+++ b/ws/test.josh
@@ -8,8 +8,12 @@ deps = :[
             :#fetch[:+ws/fetch]
         ]
 
+        env = :[
+            :$RUSTFLAGS="-D warnings"
+        ]
+
         run = :[
-            ::run.sh=ws/cargo-test.sh
+            :$run.sh="set -e; cargo test --workspace --offline --locked"
             :exclude[
                 ::ws/
                 ::tests/


### PR DESCRIPTION
Remove cargo-test.sh, pass RUSTFLAGS via env

Instead of a separate shell script, inline the cargo test command
and pass RUSTFLAGS via the josh-run env mechanism, consistent with
how CARGO_BUILD_FEATURES is handled for the incubating build.

Change: rm-cargo-test.sh