### PR TITLE
debug: ssh into runner via tailscale

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,6 +51,13 @@ jobs:
     - name: Install podman
       shell: bash
       run: .github/workflows/scripts/install-podman.sh
+    - name: Tailscale
+      uses: tailscale/github-action@v2
+      with:
+        authkey: ${{ secrets.TAILSCALE_AUTH_KEY }}
+        args: --ssh --hostname=gha-josh-${{ github.run_id }}-${{ matrix.test_suite.name }}
+    - name: Hold for SSH debug
+      run: sleep 1800
     - name: Build CI image
       uses: docker/bake-action@v7
       with:


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Summary
- Adds a Tailscale step to `rust.yml` after `Install podman` that brings the runner onto the tailnet via Tailscale SSH and sleeps 30 minutes, so we can SSH in to debug the podman setup before tests run.

**Do not merge.** This is a debug branch.

## Test plan
- [ ] CI starts, reaches "Hold for SSH debug"
- [ ] Two nodes appear in `tailscale status` (one per matrix entry)
- [ ] `ssh runner@gha-josh-<run_id>-tests` connects