### PR TITLE
Cache history graph root reachability data

### DIFF
--- a/josh-core/src/cache/backend.rs
+++ b/josh-core/src/cache/backend.rs
@@ -1,0 +1,21 @@
+/// Pluggable storage layer for josh's per-filter, per-commit cache.
+///
+/// Each backend maps `(filter, from_oid, sequence_number) → to_oid`. The
+/// `sequence_number` lets backends like the distributed one shard or skip
+/// records based on commit ordering.
+pub trait CacheBackend: Send + Sync {
+    fn read(
+        &self,
+        filter: crate::filter::Filter,
+        from: git2::Oid,
+        sequence_number: u128,
+    ) -> anyhow::Result<Option<git2::Oid>>;
+
+    fn write(
+        &self,
+        filter: crate::filter::Filter,
+        from: git2::Oid,
+        to: git2::Oid,
+        sequence_number: u128,
+    ) -> anyhow::Result<()>;
+}

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -1,4 +1,5 @@
-use super::transaction::{CACHE_VERSION, CacheBackend};
+use super::CACHE_VERSION;
+use super::backend::CacheBackend;
 use crate::filter;
 use crate::filter::Filter;
 use std::collections::HashMap;
@@ -117,7 +118,7 @@ impl CacheBackend for DistributedCacheBackend {
         from: git2::Oid,
         sequence_number: u128,
     ) -> anyhow::Result<Option<git2::Oid>> {
-        if filter == filter::sequence_number() {
+        if filter == filter::sequence_number() || filter == filter::reachable_roots() {
             return Ok(None);
         }
         let repo = self.repo.lock().unwrap();
@@ -164,7 +165,7 @@ impl CacheBackend for DistributedCacheBackend {
         to: git2::Oid,
         sequence_number: u128,
     ) -> anyhow::Result<()> {
-        if filter == filter::sequence_number() {
+        if filter == filter::sequence_number() || filter == filter::reachable_roots() {
             return Ok(());
         }
 

--- a/josh-core/src/cache/history_graph.rs
+++ b/josh-core/src/cache/history_graph.rs
@@ -1,0 +1,257 @@
+//! Per-commit history-graph hints: sequence number and reachable-roots set.
+//!
+//! Both are bottom-up monoid folds over the same DAG (`seq(C) = max(seq(p))+1`,
+//! `roots(C) = ⋃ roots(p)`), so they're computed together in a single
+//! topological walk and cached in two parallel filter slots
+//! (`filter::sequence_number()`, `filter::reachable_roots()`).
+//!
+//! Storage of the roots set: a git blob whose content is the concatenation of
+//! 20-byte root OIDs (sorted, deduplicated). The blob's OID is what the
+//! `reachable_roots` cache slot stores. In linear history every commit reuses
+//! its parent's blob OID — no read or write — so the hot path is cheap.
+
+use anyhow::anyhow;
+
+use super::transaction::Transaction;
+
+/// Per-commit graph info derived from a single topological walk:
+/// - `sequence_number` strictly greater than every parent's sequence number
+///   (so sorting by it yields topological order).
+/// - `reachable_roots`: sorted, deduplicated set of root commits (parentless
+///   commits) reachable from the commit.
+#[derive(Debug, Clone)]
+pub struct HistoryGraphInfo {
+    pub sequence_number: u128,
+    pub reachable_roots: Vec<git2::Oid>,
+}
+
+/// Backwards-compatible thin wrapper around [`collect_history_graph_info`].
+pub fn compute_sequence_number(
+    transaction: &Transaction,
+    input: git2::Oid,
+) -> anyhow::Result<u128> {
+    Ok(collect_history_graph_info(transaction, input)?.sequence_number)
+}
+
+/// Computes sequence number and reachable roots for `input` in a single walk,
+/// memoizing intermediate results so repeated calls are O(new commits).
+///
+/// Inside the walk we work with `(seq, roots_blob_oid)` tuples and only touch
+/// the ODB when parents disagree on the roots blob — in linear history every
+/// commit reuses its parent's blob OID, avoiding read/write entirely.
+pub fn collect_history_graph_info(
+    transaction: &Transaction,
+    input: git2::Oid,
+) -> anyhow::Result<HistoryGraphInfo> {
+    let (seq, blob) = ensure_hint_cached(transaction, input)?;
+
+    Ok(HistoryGraphInfo {
+        sequence_number: seq,
+        reachable_roots: read_roots_blob(transaction.repo(), blob)?,
+    })
+}
+
+/// Returns true iff the set of root commits reachable from all `parent_ids`
+/// has non-empty intersection — i.e. they share at least one common ancestor.
+/// This is the cheap analogue of `repo.merge_base_many(parent_ids).is_ok()` for
+/// the case where the caller only needs the existence answer, not the merge
+/// base OID itself. Zero OIDs in `parent_ids` cause the function to return
+/// `Ok(false)` (matching `merge_base_many`'s error behavior on invalid input).
+pub fn parents_share_root(
+    transaction: &Transaction,
+    parent_ids: &[git2::Oid],
+) -> anyhow::Result<bool> {
+    if parent_ids.is_empty() || parent_ids.iter().any(|x| *x == git2::Oid::zero()) {
+        return Ok(false);
+    }
+
+    // Ensure each parent's graph info is cached, then collect the cached blob
+    // OIDs. If all parents reference the same blob, their root sets are
+    // identical — they trivially share every root without reading any blob.
+    let parent_blobs: Vec<git2::Oid> = parent_ids
+        .iter()
+        .map(|p| Ok(ensure_hint_cached(transaction, *p)?.1))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let first_blob = parent_blobs[0];
+    if parent_blobs.iter().all(|b| *b == first_blob) {
+        return Ok(true);
+    }
+
+    // Parents disagree on the roots blob: read each blob and intersect.
+    let mut common: std::collections::BTreeSet<git2::Oid> =
+        read_roots_blob(transaction.repo(), first_blob)?
+            .into_iter()
+            .collect();
+    for blob_oid in &parent_blobs[1..] {
+        if common.is_empty() {
+            return Ok(false);
+        }
+        let p_set: std::collections::BTreeSet<_> = read_roots_blob(transaction.repo(), *blob_oid)?
+            .into_iter()
+            .collect();
+        common = common.intersection(&p_set).copied().collect();
+    }
+    Ok(!common.is_empty())
+}
+
+/// Ensures `(sequence_number, reachable_roots)` are cached for `input` and
+/// returns the cached `(seq, roots_blob_oid)`. Performs a topological walk
+/// only if neither piece is cached for `input`. Inside the walk, each commit's
+/// roots blob is reused from its parent when parents agree, so the common case
+/// (linear or shared-root merges) avoids ODB reads and writes.
+fn ensure_hint_cached(
+    transaction: &Transaction,
+    input: git2::Oid,
+) -> anyhow::Result<(u128, git2::Oid)> {
+    if let Some(hint) = try_read_cached_hint(transaction, input) {
+        return Ok(hint);
+    }
+
+    if !transaction.repo().odb()?.exists(input) {
+        return Err(anyhow!("ensure_hint_cached: input does not exist"));
+    }
+
+    let commit = transaction.repo().find_commit(input)?;
+    let parent_ids: Vec<git2::Oid> = commit.parent_ids().collect();
+
+    // Fast path: every parent already has both pieces cached.
+    let parents_hint: Option<Vec<(u128, git2::Oid)>> = parent_ids
+        .iter()
+        .map(|p| try_read_cached_hint(transaction, *p))
+        .collect();
+
+    if let Some(parents_hint) = parents_hint {
+        let hint = derive_from_parents(transaction.repo(), input, &parents_hint)?;
+        store_hint(transaction, input, hint);
+        return Ok(hint);
+    }
+
+    log::info!("ensure_hint_cached: new_walk for {:?}", input);
+    let mut walk = transaction.repo().revwalk()?;
+    walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
+    walk.push(input)?;
+
+    // Hide ancestors that already have *both* pieces cached. Hiding on seq#
+    // alone would skip commits with cached seq# but missing roots, leaving
+    // their roots unpopulated.
+    let mut hide = |id| {
+        transaction.known(crate::filter::sequence_number(), id)
+            && transaction.known(crate::filter::reachable_roots(), id)
+    };
+    let walk = walk.with_hide_callback(&mut hide)?;
+
+    for c in walk {
+        let oid = c?;
+        let c_commit = transaction.repo().find_commit(oid)?;
+        let parents_hint: Vec<(u128, git2::Oid)> = c_commit
+            .parent_ids()
+            .map(|p| {
+                try_read_cached_hint(transaction, p)
+                    .ok_or_else(|| anyhow!("parent {} hint missing during walk for {}", p, oid))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let hint = derive_from_parents(transaction.repo(), oid, &parents_hint)?;
+        store_hint(transaction, oid, hint);
+    }
+
+    try_read_cached_hint(transaction, input)
+        .ok_or_else(|| anyhow!("missing graph info after walk for {}", input))
+}
+
+/// Given that all parents have cached `(seq, roots_blob_oid)`, derive the
+/// `(seq, roots_blob_oid)` for `self_oid`. Performs blob I/O only when parents
+/// disagree on the blob; otherwise reuses the parent blob OID (or, for the
+/// root case, writes a single-element blob).
+fn derive_from_parents(
+    repo: &git2::Repository,
+    self_oid: git2::Oid,
+    parents_hint: &[(u128, git2::Oid)],
+) -> anyhow::Result<(u128, git2::Oid)> {
+    if parents_hint.is_empty() {
+        // Parentless: this commit *is* its own only reachable root.
+        return Ok((0, write_roots_blob(repo, &[self_oid])?));
+    }
+
+    let seq = parents_hint
+        .iter()
+        .map(|(s, _)| *s)
+        .max()
+        .expect("non-empty")
+        + 1;
+
+    let first_blob = parents_hint[0].1;
+    let roots_blob = if parents_hint.iter().all(|(_, b)| *b == first_blob) {
+        first_blob
+    } else {
+        let mut set: std::collections::BTreeSet<git2::Oid> = Default::default();
+        for (_, blob_oid) in parents_hint {
+            set.extend(read_roots_blob(repo, *blob_oid)?);
+        }
+        let roots: Vec<_> = set.into_iter().collect();
+        write_roots_blob(repo, &roots)?
+    };
+
+    Ok((seq, roots_blob))
+}
+
+fn try_read_cached_hint(transaction: &Transaction, input: git2::Oid) -> Option<(u128, git2::Oid)> {
+    let seq = transaction.get(crate::filter::sequence_number(), input)?;
+    let roots_blob = transaction.get(crate::filter::reachable_roots(), input)?;
+    Some((u128_from_oid(seq), roots_blob))
+}
+
+fn store_hint(transaction: &Transaction, input: git2::Oid, hint: (u128, git2::Oid)) {
+    let (seq, roots_blob) = hint;
+    transaction.insert(
+        crate::filter::sequence_number(),
+        input,
+        oid_from_u128(seq),
+        true,
+    );
+    transaction.insert(crate::filter::reachable_roots(), input, roots_blob, true);
+}
+
+fn write_roots_blob(repo: &git2::Repository, roots: &[git2::Oid]) -> anyhow::Result<git2::Oid> {
+    let mut bytes = Vec::with_capacity(roots.len() * 20);
+    for r in roots {
+        bytes.extend_from_slice(r.as_bytes());
+    }
+    Ok(repo.blob(&bytes)?)
+}
+
+fn read_roots_blob(repo: &git2::Repository, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
+    let blob = repo.find_blob(oid)?;
+    let content = blob.content();
+    if content.len() % 20 != 0 {
+        return Err(anyhow!(
+            "malformed reachable_roots blob {}: length {} not a multiple of 20",
+            oid,
+            content.len()
+        ));
+    }
+    let mut out = Vec::with_capacity(content.len() / 20);
+    for chunk in content.chunks_exact(20) {
+        out.push(git2::Oid::from_bytes(chunk)?);
+    }
+    Ok(out)
+}
+
+/// Encode a `u128` into a 20-byte git OID (SHA-1 sized).
+/// The high 4 bytes of the OID are zero; the low 16 bytes
+/// contain the big-endian integer.
+pub(crate) fn oid_from_u128(n: u128) -> git2::Oid {
+    let mut bytes = [0u8; 20];
+    // place the 16 integer bytes at the end (big-endian)
+    bytes[20 - 16..].copy_from_slice(&n.to_be_bytes());
+    // Safe: length is exactly 20
+    git2::Oid::from_bytes(&bytes).expect("20-byte OID construction cannot fail")
+}
+
+/// Decode a `u128` previously encoded by `oid_from_u128`.
+pub(crate) fn u128_from_oid(oid: git2::Oid) -> u128 {
+    let b = oid.as_bytes();
+    let mut n = [0u8; 16];
+    n.copy_from_slice(&b[20 - 16..]); // take the last 16 bytes
+    u128::from_be_bytes(n)
+}

--- a/josh-core/src/cache/mod.rs
+++ b/josh-core/src/cache/mod.rs
@@ -1,9 +1,19 @@
+mod backend;
 pub mod distributed;
+mod history_graph;
 pub mod sled;
 pub mod stack;
 mod transaction;
 
+/// Schema version for on-disk cache structures. Bump when the layout of the
+/// sled trees or distributed cache refs changes incompatibly.
+pub const CACHE_VERSION: u64 = 27;
+
+pub use backend::CacheBackend;
 pub use distributed::DistributedCacheBackend;
+pub use history_graph::{
+    HistoryGraphInfo, collect_history_graph_info, compute_sequence_number, parents_share_root,
+};
 pub use sled::{SledCacheBackend, sled_load, sled_open_josh_trees, sled_print_stats};
 pub use stack::CacheStack;
 pub use transaction::*;

--- a/josh-core/src/cache/sled.rs
+++ b/josh-core/src/cache/sled.rs
@@ -1,7 +1,8 @@
 use anyhow::anyhow;
 use std::sync::LazyLock;
 
-use super::transaction::{CACHE_VERSION, CacheBackend};
+use super::CACHE_VERSION;
+use super::backend::CacheBackend;
 use crate::filter;
 use crate::filter::Filter;
 

--- a/josh-core/src/cache/stack.rs
+++ b/josh-core/src/cache/stack.rs
@@ -1,5 +1,5 @@
+use super::backend::CacheBackend;
 use super::sled::SledCacheBackend;
-use super::transaction::CacheBackend;
 use crate::filter;
 
 pub struct CacheStack {

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -1,28 +1,10 @@
+use super::history_graph::compute_sequence_number;
 use super::sled::sled_open_josh_trees;
 use super::stack::CacheStack;
 use anyhow::anyhow;
 
 use std::collections::HashMap;
 use std::sync::{LazyLock, RwLock};
-
-pub const CACHE_VERSION: u64 = 27;
-
-pub trait CacheBackend: Send + Sync {
-    fn read(
-        &self,
-        filter: crate::filter::Filter,
-        from: git2::Oid,
-        sequence_number: u128,
-    ) -> anyhow::Result<Option<git2::Oid>>;
-
-    fn write(
-        &self,
-        filter: crate::filter::Filter,
-        from: git2::Oid,
-        to: git2::Oid,
-        sequence_number: u128,
-    ) -> anyhow::Result<()>;
-}
 
 pub trait FilterHook {
     fn filter_for_commit(
@@ -346,7 +328,9 @@ impl Transaction {
         to: git2::Oid,
         store: bool,
     ) {
-        let sequence_number = if filter != crate::filter::sequence_number() {
+        let sequence_number = if filter != crate::filter::sequence_number()
+            && filter != crate::filter::reachable_roots()
+        {
             compute_sequence_number(self, from).expect("compute_sequence_number failed")
         } else {
             0
@@ -397,7 +381,9 @@ impl Transaction {
         if filter.is_nop() {
             return Some(from);
         }
-        let sequence_number = if filter != crate::filter::sequence_number() {
+        let sequence_number = if filter != crate::filter::sequence_number()
+            && filter != crate::filter::reachable_roots()
+        {
             compute_sequence_number(self, from).expect("compute_sequence_number failed")
         } else {
             0
@@ -430,95 +416,5 @@ impl Transaction {
         }
 
         None
-    }
-}
-
-/// Encode a `u128` into a 20-byte git OID (SHA-1 sized).
-/// The high 4 bytes of the OID are zero; the low 16 bytes
-/// contain the big-endian integer.
-pub fn oid_from_u128(n: u128) -> git2::Oid {
-    let mut bytes = [0u8; 20];
-    // place the 16 integer bytes at the end (big-endian)
-    bytes[20 - 16..].copy_from_slice(&n.to_be_bytes());
-    // Safe: length is exactly 20
-    git2::Oid::from_bytes(&bytes).expect("20-byte OID construction cannot fail")
-}
-
-/// Decode a `u128` previously encoded by `oid_from_u128`.
-pub fn u128_from_oid(oid: git2::Oid) -> u128 {
-    let b = oid.as_bytes();
-    let mut n = [0u8; 16];
-    n.copy_from_slice(&b[20 - 16..]); // take the last 16 bytes
-    u128::from_be_bytes(n)
-}
-
-/// Computes the sequence number for each commit so that the sequence_number for any
-/// commit is always larger than the sequence_number of all of its parents.
-/// This means sorting by sequence number results in a topological order.
-pub fn compute_sequence_number(
-    transaction: &Transaction,
-    input: git2::Oid,
-) -> anyhow::Result<u128> {
-    if let Some(count) = transaction.get(crate::filter::sequence_number(), input) {
-        return Ok(u128_from_oid(count));
-    }
-
-    if !transaction.repo().odb()?.exists(input) {
-        return Err(anyhow!("compute_sequence_number: input does not exist",));
-    }
-
-    let commit = transaction.repo().find_commit(input)?;
-    let mut this_sequence_number = 0;
-    let mut no_walk = true;
-    for parent in commit.parent_ids() {
-        if let Some(parent_sequence_number) =
-            transaction.get(crate::filter::sequence_number(), parent)
-        {
-            let parent_sequence_number = u128_from_oid(parent_sequence_number);
-            this_sequence_number = std::cmp::max(this_sequence_number, parent_sequence_number + 1);
-        } else {
-            no_walk = false;
-            break;
-        }
-    }
-
-    if no_walk {
-        transaction.insert(
-            crate::filter::sequence_number(),
-            commit.id(),
-            oid_from_u128(this_sequence_number),
-            true,
-        );
-    } else {
-        log::info!("compute_sequence_number: new_walk for {:?}", input);
-        let mut walk = transaction.repo().revwalk()?;
-        walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
-        walk.push(input)?;
-
-        // Stop at ancestors that already have a sequence number — they (and
-        // their ancestors, transitively) have already been processed.
-        let mut hide = |id| transaction.known(crate::filter::sequence_number(), id);
-        let walk = walk.with_hide_callback(&mut hide)?;
-
-        for c in walk {
-            let commit = transaction.repo().find_commit(c?)?;
-            let mut this_sequence_number = 0;
-            for parent in commit.parent_ids() {
-                let parent_sequence_number = compute_sequence_number(transaction, parent)?;
-                this_sequence_number =
-                    std::cmp::max(this_sequence_number, parent_sequence_number + 1);
-            }
-            transaction.insert(
-                crate::filter::sequence_number(),
-                commit.id(),
-                oid_from_u128(this_sequence_number),
-                true,
-            );
-        }
-    }
-    if let Some(count) = transaction.get(crate::filter::sequence_number(), input) {
-        Ok(u128_from_oid(count))
-    } else {
-        Err(anyhow!("missing sequence_number"))
     }
 }

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -8,6 +8,7 @@ use std::sync::LazyLock;
 // Re-export from josh-filter
 pub use josh_filter::LinkMode;
 pub use josh_filter::filter::MESSAGE_MATCH_ALL_REGEX;
+pub use josh_filter::filter::reachable_roots;
 pub use josh_filter::filter::sequence_number;
 pub use josh_filter::flang::parse::{get_comments, parse};
 pub use josh_filter::opt;

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -808,7 +808,7 @@ pub fn create_filtered_commit_with_meta(
     meta: std::collections::BTreeMap<String, String>,
 ) -> anyhow::Result<git2::Oid> {
     let (r, is_new) = create_filtered_commit2(
-        transaction.repo(),
+        transaction,
         original_commit,
         filtered_parent_ids,
         rewrite_data,
@@ -840,12 +840,13 @@ pub fn create_filtered_commit(
 }
 
 fn create_filtered_commit2<'a>(
-    repo: &'a git2::Repository,
+    transaction: &'a cache::Transaction,
     original_commit: &'a git2::Commit,
     filtered_parent_ids: Vec<git2::Oid>,
     rewrite_data: filter::Rewrite,
     options: BTreeMap<String, String>,
 ) -> anyhow::Result<(git2::Oid, bool)> {
+    let repo = transaction.repo();
     let filtered_parent_commits: Result<Vec<_>, _> = filtered_parent_ids
         .iter()
         .filter(|x| **x != git2::Oid::zero())
@@ -858,8 +859,11 @@ fn create_filtered_commit2<'a>(
         .iter()
         .any(|x| x.tree_id() == filter::tree::empty_id())
     {
-        let is_initial_merge =
-            filtered_parent_ids.len() > 1 && repo.merge_base_many(&filtered_parent_ids).is_err();
+        // An "initial merge" is a merge whose parents have no common ancestor.
+        // Cheaper than `repo.merge_base_many(...).is_err()`: ask whether the
+        // parents' reachable-root sets intersect, which is cached per-commit.
+        let is_initial_merge = filtered_parent_ids.len() > 1
+            && !cache::parents_share_root(transaction, &filtered_parent_ids)?;
 
         if is_initial_merge {
             filtered_parent_commits.retain(|x| x.tree_id() != filter::tree::empty_id());

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -274,3 +274,14 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
 pub fn sequence_number() -> Filter {
     Filter::from_oid(git2::Oid::zero())
 }
+
+/// Create a reachable_roots filter used for tracking the set of root commits
+/// (parentless commits) reachable from each commit. The cached value is the OID
+/// of a git blob whose content is the concatenation of 20-byte root OIDs.
+pub fn reachable_roots() -> Filter {
+    // Sentinel OID: all zeros except the last byte = 1. Distinct from
+    // sequence_number()'s zero OID and unlikely to collide with a real SHA-1.
+    let mut bytes = [0u8; 20];
+    bytes[19] = 1;
+    Filter::from_oid(git2::Oid::from_bytes(&bytes).expect("valid sentinel oid"))
+}

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -1,7 +1,7 @@
 pub mod parse;
 
 use crate::filter::MESSAGE_MATCH_ALL_REGEX;
-use crate::filter::sequence_number;
+use crate::filter::{reachable_roots, sequence_number};
 use crate::opt;
 use crate::persist::{to_filter, to_op, to_ops};
 use crate::{Filter, Op, RevMatch};
@@ -142,6 +142,9 @@ fn pretty2(op: &Op, indent: usize, compose: bool) -> String {
 pub fn spec(filter: Filter) -> String {
     if filter == sequence_number() {
         return "sequence_number".to_string();
+    }
+    if filter == reachable_roots() {
+        return "reachable_roots".to_string();
     }
     let filter = opt::simplify(filter);
     spec2(&to_op(filter))

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::sync::LazyLock;
 
-use crate::filter::{Filter, sequence_number};
+use crate::filter::{Filter, reachable_roots, sequence_number};
 use crate::hash::PassthroughHasher;
 use crate::op::{LazyRef, Op, RevMatch};
 
@@ -23,7 +23,7 @@ pub fn peel_op(filter: Filter) -> Op {
 }
 
 pub fn to_op(filter: Filter) -> Op {
-    if filter == sequence_number() {
+    if filter == sequence_number() || filter == reachable_roots() {
         return Op::Nop;
     }
     FILTERS

--- a/tester.sh
+++ b/tester.sh
@@ -56,5 +56,6 @@ docker run --rm \
     --volume "$(pwd)":"$(pwd)" \
     --volume cache:/opt/cache \
     --user "$(id -u)":"$(id -g)" \
+    -e JOSH_EXPERIMENTAL_FEATURES=1 \
     josh-dev-local \
     bash -c "${TEST_SCRIPT}"

--- a/tests/experimental/indexer.t
+++ b/tests/experimental/indexer.t
@@ -21,6 +21,7 @@
   $ josh-filter -s :INDEX --update refs/heads/index
   7f9854361a53e0a7faa7428a5909267f6e04fb99
   [3] :INDEX
+  [3] reachable_roots
   [3] sequence_number
   [6] _trigram_index
 

--- a/tests/experimental/link-submodules.t
+++ b/tests/experimental/link-submodules.t
@@ -68,6 +68,7 @@ Test Adapt filter - should expand submodule into actual tree content
   [3] :"{@}"
   [3] :adapt=submodules
   [3] :link=embedded
+  [10] reachable_roots
   [10] sequence_number
   $ git log --graph --pretty=%s refs/josh/filter/master
   *   add libs submodule
@@ -154,6 +155,7 @@ Test Adapt with multiple submodules
   [3] :"{@}"
   [3] :link=embedded
   [4] :adapt=submodules
+  [11] reachable_roots
   [11] sequence_number
   $ git ls-tree --name-only -r refs/josh/filter/master
   libs/.link.josh
@@ -179,6 +181,7 @@ Test Adapt with multiple submodules
   [4] :"{@}"
   [4] :adapt=submodules
   [4] :link=embedded
+  [15] reachable_roots
   [15] sequence_number
   $ git log --graph --pretty=%s refs/josh/filter/master
   *   add another submodule
@@ -262,6 +265,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
+  [21] reachable_roots
   [21] sequence_number
   $ git log --graph --pretty=%s:%H refs/josh/filter/master
   *   update libs submodule:e08fc8b154ffccae088368b570905d60f1262406
@@ -314,6 +318,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   [5] :adapt=submodules
   [5] :link=embedded
   [9] :/libs
+  [29] reachable_roots
   [29] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
   *   update libs submodule:b2e90aae4a2c0e7c2f9476d50300f92546cbc58f
@@ -338,6 +343,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   [5] :link=embedded
   [6] :prune=trivial-merge
   [9] :/libs
+  [31] reachable_roots
   [31] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
   *   update libs submodule:b2e90aae4a2c0e7c2f9476d50300f92546cbc58f
@@ -365,6 +371,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   [5] :link=embedded
   [6] :prune=trivial-merge
   [9] :/libs
+  [31] reachable_roots
   [31] sequence_number
   $ git log --graph --pretty=%s:%H:%T FILTERED_HEAD
   * add file4.txt:3061af908a0dc1417902fbd7208bb2b8dc354e6c:ac420a625dfb874002210e623a7fdb55708ef2fa
@@ -386,6 +393,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   [5] :link=embedded
   [6] :prune=trivial-merge
   [9] :/libs
+  [31] reachable_roots
   [31] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
   * add file4.txt:3061af908a0dc1417902fbd7208bb2b8dc354e6c
@@ -409,6 +417,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   [6] :prune=trivial-merge
   [7] :/modules
   [9] :/libs
+  [33] reachable_roots
   [33] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
   * add another submodule:b74da266394ae690a9b37b003779a1b59373bc65
@@ -431,6 +440,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   [6] :prune=trivial-merge
   [7] :/modules
   [9] :/libs
+  [33] reachable_roots
   [33] sequence_number
   $ rm -Rf libs
   $ rm -Rf modules
@@ -472,6 +482,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   [7] :/modules
   [7] :prune=trivial-merge
   [10] :/libs
+  [36] reachable_roots
   [36] sequence_number
 
   $ git checkout testsubexported
@@ -512,6 +523,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   [7] :prune=trivial-merge
   [10] :/libs
   [10] :unlink
+  [36] reachable_roots
   [36] sequence_number
 
   $ git log --graph --pretty=%s:%H:%T refs/heads/unlinked_master
@@ -544,6 +556,7 @@ Test Adapt on repo without submodules (should be no-op)
   62f270988ac3ab05a33d0705fb1e4982165f69f2
   [1] :adapt=submodules
   [1] :link=embedded
+  [1] reachable_roots
   [1] sequence_number
   $ git ls-tree --name-only -r refs/josh/filter/master
   file.txt

--- a/tests/experimental/link.t
+++ b/tests/experimental/link.t
@@ -38,6 +38,7 @@ Test Link filter (identical to Adapt)
   [2] ::libs/.link.josh
   [2] :adapt=submodules
   [2] :link=embedded
+  [7] reachable_roots
   [7] sequence_number
   $ git ls-tree -r --name-only refs/josh/filter/master
   libs/.link.josh
@@ -63,6 +64,7 @@ Test Link on repo without submodules (should be no-op)
   $ josh-filter -s :link master --update refs/josh/filter/master
   62f270988ac3ab05a33d0705fb1e4982165f69f2
   [1] :link
+  [1] reachable_roots
   [1] sequence_number
   $ git ls-tree -r --name-only refs/josh/filter/master
   file.txt

--- a/tests/experimental/starlark_basic.t
+++ b/tests/experimental/starlark_basic.t
@@ -25,6 +25,7 @@
   $ josh-filter -s :!st/config[] master --update refs/josh/master
   3503c2ff9f931db3e256bb6deb1a2d147e7b1c2b
   [3] :!st/config[:empty]
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master

--- a/tests/experimental/starlark_subfilter.t
+++ b/tests/experimental/starlark_subfilter.t
@@ -26,6 +26,7 @@
   $ josh-filter -s :!st/config[::sub1/] master --update refs/josh/master
   0c7056c463e5edf79768f0b69ce5ed494d601389
   [3] :!st/config[::sub1/]
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master

--- a/tests/experimental/unsubmodule.t
+++ b/tests/experimental/unsubmodule.t
@@ -59,6 +59,7 @@ Test Adapt filter - should expand submodule into actual tree content
   $ josh-filter -s :adapt=submodules master --update refs/josh/filter/master
   71cd16ff3e379f18440c941c375ddacae56e4a8d
   [3] :adapt=submodules
+  [3] reachable_roots
   [3] sequence_number
   $ git log --graph --pretty=%s refs/josh/filter/master
   * add libs submodule
@@ -124,6 +125,7 @@ Test Adapt with multiple submodules
   $ josh-filter -s :adapt=submodules master --update refs/josh/filter/master
   4e48d5817374b1950f15c4a8d135863594596dfe
   [4] :adapt=submodules
+  [4] reachable_roots
   [4] sequence_number
   $ git log --graph --pretty=%s refs/josh/filter/master
   * add another submodule
@@ -168,6 +170,7 @@ Test Adapt with submodule changes - add commits to submodule and update
   $ josh-filter -s :adapt=submodules master --update refs/josh/filter/master
   814db71a8c61b7ee00b175cc9aa64b73aaef37b9
   [5] :adapt=submodules
+  [5] reachable_roots
   [5] sequence_number
   $ git log --graph --pretty=%s refs/josh/filter/master
   * update libs submodule
@@ -200,6 +203,7 @@ Test Adapt on repo without submodules (should be no-op)
   $ josh-filter -s :adapt=submodules master --update refs/josh/filter/master
   62f270988ac3ab05a33d0705fb1e4982165f69f2
   [1] :adapt=submodules
+  [1] reachable_roots
   [1] sequence_number
   $ git ls-tree --name-only -r refs/josh/filter/master
   file.txt

--- a/tests/filter/ambiguous_merge.t
+++ b/tests/filter/ambiguous_merge.t
@@ -40,6 +40,7 @@
   81a8353fd06d2ff76184dc3e55de179590872799
   [2] :prefix=sub1
   [3] :/sub1
+  [5] reachable_roots
   [5] sequence_number
   $ git checkout hidden_branch1
   Switched to branch 'hidden_branch1'
@@ -57,6 +58,7 @@
   586737e31b886be151bc20c30f0a0305e3c6568d
   [3] :prefix=sub1
   [4] :/sub1
+  [7] reachable_roots
   [7] sequence_number
   $ git checkout hidden_master
   Switched to branch 'hidden_master'
@@ -91,6 +93,7 @@
   8cbae19889134bd4ec430c0b79c61ee8547e0d1c
   [3] :prefix=sub1
   [4] :/sub1
+  [7] reachable_roots
   [7] sequence_number
 
   $ git checkout master

--- a/tests/filter/cmdline.t
+++ b/tests/filter/cmdline.t
@@ -37,6 +37,7 @@
   21a904a6f350cb1f8ea4dc6fe9bd4e3b4cc4840b
   [2] :/sub1
   [2] :prefix=c
+  [4] reachable_roots
   [4] sequence_number
   $ git log --graph --pretty=%s josh/filter/libs/master
   * add file2
@@ -48,6 +49,7 @@
   [2] :/sub1
   [2] :/sub2
   [2] :prefix=c
+  [7] reachable_roots
   [7] sequence_number
   $ git log --graph --pretty=%s josh/filter/libs/foo
   * add file3

--- a/tests/filter/commit_message_raw.t
+++ b/tests/filter/commit_message_raw.t
@@ -14,6 +14,7 @@
   7b2759b3e39a73ae111b75014a49fa511d0be927
   [1] :prefix=c
   [1] :prefix=pre
+  [2] reachable_roots
   [2] sequence_number
   $ git cat-file commit master
   tree 2f407f8ecb16a66b85e2c84d3889720b7a0e3762

--- a/tests/filter/compose_shadow_dir_same_name.t
+++ b/tests/filter/compose_shadow_dir_same_name.t
@@ -95,6 +95,7 @@
       :/xx
       :/sub/xx
   ]
+  [3] reachable_roots
   [3] sequence_number
   $ git diff ${EMPTY_TREE}..FILTERED_HEAD
   diff --git a/file1 b/file1

--- a/tests/filter/deleted_dir.t
+++ b/tests/filter/deleted_dir.t
@@ -20,6 +20,7 @@ in that subtree repo should have an empty tree
   21a904a6f350cb1f8ea4dc6fe9bd4e3b4cc4840b
   [2] :/sub1
   [2] :prefix=c
+  [4] reachable_roots
   [4] sequence_number
 
   $ git log refs/josh/filter/master --graph --pretty=%s
@@ -39,6 +40,7 @@ in that subtree repo should have an empty tree
   1e8394fa1057f9c14155ea4f612320544ec3510d
   [3] :/sub1
   [3] :prefix=c
+  [6] reachable_roots
   [6] sequence_number
 
   $ git log refs/josh/filter/master --graph --pretty=%s

--- a/tests/filter/empty_head.t
+++ b/tests/filter/empty_head.t
@@ -21,6 +21,7 @@
   $ josh-filter -s :/sub1 master --update refs/josh/filter/master
   d8388f5880393d255b371f1ed9b801d35620017e
   [2] :/sub1
+  [3] reachable_roots
   [3] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file2
@@ -30,6 +31,7 @@
   915f9d7068b11998493d4c9c373a32be4097daae
   [2] :/sub1
   [2] :/sub2
+  [3] reachable_roots
   [3] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file3
@@ -43,6 +45,7 @@
   915f9d7068b11998493d4c9c373a32be4097daae
   [2] :/sub1
   [2] :/sub2
+  [4] reachable_roots
   [4] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file3

--- a/tests/filter/empty_orphan.t
+++ b/tests/filter/empty_orphan.t
@@ -23,6 +23,7 @@ Empty root commits from unrelated parts of the tree should not be included
   540f1cbf31dcaef743774db17c00cd20b814db62
   [3] :/sub1
   [3] :prefix=c
+  [6] reachable_roots
   [6] sequence_number
 
   $ git log refs/josh/filter/master --graph --pretty=%s
@@ -86,6 +87,7 @@ Empty root commits from unrelated parts of the tree should not be included
   540f1cbf31dcaef743774db17c00cd20b814db62
   [3] :prefix=c
   [5] :/sub1
+  [10] reachable_roots
   [10] sequence_number
 
   $ git log FILTERED_HEAD --graph --pretty=%s
@@ -103,6 +105,7 @@ Empty root commits from unrelated parts of the tree should not be included
   [5] :/sub1
   [5] :exclude[::sub1/]
   [6] :prefix=c
+  [10] reachable_roots
   [10] sequence_number
 
   $ git log FILTERED_HEAD --graph --pretty=%s
@@ -120,6 +123,7 @@ Empty root commits from unrelated parts of the tree should not be included
   [5] :/sub1
   [5] :exclude[::sub1/]
   [6] :prefix=c
+  [12] reachable_roots
   [12] sequence_number
 
   $ git ls-tree --name-only -r FILTERED_HEAD

--- a/tests/filter/empty_reimport.t
+++ b/tests/filter/empty_reimport.t
@@ -41,6 +41,7 @@
   6390b3f0709aa571f835041bdab24919f119505a
   [2] :prefix=c
   [4] :/pre
+  [7] reachable_roots
   [7] sequence_number
 
   $ git log josh/filter/master --graph --pretty=%s
@@ -85,6 +86,7 @@
   7a2b86910858e80f638b4aa1a025ed9a2f62ded4
   [5] :prefix=c
   [7] :/pre
+  [14] reachable_roots
   [14] sequence_number
 
   $ git log josh/filter/master --graph --pretty=%s

--- a/tests/filter/exclude_compose.t
+++ b/tests/filter/exclude_compose.t
@@ -22,6 +22,7 @@
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   e22af2825a6c7b4b59fefb7cdb4618474d643446
   [2] :exclude[::sub2/]
+  [3] reachable_roots
   [3] sequence_number
   $ git checkout -q hidden 1> /dev/null
   $ tree
@@ -47,6 +48,7 @@
       ::sub2/
   ]
   [2] :exclude[::sub2/]
+  [3] reachable_roots
   [3] sequence_number
 
   $ git checkout -q refs/josh/filtered
@@ -65,6 +67,7 @@
   ]
   [2] :exclude[::sub2/]
   [3] :exclude[:/sub3:prefix=sub1]
+  [3] reachable_roots
   [3] sequence_number
 
   $ git checkout -q refs/josh/filtered

--- a/tests/filter/file.t
+++ b/tests/filter/file.t
@@ -34,6 +34,7 @@
       c = :/sub1
       a/b = :/sub2
   ]
+  [4] reachable_roots
   [4] sequence_number
   $ git log --graph --pretty=%s FILTERED_HEAD
   * add file3
@@ -46,6 +47,7 @@
       c = :/sub1
       a/b = :/sub2
   ]
+  [5] reachable_roots
   [5] sequence_number
   $ git log --graph --pretty=%s FILTERED_HEAD
   * initial

--- a/tests/filter/file_destination.t
+++ b/tests/filter/file_destination.t
@@ -16,6 +16,7 @@ Test File filter with destination path
   $ josh-filter -s ::renamed.txt=src/subdir/original.txt master --update refs/josh/master
   febbdb79c867625e8ce536e06f80e88a9827edf9
   [1] ::renamed.txt=src/subdir/original.txt
+  [1] reachable_roots
   [1] sequence_number
 
   $ git checkout refs/josh/master 2> /dev/null
@@ -43,6 +44,7 @@ Test File filter with destination path in subdirectory
   $ josh-filter -s ::dest/subdir/renamed.txt=src/subdir/original.txt master --update refs/josh/master
   a0a74aba925001c897af13106d526fa9a04792f3
   [1] ::dest/subdir/renamed.txt=src/subdir/original.txt
+  [1] reachable_roots
   [1] sequence_number
 
   $ git checkout refs/josh/master 2> /dev/null
@@ -76,6 +78,7 @@ Test File filter backward compatibility (no destination path - keeps same path)
   $ josh-filter -s ::src/subdir/file.txt master --update refs/josh/master
   0bbd185c6b7bc651e9557162c087cafc0dee8131
   [1] ::src/subdir/file.txt
+  [1] reachable_roots
   [1] sequence_number
 
   $ git checkout refs/josh/master 2> /dev/null
@@ -105,6 +108,7 @@ Test File filter with destination path --reverse
   $ josh-filter -s ::renamed.txt=src/subdir/original.txt master --update refs/josh/master
   febbdb79c867625e8ce536e06f80e88a9827edf9
   [1] ::renamed.txt=src/subdir/original.txt
+  [1] reachable_roots
   [1] sequence_number
 
   $ git checkout refs/josh/master 2> /dev/null
@@ -115,6 +119,7 @@ Test File filter with destination path --reverse
   $ josh-filter -s ::renamed.txt=src/subdir/original.txt --reverse master --update refs/josh/master
   c122559c82871c0c453012051d4b067158a9a8cb
   [1] ::renamed.txt=src/subdir/original.txt
+  [1] reachable_roots
   [1] sequence_number
 
   $ git checkout master 2> /dev/null
@@ -149,6 +154,7 @@ Test File filter backward compatibility --reverse
   $ josh-filter -s ::src/subdir/file.txt master --update refs/josh/master
   0bbd185c6b7bc651e9557162c087cafc0dee8131
   [1] ::src/subdir/file.txt
+  [1] reachable_roots
   [1] sequence_number
 
   $ git checkout refs/josh/master 2> /dev/null
@@ -159,6 +165,7 @@ Test File filter backward compatibility --reverse
   $ josh-filter -s ::src/subdir/file.txt --reverse master --update refs/josh/master
   49d6b8e7dbefec1836449d7a62f9f906e00521e7
   [1] ::src/subdir/file.txt
+  [1] reachable_roots
   [1] sequence_number
 
   $ git checkout master 2> /dev/null

--- a/tests/filter/gpgsig.t
+++ b/tests/filter/gpgsig.t
@@ -46,6 +46,7 @@ Remove the signature, the shas are different.
   )[
       :/
   ]
+  [1] reachable_roots
   [1] sequence_number
   $ git rev-parse master filtered
   cb22ebb8e47b109f7add68b1043e561e0db09802
@@ -57,6 +58,7 @@ Remove the signature, the shas are different.
   )[
       :/
   ]
+  [1] reachable_roots
   [1] sequence_number
   $ git rev-parse master double-filtered
   cb22ebb8e47b109f7add68b1043e561e0db09802

--- a/tests/filter/hide_view.t
+++ b/tests/filter/hide_view.t
@@ -37,6 +37,7 @@
   ba6cff78351dfd8135eb25c543f17fcb80b79e2e
   [1] :prefix=c
   [2] :exclude[::sub1/]
+  [4] reachable_roots
   [4] sequence_number
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
@@ -54,6 +55,7 @@
   [2] :exclude[::sub1/]
   [2] :exclude[::sub1/file2]
   [3] :prefix=c
+  [5] reachable_roots
   [5] sequence_number
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
@@ -75,6 +77,7 @@
   [2] :exclude[::sub1/file2]
   [2] :exclude[::sub2/file3]
   [4] :prefix=c
+  [5] reachable_roots
   [5] sequence_number
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s

--- a/tests/filter/hook_notes.t
+++ b/tests/filter/hook_notes.t
@@ -26,6 +26,7 @@
   d7ef53ca3ac61727fefea31e0f43e18de1a786a0
   [2] ::b
   [3] :hook="commits"
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/filtered

--- a/tests/filter/infofile.t
+++ b/tests/filter/infofile.t
@@ -26,6 +26,7 @@
   21a904a6f350cb1f8ea4dc6fe9bd4e3b4cc4840b
   [2] :/sub1
   [2] :prefix=c
+  [6] reachable_roots
   [6] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file2
@@ -36,6 +37,7 @@
   21a904a6f350cb1f8ea4dc6fe9bd4e3b4cc4840b
   [2] :/sub1
   [2] :prefix=c
+  [6] reachable_roots
   [6] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file2
@@ -46,6 +48,7 @@
   [2] :/sub1
   [2] :/sub2
   [3] :prefix=c
+  [7] reachable_roots
   [7] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file3
@@ -60,6 +63,7 @@
   [2] :/sub1
   [2] :/sub2
   [3] :prefix=c
+  [8] reachable_roots
   [8] sequence_number
   $ git log --graph --pretty=%s josh/filter/master
   * add file3

--- a/tests/filter/linear.t
+++ b/tests/filter/linear.t
@@ -38,6 +38,7 @@
   )[
       :/
   ]
+  [4] reachable_roots
   [4] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
@@ -69,6 +70,7 @@
   )[
       :/
   ]
+  [4] reachable_roots
   [4] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/master

--- a/tests/filter/moved_dir.t
+++ b/tests/filter/moved_dir.t
@@ -20,6 +20,7 @@ in that subtree repo should have an empty tree
   21a904a6f350cb1f8ea4dc6fe9bd4e3b4cc4840b
   [2] :/sub1
   [2] :prefix=c
+  [4] reachable_roots
   [4] sequence_number
 
   $ git log refs/josh/filter/master --graph --pretty=%s
@@ -41,6 +42,7 @@ in that subtree repo should have an empty tree
   fb6e2fa26823e0a17862feffc25e8439d75744ce
   [3] :/sub1
   [3] :prefix=c
+  [6] reachable_roots
   [6] sequence_number
 
   $ git log refs/josh/filter/master --graph --pretty=%s
@@ -57,6 +59,7 @@ in that subtree repo should have an empty tree
   fb6e2fa26823e0a17862feffc25e8439d75744ce
   [3] :/sub1
   [3] :prefix=c
+  [7] reachable_roots
   [7] sequence_number
   $ git log refs/josh/filter/master2 --graph --pretty=%s
   * mv sub1

--- a/tests/filter/prefix.t
+++ b/tests/filter/prefix.t
@@ -9,6 +9,7 @@ Apply prefix filter
   $ josh-filter -s :prefix=subtree refs/heads/master --update refs/heads/filtered
   f5ea0c2feb26f846b28627cf6275682eba3f3f3a
   [1] :prefix=subtree
+  [1] reachable_roots
   [1] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered

--- a/tests/filter/prune_trivial_merge.t
+++ b/tests/filter/prune_trivial_merge.t
@@ -40,6 +40,7 @@
   )[
       ::file1
   ]
+  [5] reachable_roots
   [5] sequence_number
   $ git log --graph --pretty=%s FILTERED_HEAD
   *   Merge branch 'branch1'
@@ -56,6 +57,7 @@
   )[
       ::file1
   ]
+  [6] reachable_roots
   [6] sequence_number
   $ git log --graph --pretty=%s FILTERED_HEAD
   *   Merge branch 'branch1'
@@ -73,6 +75,7 @@
   )[
       ::file1
   ]
+  [6] reachable_roots
   [6] sequence_number
 
   $ git log --graph --pretty=%s FILTERED_HEAD

--- a/tests/filter/rev.t
+++ b/tests/filter/rev.t
@@ -40,6 +40,7 @@
   37f8b29c9e892ea0eb7abac2759ddc6fb0337203
   [5] :prefix=x
   [5] :prefix=y
+  [10] reachable_roots
   [10] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   *   37f8b29c9e892ea0eb7abac2759ddc6fb0337203:dcbbddf47649f8e73f59fae92896c0d2cd02b6ec
@@ -53,6 +54,7 @@
   $ josh-filter -s ":rev(==ffffffffffffffffffffffffffffffffffffffff:prefix=x/y)" --update refs/heads/filtered
   [5] :prefix=x
   [5] :prefix=y
+  [10] reachable_roots
   [10] sequence_number
   ERROR: `:rev(...)` with nonexistent OID: ffffffffffffffffffffffffffffffffffffffff
   [1]
@@ -85,6 +87,7 @@
   [5] :prefix=x
   [5] :prefix=y
   [5] :rev(<=e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
+  [10] reachable_roots
   [10] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   *   5fe60a2d55b652822b3d3f25410714e9053ba72b:5f47d9fdffdc726bb8ebcfea67531d2574243c5d
@@ -106,6 +109,7 @@
   [5] :prefix=y
   [5] :rev(<=e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [5] :rev(<=e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y,<=975d4c4975912729482cc864d321c5196a969271:prefix=x/y)
+  [10] reachable_roots
   [10] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   *   63fea1234f375bd09019b676da8291f28d2ddb43:5f47d9fdffdc726bb8ebcfea67531d2574243c5d
@@ -128,6 +132,7 @@
   [5] :rev(<=e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [5] :rev(<=e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y,<=975d4c4975912729482cc864d321c5196a969271:prefix=x/y)
   [5] :rev(<=e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y,<=975d4c4975912729482cc864d321c5196a969271:prefix=x/z)
+  [10] reachable_roots
   [10] sequence_number
   $ cat > filter.josh <<EOF
   > :rev(
@@ -143,6 +148,7 @@
   [5] :rev(<=e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y)
   [5] :rev(<=e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y,<=975d4c4975912729482cc864d321c5196a969271:prefix=x/y)
   [5] :rev(<=e707f76bb6a1390f28b2162da5b5eb6933009070:prefix=x/y,<=975d4c4975912729482cc864d321c5196a969271:prefix=x/z)
+  [10] reachable_roots
   [10] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   *   a2f3cfd164ad740d899cc7b22a46bee6bce798cd:5f47d9fdffdc726bb8ebcfea67531d2574243c5d
@@ -165,6 +171,7 @@
   )[
       :/
   ]
+  [10] reachable_roots
   [10] sequence_number
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered
   * f8e8bc9daf54340c9fce647be467d2577b623bbe:5f47d9fdffdc726bb8ebcfea67531d2574243c5d
@@ -204,6 +211,7 @@
   )[
       :/
   ]
+  [11] reachable_roots
   [11] sequence_number
 
   $ git log --graph --decorate --pretty=%H:%T refs/heads/filtered

--- a/tests/filter/rev_operators.t
+++ b/tests/filter/rev_operators.t
@@ -22,6 +22,7 @@
   $ josh-filter -s ":rev(<=$COMMIT2:prefix=x,<$COMMIT2:prefix=y)" --update refs/heads/filtered
   6df7a0701cf39b99b9f772d4625d3ba6518c787e
   [3] :rev(<=e86ec4160d1359883e642e6888645d28c3358012:prefix=x,<e86ec4160d1359883e642e6888645d28c3358012:prefix=y)
+  [3] reachable_roots
   [3] sequence_number
   $ git log --oneline refs/heads/filtered
   6df7a07 commit3
@@ -37,6 +38,7 @@
   6df7a0701cf39b99b9f772d4625d3ba6518c787e
   [3] :rev(<=e86ec4160d1359883e642e6888645d28c3358012:prefix=x)
   [3] :rev(<=e86ec4160d1359883e642e6888645d28c3358012:prefix=x,<e86ec4160d1359883e642e6888645d28c3358012:prefix=y)
+  [3] reachable_roots
   [3] sequence_number
   $ git ls-tree -r --name-only refs/heads/filtered
   file1
@@ -51,6 +53,7 @@
   [3] :rev(<=e86ec4160d1359883e642e6888645d28c3358012:prefix=x)
   [3] :rev(<=e86ec4160d1359883e642e6888645d28c3358012:prefix=x,<e86ec4160d1359883e642e6888645d28c3358012:prefix=y)
   [3] :rev(==e86ec4160d1359883e642e6888645d28c3358012:prefix=x)
+  [3] reachable_roots
   [3] sequence_number
   $ git ls-tree -r --name-only refs/heads/filtered
   file1
@@ -69,6 +72,7 @@
   [3] :rev(<=e86ec4160d1359883e642e6888645d28c3358012:prefix=x)
   [3] :rev(<=e86ec4160d1359883e642e6888645d28c3358012:prefix=x,<e86ec4160d1359883e642e6888645d28c3358012:prefix=y)
   [3] :rev(==e86ec4160d1359883e642e6888645d28c3358012:prefix=x)
+  [3] reachable_roots
   [3] sequence_number
   $ git ls-tree -r --name-only refs/heads/filtered
   y/file1
@@ -83,6 +87,7 @@
   [3] :rev(<=e86ec4160d1359883e642e6888645d28c3358012:prefix=x)
   [3] :rev(<=e86ec4160d1359883e642e6888645d28c3358012:prefix=x,<e86ec4160d1359883e642e6888645d28c3358012:prefix=y)
   [3] :rev(==e86ec4160d1359883e642e6888645d28c3358012:prefix=x)
+  [3] reachable_roots
   [3] sequence_number
   $ git ls-tree -r --name-only refs/heads/filtered
   file1

--- a/tests/filter/reverse_hide.t
+++ b/tests/filter/reverse_hide.t
@@ -17,6 +17,7 @@
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   bb282e9cdc1b972fffd08fd21eead43bc0c83cb8
   [1] :exclude[::sub2/]
+  [2] reachable_roots
   [2] sequence_number
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
@@ -36,6 +37,7 @@
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   98fd34a66dabd3178d921b29e865e465042736bb
   [1] :exclude[::sub2/]
+  [2] reachable_roots
   [2] sequence_number
 
   $ git checkout master
@@ -72,6 +74,7 @@
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   d81806911addec824f6bd9c1d9386e3290237bf0
   [2] :exclude[::sub2/]
+  [3] reachable_roots
   [3] sequence_number
   $ git log --graph --pretty=%s refs/heads/master
   * empty commit

--- a/tests/filter/reverse_hide_edit.t
+++ b/tests/filter/reverse_hide_edit.t
@@ -17,6 +17,7 @@
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   bb282e9cdc1b972fffd08fd21eead43bc0c83cb8
   [1] :exclude[::sub2/]
+  [2] reachable_roots
   [2] sequence_number
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
@@ -36,6 +37,7 @@
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   04a66ac914f2040990c1a47c7dc152fe02b1c337
   [1] :exclude[::sub2/]
+  [2] reachable_roots
   [2] sequence_number
 
   $ git checkout master

--- a/tests/filter/reverse_hide_edit_missing_change.t
+++ b/tests/filter/reverse_hide_edit_missing_change.t
@@ -30,6 +30,7 @@
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   e736ad9e31a359186cd09c3a234bc497d5de7462
   [1] :exclude[::sub2/]
+  [2] reachable_roots
   [2] sequence_number
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
@@ -51,6 +52,7 @@
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden
   55031991a5c2f493f2d62201828d8f20844ab219
   [1] :exclude[::sub2/]
+  [2] reachable_roots
   [2] sequence_number
 
   $ git checkout master

--- a/tests/filter/reverse_merge.t
+++ b/tests/filter/reverse_merge.t
@@ -27,6 +27,7 @@
   $ josh-filter -s :exclude[::sub2/] branch1 --update refs/heads/hidden_branch1
   bb282e9cdc1b972fffd08fd21eead43bc0c83cb8
   [2] :exclude[::sub2/]
+  [2] reachable_roots
   [2] sequence_number
   $ git checkout hidden_branch1
   Switched to branch 'hidden_branch1'
@@ -43,6 +44,7 @@
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden_master
   60e15e185773918ce57eccb412f1e772bc6746fc
   [3] :exclude[::sub2/]
+  [3] reachable_roots
   [3] sequence_number
   $ git checkout hidden_master
   Switched to branch 'hidden_master'
@@ -78,6 +80,7 @@
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden_master
   1496b9e75273ad3a0de58812a731a7a50b0d2a66
   [3] :exclude[::sub2/]
+  [3] reachable_roots
   [3] sequence_number
 
   $ git checkout master

--- a/tests/filter/reverse_split.t
+++ b/tests/filter/reverse_split.t
@@ -19,6 +19,7 @@
       a = ::*.a
       :prefix=rest
   ]
+  [2] reachable_roots
   [2] sequence_number
   $ git checkout filtered 1> /dev/null
   Switched to branch 'filtered'
@@ -45,6 +46,7 @@
       a = ::*.a
       :prefix=rest
   ]
+  [2] reachable_roots
   [2] sequence_number
 
   $ git checkout master

--- a/tests/filter/squash.t
+++ b/tests/filter/squash.t
@@ -31,6 +31,7 @@
   $ josh-filter -s --squash-pattern "refs/tags/*" --update refs/heads/filtered
   Warning: reference refs/heads/filtered wasn't updated
   0000000000000000000000000000000000000000
+  [5] reachable_roots
   [5] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
@@ -48,6 +49,7 @@ This one tag is an annotated tag, to make sure those are handled as well
   [1] :squash(
       1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
   )
+  [7] reachable_roots
   [7] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
@@ -78,6 +80,7 @@ This one tag is an annotated tag, to make sure those are handled as well
       977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a"
   )
   [4] :author="New Author";"new@e.mail"
+  [11] reachable_roots
   [11] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
@@ -122,6 +125,7 @@ This one tag is an annotated tag, to make sure those are handled as well
       a68763bdf2f45a44304067954855749e366a5533:"refs/tags/filtered/filtered/tag_a"
       be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a"
   )
+  [16] reachable_roots
   [16] sequence_number
   $ git log --graph --pretty=%an:%ae-%cn:%ce refs/heads/filtered
   * Josh:josh@example.com-New Author:new@e.mail
@@ -190,6 +194,7 @@ This one tag is an annotated tag, to make sure those are handled as well
       be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a"
   )
   [6] :author="New Author";"new@e.mail"
+  [19] reachable_roots
   [19] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered

--- a/tests/filter/squash_empty_initial.t
+++ b/tests/filter/squash_empty_initial.t
@@ -38,6 +38,7 @@
   $ josh-filter -s --squash-pattern "refs/tags/*" --update refs/heads/filtered
   Warning: reference refs/heads/filtered wasn't updated
   0000000000000000000000000000000000000000
+  [5] reachable_roots
   [5] sequence_number
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   fatal: ambiguous argument 'refs/heads/filtered': unknown revision or path not in the working tree.
@@ -53,6 +54,7 @@
   [1] :squash(
       882f2656a5075936eb37bfefde740e0b453e4479:"refs/tags/tag_a"
   )
+  [7] reachable_roots
   [7] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered

--- a/tests/filter/stored_combine_filter.t
+++ b/tests/filter/stored_combine_filter.t
@@ -57,6 +57,7 @@
       ::sub2/subsub/
   ]
   [2] :prefix=x
+  [4] reachable_roots
   [4] sequence_number
 
   $ git log --graph --pretty=%s FILTERED_HEAD
@@ -96,6 +97,7 @@
       blub = :/sub1
   ]
   [3] :prefix=xyz
+  [7] reachable_roots
   [7] sequence_number
 
   $ git log --graph --pretty=%s FILTERED_HEAD

--- a/tests/filter/stored_implicit_filter.t
+++ b/tests/filter/stored_implicit_filter.t
@@ -29,6 +29,7 @@
       ::sub1/
       ::sub2/subsub/
   ]
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master

--- a/tests/filter/stored_redirect.t
+++ b/tests/filter/stored_redirect.t
@@ -54,6 +54,7 @@
       ::sub2/subsub/
   ]
   [3] :+st/config
+  [7] reachable_roots
   [7] sequence_number
   $ josh-filter -s :+st_new/config master --update refs/heads/filtered_new
   5f2b78a024c1abd991085bea441509b6c252eb93
@@ -71,6 +72,7 @@
       ::sub2/subsub/
       b = :/sub3
   ]
+  [7] reachable_roots
   [7] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
@@ -203,5 +205,6 @@
       ::sub2/subsub/
       b = :/sub3
   ]
