### PR TITLE
Fix get_version

### DIFF
--- a/tests/proxy/get_version.t
+++ b/tests/proxy/get_version.t
@@ -2,7 +2,7 @@
   $ cd ${TESTTMP}
 
   $ curl -s http://localhost:8002/version
-  Version: *.*.* (glob)
+  Version: r*.*.*-*-* (glob)
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   .


### PR DESCRIPTION
Fix get_version

The test depends on a git tag, which made it break after making
a release.

Change: fix-get-version