### PR TITLE
Loosen the version glob in tests

### DIFF
--- a/tests/proxy/get_version.t
+++ b/tests/proxy/get_version.t
@@ -2,7 +2,7 @@
   $ cd ${TESTTMP}
 
   $ curl -s http://localhost:8002/version
-  Version: r*.*.*-*-* (glob)
+  Version: r* (glob)
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   .


### PR DESCRIPTION
Loosen the version glob in tests

So that the job doesn't fail when release is published.

Change-Id: I0b4d7a9c764201270136618cfd8bcb7298d8f1e1