+  [8] reachable_roots
   [8] sequence_number
 

--- a/tests/filter/stored_reverse.t
+++ b/tests/filter/stored_reverse.t
@@ -30,6 +30,7 @@
       a = :/sub1
       ::sub2/subsub/
   ]
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
@@ -64,6 +65,7 @@
       a = :/sub1
       ::sub2/subsub/
   ]
+  [3] reachable_roots
   [3] sequence_number
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/stored_reverse_exclude.t
+++ b/tests/filter/stored_reverse_exclude.t
@@ -30,6 +30,7 @@
       a = :/sub1:exclude[::file1]
       ::sub2/subsub/
   ]
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
@@ -63,6 +64,7 @@
       a = :/sub1:exclude[::file1]
       ::sub2/subsub/
   ]
+  [3] reachable_roots
   [3] sequence_number
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/stored_single_file.t
+++ b/tests/filter/stored_single_file.t
@@ -41,6 +41,7 @@ by ".josh" but rather kept and extended
       ]
       ::sub2/subsub/
   ]
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master

--- a/tests/filter/submodule.t
+++ b/tests/filter/submodule.t
@@ -26,6 +26,7 @@
   $ josh-filter -s :/libs master --update refs/josh/filter/master
   01d3837a9f7183df88e956cc81f085544f9c6563
   [1] :/libs
