### PR TITLE
Rename "josh publish" to "josh changes publish"

### DIFF
--- a/docs/src/guide/stacked-changes.md
+++ b/docs/src/guide/stacked-changes.md
@@ -11,7 +11,7 @@ filtered view of a monorepo or a plain repository.
 ## Concepts
 
 In a stacked changes workflow, each commit on your local branch represents one
-self-contained change. When you use `josh publish`, Josh creates a
+self-contained change. When you use `josh changes publish`, Josh creates a
 separate git ref for each qualifying commit.
 
 A commit qualifies for a separate ref — and an automatic PR, when
@@ -136,7 +136,7 @@ do not get their own ref or PR.
 ### 2. Publish
 
 ```shell
-josh publish
+josh changes publish
 ```
 
 For each qualifying commit Josh pushes a ref under
@@ -154,10 +154,10 @@ After receiving review feedback, amend or rebase your commits as needed, keeping
 
 ```shell
 git rebase -i HEAD~3   # edit commits, preserve Change: footers
-josh publish           # re-publish; existing PRs are updated, not recreated
+josh changes publish  # re-publish; existing PRs are updated, not recreated
 ```
 
-As long as the change ID in the footer is preserved through your edits, `josh publish`
+As long as the change ID in the footer is preserved through your edits, `josh changes publish`
 updates the correct existing PRs rather than creating new ones.
 
 ### 4. Merge
@@ -171,11 +171,11 @@ josh pull --rebase --autostash
 
 This rebases your remaining local commits on top of the updated upstream state.
 `--autostash` ensures any uncommitted changes are preserved across the operation. After
-pulling, the next `josh publish` will retarget and promote the next PR in the stack
+pulling, the next `josh changes publish` will retarget and promote the next PR in the stack
 from draft to ready for review.
 
 ## Without forge integration
 
-`josh publish` works without [forge integration](../reference/forge.md). Josh still
+`josh changes publish` works without [forge integration](../reference/forge.md). Josh still
 pushes the individual `@changes/…` refs to the upstream repository; you can then create
 pull requests from them manually, or use them as part of a custom review workflow.

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -109,14 +109,14 @@ josh push [<remote>] [<refspecs>...] [options]
 
 ---
 
-## josh publish
+## josh changes publish
 
 Push each commit as an independent, minimal diff (stacked changes workflow). Each commit
 with a [Change ID](../guide/stacked-changes.md) is pushed to its own ref and, when
 [forge integration](./forge.md) is configured, gets its own pull request.
 
 ```
-josh publish [<remote>] [<refspecs>...] [options]
+josh changes publish [<remote>] [<refspecs>...] [options]
 ```
 
 | Argument | Description |

--- a/docs/src/reference/forge.md
+++ b/docs/src/reference/forge.md
@@ -6,7 +6,7 @@ cloning, pushing, and pulling all work without it, even with private repositorie
 
 Forge integration is specifically used for **automatic pull request management** during
 [stacked changes](../guide/stacked-changes.md) workflows. When you push a stack of
-commits with `josh publish`, `josh` can automatically
+commits with `josh changes publish`, `josh` can automatically
 create or update one pull request per commit on the forge.
 
 ## GitHub
@@ -46,7 +46,7 @@ export GH_TOKEN=ghp_...
 
 ### What forge integration enables
 
