### PR TITLE
Replace diff-applies downstack algorithm with path intersection

### DIFF
--- a/docs/src/guide/stacked-changes.md
+++ b/docs/src/guide/stacked-changes.md
@@ -54,41 +54,60 @@ submission. Returns an error message inline without clearing the form.
 Change: login-form-validation
 ```
 
-## Declaring dependencies with `Requires:`
+## Automatic dependency detection
 
-By default, when Josh publishes a stack it includes only the intermediate commits that
-are textually needed for a change's diff to apply. Sometimes a change depends on another
-change in ways that go beyond textual conflicts — for example, it relies on a function
-introduced by an earlier change even though they touch different files.
+When Josh publishes a change, it does not simply push the single commit. Instead, it
+builds a minimal ref for that change: the change's commit, rebased onto the base branch,
+together with only those intermediate commits from the stack that the change actually
+depends on.
 
-You can declare such dependencies with one or more `Requires:` footers in the commit
-message, referencing the change IDs of the changes you depend on:
+Josh determines dependencies by path intersection. It collects the set of files touched
+by the change, then walks backwards through the intermediates: any commit whose touched
+files overlap that set is included (and its files are added to the set, so transitive
+dependencies are picked up too). Commits that touch entirely different files are omitted,
+even if they sit between the base and the change in the local stack.
 
-```
-Add caller for the new validation helper
+This means two independent changes that touch different parts of the codebase can each
+be published directly on top of the base branch, even when they are interleaved on the
+local branch. You do not need to carefully order your commits — Josh figures out which
+changes need to come first.
 
-Uses the validate_email() function introduced in the input-validation
-change, even though this commit touches a different file.
-
-Change: form-wiring
-Requires: input-validation
-```
-
-When Josh determines the dependencies for `form-wiring`, it will include
-`input-validation` even if the two changes don't overlap textually.
-
-Multiple dependencies can be declared by repeating the footer:
+**Example:** imagine a local stack with three commits:
 
 ```