+  [2] reachable_roots
   [2] sequence_number
   $ git ls-tree --name-only -r refs/josh/filter/master 
   $ josh-filter -s c=:/libs master --update refs/josh/filter/master
@@ -33,5 +34,6 @@
   01d3837a9f7183df88e956cc81f085544f9c6563
   [1] :/libs
   [1] :prefix=c
+  [2] reachable_roots
   [2] sequence_number
   $ git ls-tree --name-only -r refs/josh/filter/master 

--- a/tests/filter/subtree_prefix.t
+++ b/tests/filter/subtree_prefix.t
@@ -50,6 +50,7 @@ Rewrite the subtree part of the history
   )[
       :rev(<=c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
   ]
+  [4] reachable_roots
   [4] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
@@ -85,6 +86,7 @@ Extract the subtree history
   )[
       :rev(<=c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
   ]
+  [7] reachable_roots
   [7] sequence_number
   $ git checkout subtree
   Switched to branch 'subtree'
@@ -107,6 +109,7 @@ Work in the subtree, and sync that back.
   )[
       :rev(<=c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
   ]
+  [7] reachable_roots
   [7] sequence_number
   $ git log --graph --pretty=%s  refs/heads/master
   * add even more content
@@ -138,6 +141,7 @@ And then re-extract, which should re-construct the same subtree.
   )[
       :rev(<=c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
   ]
+  [9] reachable_roots
   [9] sequence_number
   $ test $(git rev-parse subtree) = $(git rev-parse subtree2)
 
@@ -221,7 +225,8 @@ And finally, sync first from main to sub and then back.
   )[
       :rev(<=c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
   ]
-  [17] sequence_number
+  [22] reachable_roots
+  [22] sequence_number
 
   $ git log --graph --pretty=%H:%s refs/heads/master
   *   6ac0ba56575859cfaacd5818084333e532ffc442:Merge branch 'subtree-sync' into subtree
@@ -276,7 +281,8 @@ taken back into the main history.
   )[
       :rev(<=c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
   ]
-  [25] sequence_number
+  [30] reachable_roots
+  [30] sequence_number
   $ git ls-tree --name-only -r refs/heads/master
   feature1
   feature2

--- a/tests/filter/workspace_combine_filter.t
+++ b/tests/filter/workspace_combine_filter.t
@@ -57,6 +57,7 @@
   ]
   [2] :prefix=x
   [2] :workspace=ws
