### PR TITLE
ci: fix podman-static install

### DIFF
--- a/.github/podman/apparmor-podman
+++ b/.github/podman/apparmor-podman
@@ -1,0 +1,14 @@
+# Replaces the system /etc/apparmor.d/podman to cover both /usr/bin/podman
+# and /usr/local/bin/podman. Required on Ubuntu >=23.10 where
+# kernel.apparmor_restrict_unprivileged_userns=1 blocks rootless podman
+# launched from /usr/local/bin (where the podman-static bundle is symlinked)
+# with "reexec: Permission denied". See:
+# https://github.com/mgoltzsche/podman-static#apparmor-profile
+abi <abi/4.0>,
+include <tunables/global>
+
+profile podman /{usr/{bin,local/bin},opt/podman-*/usr/local/bin}/podman flags=(unconfined) {
+  userns,
+
+  include if exists <local/podman>
+}

--- a/.github/podman/containers.conf
+++ b/.github/podman/containers.conf
@@ -1,0 +1,12 @@
+# See https://github.com/containers/common/blob/master/pkg/config/containers.conf
+# Pin OCI runtimes to the binaries shipped in the podman-static bundle:
+# the system crun (1.14.1 on Ubuntu 24.04) is too old to parse the OCI spec
+# version emitted by podman 5.x and fails with "unknown version specified".
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger = "file"
+runtime = "crun"
+
+[engine.runtimes]
+crun = ["/usr/local/bin/crun"]
+runc = ["/usr/local/bin/runc"]

--- a/.github/workflows/scripts/install-podman.sh
+++ b/.github/workflows/scripts/install-podman.sh
@@ -24,5 +24,16 @@ PREFIX="/opt/podman-${PODMAN_VERSION#v}"
 sudo mkdir -p /opt
 sudo tar -xzf "${WORK}/${TARBALL}" -C /opt
 sudo mv /opt/podman-linux-amd64 "${PREFIX}"
-sudo ln -sf "${PREFIX}/usr/local/bin/podman" /usr/local/bin/podman
+for bin in podman crun runc pasta fuse-overlayfs fusermount3; do
+    sudo ln -sf "${PREFIX}/usr/local/bin/${bin}" "/usr/local/bin/${bin}"
+done
+
+sudo mkdir -p /etc/containers
+sudo install -m 0644 "${PODMAN_DIR}/containers.conf" /etc/containers/containers.conf
+
+if [ -f /etc/apparmor.d/podman ]; then
+    sudo install -m 0644 "${PODMAN_DIR}/apparmor-podman" /etc/apparmor.d/podman
+    sudo apparmor_parser -r /etc/apparmor.d/podman
+fi
+
 podman --version


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Summary
- `install-podman.sh` previously only symlinked `podman` out of the static bundle. Podman 5.8.2 then fell back to the system `crun 1.14.1` (Ubuntu 24.04), which cannot parse the OCI spec version podman 5.x emits — every `podman run` / `podman build` failed with `crun: unknown version specified`.
- Rootless additionally hit `reexec: Permission denied` because Ubuntu 24.04's AppArmor `unprivileged_userns` restriction is enforced and the system `/etc/apparmor.d/podman` profile only covers `/usr/bin/podman`, not `/usr/local/bin/podman`.

This PR:
- Symlinks the bundled `crun`, `runc`, `pasta`, `fuse-overlayfs`, `fusermount3` next to `podman`.
- Installs `.github/podman/containers.conf` pinning the runtime to the bundled `/usr/local/bin/crun`.
- Installs `.github/podman/apparmor-podman` (replacing the system profile) so the profile covers both `/usr/{bin,local/bin}/podman`.
- Adds a temporary `Verify podman` step to `rust.yml` that runs `podman run` + `podman build` rootful and rootless. Will be removed once CI is consistently green.

## Test plan
- [x] `Verify podman (rootful + rootless)` step passes for both matrix entries
- [x] `Build CI image` and `Run tests` continue to work after the install changes
- [x] After CI confirms, follow-up commit removes the verify step