### PR TITLE
Pass the transaction's repository handle to starlark evaluation

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -451,11 +451,7 @@ fn get_starlark<'a>(
         Ok(rw) => rw.into_tree(),
         Err(_) => return to_filter(Op::Empty),
     };
-    let repo = match git2::Repository::open(transaction.repo().path()) {
-        Ok(r) => std::sync::Arc::new(std::sync::Mutex::new(r)),
-        Err(_) => return to_filter(Op::Empty),
-    };
-    match josh_starlark::evaluate(&script, filtered_tree.id(), repo) {
+    match josh_starlark::evaluate(&script, filtered_tree.id(), transaction.repo()) {
         Ok(f) => {
             let star_file = Filter::new().file(star_path);
             compose(&[star_file, subfilter, f])

--- a/josh-starlark/src/evaluate.rs
+++ b/josh-starlark/src/evaluate.rs
@@ -9,7 +9,6 @@ use starlark::{
     syntax::{AstModule, Dialect},
     values::ValueLike,
 };
-use std::sync::{Arc, Mutex};
 
 /// Evaluate a starlark script and return the resulting Filter
 ///
@@ -19,10 +18,13 @@ use std::sync::{Arc, Mutex};
 ///
 /// The `tree_oid` parameter is made available as a global variable named "tree"
 /// in the Starlark script, allowing access to the git tree via methods.
+///
+/// SAFETY contract: `repo` must remain valid for the entire duration of this call.
+/// The evaluation is synchronous; no threads are spawned and no values escape.
 pub fn evaluate(
     script: &str,
     tree_oid: git2::Oid,
-    repo: Arc<Mutex<git2::Repository>>,
+    repo: &git2::Repository,
 ) -> anyhow::Result<Filter> {
     // Parse the starlark script
     let ast = AstModule::parse("script.star", script.to_owned(), &Dialect::Standard)

--- a/josh-starlark/src/lib.rs
+++ b/josh-starlark/src/lib.rs
@@ -1,11 +1,10 @@
 pub mod evaluate;
 pub mod filter;
 pub mod module;
-pub mod tree;
+pub(crate) mod tree;
 
 pub use evaluate::evaluate;
 pub use filter::StarlarkFilter;
-pub use tree::StarlarkTree;
 
 #[cfg(test)]
 mod tests;

--- a/josh-starlark/src/tests.rs
+++ b/josh-starlark/src/tests.rs
@@ -1,20 +1,17 @@
 use crate::evaluate::evaluate;
 use josh_filter::spec;
-use std::sync::{Arc, Mutex};
 
 #[test]
 fn test_simple_filter() -> anyhow::Result<()> {
-    // Create a temporary repository for testing
     let temp_dir = std::env::temp_dir().join("josh_starlark_test");
     let _ = std::fs::remove_dir_all(&temp_dir);
     let repo = git2::Repository::init(&temp_dir)?;
     let empty_tree_oid = git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904")?;
-    let repo_arc = Arc::new(Mutex::new(repo));
 
     let script = r#"
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, empty_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, empty_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -22,17 +19,15 @@ filter = filter.subdir("src")
 
 #[test]
 fn test_chain_filter() -> anyhow::Result<()> {
-    // Create a temporary repository for testing
     let temp_dir = std::env::temp_dir().join("josh_starlark_test2");
     let _ = std::fs::remove_dir_all(&temp_dir);
     let repo = git2::Repository::init(&temp_dir)?;
     let empty_tree_oid = git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904")?;
-    let repo_arc = Arc::new(Mutex::new(repo));
 
     let script = r#"
 filter = filter.subdir("src").prefix("lib")
 "#;
-    let filter = evaluate(script, empty_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, empty_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src:prefix=lib");
     Ok(())
@@ -40,17 +35,15 @@ filter = filter.subdir("src").prefix("lib")
 
 #[test]
 fn test_file_filter() -> anyhow::Result<()> {
-    // Create a temporary repository for testing
     let temp_dir = std::env::temp_dir().join("josh_starlark_test3");
     let _ = std::fs::remove_dir_all(&temp_dir);
     let repo = git2::Repository::init(&temp_dir)?;
     let empty_tree_oid = git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904")?;
-    let repo_arc = Arc::new(Mutex::new(repo));
 
     let script = r#"
 filter = filter.file("README.md")
 "#;
-    let filter = evaluate(script, empty_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, empty_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     // file() creates a rename from the same path to itself, which is represented as ::README.md
     assert_eq!(filter_spec, "::README.md");
@@ -59,19 +52,17 @@ filter = filter.file("README.md")
 
 #[test]
 fn test_compose() -> anyhow::Result<()> {
-    // Create a temporary repository for testing
     let temp_dir = std::env::temp_dir().join("josh_starlark_test4");
     let _ = std::fs::remove_dir_all(&temp_dir);
     let repo = git2::Repository::init(&temp_dir)?;
     let empty_tree_oid = git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904")?;
-    let repo_arc = Arc::new(Mutex::new(repo));
 
     let script = r#"
 f1 = filter.subdir("src")
 f2 = filter.subdir("lib")
 filter = compose([f1, f2])
 "#;
-    let filter = evaluate(script, empty_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, empty_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     // compose formats as :[filter1,filter2]
     assert_eq!(filter_spec, ":[:/src,:/lib]");
@@ -79,7 +70,7 @@ filter = compose([f1, f2])
 }
 
 // Helper function to create a test repository with files and directories
-fn create_test_repo() -> anyhow::Result<(Arc<Mutex<git2::Repository>>, git2::Oid)> {
+fn create_test_repo() -> anyhow::Result<(git2::Repository, git2::Oid)> {
     let temp_dir = std::env::temp_dir().join(format!(
         "josh_starlark_tree_test_{}",
         std::time::SystemTime::now()
@@ -88,7 +79,6 @@ fn create_test_repo() -> anyhow::Result<(Arc<Mutex<git2::Repository>>, git2::Oid
     ));
     let _ = std::fs::remove_dir_all(&temp_dir);
     let repo = git2::Repository::init(&temp_dir)?;
-    let repo_arc = Arc::new(Mutex::new(repo));
 
     // Create a tree with:
     // - README.md (blob)
@@ -98,51 +88,40 @@ fn create_test_repo() -> anyhow::Result<(Arc<Mutex<git2::Repository>>, git2::Oid
     //     - utils.rs (blob)
 
     let lib_tree_oid = {
-        let repo_guard = repo_arc.lock().unwrap();
-        // Create blobs
-        let utils_rs_blob = repo_guard.blob(b"pub fn helper() {\n    // helper\n}")?;
-
-        // Create nested tree (lib/)
-        let mut lib_builder = repo_guard.treebuilder(None)?;
+        let utils_rs_blob = repo.blob(b"pub fn helper() {\n    // helper\n}")?;
+        let mut lib_builder = repo.treebuilder(None)?;
         lib_builder.insert("utils.rs", utils_rs_blob, 0o100644)?;
         lib_builder.write()?
     };
 
     let src_tree_oid = {
-        let repo_guard = repo_arc.lock().unwrap();
-        let main_rs_blob = repo_guard.blob(b"fn main() {\n    println!(\"Hello\");\n}")?;
-
-        // Create src/ tree
-        let mut src_builder = repo_guard.treebuilder(None)?;
+        let main_rs_blob = repo.blob(b"fn main() {\n    println!(\"Hello\");\n}")?;
+        let mut src_builder = repo.treebuilder(None)?;
         src_builder.insert("main.rs", main_rs_blob, 0o100644)?;
         src_builder.insert("lib", lib_tree_oid, 0o040000)?;
         src_builder.write()?
     };
 
     let root_tree_oid = {
-        let repo_guard = repo_arc.lock().unwrap();
-        let readme_blob = repo_guard.blob(b"# Project\nThis is a test project.")?;
-
-        // Create root tree
-        let mut root_builder = repo_guard.treebuilder(None)?;
+        let readme_blob = repo.blob(b"# Project\nThis is a test project.")?;
+        let mut root_builder = repo.treebuilder(None)?;
         root_builder.insert("README.md", readme_blob, 0o100644)?;
         root_builder.insert("src", src_tree_oid, 0o040000)?;
         root_builder.write()?
     };
 
-    Ok((repo_arc, root_tree_oid))
+    Ok((repo, root_tree_oid))
 }
 
 #[test]
 fn test_tree_file() -> anyhow::Result<()> {
-    let (repo_arc, root_tree_oid) = create_test_repo()?;
+    let (repo, root_tree_oid) = create_test_repo()?;
 
-    // Test accessing file content
     let script = r#"
 content = tree.file("README.md")
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, root_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -150,15 +129,14 @@ filter = filter.subdir("src")
 
 #[test]
 fn test_tree_file_nonexistent() -> anyhow::Result<()> {
-    let (repo_arc, root_tree_oid) = create_test_repo()?;
+    let (repo, root_tree_oid) = create_test_repo()?;
 
-    // Test accessing non-existent file returns empty string
     let script = r#"
 content = tree.file("nonexistent.txt")
 # Should return empty string, not error
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, root_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -166,15 +144,14 @@ filter = filter.subdir("src")
 
 #[test]
 fn test_tree_tree() -> anyhow::Result<()> {
-    let (repo_arc, root_tree_oid) = create_test_repo()?;
+    let (repo, root_tree_oid) = create_test_repo()?;
 
-    // Test accessing a tree
     let script = r#"
 src_tree = tree.tree("src")
 main_content = src_tree.file("main.rs")
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, root_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -182,15 +159,14 @@ filter = filter.subdir("src")
 
 #[test]
 fn test_tree_tree_nonexistent() -> anyhow::Result<()> {
-    let (repo_arc, root_tree_oid) = create_test_repo()?;
+    let (repo, root_tree_oid) = create_test_repo()?;
 
-    // Test accessing non-existent tree returns empty tree
     let script = r#"
 nonexistent_tree = tree.tree("nonexistent")
 # Should return empty tree, not error
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, root_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -198,15 +174,14 @@ filter = filter.subdir("src")
 
 #[test]
 fn test_tree_dirs() -> anyhow::Result<()> {
-    let (repo_arc, root_tree_oid) = create_test_repo()?;
+    let (repo, root_tree_oid) = create_test_repo()?;
 
-    // Test getting list of directories
     let script = r#"
 dirs_list = tree.dirs("")
 # Should contain "src"
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, root_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -214,15 +189,14 @@ filter = filter.subdir("src")
 
 #[test]
 fn test_tree_files() -> anyhow::Result<()> {
-    let (repo_arc, root_tree_oid) = create_test_repo()?;
+    let (repo, root_tree_oid) = create_test_repo()?;
 
-    // Test getting list of files
     let script = r#"
 files_list = tree.files("")
 # Should contain "README.md"
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, root_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -230,15 +204,14 @@ filter = filter.subdir("src")
 
 #[test]
 fn test_tree_nested_access() -> anyhow::Result<()> {
-    let (repo_arc, root_tree_oid) = create_test_repo()?;
+    let (repo, root_tree_oid) = create_test_repo()?;
 
-    // Test nested access: tree.tree("src").file("main.rs")
     let script = r#"
 src_tree = tree.tree("src")
 main_content = src_tree.file("main.rs")
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, root_tree_oid, &repo)?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -246,10 +219,8 @@ filter = filter.subdir("src")
 
 #[test]
 fn test_tree_build_filter_from_all_files() -> anyhow::Result<()> {
-    let (repo_arc, root_tree_oid) = create_test_repo()?;
+    let (repo, root_tree_oid) = create_test_repo()?;
 
-    // Test building a filter that includes all files from the tree
-    // Using the new API: tree.files() to get file lists
     let script = r#"
 def collect_all_files(dir_path=""):
     """Recursively collect all files and build filters"""
@@ -266,7 +237,7 @@ def collect_all_files(dir_path=""):
 all_file_filters = collect_all_files("")
 filter = compose(all_file_filters)
 "#;
-    let filter = evaluate(script, root_tree_oid, repo_arc.clone())?;
+    let filter = evaluate(script, root_tree_oid, &repo)?;
     let filter_spec = spec(filter);
 
     // The filter should contain all files: README.md, src/main.rs, src/lib/utils.rs

--- a/josh-starlark/src/tree.rs
+++ b/josh-starlark/src/tree.rs
@@ -8,19 +8,26 @@ use starlark::{
 };
 use std::fmt::{self, Display};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
 
 /// Opaque Tree type for Starlark
-/// We wrap git2::Tree by storing its OID and a reference to the repository
+/// We wrap git2::Tree by storing its OID and a raw pointer to the repository.
 #[derive(Clone, ProvidesStaticType, NoSerialize)]
-pub struct StarlarkTree {
+pub(crate) struct StarlarkTree {
     pub tree_oid: git2::Oid,
-    pub repo: Arc<Mutex<git2::Repository>>,
+    // SAFETY: StarlarkTree is only constructed inside `evaluate()`, which is
+    // synchronous and spawns no threads. The referenced `git2::Repository` must
+    // remain alive and at a stable address for that entire duration so this raw
+    // pointer stays valid.
+    repo: *const git2::Repository,
 }
+
+// SAFETY: See the `repo` field documentation above.
+unsafe impl Send for StarlarkTree {}
+unsafe impl Sync for StarlarkTree {}
 
 impl Allocative for StarlarkTree {
     fn visit<'a, 'b: 'a>(&self, _visitor: &'a mut allocative::Visitor<'b>) {
-        // Tree OID is Copy and small, Repository is Arc so we don't need to visit it
+        // Tree OID is Copy and small; repo is a raw pointer we do not own.
     }
 }
 
@@ -54,9 +61,23 @@ impl<'v> StarlarkValue<'v> for StarlarkTree {
 }
 
 impl StarlarkTree {
-    /// Create a new StarlarkTree from a git2::Oid
-    pub fn new(tree_oid: git2::Oid, repo: Arc<Mutex<git2::Repository>>) -> Self {
-        Self { tree_oid, repo }
+    /// Create a new StarlarkTree from a git2::Oid and a repository reference.
+    ///
+    /// This constructor is crate-private because the returned value stores `repo`
+    /// as a raw pointer without carrying a lifetime. The crate must therefore only
+    /// construct `StarlarkTree` values in contexts that guarantee the repository
+    /// outlives the tree and all of its clones, such as the synchronous
+    /// `evaluate()` flow described in the struct-level safety comments.
+    pub(crate) fn new(tree_oid: git2::Oid, repo: &git2::Repository) -> Self {
+        Self {
+            tree_oid,
+            repo: repo as *const _,
+        }
+    }
+
+    fn repo(&self) -> &git2::Repository {
+        // SAFETY: See the `repo` field documentation on the struct.
+        unsafe { &*self.repo }
     }
 
     /// Get empty tree OID
@@ -103,16 +124,12 @@ impl StarlarkTree {
 
     /// Navigate to a path in the tree, returning the OID of the tree at that path
     fn navigate_to_path_oid(&self, path: &str) -> anyhow::Result<git2::Oid> {
-        let repo = self.repo.lock().unwrap();
-        self.navigate_to_path_oid_with_repo(path, &repo)
+        self.navigate_to_path_oid_with_repo(path, self.repo())
     }
 
     /// Get blob content at path, returning empty string if not found or binary
     fn get_file_content(&self, path: &str) -> String {
-        let repo = match self.repo.lock() {
-            Ok(r) => r,
-            Err(_) => return String::new(),
-        };
+        let repo = self.repo();
 
         let tree = match repo.find_tree(self.tree_oid) {
             Ok(t) => t,
@@ -158,12 +175,12 @@ fn tree_methods(_builder: &mut MethodsBuilder) {
         path: StringValue,
         heap: &'v starlark::values::Heap,
     ) -> anyhow::Result<Vec<Value<'v>>> {
-        let repo = this.repo.lock().unwrap();
+        let repo = this.repo();
 
         let target_tree_oid = if path.as_str().is_empty() {
             this.tree_oid
         } else {
-            match this.navigate_to_path_oid_with_repo(path.as_str(), &repo) {
+            match this.navigate_to_path_oid_with_repo(path.as_str(), repo) {
                 Ok(oid) => oid,
                 Err(_) => return Ok(Vec::new()), // Path doesn't exist, return empty list
             }
@@ -203,12 +220,12 @@ fn tree_methods(_builder: &mut MethodsBuilder) {
         path: StringValue,
         heap: &'v starlark::values::Heap,
     ) -> anyhow::Result<Vec<Value<'v>>> {
-        let repo = this.repo.lock().unwrap();
+        let repo = this.repo();
 
         let target_tree_oid = if path.as_str().is_empty() {
             this.tree_oid
         } else {
-            match this.navigate_to_path_oid_with_repo(path.as_str(), &repo) {
+            match this.navigate_to_path_oid_with_repo(path.as_str(), repo) {
                 Ok(oid) => oid,
                 Err(_) => return Ok(Vec::new()), // Path doesn't exist, return empty list
             }
@@ -251,8 +268,7 @@ fn tree_methods(_builder: &mut MethodsBuilder) {
 
         Ok(StarlarkTree {
             tree_oid,
-
-            repo: this.repo.clone(),
+            repo: this.repo,
         })
     }
 }

--- a/tests/experimental/starlark_mempack.t
+++ b/tests/experimental/starlark_mempack.t
@@ -1,0 +1,35 @@
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1
+  $ echo contents1 > sub1/file1
+  $ echo contents2 > sub1/file2
+  $ git add sub1
+  $ git commit -m "add sub1" 1> /dev/null
+
+  $ cat > config.star <<'EOF'
+  > # The subfilter (:/sub1:prefix=lib) produces a tree that is written to the
+  > # mempack backend when running with --pack. This test verifies that the
+  > # starlark evaluation can access that mempack tree.
+  > content = tree.file("lib/file1")
+  > filter = filter.blob("foobar", content)
+  > # else:
+  > #     filter = filter.empty()
+  > EOF
+
+Apply with --pack: starlark must see the mempack tree to return the correct filter
+  $ josh-filter --pack ':!config[:/sub1::file1:prefix=lib]' . --update refs/josh/master
+  e915167514a08e5e19839b871c13ec581f7d9618
+
+  $ git ls-tree -r refs/josh/master
+  100644 blob 2b30477c6e975a7b6e8edec18bd617a629594681\tconfig.star (esc)
+  100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfoobar (esc)
+  100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tlib/file1 (esc)
+
+The starlark filter read "lib/file1" from the mempack tree and returned
+filter.subdir("sub1"), so "file1" is present at the root of the result.
+  $ git show refs/josh/master:foobar
+  contents1


### PR DESCRIPTION
Pass the transaction's repository handle to starlark evaluation

get_starlark was opening a fresh git2::Repository handle wrapped in a Arc/Mutex
to pass into josh_starlark::evaluate(). This was because the starlark value must
satisfy 'static + Send + Sync.
However using a new Repository handle means objects written via the original handle
are not present if the original handle uses the mempack backend.
Now a raw pointer is used as the starlark evaluation is not actually multithreaded.

Change: starlark-mempack-fix
Requires: rust-1-95