+  [4] reachable_roots
   [4] sequence_number
 
   $ git log --graph --pretty=%s FILTERED_HEAD
@@ -95,6 +96,7 @@
       blub = :/sub1
   ]
   [3] :prefix=xyz
+  [7] reachable_roots
   [7] sequence_number
 
   $ git log --graph --pretty=%s FILTERED_HEAD

--- a/tests/filter/workspace_discover.t
+++ b/tests/filter/workspace_discover.t
@@ -67,6 +67,7 @@
   ]
   [2] :workspace=ws
   [2] :workspace=ws2
+  [9] reachable_roots
   [9] sequence_number
 
   $ cat > workspace.josh <<EOF
@@ -105,4 +106,5 @@
   ]
   [2] :workspace=ws
   [2] :workspace=ws2
+  [10] reachable_roots
   [10] sequence_number

--- a/tests/filter/workspace_exclude.t
+++ b/tests/filter/workspace_exclude.t
@@ -30,6 +30,7 @@
       ::sub2/subsub/
   ]
   [2] :workspace=ws
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
@@ -62,6 +63,7 @@
       ::sub2/subsub/
   ]
   [2] :workspace=ws
+  [3] reachable_roots
   [3] sequence_number
   $ josh-filter -s :workspace=ws --reverse --check-roundtrip master --update refs/heads/filtered
   Roundtrip failed