-Once authenticated, `josh publish` will, in addition to pushing the git refs:
+Once authenticated, `josh changes publish` will, in addition to pushing the git refs:
 
 - **Create** a pull request for each commit that does not yet have one.
 - **Update** existing pull requests (title, body, base branch) when commits are amended

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -46,8 +46,8 @@ pub enum RepoCommand {
     /// Push refs to a remote (like `git push`) with projection-aware options
     Push(PushArgs),
 
-    /// Push each commit as an independent, minimal diff (stacked changes workflow)
-    Publish(PublishArgs),
+    /// Manage stacked changes (publish, etc.)
+    Changes(ChangesArgs),
 
     /// Add a remote with optional projection/filtering (like `git remote add`)
     Remote(RemoteArgs),
@@ -122,6 +122,18 @@ pub struct FetchArgs {
     /// Ref to fetch (branch, tag, or commit-ish)
     #[arg(short = 'R', long = "ref", default_value = "HEAD")]
     pub rref: String,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct ChangesArgs {
+    #[command(subcommand)]
+    pub command: ChangesCommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum ChangesCommand {
+    /// Push each commit as an independent, minimal diff (stacked changes workflow)
+    Publish(PublishArgs),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -239,7 +251,19 @@ fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
         RepoCommand::Fetch(args) => handle_fetch(args, &transaction),
         RepoCommand::Pull(args) => handle_pull(args, &transaction),
         RepoCommand::Push(args) => josh_cli::commands::push::handle_push(args, &transaction),
-        RepoCommand::Publish(args) => josh_cli::commands::push::handle_publish(args, &transaction),
+        RepoCommand::Changes(args) => match &args.command {
+            ChangesCommand::Publish(publish_args) => {
+                josh_cli::commands::push::handle_publish(publish_args, &transaction)?;
+                let remote = publish_args.remote.as_deref().unwrap_or("origin");
+                handle_fetch(
+                    &FetchArgs {
+                        remote: remote.to_string(),
+                        rref: "HEAD".to_string(),
+                    },
+                    &transaction,
+                )
+            }
+        },
         RepoCommand::Remote(args) => handle_remote(args, &transaction),
         RepoCommand::Filter(args) => handle_filter(args, &transaction),
         RepoCommand::Link(args) => josh_cli::commands::link::handle_link(args, &transaction),

--- a/tests/cli/push_stacked.t
+++ b/tests/cli/push_stacked.t
@@ -72,7 +72,7 @@ Push with stacked changes (should create multiple refs)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/namespaces/josh-origin/refs/heads/master (esc)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/remotes/origin/HEAD (esc)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/remotes/origin/master (esc)
-  $ josh publish
+  $ josh changes publish
   Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/1234
   Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/foo7
   Pushing c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
@@ -86,15 +86,45 @@ Push with stacked changes (should create multiple refs)
    * [new branch]      2cbfa8cb8d9a9f1de029fcba547a6e56c742733f -> @heads/master/josh@example.com
   
   Pushed 5 ref(s) to origin
+  From file://${TESTTMP}/remote
+   * [new branch]      @base/master/josh@example.com/1234 -> refs/josh/remotes/origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/foo7 -> refs/josh/remotes/origin/@base/master/josh@example.com/foo7
+   * [new branch]      @changes/master/josh@example.com/1234 -> refs/josh/remotes/origin/@changes/master/josh@example.com/1234
+   * [new branch]      @changes/master/josh@example.com/foo7 -> refs/josh/remotes/origin/@changes/master/josh@example.com/foo7
+   * [new branch]      @heads/master/josh@example.com -> refs/josh/remotes/origin/@heads/master/josh@example.com
+  
+  From file://${TESTTMP}/filtered
+   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
+   * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
+   * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
+   * [new branch]      @heads/master/josh@example.com -> origin/@heads/master/josh@example.com
+  
+  Fetched from remote: origin
 
   $ git ls-remote .
   da80e49d24d110866ce2ec7a5c21112696fd165b\tHEAD (esc)
   da80e49d24d110866ce2ec7a5c21112696fd165b\trefs/heads/master (esc)
   431531b7907fc16b4c9e7e335438937b9d2d9c59\trefs/josh/cache/27/0/bf567e0faf634a663d6cef48145a035e1974ab1d (esc)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master (esc)
+  6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d\trefs/josh/remotes/origin/@base/master/josh@example.com/1234 (esc)
+  6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d\trefs/josh/remotes/origin/@base/master/josh@example.com/foo7 (esc)
+  c61c37f4a3d5eb447f41dde15620eee1a181d60b\trefs/josh/remotes/origin/@changes/master/josh@example.com/1234 (esc)
+  c1b55ea7e5f27f82d3565c1f5d64113adf635c2c\trefs/josh/remotes/origin/@changes/master/josh@example.com/foo7 (esc)
+  2cbfa8cb8d9a9f1de029fcba547a6e56c742733f\trefs/josh/remotes/origin/@heads/master/josh@example.com (esc)
   6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d\trefs/josh/remotes/origin/master (esc)
   da80e49d24d110866ce2ec7a5c21112696fd165b\trefs/namespaces/josh-origin/HEAD (esc)
+  5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/namespaces/josh-origin/refs/heads/@base/master/josh@example.com/1234 (esc)
+  5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/namespaces/josh-origin/refs/heads/@base/master/josh@example.com/foo7 (esc)
+  43d6fcc9e7a81452d7343c78c0102f76027717fb\trefs/namespaces/josh-origin/refs/heads/@changes/master/josh@example.com/1234 (esc)
+  ecb19ea4b4fbfb6afff253ec719909e80a480a18\trefs/namespaces/josh-origin/refs/heads/@changes/master/josh@example.com/foo7 (esc)
+  da80e49d24d110866ce2ec7a5c21112696fd165b\trefs/namespaces/josh-origin/refs/heads/@heads/master/josh@example.com (esc)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/namespaces/josh-origin/refs/heads/master (esc)
+  5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/remotes/origin/@base/master/josh@example.com/1234 (esc)
+  5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/remotes/origin/@base/master/josh@example.com/foo7 (esc)
+  43d6fcc9e7a81452d7343c78c0102f76027717fb\trefs/remotes/origin/@changes/master/josh@example.com/1234 (esc)
+  ecb19ea4b4fbfb6afff253ec719909e80a480a18\trefs/remotes/origin/@changes/master/josh@example.com/foo7 (esc)
+  da80e49d24d110866ce2ec7a5c21112696fd165b\trefs/remotes/origin/@heads/master/josh@example.com (esc)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/remotes/origin/HEAD (esc)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/remotes/origin/master (esc)
 

--- a/tests/cli/push_stacked_binary.t
+++ b/tests/cli/push_stacked_binary.t
@@ -52,7 +52,7 @@ Set up git config for author
 
 Push with stacked changes containing binary files
 
-  $ josh publish
+  $ josh changes publish
   Pushing 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/bin1
   Pushing 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/bin2
   Pushing 61d809929bf6b7a29d194f43368936fc82b033db to origin/refs/heads/@changes/master/josh@example.com/bin1
@@ -66,6 +66,21 @@ Push with stacked changes containing binary files
    * [new branch]      bcf10470382d693f9188a7a75872bcf3cd117dbc -> @heads/master/josh@example.com
   
   Pushed 5 ref(s) to origin
+  From file://${TESTTMP}/remote
+   * [new branch]      @base/master/josh@example.com/bin1 -> refs/josh/remotes/origin/@base/master/josh@example.com/bin1
+   * [new branch]      @base/master/josh@example.com/bin2 -> refs/josh/remotes/origin/@base/master/josh@example.com/bin2
+   * [new branch]      @changes/master/josh@example.com/bin1 -> refs/josh/remotes/origin/@changes/master/josh@example.com/bin1
+   * [new branch]      @changes/master/josh@example.com/bin2 -> refs/josh/remotes/origin/@changes/master/josh@example.com/bin2
+   * [new branch]      @heads/master/josh@example.com -> refs/josh/remotes/origin/@heads/master/josh@example.com
+  
+  From file://${TESTTMP}/filtered
+   * [new branch]      @base/master/josh@example.com/bin1 -> origin/@base/master/josh@example.com/bin1
+   * [new branch]      @base/master/josh@example.com/bin2 -> origin/@base/master/josh@example.com/bin2
+   * [new branch]      @changes/master/josh@example.com/bin1 -> origin/@changes/master/josh@example.com/bin1
+   * [new branch]      @changes/master/josh@example.com/bin2 -> origin/@changes/master/josh@example.com/bin2
+   * [new branch]      @heads/master/josh@example.com -> origin/@heads/master/josh@example.com
+  
+  Fetched from remote: origin
 
 
 Verify binary content is preserved on the change branches

--- a/tests/cli/push_stacked_requires.t
+++ b/tests/cli/push_stacked_requires.t
@@ -70,7 +70,7 @@ Change-Series, and beta has no series at all.
 
 Publish with split mode
 
-  $ josh publish > /dev/null 2>&1
+  $ josh changes publish > /dev/null 2>&1
 
 Verify gamma's downstack includes alpha (due to shared Change-Series: dep1)
 but not beta (different series / no series, no file overlap).

--- a/tests/cli/push_stacked_split.t
+++ b/tests/cli/push_stacked_split.t
@@ -68,9 +68,9 @@ Set up git config for author
   $ git config user.email "josh@example.com"
   $ git config user.name "Josh Test"
 
-Publish changes (josh publish should create multiple refs for each change)
+Publish changes (josh changes publish should create multiple refs for each change)
 
-  $ josh publish
+  $ josh changes publish
   Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/1234
   Pushing c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@base/master/josh@example.com/1235
   Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/foo7
@@ -88,6 +88,25 @@ Publish changes (josh publish should create multiple refs for each change)
    * [new branch]      929b441481dc5e1a946004a5615592d837ad564b -> @heads/master/josh@example.com
   
   Pushed 7 ref(s) to origin
+  From file://${TESTTMP}/remote
+   * [new branch]      @base/master/josh@example.com/1234 -> refs/josh/remotes/origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/1235 -> refs/josh/remotes/origin/@base/master/josh@example.com/1235
+   * [new branch]      @base/master/josh@example.com/foo7 -> refs/josh/remotes/origin/@base/master/josh@example.com/foo7
+   * [new branch]      @changes/master/josh@example.com/1234 -> refs/josh/remotes/origin/@changes/master/josh@example.com/1234
+   * [new branch]      @changes/master/josh@example.com/1235 -> refs/josh/remotes/origin/@changes/master/josh@example.com/1235
+   * [new branch]      @changes/master/josh@example.com/foo7 -> refs/josh/remotes/origin/@changes/master/josh@example.com/foo7
+   * [new branch]      @heads/master/josh@example.com -> refs/josh/remotes/origin/@heads/master/josh@example.com
+  
+  From file://${TESTTMP}/filtered
+   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
+   * [new branch]      @base/master/josh@example.com/1235 -> origin/@base/master/josh@example.com/1235
+   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
+   * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
+   * [new branch]      @changes/master/josh@example.com/1235 -> origin/@changes/master/josh@example.com/1235
+   * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
+   * [new branch]      @heads/master/josh@example.com -> origin/@heads/master/josh@example.com
+  
+  Fetched from remote: origin
 
 Verify the refs were created in the remote
 
@@ -117,24 +136,6 @@ Test that we can fetch the split refs back
 
   $ cd ${TESTTMP}/filtered
   $ josh fetch
-  From file://${TESTTMP}/remote
-   * [new branch]      @base/master/josh@example.com/1234 -> refs/josh/remotes/origin/@base/master/josh@example.com/1234
-   * [new branch]      @base/master/josh@example.com/1235 -> refs/josh/remotes/origin/@base/master/josh@example.com/1235
-   * [new branch]      @base/master/josh@example.com/foo7 -> refs/josh/remotes/origin/@base/master/josh@example.com/foo7
-   * [new branch]      @changes/master/josh@example.com/1234 -> refs/josh/remotes/origin/@changes/master/josh@example.com/1234
-   * [new branch]      @changes/master/josh@example.com/1235 -> refs/josh/remotes/origin/@changes/master/josh@example.com/1235
-   * [new branch]      @changes/master/josh@example.com/foo7 -> refs/josh/remotes/origin/@changes/master/josh@example.com/foo7
-   * [new branch]      @heads/master/josh@example.com -> refs/josh/remotes/origin/@heads/master/josh@example.com
-  
-  From file://${TESTTMP}/filtered
-   * [new branch]      @base/master/josh@example.com/1234 -> origin/@base/master/josh@example.com/1234
-   * [new branch]      @base/master/josh@example.com/1235 -> origin/@base/master/josh@example.com/1235
-   * [new branch]      @base/master/josh@example.com/foo7 -> origin/@base/master/josh@example.com/foo7
-   * [new branch]      @changes/master/josh@example.com/1234 -> origin/@changes/master/josh@example.com/1234
-   * [new branch]      @changes/master/josh@example.com/1235 -> origin/@changes/master/josh@example.com/1235
-   * [new branch]      @changes/master/josh@example.com/foo7 -> origin/@changes/master/josh@example.com/foo7
-   * [new branch]      @heads/master/josh@example.com -> origin/@heads/master/josh@example.com
-  
   Fetched from remote: origin
 
   $ git log --all --decorate --graph --pretty="%s %d %H"


### PR DESCRIPTION
Rename "josh publish" to "josh changes publish"

The publish subcommand is now nested under a "changes" subcommand group,
matching the pattern of "josh remote add". This leaves room for future
changes-related subcommands alongside publish.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Change: rename-josh-publish