### PR TITLE
Restore sccache R2 remote cache via sidecar proxy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,4 +55,7 @@ jobs:
       if: steps.cache-josh.outputs.cache-hit != 'true'
       run: cargo build --release -p josh-cli
     - name: Run tests
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       run: target/release/josh compose run

--- a/compose.josh
+++ b/compose.josh
@@ -1,1 +1,21 @@
+:#sidecar_image[:+images/sccache-proxy]
+
+sidecar_env = :[
+    :$SCCACHE_BUCKET="josh-project-cache"
+    :$SCCACHE_ENDPOINT="https://19f2dfdd7c93980184be5e5809e8b252.r2.cloudflarestorage.com"
+    :$SCCACHE_REGION="auto"
+]
+
+sidecar_passthrough = :[
+    :$AWS_ACCESS_KEY_ID="AWS_ACCESS_KEY_ID"
+    :$AWS_SECRET_ACCESS_KEY="AWS_SECRET_ACCESS_KEY"
+]
+
+sidecar_inject = :[
+    :$SCCACHE_BUCKET="josh-project-cache"
+    :$SCCACHE_ENDPOINT="http://{SIDECAR_IP}:3000"
+    :$SCCACHE_REGION="auto"
+    :$SCCACHE_S3_USE_SSL="false"
+]
+
 :+ws/test

--- a/images/sccache-proxy.josh
+++ b/images/sccache-proxy.josh
@@ -1,0 +1,1 @@
+context = :/images/sccache-proxy

--- a/images/sccache-proxy/Dockerfile
+++ b/images/sccache-proxy/Dockerfile
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1.23.0@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+FROM golang:alpine AS builder
+
+# Update check: https://github.com/awslabs/aws-sigv4-proxy/releases
+ARG AWS_SIGV4_PROXY_VERSION=1.11.1
+# `go install pkg@version` refuses modules with `replace` directives in go.mod,
+# so clone the tag and build from inside the module instead.
+RUN apk add --no-cache git \
+    && git clone --depth 1 --branch v${AWS_SIGV4_PROXY_VERSION} \
+        https://github.com/awslabs/aws-sigv4-proxy.git /src \
+    && cd /src \
+    && go build -o /go/bin/aws-sigv4-proxy ./cmd/aws-sigv4-proxy
+
+FROM alpine:3.22
+COPY --from=builder /go/bin/aws-sigv4-proxy /usr/local/bin/
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/sccache-proxy/entrypoint.sh
+++ b/images/sccache-proxy/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# Extract hostname from the full endpoint URL.
+# e.g. https://xxx.r2.cloudflarestorage.com -> xxx.r2.cloudflarestorage.com
+host=$(echo "$SCCACHE_ENDPOINT" | awk -F/ '{print $3}')
+
+exec aws-sigv4-proxy \
+    --name s3 \
+    --region "${SCCACHE_REGION:-auto}" \
+    --host "$host"

--- a/josh-compose/src/container.rs
+++ b/josh-compose/src/container.rs
@@ -4,14 +4,72 @@ use std::process::Command;
 
 use crate::image;
 use crate::job_cache;
-use crate::meta::{self, OutputMode};
+use crate::meta::{self, NetworkMode, OutputMode};
 use crate::podman::{self, PodmanRunArgs};