@@ -70,6 +72,7 @@
       ::sub2/subsub/
   ]
   [3] :workspace=ws
+  [4] reachable_roots
   [4] sequence_number
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/workspace_implicit_filter.t
+++ b/tests/filter/workspace_implicit_filter.t
@@ -29,6 +29,7 @@
       ::sub2/subsub/
   ]
   [2] :workspace=ws
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master

--- a/tests/filter/workspace_keep_trivial_merges.t
+++ b/tests/filter/workspace_keep_trivial_merges.t
@@ -60,6 +60,7 @@ Without keep-trivial-merges: the trivial merge in b/ (extra-parent history) is d
   e90832787df33830788ecf12bbd4a2fd2750ddb5
   [3] :/b
   [4] :workspace=ws
+  [5] reachable_roots
   [5] sequence_number
   $ git log --graph --pretty=%s FILTERED_HEAD
   *   extend workspace
@@ -88,6 +89,7 @@ With keep-trivial-merges: the trivial merge is preserved in b/'s extra-parent hi
   )[
       :workspace=ws
   ]
+  [5] reachable_roots
   [5] sequence_number
   $ git log --graph --pretty=%s FILTERED_HEAD
   *   extend workspace

--- a/tests/filter/workspace_modify_chain.t
+++ b/tests/filter/workspace_modify_chain.t
@@ -30,6 +30,7 @@
   [1] :prefix=subsub
   [2] :workspace=ws
   [3] :/sub2
