### PR TITLE
Add josh cache build/push/fetch subcommands

### DIFF
--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -203,6 +203,72 @@ The only currently supported forge is `github`. See
 
 ---
 
+## josh cache
+
+Manage the distributed filter cache. The distributed cache stores filter results inside
+a ref in the git repository, allowing a warm cache to be shared between machines via
+ordinary git push/fetch.
+
+The cache subcommand requires a josh remote to be configured (see `josh remote add`).
+
+### josh cache build
+
+Apply the configured filter to all already-fetched refs and populate the local distributed
+cache with the results.
+
+```
+josh cache build [remote]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `[remote]` | Remote name to build cache for (default: `origin`) |
+
+Run this before `josh cache push` to ensure the cache is up to date.
+
+### josh cache push
+
+Push the local distributed cache and the filtered refs to the backing remote, so that
+other machines can fetch them.
+
+```
+josh cache push [remote]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `[remote]` | Remote name to push cache to (default: `origin`) |
+
+### josh cache fetch
+
+Fetch the distributed cache and filtered refs from the remote, warming the local cache
+without re-computing filters from scratch.
+
+```
+josh cache fetch [remote]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `[remote]` | Remote name to fetch cache from (default: `origin`) |
+
+**Typical workflow:**
+
+```shell
+# On the machine that computes the cache (e.g. CI):
+josh cache build
+josh cache push
+
+# On another machine (e.g. a developer workstation):
+josh cache fetch
+# subsequent josh fetch / clone operations use the pre-built cache
+```
+
+> **Note:** The distributed cache is currently only available through the `josh` CLI.
+> It is not yet supported by `josh-proxy`.
+
+---
+
 ## josh-filter (standalone binary)
 
 `josh-filter` is a lower-level command that rewrites git history using Josh filter specs.

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -1,7 +1,8 @@
-use anyhow::{Context, anyhow};
+use anyhow::Context;
 use clap::Parser;
 
 use josh_cli::commands::auth::AuthArgs;
+use josh_cli::commands::cache::CacheArgs;
 use josh_cli::commands::link::LinkArgs;
 use josh_cli::commands::push::{PublishArgs, PushArgs};
 use josh_cli::config::{RemoteConfig, read_remote_config, write_remote_config};
@@ -55,6 +56,9 @@ pub enum RepoCommand {
 
     /// Manage josh links (like `josh remote` but for links)
     Link(LinkArgs),
+
+    /// Manage the distributed filter cache
+    Cache(CacheArgs),
 }
 
 /// Commands that don't require a git repository
@@ -227,69 +231,8 @@ fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
         RepoCommand::Remote(args) => handle_remote(args, &transaction),
         RepoCommand::Filter(args) => handle_filter(args, &transaction),
         RepoCommand::Link(args) => josh_cli::commands::link::handle_link(args, &transaction),
+        RepoCommand::Cache(args) => josh_cli::commands::cache::handle_cache(args, &transaction),
     }
-}
-
-/// Apply josh filtering to all remote refs and update local refs
-fn apply_josh_filtering(
-    transaction: &josh_core::cache::Transaction,
-    repo_path: &std::path::Path,
-    filter: josh_core::filter::Filter,
-    remote_name: &str,
-) -> anyhow::Result<()> {
-    let repo = transaction.repo();
-
-    // Get all remote refs from refs/josh/remotes/{remote_name}/*
-    let mut input_refs = Vec::new();
-    let josh_remotes = repo.references_glob(&format!("refs/josh/remotes/{}/*", remote_name))?;
-
-    for reference in josh_remotes {
-        let reference = reference?;
-        if let Some(target) = reference.target() {
-            let ref_name = reference.name().unwrap().to_string();
-            input_refs.push((ref_name, target));
-        }
-    }
-
-    if input_refs.is_empty() {
-        return Err(anyhow!("No remote references found"));
-    }
-
-    // Apply the filter to all remote refs
-    let (updated_refs, errors) = josh_core::filter_refs(&transaction, filter, &input_refs);
-
-    // Check for errors
-    if let Some(error) = errors.into_iter().next() {
-        return Err(anyhow!("josh filter error: {}", error.1));
-    }
-
-    // Second pass: create all references
-    for (original_ref, filtered_oid) in updated_refs {
-        // Check if the filtered result is empty (zero OID indicates empty result)
-        if filtered_oid == git2::Oid::zero() {
-            // Skip creating references for empty filtered results
-            continue;
-        }
-
-        // Extract branch name from refs/josh/remotes/{remote_name}/branch_name
-        let branch_name = original_ref
-            .strip_prefix(&format!("refs/josh/remotes/{}/", remote_name))
-            .context("Invalid josh remote reference")?;
-
-        // Create filtered reference in josh/filtered namespace
-        let filtered_ref = format!(
-            "refs/namespaces/josh-{}/refs/heads/{}",
-            remote_name, branch_name
-        );
-
-        repo.reference(&filtered_ref, filtered_oid, true, "josh filter")
-            .context("failed to create filtered reference")?;
-    }
-
-    spawn_git_command(repo_path, &["fetch", remote_name], &[])
-        .context("failed to fetch filtered refs")?;
-
-    Ok(())
 }
 
 fn to_absolute_remote_url(url: &str) -> anyhow::Result<String> {
@@ -443,13 +386,7 @@ fn handle_pull(args: &PullArgs, transaction: &josh_core::cache::Transaction) -> 
 }
 
 fn try_parse_symref(remote: &str, output: &str) -> Option<(String, String)> {
-    let line = output.lines().next()?;
-    let symref_part = line.split('\t').next()?;
-
-    let default_branch = symref_part.strip_prefix("ref: refs/heads/")?;
-    let default_branch_ref = format!("refs/remotes/{}/{}", remote, default_branch);
-
-    Some((default_branch.to_string(), default_branch_ref))
+    josh_cli::remote_ops::try_parse_symref(remote, output)
 }
 
 fn handle_fetch(
@@ -460,12 +397,23 @@ fn handle_fetch(
     let repo_path = normalize_repo_path(repo.path());
 
     // Read the remote configuration from .git/josh/remotes/<name>.josh
-    let RemoteConfig { url, ref_spec, .. } = read_remote_config(&repo_path, &args.remote)
+    let RemoteConfig {
+        url,
+        ref_spec,
+        filter_with_meta,
+        ..
+    } = read_remote_config(&repo_path, &args.remote)
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
 
     // First, fetch unfiltered refs to refs/josh/remotes/*
     spawn_git_command(repo.path(), &["fetch", &url, &ref_spec], &[])
         .context("git fetch to josh/remotes failed")?;
+
+    // Warm the local cache from the remote before filtering
+    let filter = filter_with_meta.peel();
+    if let Err(e) = josh_cli::commands::cache::fetch_remote_cache(repo, &url, filter) {
+        eprintln!("Warning: could not fetch remote cache: {e}");
+    }
 
     // Set up remote HEAD reference using git ls-remote
     // This is the proper way to get the default branch from the remote
@@ -495,18 +443,7 @@ fn handle_fetch(
         }
     }
 
-    let repo_path = normalize_repo_path(repo.path());
-    let RemoteConfig {
-        filter_with_meta, ..
-    } = read_remote_config(&repo_path, &args.remote)
-        .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
-
-    apply_josh_filtering(
-        transaction,
-        &repo_path,
-        filter_with_meta.peel(),
-        &args.remote,
-    )?;
+    josh_cli::remote_ops::apply_josh_filtering(transaction, &repo_path, filter, &args.remote)?;
 
     // Note: fetch doesn't checkout, it just updates the refs
     eprintln!("Fetched from remote: {}", args.remote);
@@ -613,7 +550,7 @@ fn handle_filter(
         filter_str, args.remote
     );
 
-    apply_josh_filtering(transaction, &repo_path, filter, &args.remote)?;
+    josh_cli::remote_ops::apply_josh_filtering(transaction, &repo_path, filter, &args.remote)?;
 
     println!(
         "Applied filter '{}' to remote '{}'",

--- a/josh-cli/src/commands/cache.rs
+++ b/josh-cli/src/commands/cache.rs
@@ -1,0 +1,262 @@
+use anyhow::Context;
+
+use josh_core::cache::{
+    CACHE_VERSION, CacheStack, DistributedCacheBackend, Transaction, TransactionContext,
+};
+use josh_core::filter::{Filter, flatten_chain};
+use josh_core::git::{normalize_repo_path, spawn_git_command};
+
+use crate::config::{RemoteConfig, read_remote_config};
+use crate::remote_ops;
+
+#[derive(Debug, clap::Parser)]
+pub struct CacheArgs {
+    #[command(subcommand)]
+    pub command: CacheCommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum CacheCommand {
+    /// Build the distributed cache by applying the configured filter to already-fetched refs
+    Build(CacheBuildArgs),
+    /// Push the distributed cache and filtered refs to the backing remote
+    Push(CachePushArgs),
+    /// Fetch the distributed cache and filtered refs from the remote
+    Fetch(CacheFetchArgs),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct CacheBuildArgs {
+    /// Remote name (defaults to "origin")
+    #[arg(default_value = "origin")]
+    pub remote: String,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct CachePushArgs {
+    /// Remote name (defaults to "origin")
+    #[arg(default_value = "origin")]
+    pub remote: String,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct CacheFetchArgs {
+    /// Remote name (defaults to "origin")
+    #[arg(default_value = "origin")]
+    pub remote: String,
+}
+
+pub fn handle_cache(args: &CacheArgs, transaction: &Transaction) -> anyhow::Result<()> {
+    match &args.command {
+        CacheCommand::Build(a) => handle_cache_build(a, transaction),
+        CacheCommand::Push(a) => handle_cache_push(a, transaction),
+        CacheCommand::Fetch(a) => handle_cache_fetch(a, transaction),
+    }
+}
+
+/// Build the ref-path prefix for step `step_idx` in a chain.
+///
+/// The path encodes the filter history newest-first so that each ref path
+/// uniquely identifies both *what* was applied and *to what* it was applied:
+///
+/// - step 0 of [A, B, C] → `"{A_id}"`
+/// - step 1 of [A, B, C] → `"{B_id}/{A_id}"`
+/// - step 2 of [A, B, C] → `"{C_id}/{B_id}/{A_id}"`
+fn step_ref_prefix(step_idx: usize, steps: &[Filter]) -> String {
+    (0..=step_idx)
+        .rev()
+        .map(|i| steps[i].id().to_string())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+    let repo_path = normalize_repo_path(repo.path());
+
+    let RemoteConfig {
+        filter_with_meta, ..
+    } = read_remote_config(&repo_path, &args.remote)
+        .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
+
+    let filter = filter_with_meta.peel();
+    let steps = flatten_chain(filter);
+
+    // Build a transaction that has ONLY the DistributedCacheBackend — no Sled.
+    // This ensures every filter operation writes a new entry to the distributed
+    // cache even if Sled already has a result for that commit.
+    let cache = std::sync::Arc::new(CacheStack::new().with_backend(
+        DistributedCacheBackend::new(&repo_path).context("Failed to open distributed cache")?,
+    ));
+    let build_transaction = TransactionContext::new(&repo_path, cache)
+        .open(None)
+        .context("Failed to open build transaction")?;
+
+    // Seed with the raw backing refs; the ref names act as branch labels.
+    let prefix = format!("refs/josh/remotes/{}/", args.remote);
+    let mut current_commits: Vec<(String, git2::Oid)> =
+        remote_ops::get_backing_refs(&build_transaction, &args.remote)?
+            .into_iter()
+            .map(|(refname, oid)| {
+                let branch = refname
+                    .strip_prefix(&prefix)
+                    .unwrap_or(&refname)
+                    .to_string();
+                (branch, oid)
+            })
+            .collect();
+
+    // Walk through each step in the chain, applying it to the previous step's
+    // results and writing an intermediate filtered ref.
+    for (step_idx, step_filter) in steps.iter().enumerate() {
+        let (filtered, errors) =
+            josh_core::filter_refs(&build_transaction, *step_filter, &current_commits);
+
+        if let Some(error) = errors.into_iter().next() {
+            return Err(anyhow::anyhow!("filter error: {}", error.1));
+        }
+
+        let prefix_path = step_ref_prefix(step_idx, &steps);
+        let mut next_commits = Vec::new();
+
+        for (branch_name, filtered_oid) in filtered {
+            if filtered_oid == git2::Oid::zero() {
+                continue;
+            }
+            let filtered_ref = format!("refs/josh/filtered/{}/heads/{}", prefix_path, branch_name);
+            repo.reference(&filtered_ref, filtered_oid, true, "josh cache build")
+                .with_context(|| format!("failed to write filtered ref '{}'", filtered_ref))?;
+            next_commits.push((branch_name, filtered_oid));
+        }
+
+        current_commits = next_commits;
+    }
+
+    eprintln!("Built cache for remote '{}'", args.remote);
+    Ok(())
+}
+
+fn handle_cache_push(args: &CachePushArgs, transaction: &Transaction) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+    let repo_path = normalize_repo_path(repo.path());
+
+    let RemoteConfig {
+        url,
+        filter_with_meta,
+        ..
+    } = read_remote_config(&repo_path, &args.remote)
+        .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
+
+    let filter = filter_with_meta.peel();
+    let steps = flatten_chain(filter);
+
+    // Resolve the default branch from the locally stored HEAD symref.
+    // This is set by `josh fetch`; fall back to "master" if not present.
+    let head_symref = format!("refs/remotes/{}/HEAD", args.remote);
+    let default_branch = repo
+        .find_reference(&head_symref)
+        .ok()
+        .and_then(|r| r.symbolic_target().map(|s| s.to_string()))
+        .and_then(|target| {
+            target
+                .strip_prefix(&format!("refs/remotes/{}/", args.remote))
+                .map(|s| s.to_string())
+        })
+        .unwrap_or_else(|| {
+            eprintln!(
+                "Warning: could not resolve default branch from '{}', falling back to 'master'",
+                head_symref
+            );
+            "master".to_string()
+        });
+
+    // Push all cache refs for the current cache version
+    let cache_refspec = format!(
+        "+refs/josh/cache/{}/*:refs/josh/cache/{}/*",
+        CACHE_VERSION, CACHE_VERSION
+    );
+    spawn_git_command(repo.path(), &["push", &url, &cache_refspec], &[])
+        .context("Failed to push cache refs")?;
+
+    // Push filtered refs for the default branch only so that recipients have
+    // all intermediate git objects needed to use the cache.
+    for step_idx in 0..steps.len() {
+        let prefix_path = step_ref_prefix(step_idx, &steps);
+        let local_ref = format!(
+            "refs/josh/filtered/{}/heads/{}",
+            prefix_path, default_branch
+        );
+
+        if repo.find_reference(&local_ref).is_err() {
+            eprintln!(
+                "Warning: filtered ref '{}' not found — run 'josh cache build' first",
+                local_ref
+            );
+            continue;
+        }
+
+        let filtered_refspec = format!("+{r}:{r}", r = local_ref);
+        spawn_git_command(repo.path(), &["push", &url, &filtered_refspec], &[])
+            .with_context(|| format!("Failed to push filtered ref for step {}", step_idx))?;
+    }
+
+    eprintln!(
+        "Pushed cache for remote '{}' (filter: {})",
+        args.remote,
+        &filter.id().to_string()[..8]
+    );
+    Ok(())
+}
+
+/// Fetch cache refs from `url` into the local repo.
+///
+/// - `refs/josh/cache/{VERSION}/*` is fetched; errors are surfaced to the caller.
+/// - `refs/josh/filtered/…` per-step refs are fetched best-effort (errors ignored).
+pub fn fetch_remote_cache(
+    repo: &git2::Repository,
+    url: &str,
+    filter: Filter,
+) -> anyhow::Result<()> {
+    let cache_refspec = format!(
+        "+refs/josh/cache/{v}/*:refs/josh/cache/{v}/*",
+        v = CACHE_VERSION
+    );
+    spawn_git_command(repo.path(), &["fetch", url, &cache_refspec], &[])
+        .context("Failed to fetch cache refs")?;
+
+    let steps = flatten_chain(filter);
+    for step_idx in 0..steps.len() {
+        let prefix_path = step_ref_prefix(step_idx, &steps);
+        let filtered_refspec = format!(
+            "+refs/josh/filtered/{p}/heads/*:refs/josh/filtered/{p}/heads/*",
+            p = prefix_path
+        );
+        // Ignore errors: the remote may not have filtered refs for this step yet
+        let _ = spawn_git_command(repo.path(), &["fetch", url, &filtered_refspec], &[]);
+    }
+
+    Ok(())
+}
+
+fn handle_cache_fetch(args: &CacheFetchArgs, transaction: &Transaction) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+    let repo_path = normalize_repo_path(repo.path());
+
+    let RemoteConfig {
+        url,
+        filter_with_meta,
+        ..
+    } = read_remote_config(&repo_path, &args.remote)
+        .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
+
+    let filter = filter_with_meta.peel();
+
+    fetch_remote_cache(repo, &url, filter)?;
+
+    eprintln!(
+        "Fetched cache for remote '{}' (filter: {})",
+        args.remote,
+        &filter.id().to_string()[..8]
+    );
+    Ok(())
+}

--- a/josh-cli/src/commands/mod.rs
+++ b/josh-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod auth;
+pub mod cache;
 pub mod link;
 pub mod push;

--- a/josh-cli/src/lib.rs
+++ b/josh-cli/src/lib.rs
@@ -2,3 +2,4 @@ pub mod commands;
 pub mod config;
 pub mod forge;
 pub mod keyring;
+pub mod remote_ops;

--- a/josh-cli/src/remote_ops.rs
+++ b/josh-cli/src/remote_ops.rs
@@ -1,0 +1,128 @@
+use anyhow::Context;
+
+use josh_core::git::{normalize_repo_path, spawn_git_command};
+
+/// Parse the symref output from `git ls-remote --symref` to extract the default branch.
+/// Returns `(branch_name, full_ref)` e.g. `("master", "refs/remotes/origin/master")`.
+pub fn try_parse_symref(remote: &str, output: &str) -> Option<(String, String)> {
+    let line = output.lines().next()?;
+    let symref_part = line.split('\t').next()?;
+
+    let default_branch = symref_part.strip_prefix("ref: refs/heads/")?;
+    let default_branch_ref = format!("refs/remotes/{}/{}", remote, default_branch);
+
+    Some((default_branch.to_string(), default_branch_ref))
+}
+
+/// Query the remote's HEAD branch via `git ls-remote --symref`.
+/// Falls back to `"master"` if the remote does not advertise a symref.
+pub fn get_head_branch(
+    url: &str,
+    repo_path: &std::path::Path,
+    remote_name: &str,
+) -> anyhow::Result<String> {
+    let output = std::process::Command::new("git")
+        .args(["ls-remote", "--symref", url, "HEAD"])
+        .current_dir(repo_path)
+        .output()
+        .context("Failed to run git ls-remote")?;
+
+    if output.status.success() {
+        let text = String::from_utf8(output.stdout).context("Invalid ls-remote output")?;
+        if let Some((branch, _)) = try_parse_symref(remote_name, &text) {
+            return Ok(branch);
+        }
+    }
+
+    Ok("master".to_string())
+}
+
+/// Apply a josh filter to all refs under `refs/josh/remotes/{remote_name}/*`.
+/// Returns a list of `(branch_name, filtered_oid)` pairs (zero OIDs omitted).
+pub fn filter_remote_refs(
+    transaction: &josh_core::cache::Transaction,
+    filter: josh_core::filter::Filter,
+    remote_name: &str,
+) -> anyhow::Result<Vec<(String, git2::Oid)>> {
+    let input_refs = get_backing_refs(transaction, remote_name)?;
+    let prefix = format!("refs/josh/remotes/{}/", remote_name);
+
+    let (updated_refs, errors) = josh_core::filter_refs(transaction, filter, &input_refs);
+
+    if let Some(error) = errors.into_iter().next() {
+        return Err(anyhow::anyhow!("josh filter error: {}", error.1));
+    }
+
+    let result = updated_refs
+        .into_iter()
+        .filter(|(_, oid)| *oid != git2::Oid::zero())
+        .map(|(original_ref, oid)| {
+            let branch = original_ref
+                .strip_prefix(&prefix)
+                .unwrap_or(&original_ref)
+                .to_string();
+            (branch, oid)
+        })
+        .collect();
+
+    Ok(result)
+}
+
+/// Return raw `(refname, oid)` pairs for all refs under
+/// `refs/josh/remotes/{remote_name}/*`, suitable as input to
+/// `josh_core::filter_refs`.  Errors if no refs are found.
+pub fn get_backing_refs(
+    transaction: &josh_core::cache::Transaction,
+    remote_name: &str,
+) -> anyhow::Result<Vec<(String, git2::Oid)>> {
+    let repo = transaction.repo();
+    let mut input_refs = Vec::new();
+    let josh_remotes = repo.references_glob(&format!("refs/josh/remotes/{}/*", remote_name))?;
+
+    for reference in josh_remotes {
+        let reference = reference?;
+        if let Some(target) = reference.target() {
+            let ref_name = reference.name().unwrap().to_string();
+            input_refs.push((ref_name, target));
+        }
+    }
+
+    if input_refs.is_empty() {
+        return Err(anyhow::anyhow!(
+            "No remote references found for '{}'",
+            remote_name
+        ));
+    }
+
+    Ok(input_refs)
+}
+
+/// Apply a josh filter to all refs under `refs/josh/remotes/{remote_name}/*` and write
+/// the filtered commits to `refs/namespaces/josh-{remote_name}/refs/heads/*`.
+/// Then runs `git fetch {remote_name}` to expose them through the configured remote.
+pub fn apply_josh_filtering(
+    transaction: &josh_core::cache::Transaction,
+    repo_path: &std::path::Path,
+    filter: josh_core::filter::Filter,
+    remote_name: &str,
+) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+
+    for (branch_name, filtered_oid) in filter_remote_refs(transaction, filter, remote_name)? {
+        let filtered_ref = format!(
+            "refs/namespaces/josh-{}/refs/heads/{}",
+            remote_name, branch_name
+        );
+        repo.reference(&filtered_ref, filtered_oid, true, "josh filter")
+            .context("failed to create filtered reference")?;
+    }
+
+    spawn_git_command(
+        normalize_repo_path(repo_path).as_path(),
+        &["fetch", remote_name],
+        &[],
+    )
+    .context("failed to fetch filtered refs")?;
+
+    Ok(())
+}

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -146,6 +146,11 @@ impl CacheBackend for DistributedCacheBackend {
         if let Ok(e) = tree.get_path(&fanout(from)) {
             let blob = repo.find_blob(e.id())?;
             let s = std::str::from_utf8(blob.content())?.to_owned();
+            log::debug!(
+                "DistributedCacheBackend: HIT {:?} {}",
+                from,
+                filter::spec(filter)
+            );
             return Ok(Some(git2::Oid::from_str(&s)?));
         } else {
             return Ok(None);

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
 
-pub(crate) const CACHE_VERSION: u64 = 26;
+pub const CACHE_VERSION: u64 = 26;
 
 pub trait CacheBackend: Send + Sync {
     fn read(

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -308,6 +308,56 @@ fn dst_path2(op: &Op) -> std::path::PathBuf {
     })
 }
 
+/// Fully flatten a (possibly nested) chain filter into an ordered list of
+/// primitive (non-chain) steps with their accumulated metadata.
+///
+/// The outer `Meta` of a chain is merged into each step before recursing.
+/// When a step is itself a meta-wrapped chain the process repeats,
+/// accumulating metadata all the way down to the leaf filters.
+///
+/// This makes all intermediate cache-key filters visible so they can be stored
+/// as git refs for the distributed cache.
+///
+/// Examples:
+/// ```text
+/// Chain([A, B, C])
+///   → [A, B, C]
+///
+/// Meta(m, Chain([A, B, C]))
+///   → [Meta(m,A), Meta(m,B), Meta(m,C)]
+///
+/// Meta(m1, Chain([Meta(m2, Chain([A, B])), C]))
+///   → [Meta(m1∪m2,A), Meta(m1∪m2,B), Meta(m1,C)]
+/// ```
+pub fn flatten_chain(filter: Filter) -> Vec<Filter> {
+    fn expand(
+        filter: Filter,
+        outer_meta: std::collections::BTreeMap<String, String>,
+    ) -> Vec<Filter> {
+        // Merge this filter's own meta with the outer meta.
+        // The filter's own meta takes precedence (inner wins on key collision).
+        let mut meta = filter.into_meta();
+        for (k, v) in outer_meta {
+            meta.entry(k).or_insert(v);
+        }
+        match peel_op(filter) {
+            Op::Chain(steps) => steps
+                .into_iter()
+                .flat_map(|f| expand(f, meta.clone()))
+                .collect(),
+            _ => {
+                // Leaf step: reassemble with the fully accumulated meta.
+                let mut f = filter.peel();
+                for (k, v) in meta {
+                    f = f.with_meta(k, v);
+                }
+                vec![f]
+            }
+        }
+    }
+    expand(filter, std::collections::BTreeMap::new())
+}
+
 /// Calculate the filtered commit for `commit`. This can take some time if done
 /// for the first time and thus should generally be done asynchronously.
 pub fn apply_to_commit(
@@ -533,14 +583,9 @@ pub fn apply_to_commit2(
     match &op {
         Op::Empty => return Ok(Some(git2::Oid::zero())),
 
-        Op::Chain(filters) => {
+        Op::Chain(_) => {
             let mut current_oid = commit.id();
-            let chain_meta = filter.into_meta();
-            for f in filters {
-                let mut f = *f;
-                for (k, v) in chain_meta.iter() {
-                    f = f.with_meta(k, v);
-                }
+            for f in flatten_chain(filter) {
                 if current_oid == git2::Oid::zero() {
                     break;
                 }

--- a/tests/cli/cache.t
+++ b/tests/cli/cache.t
@@ -1,0 +1,151 @@
+  $ export TESTTMP=${PWD}
+
+
+  $ cd ${TESTTMP}
+
+Setup: create a bare remote and populate it with some commits
+
+  $ mkdir remote
+  $ cd remote
+  $ git init -q --bare libs 1>/dev/null
+  $ cd ..
+
+  $ mkdir source
+  $ cd source
+  $ git init -q 1>/dev/null
+  $ mkdir sub1
+  $ echo file1 > sub1/file1
+  $ echo file2 > sub1/file2
+  $ git add sub1
+  $ git commit -q -m "add files"
+  $ git remote add origin ${TESTTMP}/remote/libs
+  $ git push -q origin master
+  $ cd ..
+
+  $ which git
+  /opt/git-install/bin/git
+
+Initialize a local workspace and add the josh remote (no fetch yet)
+
+  $ git init -q local1 1>/dev/null
+  $ cd local1
+  $ josh remote add origin ${TESTTMP}/remote/libs :/sub1
+  Added remote 'origin' with filter ':/sub1'
+
+Build the distributed cache (applies the filter to already-fetched refs)
+
+  $ josh fetch
+  From file://${TESTTMP}/remote/libs
+   * [new branch]      master     -> refs/josh/remotes/origin/master
+  
+  From file://${TESTTMP}/local1
+   * [new branch]      master     -> origin/master
+  
+  Fetched from remote: origin
+
+  $ josh cache build
+  Built cache for remote 'origin'
+
+
+Verify local cache refs were created
+
+  $ git for-each-ref --format='%(refname)' 'refs/josh/cache/'
+  refs/josh/cache/26/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+
+Push the distributed cache and filtered ref to the backing remote
+
+  $ josh cache push
+  To file://${TESTTMP}/remote/libs
+   * [new reference]   refs/josh/cache/26/0/bf567e0faf634a663d6cef48145a035e1974ab1d -> refs/josh/cache/26/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+  
+  To file://${TESTTMP}/remote/libs
+   * [new reference]   refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master -> refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master
+  
+  Pushed cache for remote 'origin' (filter: bf567e0f)
+
+Verify the remote now has cache refs and filtered refs
+
+  $ git ls-remote ${TESTTMP}/remote/libs 'refs/josh/cache/*' | wc -l | tr -d ' '
+  1
+
+  $ git ls-remote ${TESTTMP}/remote/libs 'refs/josh/filtered/*' | wc -l | tr -d ' '
+  1
+
+  $ cd ..
+
+Initialize a second local workspace to test cache fetch
+
+  $ git init -q local2 1>/dev/null
+  $ cd local2
+  $ josh remote add origin ${TESTTMP}/remote/libs :/sub1
+  Added remote 'origin' with filter ':/sub1'
+
+Verify no cache refs before fetch
+
+  $ git for-each-ref --format='%(refname)' 'refs/josh/cache/' | wc -l | tr -d ' '
+  0
+
+Fetch the distributed cache and filtered objects from the remote
+
+  $ josh cache fetch
+  From file://${TESTTMP}/remote/libs
+   * [new ref]         refs/josh/cache/26/0/bf567e0faf634a663d6cef48145a035e1974ab1d -> refs/josh/cache/26/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+  
+  From file://${TESTTMP}/remote/libs
+   * [new ref]         refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master -> refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master
+  
+  Fetched cache for remote 'origin' (filter: bf567e0f)
+
+Verify cache refs are now present locally
+
+  $ git for-each-ref --format='%(refname)' 'refs/josh/cache/'
+  refs/josh/cache/26/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+
+  $ cd ${TESTTMP}
+
+Chain filter section: test that intermediate refs are created for each step in the chain
+
+  $ git init -q local3 1>/dev/null
+  $ cd local3
+  $ josh remote add origin ${TESTTMP}/remote/libs :/sub1:prefix=libs
+  Added remote 'origin' with filter ':/sub1:prefix=libs'
+
+  $ josh fetch 2>/dev/null
+
+  $ josh cache build
+  Built cache for remote 'origin'
+
+After building a 2-step chain, there should be 2 filtered ref entries locally (one per step)
+
+  $ git for-each-ref --format='%(refname)' 'refs/josh/filtered/' | wc -l | tr -d ' '
+  2
+
+Push cache and both step refs to the remote
+
+  $ josh cache push 2>/dev/null
+
+Remote should now have 2 filtered ref entries (step-0 and step-1)
+
+  $ git ls-remote ${TESTTMP}/remote/libs 'refs/josh/filtered/*' | wc -l | tr -d ' '
+  2
+
+  $ cd ${TESTTMP}
+
+Test cache fetch in a fresh repo with a chain filter
+
+  $ git init -q local4 1>/dev/null
+  $ cd local4
+  $ josh remote add origin ${TESTTMP}/remote/libs :/sub1:prefix=libs
+  Added remote 'origin' with filter ':/sub1:prefix=libs'
+
+  $ git for-each-ref --format='%(refname)' 'refs/josh/filtered/' | wc -l | tr -d ' '
+  0
+
+  $ josh cache fetch 2>/dev/null
+
+After fetching, both sets of intermediate refs should be present locally
+
+  $ git for-each-ref --format='%(refname)' 'refs/josh/filtered/' | wc -l | tr -d ' '
+  2
+
+  $ cd ${TESTTMP}

--- a/tests/cli/remote-migration.t
+++ b/tests/cli/remote-migration.t
@@ -33,8 +33,8 @@ Test migration from legacy git config to new file format
 
   $ josh filter origin
   Applying filter ':/sub1' to remote 'origin'
-  Error: No remote references found
-  No remote references found
+  Error: No remote references found for 'origin'
+  No remote references found for 'origin'
   [1]
 
   $ cat .git/josh/remotes/origin.josh | sed "s|file://.*/remote/libs|file://\${TESTTMP}/remote/libs|"


### PR DESCRIPTION
Add josh cache build/push/fetch subcommands

This will allow transferring the cache between repos
and avoiding cold starts.

Change: cache-build-fetch-push