### PR TITLE
Add gpgsig clrf normalization mode

### DIFF
--- a/docs/src/reference/filters.md
+++ b/docs/src/reference/filters.md
@@ -74,6 +74,42 @@ It affects both how commits are walked and how merge commits are handled in the 
   default behavior. If you're upgrading from an older version and need to recreate the same history
   structure, you should explicitly set `history="keep-trivial-merges"` in your filter options.
 
+### Gpgsig option
+
+The `gpgsig` option controls how PGP/GPG signature headers (`gpgsig`) in commit objects are
+handled during filtering.
+
+By default Josh preserves the `gpgsig` header byte-for-byte. This keeps the commit hash stable
+across round-trips but makes the signature invalid (since the tree and parent references change).
+
+**Available values:**
+
+- **`gpgsig="remove"`** - Strips the `gpgsig` header from every filtered commit.
+  Equivalent to the `:unsign` shorthand filter.
+
+  **Example:**
+  ```
+  :~(gpgsig="remove")[:/sub1]
+  ```
+
+- **`gpgsig="norm-lf"`** - Normalizes `\r\n` line endings to `\n` inside the `gpgsig` header
+  before writing the filtered commit.
+
+  The standard git commit object format uses `\n` line endings throughout, including inside
+  `gpgsig` headers. Some signing tools or forges write `\r\n` instead, which is technically
+  non-standard but valid as far as git is concerned — git treats the header value as opaque bytes.
+  Josh preserves whichever line endings are present in the original commit.
+
+  An older version of Josh accidentally normalized `\r\n` to `\n` during filtering. This option
+  restores that behavior and is intended **only** for deployments that need to reproduce a history
+  produced by the old version — both variants represent the same logical content but produce
+  different commit hashes, causing history to diverge.
+
+  **Example:**
+  ```
+  :~(gpgsig="norm-lf")[:/sub1]
+  ```
+
 ## Available filters
 
 ### Subdirectory **`:/a`**
@@ -181,6 +217,8 @@ the filtered commit. This makes the signature invalid, but allows a perfect roun
 able to recreate the original commit from the filtered one.
 
 This behaviour might not be desirable, and this filter drops the signatures from the history.
+It is a shorthand for `:~(gpgsig="remove")[:/]`. See the [gpgsig option](#gpgsig-option) for
+additional gpgsig-related options.
 
 ## Pattern filters
 

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -158,7 +158,7 @@ pub fn downstack(
             intermediate,
             &[&current_base],
             josh_core::filter::Rewrite::from_tree(new_tree),
-            false,
+            josh_core::history::GpgsigMode::Preserve,
         )?;
         current_base = repo.find_commit(new_oid)?;
     }
@@ -172,7 +172,7 @@ pub fn downstack(
         &change_commit,
         &[&current_base],
         josh_core::filter::Rewrite::from_tree(new_tree),
-        false,
+        josh_core::history::GpgsigMode::Preserve,
     )
 }
 

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -548,7 +548,7 @@ pub fn apply_to_commit2(
                 commit,
                 &[],
                 Rewrite::from_commit(commit)?,
-                true,
+                history::GpgsigMode::Remove,
             ))
             .transpose();
         }