+  [7] reachable_roots
   [7] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
@@ -56,6 +57,7 @@
   [1] :prefix=subsub
   [2] :workspace=ws
   [3] :/sub2
+  [7] reachable_roots
   [7] sequence_number
   $ josh-filter -s $FILTER --reverse --check-roundtrip master --update refs/heads/filtered
   96bf13926606a13c7b7bc4caf3bcf80a1b3e4a36
@@ -64,6 +66,7 @@
   [1] :prefix=subsub
   [3] :workspace=ws
   [4] :/sub2
+  [9] reachable_roots
   [9] sequence_number
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/workspace_multiple_globs.t
+++ b/tests/filter/workspace_multiple_globs.t
@@ -34,6 +34,7 @@
       b = ::**/file1
   ]
   [2] :workspace=ws
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master

--- a/tests/filter/workspace_redirect.t
+++ b/tests/filter/workspace_redirect.t
@@ -54,6 +54,7 @@
       ::sub2/subsub/
   ]
   [3] :workspace=ws
+  [7] reachable_roots
   [7] sequence_number
   $ josh-filter -s :workspace=ws_new master --update refs/heads/filtered_new
   b9624622ee21a49c687f9fe717803c10aeb7829d
@@ -66,6 +67,7 @@
   [2] :workspace=ws_new
   [3] :workspace=ws
   [5] :exclude[::ws_new]
+  [7] reachable_roots
   [7] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/filtered
@@ -193,4 +195,5 @@
   [4] :exclude[::ws]
   [4] :workspace=ws
   [6] :exclude[::ws_new]
+  [10] reachable_roots
   [10] sequence_number

--- a/tests/filter/workspace_single_file.t
+++ b/tests/filter/workspace_single_file.t
@@ -47,6 +47,7 @@
       ::sub2/subsub/
   ]
   [2] :workspace=ws
+  [4] reachable_roots
   [4] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master
@@ -89,6 +90,7 @@
   ]
   [2] :workspace=ws
   [2] :workspace=ws2
+  [4] reachable_roots
   [4] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master

--- a/tests/filter/workspace_trailing_slash.t
+++ b/tests/filter/workspace_trailing_slash.t
@@ -29,6 +29,7 @@
       a/b = :/sub2
   ]
   [2] :workspace=ws
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master
@@ -51,6 +52,7 @@
       a/b = :/sub2
   ]
   [3] :workspace=ws
+  [4] reachable_roots
   [4] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master

--- a/tests/filter/workspace_unique.t
+++ b/tests/filter/workspace_unique.t
@@ -39,6 +39,7 @@ so the workspace.josh will still appear in the root of the workspace
       b = ::ws/workspace.josh
   ]
   [2] :workspace=ws
+  [3] reachable_roots
   [3] sequence_number
 
   $ git log --graph --pretty=%s refs/josh/master

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -210,6 +210,8 @@
       |   |   `-- 4ad756a74e200f89b43b0d6f21b41eb284b454
       |   |-- d5
       |   |   `-- 89c2fd7b5d736b868c4e196898cd9f578eb77f
+      |   |-- d9
+      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
       |   |-- info
       |   `-- pack
       `-- refs
@@ -217,4 +219,4 @@
           |-- namespaces
           `-- tags
   
-  55 directories, 39 files
+  56 directories, 40 files

--- a/tests/proxy/caching.t
+++ b/tests/proxy/caching.t
@@ -102,6 +102,8 @@
       |   |   `-- d7000ec2f13c49605cd675075e1852881e4fea
       |   |-- bd
       |   |   `-- c926c483c4dfa77e84105c6967e74d8ff9bf5f
+      |   |-- be
+      |   |   `-- 911fd840d34b691403cf4e7d2a8e8bacec8d89
       |   |-- eb
       |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
       |   |-- info
@@ -111,7 +113,7 @@
           |-- namespaces
           `-- tags
   
-  38 directories, 23 files
+  39 directories, 24 files
 
 # setup without caching
   $ EXTRA_OPTS= . ${TESTDIR}/setup_test_env.sh
@@ -222,6 +224,10 @@
       |   |   `-- d7000ec2f13c49605cd675075e1852881e4fea
       |   |-- bd
       |   |   `-- c926c483c4dfa77e84105c6967e74d8ff9bf5f
+      |   |-- be
+      |   |   `-- 911fd840d34b691403cf4e7d2a8e8bacec8d89
+      |   |-- d9
+      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
       |   |-- eb
       |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
       |   |-- info
@@ -231,4 +237,4 @@
           |-- namespaces
           `-- tags
   
-  42 directories, 27 files
+  44 directories, 29 files

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -123,6 +123,8 @@
       |-- objects
       |   |-- 00
       |   |   `-- f1db8b2e4bd1bf8337e0fe3a2ad9aeea478280
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 1f
       |   |   `-- 0b9d8a7b40a35bb4ff64ffc0f08369df23bc61
       |   |-- b5
@@ -136,4 +138,4 @@
           |-- namespaces
           `-- tags
   
-  39 directories, 24 files
+  40 directories, 25 files

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -138,6 +138,10 @@
       |-- objects
       |   |-- 0b
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 55
+      |   |   `-- 279561e012bf3a8946e23cf16c909e8eb7a5f9
+      |   |-- b0
+      |   |   `-- 4a61a938114efbb60395f72e5904fc42eb123a
       |   |-- ea
       |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
       |   |-- info
@@ -147,4 +151,4 @@
           |-- namespaces
           `-- tags
   
-  38 directories, 23 files
+  40 directories, 25 files

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -134,6 +134,8 @@
       |-- objects
       |   |-- 0b
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- info
       |   `-- pack
       `-- refs
@@ -141,4 +143,4 @@
           |-- namespaces
           `-- tags
   
-  36 directories, 21 files
+  37 directories, 22 files