+
+const SIDECAR_NETWORK: &str = "josh-sccache-net";
+const SIDECAR_IP_PLACEHOLDER: &str = "{SIDECAR_IP}";
+
+/// Read env var names from `sidecar_passthrough` (keys only) and look each up in the
+/// outer process environment. Returns `None` if any listed variable is absent or empty.
+fn resolve_passthrough(passthrough: &[(String, String)]) -> Option<Vec<(String, String)>> {
+    passthrough
+        .iter()
+        .map(|(name, _)| {
+            let val = std::env::var(name).unwrap_or_default();
+            if val.is_empty() {
+                None
+            } else {
+                Some((name.clone(), val))
+            }
+        })
+        .collect()
+}
+
+/// Start the sccache proxy sidecar. Returns the container name.
+fn start_sccache_proxy(
+    repo: &git2::Repository,
+    proxy_image_oid: git2::Oid,
+    sidecar_env: &[(String, String)],
+    passthrough_env: Vec<(String, String)>,
+) -> anyhow::Result<String> {
+    let image_name = image::ensure_image(repo, proxy_image_oid)?;
+    podman::ensure_network_internal(SIDECAR_NETWORK)?;
+
+    let bytes: [u8; 4] = rand::random();
+    let container_name = format!("josh-sccache-proxy-{}", hex::encode(bytes));
+
+    let mut env_vars: Vec<(String, String)> = sidecar_env.to_vec();
+    env_vars.extend(passthrough_env);
+
+    podman::run_detached(podman::PodmanRunDetachedArgs {
+        image: image_name,
+        name: container_name.clone(),
+        networks: vec!["bridge".to_string(), SIDECAR_NETWORK.to_string()],
+        env_vars,
+    })?;
+
+    // Give the proxy a moment to start listening.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    Ok(container_name)
+}
+
+fn stop_sccache_proxy(container_name: &str) {
+    let _ = podman::stop_container(container_name);
+    let _ = podman::rm_container_force(container_name);
+}
+
 /// Run a container workspace identified by `ws_tree`.
 /// Uses the output cache if available.
 /// `attempted` tracks ws_trees already tried in this invocation to avoid redundant re-runs.
 pub fn run_container(
     repo: &git2::Repository,
     ws_tree: git2::Oid,
+    sidecar_image: Option<git2::Oid>,
+    sidecar_env: &[(String, String)],
+    sidecar_passthrough: &[(String, String)],
+    sidecar_inject: &[(String, String)],
     attempted: &mut HashSet<git2::Oid>,
 ) -> anyhow::Result<()> {
     let workspace_meta = meta::read_meta(repo, ws_tree)?;
@@ -50,7 +108,15 @@ pub fn run_container(
                 continue;
             }
         };
