### PR TITLE
Pass bake metadata via env in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,11 @@ jobs:
         if: needs.generate-tags.outputs.should_build == 'true'
         id: build
         uses: docker/bake-action@v7
+        env:
+          # Without this, bake-action embeds the full GitHub event payload in
+          # the metadata output, which exceeds env-var size limits when read
+          # by downstream steps.
+          BUILDX_METADATA_PROVENANCE: disabled
         with:
           targets: run
           set: |
@@ -143,10 +148,12 @@ jobs:
         if: needs.generate-tags.outputs.should_build == 'true'
         # Create digests directory with a file whose name matches
         # the digest with the 'sha256:' prefix removed.
-        # Note: metadata is inlined into the script (not passed as env var) to avoid
-        # "Argument list too long" errors — bake-action embeds the full GitHub context.
+        # The metadata is passed via env to avoid `${{ ... }}` interpolation
+        # injecting unescaped quotes from the release body into the script.
+        env:
+          BAKE_METADATA: ${{ steps.build.outputs.metadata }}
         run: |
-          digest=$(printf '%s' '${{ steps.build.outputs.metadata }}' | jq -r '.run."containerimage.digest"')
+          digest=$(jq -r '.run."containerimage.digest"' <<< "$BAKE_METADATA")
           if [ -z "$digest" ] || [ "$digest" = "null" ]; then
             echo "Failed to extract digest from bake metadata" >&2
             exit 1


### PR DESCRIPTION
## Summary

- Inlining `\${{ steps.build.outputs.metadata }}` into the `Export digest` script broke when the metadata contained apostrophes (e.g. from the GitHub release body) — they closed the single-quoted string and left JSON fragments to be parsed as shell commands.
- Pass the metadata through a step env var instead and read it via a `jq` here-string, eliminating script-level escaping concerns.
- Set `BUILDX_METADATA_PROVENANCE: disabled` on the bake step so the metadata stays under the runner's per-env-var size limit. Without this, bake-action v7 embeds the full GitHub event payload in `buildx.build.provenance` for every target, which trips \`Argument list too long\` when the env var is passed to bash.

Failed run that exposed both issues: https://github.com/josh-project/josh/actions/runs/25489339354

🤖 Generated with [Claude Code](https://claude.com/claude-code)