@@ -1852,6 +1852,15 @@ fn per_rev_filter(
     commit_filter: Filter,
     parent_filters: Vec<(git2::Commit, Filter)>,
 ) -> anyhow::Result<Option<git2::Oid>> {
+    // Propagate any meta-options from the outer filter (e.g. :~(gpgsig="norm-lf")[:rev(...)])
+    // into the per-commit filter so they are applied during commit rewriting.
+    let commit_filter = {
+        let mut f = commit_filter;
+        for (k, v) in filter.into_meta().iter() {
+            f = f.with_meta(k, v);
+        }
+        f
+    };
     // Compute the difference between the current commit's filter and each parent's filter.
     // This determines what new content should be contributed by that parent in the filtered history.
     let extra_parents = parent_filters

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -3,6 +3,12 @@ use anyhow::anyhow;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
+pub enum GpgsigMode {
+    Preserve,
+    Remove,
+    NormLf,
+}
+
 pub fn walk2(
     filter: filter::Filter,
     input: git2::Oid,
@@ -264,7 +270,7 @@ pub fn rewrite_commit(
     base: &git2::Commit,
     parents: &[&git2::Commit],
     rewrite_data: filter::Rewrite,
-    unsign: bool,
+    gpgsig: GpgsigMode,
 ) -> anyhow::Result<git2::Oid> {
     use gix_object::bstr::BString;
 
@@ -337,9 +343,22 @@ pub fn rewrite_commit(
         commit.message = message.as_ref();
     }
 
-    commit
-        .extra_headers
-        .retain(|(k, _)| *k != "gpgsig".as_bytes() || !unsign);
+    match gpgsig {
+        GpgsigMode::Remove => {
+            commit
+                .extra_headers
+                .retain(|(k, _)| *k != "gpgsig".as_bytes());
+        }
+        GpgsigMode::NormLf => {
+            use gix_object::bstr::ByteSlice;
+            for (k, v) in commit.extra_headers.iter_mut() {
+                if *k == "gpgsig".as_bytes() && v.contains_str(b"\r\n") {
+                    *v = std::borrow::Cow::Owned(v.replace(b"\r\n", b"\n").into());
+                }
+            }
+        }
+        GpgsigMode::Preserve => {}
+    }
 
     let mut b = vec![];
     gix_object::WriteTo::write_to(&commit, &mut b)?;
@@ -733,7 +752,7 @@ pub fn unapply_filter(
             &module_commit,
             &original_parents,
             apply,
-            false,
+            GpgsigMode::Preserve,
         )?;
 
         ret = if original_parents.len() == 1
@@ -898,7 +917,11 @@ fn create_filtered_commit2<'a>(
         }
     }
 
-    let unsign = options.get("signature").is_some_and(|s| s == "remove");
+    let gpgsig = match options.get("gpgsig").map(String::as_str) {
+        Some("remove") => GpgsigMode::Remove,
+        Some("norm-lf") => GpgsigMode::NormLf,
+        _ => GpgsigMode::Preserve,
+    };
 
     Ok((
         rewrite_commit(
@@ -906,7 +929,7 @@ fn create_filtered_commit2<'a>(
             original_commit,
             &selected_filtered_parent_commits,
             rewrite_data,
-            unsign,
+            gpgsig,
         )?,
         true,
     ))

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -161,7 +161,7 @@ impl Filter {
     /// Chain a filter that removes commit signatures
     /// The filtered commits will not have GPG signatures
     pub fn unsign(self) -> Filter {
-        self.with_meta("signature", "remove")
+        self.with_meta("gpgsig", "remove")
     }
 
     /// Chain a squash filter

--- a/tests/filter/filter_id.t
+++ b/tests/filter/filter_id.t
@@ -731,7 +731,7 @@ Test :unsign
   $ FILTER_HASH=$(josh-filter -i ':unsign')
   $ josh-filter -p ${FILTER_HASH}
   :~(
-      signature="remove"
+      gpgsig="remove"
   )[
       :/
   ]
@@ -741,7 +741,7 @@ Test :unsign
   `-- meta
       |-- 0
       |   `-- nop
-      `-- signature
+      `-- gpgsig
   
   3 directories, 2 files
 

--- a/tests/filter/gpgsig.t
+++ b/tests/filter/gpgsig.t
@@ -42,7 +42,7 @@ Remove the signature, the shas are different.
   $ josh-filter :unsign refs/heads/master --update refs/heads/filtered -s
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb
   [1] :~(
-      signature="remove"
+      gpgsig="remove"
   )[
       :/
   ]
@@ -53,7 +53,7 @@ Remove the signature, the shas are different.
   $ josh-filter --reverse :unsign refs/heads/double-filtered --update refs/heads/filtered -s
   cb22ebb8e47b109f7add68b1043e561e0db09802
   [1] :~(
-      signature="remove"
+      gpgsig="remove"
   )[
       :/
   ]
@@ -74,3 +74,17 @@ Round trip does not work but reversed works since the commit exists
   cb22ebb8e47b109f7add68b1043e561e0db09802
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb
   cb22ebb8e47b109f7add68b1043e561e0db09802
+
+Test gpgsig="norm-lf" meta-option: normalizes line endings to LF in gpgsig headers.
+Reuse the known tree from the initial commit.
+  $ CRLF_COMMIT=$(printf "tree 3d77ff51363c9825cc2a221fc0ba5a883a1a2c72\nauthor Josh <josh@example.com> 1112911993 +0000\ncommitter Josh <josh@example.com> 1112911993 +0000\ngpgsig hello\r\n world\r\n\nadd file1\n" | git hash-object -t commit -w --stdin)
+  $ git update-ref refs/heads/crlf_master "$CRLF_COMMIT"
+
+Without norm-lf the CR is preserved (shown as ^M by cat -v).
+  $ git cat-file commit refs/heads/crlf_master | cat -v | grep gpgsig
+  gpgsig hello^M
+
+With gpgsig="norm-lf" the CR is removed.
+  $ josh-filter ':~(gpgsig="norm-lf")[:/]' refs/heads/crlf_master --update refs/heads/norm_filtered 1>/dev/null
+  $ git cat-file commit refs/heads/norm_filtered | cat -v | grep gpgsig
+  gpgsig hello


### PR DESCRIPTION
Add gpgsig clrf normalization mode

An old version of Josh normalised line endings in gpg signatures.
That was accidentally fixed at some point. Since the new behaviour
is correct it remains the default, but a meta option is added to
restore the old behaviour for backwards compatibility.

Change: normclrf