-Change: integration-tests
-Requires: input-validation
-Requires: form-wiring
+[base] ← A (modifies auth/login.rs) ← B (modifies ui/button.rs) ← C (modifies auth/session.rs)
 ```
 
-If a `Requires:` references a change ID that does not exist in the current stack, it is
-silently ignored. This commonly happens when the required change has already been merged
-into the base branch — the dependency is satisfied by the base itself, so there is
-nothing extra to include.
+When publishing C, Josh sees it touches `auth/session.rs`. A also touches `auth/`, so A
+is included. B only touches `ui/`, so B is skipped. C's ref will contain just A and C on
+top of base. B's ref will contain only B on top of base.
+
+## Ordering with `Change-Series:`
+
+Sometimes two changes are logically ordered but touch disjoint files, so the automatic
+path intersection does not pull them together. Assigning both the same `Change-Series:`
+label tells Josh to treat them as ordered: when publishing the later commit, the earlier
+one will be included even though they share no files.
+
+```
+Add unit tests for the new validation helper
+
+Change: validation-tests
+Change-Series: login-validation
+```
+
+```
+Add input validation helper
+
+Change: input-validation
+Change-Series: login-validation
+```
+
+When Josh publishes `validation-tests`, it sees that both commits share the
+`login-validation` series and ensures `input-validation` is published before it.
+
+A commit can carry multiple `Change-Series:` footers if it belongs to more than one
+ordered group.
 
 ## Workflow
 

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 struct Change {
     pub author: String,
     pub id: Option<String>,
-    pub requires: Vec<String>,
+    pub series: Vec<String>,
     pub commit: git2::Oid,
 }
 
@@ -13,7 +13,7 @@ impl Change {
         Self {
             author: Default::default(),
             id: Default::default(),
-            requires: Default::default(),
+            series: Default::default(),
             commit,
         }
     }
@@ -30,8 +30,8 @@ fn get_change_id(commit: &git2::Commit) -> Change {
         if let Some(id) = line.strip_prefix("Change-Id: ") {
             change.id = Some(id.to_string());
         }
-        if let Some(id) = line.strip_prefix("Requires: ") {
-            change.requires.push(id.to_string());
+        if let Some(s) = line.strip_prefix("Change-Series: ") {
+            change.series.push(s.to_string());
         }
     }
     change
@@ -90,16 +90,33 @@ fn split_changes(
 
     changes
         .iter()
-        .map(|(_, c)| downstack(repo, base, c, &changes))
+        .map(|(_, c)| downstack(repo, base, c))
         .collect()
 }
 
-fn downstack(
+fn changed_paths(
     repo: &git2::Repository,
-    base: git2::Oid,
-    change: &Change,
-    all_changes: &std::collections::HashMap<git2::Oid, Change>,
-) -> anyhow::Result<Change> {
+    commit: &git2::Commit,
+) -> anyhow::Result<std::collections::HashSet<String>> {
+    let parent_tree = if commit.parent_count() > 0 {
+        Some(commit.parent(0)?.tree()?)
+    } else {
+        None
+    };
+    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
+    let mut paths = std::collections::HashSet::new();
+    for delta in diff.deltas() {
+        if let Some(p) = delta.old_file().path().and_then(|p| p.to_str()) {
+            paths.insert(p.to_string());
+        }
+        if let Some(p) = delta.new_file().path().and_then(|p| p.to_str()) {
+            paths.insert(p.to_string());
+        }
+    }
+    Ok(paths)
+}
+
+fn downstack(repo: &git2::Repository, base: git2::Oid, change: &Change) -> anyhow::Result<Change> {
     let change_oid = change.commit;
     if !repo.graph_descendant_of(change_oid, base)? {
         return Err(anyhow!(
@@ -131,44 +148,33 @@ fn downstack(
     let change_commit = commits.pop().unwrap();
     let change_parent = change_commit.parent(0)?;
 
-    // Use pre-parsed requires, keeping only those referencing changes
-    // actually present in the intermediates
-    let intermediate_ids: Vec<Option<&str>> = commits
-        .iter()
-        .map(|c| all_changes.get(&c.id()).and_then(|ch| ch.id.as_deref()))
-        .collect();
-    let available_ids: std::collections::HashSet<&str> =
-        intermediate_ids.iter().filter_map(|id| *id).collect();
-    let mut required: std::collections::HashSet<&str> = change
-        .requires
-        .iter()
-        .map(|s| s.as_str())
-        .filter(|id| available_ids.contains(id))
-        .collect();
-
-    // Walk through intermediates, including only those needed for
-    // the change to apply cleanly.
-    let mut current_base = repo.find_commit(base)?;
-
-    for (intermediate, change_id) in commits.iter().zip(intermediate_ids.iter()) {
-        // Stop when the change merges cleanly and all Requires: are satisfied
-        let diff_applies = repo
-            .merge_trees(
-                &change_parent.tree()?,
-                &current_base.tree()?,
-                &change_commit.tree()?,
-                None,
-            )
-            .map(|index| !index.has_conflicts())
-            .unwrap_or(false);
-        if diff_applies && required.is_empty() {
-            break;
+    // Seed the affected path set with the change's own modified paths, then
+    // walk intermediates backwards, keeping any commit whose paths intersect.
+    let change_meta = get_change_id(&change_commit);
+    let mut affected_paths = changed_paths(repo, &change_commit)?;
+    for s in &change_meta.series {
+        affected_paths.insert(format!("\x00series:{}", s));
+    }
+    let mut needed: Vec<bool> = vec![false; commits.len()];
+    for (i, intermediate) in commits.iter().enumerate().rev() {
+        let meta = get_change_id(intermediate);
+        let mut paths = changed_paths(repo, intermediate)?;
+        for s in &meta.series {
+            paths.insert(format!("\x00series:{}", s));
         }
+        if !paths.is_disjoint(&affected_paths) {
+            needed[i] = true;
+            affected_paths.extend(paths);
+        }
+    }
 
-        // Change does not apply yet; we need this intermediate commit.
-        // Rebase it onto current_base via 3-way merge.
+    // Rebase needed intermediates forward onto current_base.
+    let mut current_base = repo.find_commit(base)?;
+    for (intermediate, is_needed) in commits.iter().zip(needed.iter()) {
+        if !is_needed {
+            continue;
+        }
         let inter_parent = intermediate.parent(0)?;
-
         let mut index = repo.merge_trees(
             &inter_parent.tree()?,
             &current_base.tree()?,
@@ -176,7 +182,6 @@ fn downstack(
             None,
         )?;
         let new_tree = repo.find_tree(index.write_tree_to(repo)?)?;
-
         let new_oid = josh_core::history::rewrite_commit(
             repo,
             intermediate,
@@ -185,13 +190,9 @@ fn downstack(
             josh_core::history::GpgsigMode::Preserve,
         )?;
         current_base = repo.find_commit(new_oid)?;
-
-        if let Some(id) = change_id {
-            required.remove(id);
-        }
     }
 
-    // Apply the change on top of the minimal base via 3-way merge
+    // Apply the change on top of the minimal base via 3-way merge.
     let mut index = repo.merge_trees(
         &change_parent.tree()?,
         &current_base.tree()?,

--- a/tests/cli/push_stacked_requires.t
+++ b/tests/cli/push_stacked_requires.t
@@ -37,6 +37,9 @@ Clone with josh filter
 
 
 
+
+
+
   $ cd filtered
 
 Set up git config for author
@@ -44,12 +47,12 @@ Set up git config for author
   $ git config user.email "josh@example.com"
   $ git config user.name "Josh Test"
 
-Create a stack where the last change is textually independent of an intermediate
-but declares a Requires: dependency on it.
+Create a stack where gamma is textually independent of alpha but shares a
+Change-Series, and beta has no series at all.
 
   $ echo "aaa" > fileA
   $ git add fileA
-  $ git commit -q -m "Change: alpha"
+  $ printf "Change: alpha\n\nChange-Series: dep1" | git commit -q -F -
 
   $ echo "bbb" > fileB
   $ git add fileB
@@ -57,7 +60,7 @@ but declares a Requires: dependency on it.
 
   $ echo "ccc" > fileC
   $ git add fileC
-  $ printf "Change: gamma\n\nRequires: alpha" | git commit -q -F -
+  $ printf "Change: gamma\n\nChange-Series: dep1" | git commit -q -F -
 
   $ git log --decorate --graph --pretty="%s %d"
   * Change: gamma  (HEAD -> master)
@@ -69,9 +72,8 @@ Publish with split mode
 
   $ josh publish > /dev/null 2>&1
 
-Verify gamma's downstack includes alpha (due to Requires:) but not beta.
-Without the Requires: footer, gamma would sit directly on base since fileC
-is textually independent. With Requires: alpha, alpha must be included.
+Verify gamma's downstack includes alpha (due to shared Change-Series: dep1)
+but not beta (different series / no series, no file overlap).
 
   $ cd ${TESTTMP}/remote
 


### PR DESCRIPTION
Replace diff-applies downstack algorithm with path intersection

The old algorithm walked intermediates forward and kept every commit
until the change's diff applied cleanly (and all Requires: were
satisfied). Because it was a single forward pass, it included commits
that were order-independent of the change — any intermediate before
the first clean-apply point was pulled in, even if it touched
completely unrelated files.

The new algorithm does a single backward scan: it seeds an
affected-path set from the change's own modified paths, then marks
only those intermediates whose touched paths intersect that set
(expanding the set as it goes). This lets intermediates that don't
conflict with the change be skipped regardless of their position in
the stack.

As part of this, the Requires: commit footer is replaced by
Change-Series: — authors can assign two or more commits to a named
series to ensure they are merged in order even when they touch
disjoint files. Series membership is encoded as a synthetic
"\x00series:<name>" path entry so it participates in the same
intersection logic without special-casing.

Change: path-intersection-deps

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>