### PR TITLE
Remove repeated parsing of change commit message

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1,11 +1,11 @@
 use anyhow::anyhow;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct Change {
-    author: String,
-    id: Option<String>,
-    requires: Vec<String>,
-    commit: git2::Oid,
+    pub author: String,
+    pub id: Option<String>,
+    pub requires: Vec<String>,
+    pub commit: git2::Oid,
 }
 
 impl Change {
@@ -109,29 +109,30 @@ fn add_base_refs(repo: &git2::Repository, refs: &mut Vec<PushRef>) -> anyhow::Re
 
 fn split_changes(
     repo: &git2::Repository,
-    changes: &mut [PushRef],
+    changes: std::collections::HashMap<git2::Oid, Change>,
     base: git2::Oid,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<Vec<Change>> {
     if base == git2::Oid::zero() {
-        return Ok(());
+        return Ok(changes.into_values().collect());
     }
 
-    for push_ref in changes.iter_mut() {
-        push_ref.oid = downstack(repo, base, push_ref.oid)?;
-    }
-
-    Ok(())
+    changes
+        .iter()
+        .map(|(_, c)| downstack(repo, base, c, &changes))
+        .collect()
 }
 
-pub fn downstack(
+fn downstack(
     repo: &git2::Repository,
     base: git2::Oid,
-    change: git2::Oid,
-) -> anyhow::Result<git2::Oid> {
-    if !repo.graph_descendant_of(change, base)? {
+    change: &Change,
+    all_changes: &std::collections::HashMap<git2::Oid, Change>,
+) -> anyhow::Result<Change> {
+    let change_oid = change.commit;
+    if !repo.graph_descendant_of(change_oid, base)? {
         return Err(anyhow!(
             "change {} is not a descendant of base {}",
-            change,
+            change_oid,
             base
         ));
     }
@@ -140,13 +141,13 @@ pub fn downstack(
     let mut walk = repo.revwalk()?;
     walk.simplify_first_parent()?;
     walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
-    walk.push(change)?;
+    walk.push(change_oid)?;
     walk.hide(base)?;
 
     let oids: Vec<git2::Oid> = walk.collect::<Result<Vec<_>, _>>()?;
 
     if oids.is_empty() {
-        return Ok(change);
+        return Ok(change.clone());
     }
 
     let mut commits: Vec<git2::Commit> = oids
@@ -158,19 +159,19 @@ pub fn downstack(
     let change_commit = commits.pop().unwrap();
     let change_parent = change_commit.parent(0)?;
 
-    // Parse Requires: footers, keeping only those referencing changes
+    // Use pre-parsed requires, keeping only those referencing changes
     // actually present in the intermediates
-    let required_raw: std::collections::HashSet<String> =
-        get_change_id(&change_commit).requires.into_iter().collect();
-    let intermediate_ids: Vec<Option<String>> =
-        commits.iter().map(|c| get_change_id(c).id).collect();
-    let available_ids: std::collections::HashSet<&str> = intermediate_ids
+    let intermediate_ids: Vec<Option<&str>> = commits
         .iter()
-        .filter_map(|id| id.as_deref())
+        .map(|c| all_changes.get(&c.id()).and_then(|ch| ch.id.as_deref()))
         .collect();
-    let mut required: std::collections::HashSet<String> = required_raw
-        .into_iter()
-        .filter(|id| available_ids.contains(id.as_str()))
+    let available_ids: std::collections::HashSet<&str> =
+        intermediate_ids.iter().filter_map(|id| *id).collect();
+    let mut required: std::collections::HashSet<&str> = change
+        .requires
+        .iter()
+        .map(|s| s.as_str())
+        .filter(|id| available_ids.contains(id))
         .collect();
 
     // Walk through intermediates, including only those needed for
@@ -227,13 +228,17 @@ pub fn downstack(
     )?;
     let new_tree = repo.find_tree(index.write_tree_to(repo)?)?;
 
-    josh_core::history::rewrite_commit(
+    let new_oid = josh_core::history::rewrite_commit(
         repo,
         &change_commit,
         &[&current_base],
         josh_core::filter::Rewrite::from_tree(new_tree),
         josh_core::history::GpgsigMode::Preserve,
-    )
+    )?;
+
+    let mut result = change.clone();
+    result.commit = new_oid;
+    Ok(result)
 }
 
 fn changes_to_refs(
@@ -289,7 +294,7 @@ fn get_changes(
     repo: &git2::Repository,
     tip: git2::Oid,
     base: git2::Oid,
-) -> anyhow::Result<Vec<Change>> {
+) -> anyhow::Result<std::collections::HashMap<git2::Oid, Change>> {
     let mut walk = repo.revwalk()?;
     walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
     walk.simplify_first_parent()?;
@@ -298,10 +303,11 @@ fn get_changes(
         walk.hide(base)?;
     }
 
-    let mut changes = vec![];
+    let mut changes = std::collections::HashMap::new();
     for rev in walk {
         let commit = repo.find_commit(rev?)?;
-        changes.push(get_change_id(&commit));
+        let change = get_change_id(&commit);
+        changes.insert(change.commit, change);
     }
 
     Ok(changes)
@@ -318,11 +324,14 @@ pub fn build_to_push(
     match push_mode {
         PushMode::Stack(author) | PushMode::Split(author) => {
             let changes = get_changes(repo, oid_to_push, base_oid)?;
-            let mut push_refs = changes_to_refs(baseref, author, changes)?;
 
-            if matches!(push_mode, PushMode::Split(_)) {
-                split_changes(repo, &mut push_refs, base_oid)?;
-            }
+            let changes = if matches!(push_mode, PushMode::Split(_)) {
+                split_changes(repo, changes, base_oid)?
+            } else {
+                changes.into_values().collect()
+            };
+
+            let mut push_refs = changes_to_refs(baseref, author, changes)?;
 
             add_base_refs(repo, &mut push_refs)?;
 
@@ -336,6 +345,7 @@ pub fn build_to_push(
                 change_id: baseref.replacen("refs/heads/", "", 1),
             });
 
+            push_refs.sort_by(|a, b| a.ref_name.cmp(&b.ref_name));
             Ok(push_refs)
         }
         PushMode::Normal => Ok(vec![PushRef {

--- a/tests/cli/push_stacked.t
+++ b/tests/cli/push_stacked.t
@@ -73,16 +73,16 @@ Push with stacked changes (should create multiple refs)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/remotes/origin/HEAD (esc)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/remotes/origin/master (esc)
   $ josh publish
-  Pushing c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
   Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/1234
-  Pushing c1b55ea7e5f27f82d3565c1f5d64113adf635c2c to origin/refs/heads/@changes/master/josh@example.com/foo7
   Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/foo7
+  Pushing c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
+  Pushing c1b55ea7e5f27f82d3565c1f5d64113adf635c2c to origin/refs/heads/@changes/master/josh@example.com/foo7
   Pushing 2cbfa8cb8d9a9f1de029fcba547a6e56c742733f to origin/refs/heads/@heads/master/josh@example.com
   To file://${TESTTMP}/remote
-   * [new branch]      c61c37f4a3d5eb447f41dde15620eee1a181d60b -> @changes/master/josh@example.com/1234
    * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/1234
-   * [new branch]      c1b55ea7e5f27f82d3565c1f5d64113adf635c2c -> @changes/master/josh@example.com/foo7
    * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/foo7
+   * [new branch]      c61c37f4a3d5eb447f41dde15620eee1a181d60b -> @changes/master/josh@example.com/1234
+   * [new branch]      c1b55ea7e5f27f82d3565c1f5d64113adf635c2c -> @changes/master/josh@example.com/foo7
    * [new branch]      2cbfa8cb8d9a9f1de029fcba547a6e56c742733f -> @heads/master/josh@example.com
   
   Pushed 5 ref(s) to origin

--- a/tests/cli/push_stacked_binary.t
+++ b/tests/cli/push_stacked_binary.t
@@ -53,16 +53,16 @@ Set up git config for author
 Push with stacked changes containing binary files
 
   $ josh publish
-  Pushing 61d809929bf6b7a29d194f43368936fc82b033db to origin/refs/heads/@changes/master/josh@example.com/bin1
   Pushing 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/bin1
-  Pushing a4f8ccd2c1cf12aaf3b46eae73e38c71185867e7 to origin/refs/heads/@changes/master/josh@example.com/bin2
   Pushing 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/bin2
+  Pushing 61d809929bf6b7a29d194f43368936fc82b033db to origin/refs/heads/@changes/master/josh@example.com/bin1
+  Pushing a4f8ccd2c1cf12aaf3b46eae73e38c71185867e7 to origin/refs/heads/@changes/master/josh@example.com/bin2
   Pushing bcf10470382d693f9188a7a75872bcf3cd117dbc to origin/refs/heads/@heads/master/josh@example.com
   To file://${TESTTMP}/remote
-   * [new branch]      61d809929bf6b7a29d194f43368936fc82b033db -> @changes/master/josh@example.com/bin1
    * [new branch]      115b269a011d493259a125fa941fd790b903175f -> @base/master/josh@example.com/bin1
-   * [new branch]      a4f8ccd2c1cf12aaf3b46eae73e38c71185867e7 -> @changes/master/josh@example.com/bin2
    * [new branch]      115b269a011d493259a125fa941fd790b903175f -> @base/master/josh@example.com/bin2
+   * [new branch]      61d809929bf6b7a29d194f43368936fc82b033db -> @changes/master/josh@example.com/bin1
+   * [new branch]      a4f8ccd2c1cf12aaf3b46eae73e38c71185867e7 -> @changes/master/josh@example.com/bin2
    * [new branch]      bcf10470382d693f9188a7a75872bcf3cd117dbc -> @heads/master/josh@example.com
   
   Pushed 5 ref(s) to origin

--- a/tests/cli/push_stacked_split.t
+++ b/tests/cli/push_stacked_split.t
@@ -71,20 +71,20 @@ Set up git config for author
 Publish changes (josh publish should create multiple refs for each change)
 
   $ josh publish
-  Pushing c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
   Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/1234
-  Pushing 955da8395478e58213ad4ae975d9d885f87fdcec to origin/refs/heads/@changes/master/josh@example.com/foo7
-  Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/foo7
-  Pushing ef7c3c85ad4c5875f308003d42a6e11d9b14aeb9 to origin/refs/heads/@changes/master/josh@example.com/1235
   Pushing c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@base/master/josh@example.com/1235
+  Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/foo7
+  Pushing c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
+  Pushing ef7c3c85ad4c5875f308003d42a6e11d9b14aeb9 to origin/refs/heads/@changes/master/josh@example.com/1235
+  Pushing 955da8395478e58213ad4ae975d9d885f87fdcec to origin/refs/heads/@changes/master/josh@example.com/foo7
   Pushing 929b441481dc5e1a946004a5615592d837ad564b to origin/refs/heads/@heads/master/josh@example.com
   To file://${TESTTMP}/remote
-   * [new branch]      c61c37f4a3d5eb447f41dde15620eee1a181d60b -> @changes/master/josh@example.com/1234
    * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/1234
-   * [new branch]      955da8395478e58213ad4ae975d9d885f87fdcec -> @changes/master/josh@example.com/foo7
-   * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/foo7
-   * [new branch]      ef7c3c85ad4c5875f308003d42a6e11d9b14aeb9 -> @changes/master/josh@example.com/1235
    * [new branch]      c61c37f4a3d5eb447f41dde15620eee1a181d60b -> @base/master/josh@example.com/1235
+   * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/foo7
+   * [new branch]      c61c37f4a3d5eb447f41dde15620eee1a181d60b -> @changes/master/josh@example.com/1234
+   * [new branch]      ef7c3c85ad4c5875f308003d42a6e11d9b14aeb9 -> @changes/master/josh@example.com/1235
+   * [new branch]      955da8395478e58213ad4ae975d9d885f87fdcec -> @changes/master/josh@example.com/foo7
    * [new branch]      929b441481dc5e1a946004a5615592d837ad564b -> @heads/master/josh@example.com
   
   Pushed 7 ref(s) to origin

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -44,13 +44,13 @@
   remote: upstream: response body:        
   remote: 
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new branch]      1234 -> @changes/master/josh@example.com/1234        
-  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1234 -> @base/master/josh@example.com/1234        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new branch]      foo7 -> @changes/master/josh@example.com/foo7        
-  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      foo7 -> @base/master/josh@example.com/foo7        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      1234 -> @changes/master/josh@example.com/1234        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      foo7 -> @changes/master/josh@example.com/foo7        
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      master -> @heads/master/josh@example.com        
   To http://localhost:8002/real_repo.git

--- a/tests/proxy/push_stacked_split.t
+++ b/tests/proxy/push_stacked_split.t
@@ -39,17 +39,17 @@
   remote: upstream: response body:        
   remote: 
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new branch]      1234 -> @changes/master/josh@example.com/1234        
-  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1234 -> @base/master/josh@example.com/1234        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new branch]      foo7 -> @changes/master/josh@example.com/foo7        
+  remote:  * [new branch]      1235 -> @base/master/josh@example.com/1235        
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      foo7 -> @base/master/josh@example.com/foo7        
   remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      1234 -> @changes/master/josh@example.com/1234        
+  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1235 -> @changes/master/josh@example.com/1235        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new branch]      1235 -> @base/master/josh@example.com/1235        
+  remote:  * [new branch]      foo7 -> @changes/master/josh@example.com/foo7        
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      master -> @heads/master/josh@example.com        
   To http://localhost:8002/real_repo.git

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -34,13 +34,13 @@
   remote: upstream: response body:        
   remote: 
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new branch]      1234 -> @changes/master/josh@example.com/1234        
-  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1234 -> @base/master/josh@example.com/1234        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new branch]      foo7 -> @changes/master/josh@example.com/foo7        
-  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      foo7 -> @base/master/josh@example.com/foo7        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      1234 -> @changes/master/josh@example.com/1234        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      foo7 -> @changes/master/josh@example.com/foo7        
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      master -> @heads/master/josh@example.com        
   To http://localhost:8002/real_repo.git:/sub1.git
@@ -65,13 +65,13 @@
   remote: upstream: response body:        
   remote: 
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new branch]      1234 -> @changes/other_branch/josh@example.com/1234        
-  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      1234 -> @base/other_branch/josh@example.com/1234        
   remote: To http://localhost:8001/real_repo.git        
-  remote:  * [new branch]      foo7 -> @changes/other_branch/josh@example.com/foo7        
-  remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      foo7 -> @base/other_branch/josh@example.com/foo7        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      1234 -> @changes/other_branch/josh@example.com/1234        
+  remote: To http://localhost:8001/real_repo.git        
+  remote:  * [new branch]      foo7 -> @changes/other_branch/josh@example.com/foo7        
   remote: To http://localhost:8001/real_repo.git        
   remote:  * [new branch]      other_branch -> @heads/other_branch/josh@example.com        
   To http://localhost:8002/real_repo.git:/sub1.git


### PR DESCRIPTION
Remove repeated parsing of change commit message

By doing the split/downstack based on Change instances rather
than refs the commit messages need to be parsed only once.

Change: split-change-struct