### PR TITLE
Don't distribute Chain over Compose when elements are non-invertible

### DIFF
--- a/josh-filter/src/opt.rs
+++ b/josh-filter/src/opt.rs
@@ -222,6 +222,20 @@ pub fn flatten(filter: Filter) -> Filter {
             // Check if any filter is a Compose and distribute
             for (i, filter) in flattened.iter().enumerate() {
                 if let Op::Compose(compose_filters) = to_op(*filter) {
+                    // Distribution duplicates the other chain elements into
+                    // each branch of a new Compose. Compose children must be
+                    // invertible (downstream `step()`/`common_post` calls
+                    // `invert()` on them), so only distribute when every other
+                    // chain element is invertible. Otherwise leave the Chain
+                    // intact — distribution is an optimization, not required
+                    // for correctness.
+                    let others_invertible = flattened
+                        .iter()
+                        .enumerate()
+                        .all(|(j, f)| j == i || invert(*f).is_ok());
+                    if !others_invertible {
+                        break;
+                    }
                     // Distribute: create a Compose where each element is the chain with one compose element
                     let mut result = vec![];
                     for compose_filter in compose_filters {

--- a/tests/filter/flatten_stored_compose.t
+++ b/tests/filter/flatten_stored_compose.t
@@ -1,0 +1,39 @@
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1
+  $ echo contents1 > sub1/file1
+  $ git add sub1
+  $ git commit -m "add file1" 1> /dev/null
+
+  $ mkdir sub2
+  $ echo contents2 > sub2/file2
+  $ git add sub2
+  $ git commit -m "add file2" 1> /dev/null
+
+  $ mkdir st
+  $ cat > st/a.josh <<EOF
+  > wrap = :/sub1
+  > EOF
+  $ git add .
+  $ git commit -m "add stored filter" 1> /dev/null
+
+Chaining a Compose with a Stored filter must not error. The flatten optimizer
+used to distribute the Chain over the Compose, producing a Compose whose
+elements (Chains containing the non-invertible :+st/a) could not be inverted
+by downstream optimization. The fix keeps the Chain intact when any duplicated
+element is non-invertible.
+
+  $ josh-filter -s ':[:/sub1,:/sub2]:+st/a'
+  .{40} (re)
+  [1] :+st/a
+  [2] :[
+      :/sub1
+      :/sub2
+  ]
+  [5] reachable_roots
+  [5] sequence_number
+


### PR DESCRIPTION
Don't distribute Chain over Compose when elements are non-invertible

The flatten optimizer's Chain-over-Compose distribution duplicated
non-invertible filters (e.g., :+st/a) into each Compose branch. Downstream
optimization then called invert() on those branches and failed. Skip
distribution when any duplicated chain element is non-invertible; the Chain
stays intact, trading a minor optimization for correctness.

Change: flatten-invert-check
Change-Series: fix-compose-stored
Assisted-By: deepseek-v4-pro[1m]