-        if let Err(e) = run_container(repo, dep_tree, attempted) {
+        if let Err(e) = run_container(
+            repo,
+            dep_tree,
+            sidecar_image,
+            sidecar_env,
+            sidecar_passthrough,
+            sidecar_inject,
+            attempted,
+        ) {
             dep_errors.push(format!("dependency {dep_name} failed: {e}"));
             continue;
         }
@@ -91,7 +157,64 @@ pub fn run_container(
     }
 
     // Read env vars from env/ subtree
-    let env_vars = meta::read_blob_entries(repo, ws_tree, "env");
+    let mut env_vars = meta::read_blob_entries(repo, ws_tree, "env");
+
+    // Resolve network mode: Sidecar starts a proxy and injects env vars.
+    // `proxy_container` holds the name of a running proxy that must be stopped after the build.
+    let mut proxy_container: Option<String> = None;
+    let network = match workspace_meta.network {
+        NetworkMode::Sidecar => match (sidecar_image, resolve_passthrough(sidecar_passthrough)) {
+            (Some(img_oid), Some(pass_env)) if !sidecar_env.is_empty() => {
+                match start_sccache_proxy(repo, img_oid, sidecar_env, pass_env) {
+                    Ok(proxy_name) => match podman::container_ip(&proxy_name, SIDECAR_NETWORK) {
+                        Ok(proxy_ip) => {
+                            let injected: Vec<(String, String)> = sidecar_inject
+                                .iter()
+                                .map(|(k, v)| {
+                                    (k.clone(), v.replace(SIDECAR_IP_PLACEHOLDER, &proxy_ip))
+                                })
+                                .collect();
+                            env_vars.extend(injected);
+                            proxy_container = Some(proxy_name);
+                            NetworkMode::Named(SIDECAR_NETWORK.to_string())
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "[{}] Sidecar: failed to get proxy IP: {e}; \
+                                         using local sccache only",
+                                workspace_meta.label
+                            );
+                            stop_sccache_proxy(&proxy_name);
+                            NetworkMode::None
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!(
+                            "[{}] Sidecar: failed to start proxy: {e}; \
+                                 using local sccache only",
+                            workspace_meta.label
+                        );
+                        NetworkMode::None
+                    }
+                }
+            }
+            _ => {
+                eprintln!(
+                    "[{}] Sidecar: missing image, credentials, or config; \
+                         using local sccache only",
+                    workspace_meta.label
+                );
+                NetworkMode::None
+            }
+        },
+        other => other,
+    };
+    // Ensure the proxy is stopped when this function returns, whether success or failure.
+    let _proxy_cleanup = defer::defer(move || {
+        if let Some(name) = proxy_container {
+            stop_sccache_proxy(&name);
+        }
+    });
 
     // Create ephemeral snapshot volume from worktree
     let snapshot_vol = {
@@ -148,7 +271,7 @@ pub fn run_container(
         volumes,
         env_vars,
         user: Some(user_str),
-        network: workspace_meta.network,
+        network,
         workdir: Some(workdir),
         rm: true,
     })?;

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -51,8 +51,24 @@ pub fn run(transaction: &josh_core::cache::Transaction, opts: RunOptions) -> any
     let (ws_tree, _safe_name) =
         filter::compute_ws_tree(transaction, &filter_spec, source_commit, &version)?;
 
+    let sidecar_image: Option<git2::Oid> = meta::read_blob(repo, ws_tree, "sidecar_image")
+        .filter(|s| !s.is_empty())
+        .and_then(|sha| git2::Oid::from_str(&sha).ok());
+
+    let sidecar_env = meta::read_blob_entries(repo, ws_tree, "sidecar_env");
+    let sidecar_passthrough = meta::read_blob_entries(repo, ws_tree, "sidecar_passthrough");
+    let sidecar_inject = meta::read_blob_entries(repo, ws_tree, "sidecar_inject");
+
     let mut attempted = std::collections::HashSet::new();
-    container::run_container(repo, ws_tree, &mut attempted)?;
+    container::run_container(
+        repo,
+        ws_tree,
+        sidecar_image,
+        &sidecar_env,
+        &sidecar_passthrough,
+        &sidecar_inject,
+        &mut attempted,
+    )?;
 
     Ok(())
 }