--- a/tests/proxy/clone_subtree_no_master.t
+++ b/tests/proxy/clone_subtree_no_master.t
@@ -126,10 +126,12 @@
       |-- objects
       |   |-- 0b
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- info
       |   `-- pack
       `-- refs
           |-- heads
           `-- tags
   
-  35 directories, 20 files
+  36 directories, 21 files

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -175,6 +175,8 @@
       |-- objects
       |   |-- 0b
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 6e
       |   |   `-- 99e1e5ba1de7225f0d09a0b91d2e29ae15569c
       |   |-- info
@@ -184,5 +186,5 @@
           |-- namespaces
           `-- tags
   
-  40 directories, 28 files
+  41 directories, 29 files
 $ cat ${TESTTMP}/josh-proxy.out | grep TAGS

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -395,24 +395,38 @@ Flushed credential cache
       |-- info
       |   `-- exclude
       |-- objects
+      |   |-- 31
+      |   |   `-- c287b0dca7d1ae668b175ba5fee1e010e5cb68
+      |   |-- 50
+      |   |   `-- f9324abab8bcfcf9ef3b86c4c9b81a258e4c8f
       |   |-- 5d
       |   |   `-- 98d297b3b16d5946dada2496accc9f99dc7056
       |   |-- 6e
       |   |   `-- 9a62b40f85b0952ea06023a8ee1fb99685e6f7
       |   |-- 6f
       |   |   `-- e45a9254eb9dd78951a804fa94a035a937ef0b
+      |   |-- 70
+      |   |   `-- 574c42095b00b4a0757af989a9211bd2c95c91
       |   |-- 71
       |   |   `-- 28ce7713fc45163e65c7ac4a9057ed1913a569
       |   |-- 80
       |   |   `-- 472110df082d0a921ecdcd6f0dd0021f48e019
       |   |-- 85
       |   |   `-- c3ce1926696ef4bdf2eff358bd83b079dcc8d4
+      |   |-- 92
+      |   |   `-- b32c39e590a35edb6c1b12dc8919da56869fe5
       |   |-- 9c
       |   |   `-- b7c3c14c5c084f6a6897b6e6bab231fae98ae5
+      |   |-- b1
+      |   |   `-- 5fcd0ea97c1755068288984cd9b4ec57ae02b4
       |   |-- c4
       |   |   `-- df336cf6578b6dac651a33fd265d92308c0e39
       |   |-- e5
       |   |   `-- 2c4e8d6c1f4960b92676424944ff3951f472aa
+      |   |-- ef
+      |   |   `-- 7e2202b63572aa95b06cda4f844fe8f83c2673
+      |   |-- f2
+      |   |   `-- 099eb4510f85688a21ce5fc3992ca4274a837b
       |   |-- f9
       |   |   `-- 97320406328b16277aca038db747cf60232267
       |   |-- info
@@ -422,4 +436,4 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  68 directories, 54 files
+  75 directories, 61 files

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -124,6 +124,8 @@
       |   |   `-- 9aa8ffc35bbc452f9654b834047168ce02dc48
       |   |-- c3
       |   |   `-- 0a8aef421831a8492d21efde601e90a742544f
+      |   |-- d9
+      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
       |   |-- db
       |   |   `-- dfb5702a23dd0a3502f4d6ce7287a3a4d85abe
       |   |-- info
@@ -133,4 +135,4 @@
           |-- namespaces
           `-- tags
   
-  45 directories, 30 files
+  46 directories, 31 files

--- a/tests/proxy/push_graphql.t
+++ b/tests/proxy/push_graphql.t
@@ -111,6 +111,8 @@
       |-- info
       |   `-- exclude
       |-- objects
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 7e
       |   |   `-- 14e7e562164fb65d8f294303e07e915b95c5fe
       |   |-- c9
@@ -121,5 +123,5 @@
           |-- heads
           `-- tags
   
-  33 directories, 20 files
+  34 directories, 21 files
 

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -189,6 +189,8 @@ Check the branch again
       |   |   `-- 26032e5a4ef35d64849e0af272ceb4b27948bf
       |   |-- b5
       |   |   `-- afbb444fd22857e78ee11ddd92b7dd2f5c7d11
+      |   |-- cf
+      |   |   `-- 704ed443e7351ab990ab68c916c2428dcf9100
       |   |-- de
       |   |   `-- 7cba2eb70af5ce3555c3670e7641f2f547db74
       |   |-- e5
@@ -204,4 +206,4 @@ Check the branch again
           |-- namespaces
           `-- tags
   
-  52 directories, 39 files
+  53 directories, 40 files

--- a/tests/proxy/push_new_orphan_branch.t
+++ b/tests/proxy/push_new_orphan_branch.t
@@ -187,6 +187,8 @@ Make sure all temporary namespace got removed
       |-- objects
       |   |-- 0b
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 4b
       |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
       |   |-- 6b
@@ -203,8 +205,12 @@ Make sure all temporary namespace got removed
       |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
       |   |-- c2
       |   |   `-- 1c9352f7526e9576892a6631e0e8cf1fccd34d
+      |   |-- c4
+      |   |   `-- 8e30c7eeafdc8b5e6a103f26367c973b2c4df9
       |   |-- c6
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+      |   |-- cb
+      |   |   `-- b66c35294ac2d5ba60420854a3a50ca4c88887
       |   |-- d8
       |   |   |-- 388f5880393d255b371f1ed9b801d35620017e
       |   |   `-- 43530e8283da7185faac160347db5c70ef4e18
@@ -219,6 +225,6 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  54 directories, 41 files
+  57 directories, 44 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -99,6 +99,8 @@
       |-- objects
       |   |-- 0f
       |   |   `-- 17ab2c89a1278ecb6a7438e915e491884d3efb
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 1f
       |   |   `-- 0b9d8a7b40a35bb4ff64ffc0f08369df23bc61
       |   |-- 55
@@ -118,5 +120,5 @@
           |-- namespaces
           `-- tags
   
-  39 directories, 24 files
+  40 directories, 25 files
 

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -130,6 +130,8 @@ Make sure all temporary namespace got removed
       |-- objects
       |   |-- 0b
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
       |   |-- 81
@@ -147,7 +149,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  38 directories, 23 files
+  39 directories, 24 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -140,6 +140,8 @@ Flushed credential cache
       |   |   `-- d81bc99ff2b4a426c236dc1a36f7a2d1027c7b
       |   |-- 1c
       |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 89
       |   |   `-- 52f96884e0ee453406177bebbf4f74a8a8d1be
       |   |-- ad
@@ -155,7 +157,7 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  43 directories, 28 files
+  44 directories, 29 files
 
   $ cat ${TESTTMP}/josh-proxy.out | grep graph_descendant_of
   [1]

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -85,6 +85,8 @@ Make sure all temporary namespace got removed
       |-- objects
       |   |-- 0b
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
       |   |-- 81
@@ -102,7 +104,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  38 directories, 23 files
+  39 directories, 24 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -260,6 +260,8 @@ Make sure all temporary namespace got removed
       |   |   `-- 539577d449c8e5446b5339c20436a13ec51f41
       |   |-- 9a
       |   |   `-- 91b9f3056d29fafb535b6e801f26449b291daf
+      |   |-- a0
+      |   |   `-- 18dae3609294bc68eff023fabb96386ec483db
       |   |-- ae
       |   |   `-- a557394ce29f000108607abd97f19fed4d1b7c
       |   |-- b2
@@ -275,7 +277,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  63 directories, 46 files
+  64 directories, 47 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -237,6 +237,8 @@ Make sure all temporary namespace got removed
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
       |   |-- 11
       |   |   `-- 06a6f09b169109f5ebd17428219142c67e84b9
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 2b
       |   |   `-- b94719cad2e76eb5dbcae874a2b0e44521e802
       |   |-- 40
@@ -267,7 +269,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  67 directories, 51 files
+  68 directories, 52 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -91,6 +91,8 @@
       |-- objects
       |   |-- 0b
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 32
       |   |   `-- bc15e3ec04d5d9d2a216055ea51bafb2249877
       |   |-- 50
@@ -105,6 +107,8 @@
       |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
       |   |-- c6
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
+      |   |-- cf
+      |   |   `-- 704ed443e7351ab990ab68c916c2428dcf9100
       |   |-- d8
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- e6
@@ -116,6 +120,6 @@
           |-- namespaces
           `-- tags
   
-  42 directories, 27 files
+  44 directories, 29 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -142,6 +142,8 @@ Make sure all temporary namespace got removed
       |-- objects
       |   |-- 0b
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
       |   |-- 81
@@ -159,6 +161,6 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  42 directories, 28 files
+  43 directories, 29 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -172,8 +172,12 @@ Put a double slash in the URL to see that it also works
       |-- info
       |   `-- exclude
       |-- objects
+      |   |-- 03
+      |   |   `-- e4d4431d56b09a58ee53e177a966b75b5adc2a
       |   |-- 0b
       |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+      |   |-- 1d
+      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 3c
       |   |   `-- cd09de42d21f7e5318bc5eaf258bf82e4103e6
       |   |-- 5c
@@ -203,5 +207,5 @@ Put a double slash in the URL to see that it also works
           |-- namespaces
           `-- tags
   
-  51 directories, 35 files
+  53 directories, 37 files
 

--- a/tests/proxy/unrelated_leak.t
+++ b/tests/proxy/unrelated_leak.t
@@ -210,6 +210,8 @@ Flushed credential cache
       |   |   `-- ce298ca12ec52cff187ef6638a2ba3d1c9503d
       |   |-- 26
       |   |   `-- 1fdca7dd1cc67009c11551191e84aa1ba21c20
+      |   |-- 35
+      |   |   `-- 95f38d11ec8c849f1c1a11fe676ed8dfac8145
       |   |-- 36
       |   |   `-- 8bfdc83325632d67cb93d96f095f0b04e4e26d
       |   |-- 37
@@ -247,4 +249,4 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  64 directories, 51 files
+  65 directories, 52 files

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -308,6 +308,8 @@
       |-- info
       |   `-- exclude
       |-- objects
+      |   |-- 0b
+      |   |   `-- 3b1286342fd8f9cd6c83347ba939815ce4ce9b
       |   |-- 10
       |   |   `-- 4395792f8b6494b9a0fad94ebaf2d1b57422b8
       |   |-- 13
@@ -401,6 +403,6 @@
           |-- namespaces
           `-- tags
   
-  95 directories, 82 files
+  96 directories, 83 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -658,6 +658,7 @@ Note that ws/d/ is now present in the ws
       |   |-- 87
       |   |   `-- 7af85c0624835da58fe4b2fa9a259a44213acf
       |   |-- 8c
+      |   |   |-- 4e94969f16bfec56af4b29c1a20e732401ed32
       |   |   `-- c4bb045e98da7cf00714d91ac77c7ea7e08b63
       |   |-- 93
       |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
@@ -709,6 +710,8 @@ Note that ws/d/ is now present in the ws
       |   |-- d7
       |   |   |-- 330ea337031af43ba1cf6982a873a40b9170ac
       |   |   `-- e36a04a3c59c966815fae6db6fe5d518a3456a
+      |   |-- d9
+      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
       |   |-- da
       |   |   `-- af0560e4e779353311a9039b31ea4f0f1dec37
       |   |-- e1
@@ -747,6 +750,6 @@ Note that ws/d/ is now present in the ws
           |-- namespaces
           `-- tags
   
-  151 directories, 155 files
+  152 directories, 157 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -185,6 +185,8 @@
       |-- info
       |   `-- exclude
       |-- objects
+      |   |-- 18
+      |   |   `-- fc53a050ffb86358d5e58e4280ce3c5fc218a4
       |   |-- 1b
       |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
       |   |-- 22
@@ -224,6 +226,6 @@
           |-- namespaces
           `-- tags
   
-  69 directories, 54 files
+  70 directories, 55 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -305,6 +305,8 @@
       |   |   `-- abc9b48b4da3daca498937b225ff8d54ba8c56
       |   |-- 0c
       |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
