### PR TITLE
Loosen the version glob in tests

### DIFF
--- a/tests/proxy/get_version.t
+++ b/tests/proxy/get_version.t
@@ -2,7 +2,7 @@
   $ cd ${TESTTMP}
 
   $ curl -s http://localhost:8002/version
-  Version: r*.*.*-*-* (glob)
+  Version: r* (glob)
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   .


### PR DESCRIPTION
So that the job doesn't fail when release is published.