### PR TITLE
Use nesting level for choosing next missing filter to process

### DIFF
--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -91,9 +91,9 @@ struct Transaction2 {
     path_tree: sled::Tree,
     invert_tree: sled::Tree,
     trigram_index_tree: sled::Tree,
-    missing: Vec<(crate::filter::Filter, git2::Oid)>,
+    missing: Vec<(usize, crate::filter::Filter, git2::Oid)>,
     misses: usize,
-    walks: usize,
+    nesting_level: usize,
 }
 
 pub struct Transaction {
@@ -128,7 +128,7 @@ impl Transaction {
                 trigram_index_tree,
                 missing: vec![],
                 misses: 0,
-                walks: 0,
+                nesting_level: 0,
             }),
             repo,
             ref_prefix: ref_prefix.unwrap_or("").to_string(),
@@ -157,14 +157,10 @@ impl Transaction {
         self.t2.borrow().misses
     }
 
-    pub fn new_walk(&self) -> usize {
-        let prev = self.t2.borrow().walks;
-        self.t2.borrow_mut().walks += 1;
+    pub fn set_nesting(&self, level: usize) -> usize {
+        let prev = self.t2.borrow().nesting_level;
+        self.t2.borrow_mut().nesting_level = level;
         prev
-    }
-
-    pub fn end_walk(&self) {
-        self.t2.borrow_mut().walks -= 1;
     }
 
     pub fn insert_apply(&self, filter: crate::filter::Filter, from: git2::Oid, to: git2::Oid) {
@@ -371,10 +367,12 @@ impl Transaction {
         }
     }
 
-    pub fn get_missing(&self) -> Vec<(crate::filter::Filter, git2::Oid)> {
+    pub fn get_missing(&self) -> Vec<(usize, crate::filter::Filter, git2::Oid)> {
         let mut missing = self.t2.borrow().missing.clone();
-        missing.dedup();
-        missing.retain(|(f, i)| !self.known(*f, *i));
+        missing.retain(|(_, f, i)| !self.known(*f, *i));
+        missing.sort_by_key(|(l, f, i)| (*f, *i, *l));
+        missing.dedup_by_key(|(_, f, i)| (*f, *i));
+        missing.sort();
         self.t2.borrow_mut().missing = missing.clone();
         missing
     }
@@ -388,8 +386,9 @@ impl Transaction {
             Some(x)
         } else {
             let mut t2 = self.t2.borrow_mut();
+            let nesting_level = t2.nesting_level;
             t2.misses += 1;
-            t2.missing.push((filter, from));
+            t2.missing.push((nesting_level, filter, from));
             None
         }
     }

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -325,8 +325,18 @@ pub fn apply_to_commit(
 
         let missing = transaction.get_missing();
 
-        for (f, i) in missing.into_iter().rev() {
-            history::walk2(f, i, transaction)?;
+        let max_level = missing.last().map(|(w, _, _)| *w).unwrap_or(0);
+
+        for (level, filter, input) in missing.iter().rev() {
+            log::info!("MISSING {} {} {}", level, input, filter::spec(*filter));
+        }
+
+        for (level, filter, input) in missing.into_iter().rev() {
+            if level != max_level {
+                break;
+            }
+            transaction.set_nesting(level + 1);
+            history::walk2(filter, input, transaction)?;
         }
     }
 }

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -20,7 +20,7 @@ pub fn walk2(
         return Ok(());
     }
 
-    ok_or!(transaction.repo().find_commit(input), {
+    let input_commit = ok_or!(transaction.repo().find_commit(input), {
         return Ok(());
     });
 
@@ -38,44 +38,33 @@ pub fn walk2(
     let walk = walk.with_hide_callback(&mut hide_callback)?;
 
     log::info!(
-        "Walking {} new commits for:\n{}\n",
-        0,
-        filter::pretty(filter, 4),
+        "Walking {} commits for: {} {:?}",
+        crate::cache::compute_sequence_number(transaction, input)
+            .expect("compute_sequence_number failed"),
+        filter::spec(filter),
+        input_commit,
     );
     let mut n_in = 0;
     let mut n_out = 0;
 
-    let walks = transaction.new_walk();
-
     for original_commit_id in walk {
-        if filter::apply_to_commit2(
-            filter,
-            &transaction.repo().find_commit(original_commit_id?)?,
-            transaction,
-        )?
-        .is_some()
+        let id = original_commit_id?;
+
+        if filter::apply_to_commit2(filter, &transaction.repo().find_commit(id)?, transaction)?
+            .is_some()
         {
             n_out += 1;
+        } else {
+            break;
         }
 
         n_in += 1;
         if n_in % 1000 == 0 {
-            log::debug!(
-                "{} {} commits filtered, {} written",
-                " ->".repeat(walks),
-                n_in,
-                n_out,
-            );
+            log::debug!("{} commits filtered, {} written", n_in, n_out,);
         }
     }
 
-    log::info!(
-        "{} {} commits filtered, {} written",
-        " ->".repeat(walks),
-        n_in,
-        n_out,
-    );
-    transaction.end_walk();
+    log::info!("{} commits filtered, {} written", n_in, n_out,);
 
     Ok(())
 }


### PR DESCRIPTION
Use nesting level for choosing next missing filter to process

The previous approach caused bad performance on complex
workspace/stored filters by generating an excessive amount
of "missing" entries.
With this new approach the size of missing entires stays low
in most of the cases and performance is much better.

Change: missing-level