+      |   |-- 10
+      |   |   `-- 105c45d21be850089b3f326502436adfa5ab0e
       |   |-- 16
       |   |   `-- f299bec8b6eece08fd28777d7cff5edf6132ed
       |   |-- 19
@@ -373,6 +375,8 @@
       |   |   `-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
       |   |-- 89
       |   |   `-- ae198bc1b2f11718bd1e76fbe6473054801274
+      |   |-- 8c
+      |   |   `-- 4e94969f16bfec56af4b29c1a20e732401ed32
       |   |-- 8f
       |   |   `-- 1b78740f35dafecc063980e2afb231b9ee74a3
       |   |-- 91
@@ -448,4 +452,4 @@
           |-- namespaces
           `-- tags
   
-  130 directories, 123 files
+  132 directories, 125 files

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -352,6 +352,8 @@
       |-- objects
       |   |-- 00
       |   |   `-- e02597bb7117c22dc0b551a4062607895fc3d3
+      |   |-- 10
+      |   |   `-- 105c45d21be850089b3f326502436adfa5ab0e
       |   |-- 11
       |   |   `-- e2559617afa238a8332c15d15fff48d5b57c83
       |   |-- 13
@@ -471,5 +473,5 @@
           |-- namespaces
           `-- tags
   
-  118 directories, 109 files
+  119 directories, 110 files
 

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -252,8 +252,12 @@ Flushed credential cache
       |-- objects
       |   |-- 0a
       |   |   `-- 3e20b963d30a7071105313fada241306df8695
+      |   |-- 0b
+      |   |   `-- 5d2fad8a9bd1ebecf89f086ffedcb2741d7a1b
       |   |-- 0f
       |   |   `-- 70f195d1852ceed0a13b3839eee7aeb07571f7
+      |   |-- 24
+      |   |   `-- cce5c76886d1a63b5eeb02e78f64f9bc399ee3
       |   |-- 2b
       |   |   `-- 20b4f8abb6d70648e2573e2f798a18e0079f9e
       |   |-- 31
@@ -272,6 +276,8 @@ Flushed credential cache
       |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
       |   |-- 51
       |   |   `-- 45dedc66248700cf33e354ef555877bc24f533
+      |   |-- 63
+      |   |   `-- eda6a178059b4e910cf10492006a162316c988
       |   |-- 66
       |   |   `-- 1bafe5fb60524a9efafd413c42e4c2d706bae8
       |   |-- 6c
@@ -300,6 +306,10 @@ Flushed credential cache
       |   |   `-- 8eb888451be077531b50794384c2faec025765
       |   |-- cd
       |   |   `-- 9ae8cb61e7d1aaa7b90766ff9aa9b3dc78c856
+      |   |-- d8
+      |   |   `-- b5906ab0322bc119e3142d76447591c41c29a4
+      |   |-- d9
+      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
       |   |-- db
       |   |   `-- 9120ba624b0afe79d37a5a262d8deb14e13707
       |   |-- f0
@@ -313,4 +323,4 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  72 directories, 58 files
+  77 directories, 63 files

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -602,6 +602,8 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 48804b01e298df4a6e1bc60a1e3b2ca0b016bd
       |   |-- 31
       |   |   `-- af3d0a5be6cc36a10a6b984673087c2d068432
+      |   |-- 32
+      |   |   `-- 3e79ffc7608345e286a313b55d97a3652de33b
       |   |-- 34
       |   |   `-- c24765275d6f3ec5d6baeaaa4299471d6f7df0
       |   |-- 36
@@ -658,6 +660,7 @@ Note that ws/d/ is now present in the ws
       |   |-- 7c
       |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
       |   |-- 7d
+      |   |   |-- 46532a74cbb9e9f9f17d760a4eb7fea62e888e
       |   |   |-- a1ae7f2b93967ad7ea421fa7db95b73b8aa07e
       |   |   `-- fca2962177d9c9925fedf2fbdd79fc7e9309fc
       |   |-- 7f
@@ -666,6 +669,7 @@ Note that ws/d/ is now present in the ws
       |   |-- 82
       |   |   `-- 4c0e846b41e1eb9f95d141b47bbb9ff9baef17
       |   |-- 8c
+      |   |   |-- 4e94969f16bfec56af4b29c1a20e732401ed32
       |   |   `-- c4bb045e98da7cf00714d91ac77c7ea7e08b63
       |   |-- 93
       |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
@@ -716,7 +720,8 @@ Note that ws/d/ is now present in the ws
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
       |   |-- d9
-      |   |   `-- 1fa4981fe3546f44fa5a779ec6f69b20fdaa0f
+      |   |   |-- 1fa4981fe3546f44fa5a779ec6f69b20fdaa0f
+      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
       |   |-- da
       |   |   `-- af0560e4e779353311a9039b31ea4f0f1dec37
       |   |-- dc
@@ -758,6 +763,6 @@ Note that ws/d/ is now present in the ws
           |-- namespaces
           `-- tags
   
-  160 directories, 158 files
+  161 directories, 162 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -386,6 +386,8 @@
       |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
       |   |-- 4b
       |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
+      |   |-- 4e
+      |   |   `-- 8ed8ed549306fc01dba32ee643084f1070ba9c
       |   |-- 4f
       |   |   `-- 314491719dffbb4340268e5f04136e74821e2c
       |   |-- 53
@@ -394,9 +396,13 @@
       |   |   `-- 38ed8e4d96b624c6ef7e36f8b696d52be785db
       |   |-- 5b
       |   |   `-- 545e12c5b297509b8d99df5f0b952a2dd7862d
+      |   |-- 5d
+      |   |   `-- 0e549ae0392ba043767615c0225b9a9c7f40ab
       |   |-- 64
       |   |   |-- 6fd2c5bfe156d57ba03f62f2fe735ddbb74e22
       |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
+      |   |-- 65
+      |   |   `-- 1de74dfe1abe2024ed2798bbfcf9ba683d3f86
       |   |-- 67
       |   |   `-- 48a16f7d9b29607fcd4df93681361a6105a14a
       |   |-- 69
@@ -409,6 +415,8 @@
       |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
       |   |-- 78
       |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
+      |   |-- 7a
+      |   |   `-- 185c5a9aa33cf2e7749b1ad15a4aebfdd070a5
       |   |-- 7c
       |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
       |   |-- 7f
@@ -417,6 +425,8 @@
       |   |   `-- 8b763a1483259f4667f399a019b96f52a28f8c
       |   |-- 8a
       |   |   `-- bb8094049472170b402ad3aaee6db3d5a97286
+      |   |-- 8c
+      |   |   `-- 4e94969f16bfec56af4b29c1a20e732401ed32
       |   |-- 91
       |   |   `-- 584adddb4f190d805ec45ce500a0661671fb25
       |   |-- 93
@@ -429,6 +439,8 @@
       |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
       |   |-- 9f
       |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
+      |   |-- a0
+      |   |   `-- aedc37ec419934689622688e75ae66f5aa0742
       |   |-- a3
       |   |   `-- d027b4cc082c08af95fcbe03eecd9a62a08c48
       |   |-- a7
@@ -456,6 +468,8 @@
       |   |-- cd
       |   |   |-- 0544cd5f702a9b3418205ec0425c6ae77f9e3e
       |   |   `-- 7c94c08f59302a2b1587a01d4fd1680d7378c9
+      |   |-- d0
+      |   |   `-- a80cebe6f692edee7c959da2ffa66cf7d6c755
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
       |   |-- e1
@@ -488,6 +502,6 @@
           |-- namespaces
           `-- tags
   
-  123 directories, 117 files
+  130 directories, 124 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -520,6 +520,7 @@ Note that ws/d/ is now present in the ws
       |   |-- 82
       |   |   `-- 4c0e846b41e1eb9f95d141b47bbb9ff9baef17
       |   |-- 8c
+      |   |   |-- 4e94969f16bfec56af4b29c1a20e732401ed32
       |   |   `-- c4bb045e98da7cf00714d91ac77c7ea7e08b63
       |   |-- 93
       |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
@@ -563,6 +564,8 @@ Note that ws/d/ is now present in the ws
       |   |   `-- bceb2fb07839b8796fadb2b6a8b785b8fd7440
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
+      |   |-- d9
+      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
       |   |-- e1
       |   |   |-- 0bf0281a70e6b19939ad6e26e10252bbebe300
       |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
@@ -598,6 +601,6 @@ Note that ws/d/ is now present in the ws
           |-- namespaces
           `-- tags
   
-  148 directories, 147 files
+  149 directories, 149 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -163,6 +163,8 @@ file was created
       |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
       |   |-- a8
       |   |   `-- 6544ef29b946481d26cb4cfb55844342069c0e
+      |   |-- a9
+      |   |   `-- 252e3936cb6309dfebcafd688cd6a0d2225036
       |   |-- b6
       |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
       |   |-- eb
@@ -176,6 +178,6 @@ file was created
           |-- namespaces
           `-- tags
   
-  52 directories, 37 files
+  53 directories, 38 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -211,6 +211,8 @@
       |   |   `-- b0ecf29d3808ba274af864643f5a3f9c8706f1
       |   |-- 66
       |   |   `-- b81c71c0ad10acdb2b4df3b04eef8abd79e64b
+      |   |-- 67
+      |   |   `-- c1c331298672b86d90c2c847942ee7714463a9
       |   |-- 6e
       |   |   `-- 8d20f7effed65135756c3d3428ccf7d7efb818
       |   |-- 73
@@ -266,6 +268,6 @@
           |-- namespaces
           `-- tags
   
-  77 directories, 65 files
+  78 directories, 66 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -332,6 +332,8 @@
       |-- objects
       |   |-- 00
       |   |   `-- e02597bb7117c22dc0b551a4062607895fc3d3
+      |   |-- 10
+      |   |   `-- 105c45d21be850089b3f326502436adfa5ab0e
       |   |-- 11
       |   |   `-- e2559617afa238a8332c15d15fff48d5b57c83
       |   |-- 13
@@ -374,6 +376,8 @@
       |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
       |   |-- 6b
       |   |   `-- e0d68b8e87001c8b91281636e21d6387010332
+      |   |-- 6f
+      |   |   `-- 361fef653a193d6f2241b7226c3be8610d1262
       |   |-- 78
       |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
       |   |-- 7f
@@ -395,10 +399,13 @@
       |   |-- a4
       |   |   |-- 1772e0c7cdad1a13b7a7bc38c0d382a5a827ce
       |   |   `-- 8223bf4fc7801a0322b4ecaa5ed6a2c5dce7f1
+      |   |-- a6
+      |   |   `-- a87b60d0096fd465f5190507aaa1e06248bced
       |   |-- b0
       |   |   `-- fdeb65d9b9069015ef9c0f735a4f6f2f28fe77
       |   |-- b1
-      |   |   `-- c1b15558aebbce0682f25933cb729e9acd209c
+      |   |   |-- c1b15558aebbce0682f25933cb729e9acd209c
+      |   |   `-- cbc68940fd6afb1420b1be50c3acd06e8b3fc2
       |   |-- b6
       |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
       |   |-- b8
@@ -423,6 +430,8 @@
       |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
       |   |-- ed
       |   |   `-- 8ae0c02d30bd34d7a8584cb0930d0d7a58df26
+      |   |-- f1
+      |   |   `-- 84b6c58c9b6470ea291406c20ed54ae50d0ce3
       |   |-- f2
       |   |   |-- 257977b96d2272be155d6699046148e477e9fb
       |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
@@ -437,6 +446,6 @@
           |-- namespaces
           `-- tags
   
-  108 directories, 99 files
+  112 directories, 104 files
 
 $ cat ${TESTTMP}/josh-proxy.out


### PR DESCRIPTION
this enables fast reachability checks at the expense of losing some information. the merge_base_many function gives the nearest common ancestor for a set of tips; however, we aren't actually interested in which common ancestor is the nearest one, we only care whether such ancestors exist at all.

Change-Id: I6543d46863e1b7a22955c76708db16e821882c6e