--- a/josh-compose/src/meta.rs
+++ b/josh-compose/src/meta.rs
@@ -6,6 +6,8 @@ pub use crate::OutputMode;
 pub enum NetworkMode {
     None,
     Host,
+    Named(String),
+    Sidecar,
 }
 
 pub struct WorkspaceMeta {
@@ -85,6 +87,7 @@ pub fn read_meta(repo: &git2::Repository, ws_tree: git2::Oid) -> anyhow::Result<
 
     let network = match read_blob(repo, ws_tree, "network").as_deref() {
         Some("host") => NetworkMode::Host,
+        Some("sidecar") => NetworkMode::Sidecar,
         _ => NetworkMode::None,
     };
 

--- a/josh-compose/src/podman.rs
+++ b/josh-compose/src/podman.rs
@@ -208,6 +208,12 @@ pub fn run(args: PodmanRunArgs) -> anyhow::Result<RunOutput> {
         NetworkMode::None => {
             cmd.args(["--network", "none"]);
         }
+        NetworkMode::Named(ref net) => {
+            cmd.args(["--network", net]);
+        }
+        NetworkMode::Sidecar => {
+            cmd.args(["--network", "none"]);
+        }
     }
 
     if let Some(workdir) = &args.workdir {
@@ -288,4 +294,101 @@ pub fn run(args: PodmanRunArgs) -> anyhow::Result<RunOutput> {
         stdout,
         stderr,
     })
+}
+
+pub fn network_exists(name: &str) -> anyhow::Result<bool> {
+    let status = Command::new("podman")
+        .args(["network", "inspect", "--format", "{{.Name}}", name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("failed to run podman network inspect")?;
+    Ok(status.success())
+}
+
+pub fn network_create_internal(name: &str) -> anyhow::Result<()> {
+    let output = Command::new("podman")
+        .args(["network", "create", "--internal", name])
+        .output()
+        .context("failed to run podman network create")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("podman network create {name} failed: {stderr}");
+    }
+    Ok(())
+}
+
+pub fn ensure_network_internal(name: &str) -> anyhow::Result<()> {
+    if !network_exists(name)? {
+        network_create_internal(name)?;
+    }
+    Ok(())
+}
+
+pub struct PodmanRunDetachedArgs {
+    pub image: String,
+    pub name: String,
+    pub networks: Vec<String>,
+    pub env_vars: Vec<(String, String)>,
+}
+
+pub fn run_detached(args: PodmanRunDetachedArgs) -> anyhow::Result<()> {
+    let mut cmd = Command::new("podman");
+    cmd.args(["run", "--rm", "-d", "--name", &args.name]);
+
+    for net in &args.networks {
+        cmd.args(["--network", net]);
+    }
+    for (key, val) in &args.env_vars {
+        cmd.args(["-e", &format!("{key}={val}")]);
+    }
+    cmd.arg(&args.image);
+
+    let output = cmd.output().context("failed to run podman run --detach")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("podman run --detach {} failed: {stderr}", args.name);
+    }
+    Ok(())
+}
+
+pub fn container_ip(container: &str, network: &str) -> anyhow::Result<String> {
+    let format = format!("{{{{.NetworkSettings.Networks.{network}.IPAddress}}}}");
+    let output = Command::new("podman")
+        .args(["inspect", "--format", &format, container])
+        .output()
+        .context("failed to run podman inspect")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("podman inspect {container} failed: {stderr}");
+    }
+    let ip = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if ip.is_empty() {
+        anyhow::bail!("container {container} has no IP on network {network}");
+    }
+    Ok(ip)
+}
+
+pub fn stop_container(name: &str) -> anyhow::Result<()> {
+    let output = Command::new("podman")
+        .args(["stop", name])
+        .output()
+        .context("failed to run podman stop")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::warn!("podman stop {name} failed: {stderr}");
+    }
+    Ok(())
+}
+
+pub fn rm_container_force(name: &str) -> anyhow::Result<()> {
+    let output = Command::new("podman")
+        .args(["rm", "-f", name])
+        .output()
+        .context("failed to run podman rm")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::warn!("podman rm -f {name} failed: {stderr}");
+    }
+    Ok(())
 }

--- a/ws/build-rust.josh
+++ b/ws/build-rust.josh
@@ -1,6 +1,7 @@
 :$label="rust build"
 :#image[:+images/dev-local]
 :$cache="rust"
+:$network="sidecar"
 
 inputs = :[
     :#fetch[:+ws/fetch]

--- a/ws/test.josh
+++ b/ws/test.josh
@@ -5,6 +5,7 @@ inputs = :[
         :$label="cargo test"
         :#image[:+images/dev-local]
         :$cache="rust"
+        :$network="sidecar"
         :$cmd="cargo test --workspace --offline --locked"
 
         inputs = :[


### PR DESCRIPTION
Restore sccache R2 remote cache via sidecar proxy

Build containers run with --network none, so sccache cannot reach Cloudflare R2
directly. This adds a sidecar proxy container (aws-sigv4-proxy) that sits on a
shared internal podman network, has external internet access, and signs S3
requests with R2 credentials on behalf of the build container.

The build container reaches only the proxy (internal network, no internet
routing) and never receives credentials. All env var names are declared in
compose.josh — nothing R2/sccache-specific is hardcoded in Rust. When
credentials are absent (e.g. on forks), the proxy is skipped and the existing
local filesystem sccache cache continues to work.

Assisted-By: Claude Sonnet 4.6
Change: sidecar-sccache
Change-Series: compose-ci