### PR TITLE
Use 3 way merge instead of diff for downstack

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -173,35 +173,35 @@ pub fn downstack(
         .filter(|id| available_ids.contains(id.as_str()))
         .collect();
 
-    // Compute d_change: the diff introduced by the change commit itself
-    let change_diff = repo.diff_tree_to_tree(
-        Some(&change_parent.tree()?),
-        Some(&change_commit.tree()?),
-        None,
-    )?;
-
-    // Walk through intermediates, including only those needed for d_change to apply
+    // Walk through intermediates, including only those needed for
+    // the change to apply cleanly.
     let mut current_base = repo.find_commit(base)?;
 
     for (intermediate, change_id) in commits.iter().zip(intermediate_ids.iter()) {
-        // Stop when d_change applies and all Requires: are satisfied
+        // Stop when the change merges cleanly and all Requires: are satisfied
         let diff_applies = repo
-            .apply_to_tree(&current_base.tree()?, &change_diff, None)
-            .is_ok();
+            .merge_trees(
+                &change_parent.tree()?,
+                &current_base.tree()?,
+                &change_commit.tree()?,
+                None,
+            )
+            .map(|index| !index.has_conflicts())
+            .unwrap_or(false);
         if diff_applies && required.is_empty() {
             break;
         }
 
-        // d_change does not apply yet; we need this intermediate commit.
-        // Rebase it onto current_base by applying its diff.
+        // Change does not apply yet; we need this intermediate commit.
+        // Rebase it onto current_base via 3-way merge.
         let inter_parent = intermediate.parent(0)?;
-        let inter_diff = repo.diff_tree_to_tree(
-            Some(&inter_parent.tree()?),
-            Some(&intermediate.tree()?),
+
+        let mut index = repo.merge_trees(
+            &inter_parent.tree()?,
+            &current_base.tree()?,
+            &intermediate.tree()?,
             None,
         )?;
-
-        let mut index = repo.apply_to_tree(&current_base.tree()?, &inter_diff, None)?;
         let new_tree = repo.find_tree(index.write_tree_to(repo)?)?;
 
         let new_oid = josh_core::history::rewrite_commit(
@@ -218,8 +218,13 @@ pub fn downstack(
         }
     }
 
-    // Apply d_change on top of the minimal base and create the new change commit
-    let mut index = repo.apply_to_tree(&current_base.tree()?, &change_diff, None)?;
+    // Apply the change on top of the minimal base via 3-way merge
+    let mut index = repo.merge_trees(
+        &change_parent.tree()?,
+        &current_base.tree()?,
+        &change_commit.tree()?,
+        None,
+    )?;
     let new_tree = repo.find_tree(index.write_tree_to(repo)?)?;
 
     josh_core::history::rewrite_commit(

--- a/tests/cli/push_stacked_binary.t
+++ b/tests/cli/push_stacked_binary.t
@@ -1,0 +1,84 @@
+Setup
+
+  $ export TESTTMP=${PWD}
+
+Create a test repository with some content
+
+  $ mkdir remote
+  $ cd remote
+  $ git init -q --bare
+  $ cd ..
+
+  $ mkdir local
+  $ cd local
+  $ git init -q
+  $ mkdir -p sub1
+  $ echo "file1 content" > sub1/file1
+  $ git add .
+  $ git commit -q -m "add file1"
+  $ git remote add origin ${TESTTMP}/remote
+  $ git push -q origin master
+  $ cd ..
+
+Clone with josh filter
+
+  $ josh clone ${TESTTMP}/remote :/sub1 filtered
+  Added remote 'origin' with filter ':/sub1'
+  From file://${TESTTMP}/remote
+   * [new branch]      master     -> refs/josh/remotes/origin/master
+  
+  From file://${TESTTMP}/filtered
+   * [new branch]      master     -> origin/master
+  
+  Fetched from remote: origin
+  Already on 'master'
+  
+  Cloned repository to: ${TESTTMP}/filtered
+  $ cd filtered
+
+Make stacked changes with binary files
+
+  $ printf '\x00\x01\x02' > binfile
+  $ git add binfile
+  $ git commit -q -m "Change-Id: bin1"
+  $ printf '\x00\x03\x04' > binfile2
+  $ git add binfile2
+  $ git commit -q -m "Change-Id: bin2"
+
+Set up git config for author
+
+  $ git config user.email "josh@example.com"
+  $ git config user.name "Josh Test"
+
+Push with stacked changes containing binary files
+
+  $ josh publish
+  To file://${TESTTMP}/remote
+   * [new branch]      61d809929bf6b7a29d194f43368936fc82b033db -> @changes/master/josh@example.com/bin1
+  
+  Pushed 61d809929bf6b7a29d194f43368936fc82b033db to origin/refs/heads/@changes/master/josh@example.com/bin1
+  To file://${TESTTMP}/remote
+   * [new branch]      115b269a011d493259a125fa941fd790b903175f -> @base/master/josh@example.com/bin1
+  
+  Pushed 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/bin1
+  To file://${TESTTMP}/remote
+   * [new branch]      a4f8ccd2c1cf12aaf3b46eae73e38c71185867e7 -> @changes/master/josh@example.com/bin2
+  
+  Pushed a4f8ccd2c1cf12aaf3b46eae73e38c71185867e7 to origin/refs/heads/@changes/master/josh@example.com/bin2
+  To file://${TESTTMP}/remote
+   * [new branch]      115b269a011d493259a125fa941fd790b903175f -> @base/master/josh@example.com/bin2
+  
+  Pushed 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/bin2
+  To file://${TESTTMP}/remote
+   * [new branch]      * -> @heads/master/josh@example.com (glob)
+  
+  Pushed * to origin/refs/heads/@heads/master/josh@example.com (glob)
+
+
+Verify binary content is preserved on the change branches
+
+  $ cd ${TESTTMP}/remote
+  $ git cat-file -p refs/heads/@changes/master/josh@example.com/bin1:sub1/binfile | xxd
+  00000000: 0001 02                                  ...
+  $ git cat-file -p refs/heads/@changes/master/josh@example.com/bin2:sub1/binfile2 | xxd
+  00000000: 0003 04                                  ...


### PR DESCRIPTION
Use 3 way merge instead of diff for downstack

The approach of going through Diff did not work with
binary files. The 3-way merge does.

Change: stack-bin-files