### PR TITLE
Extract compose sidecar definitions to shared CI file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,4 +58,4 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      run: target/release/josh compose run
+      run: target/release/josh compose run HEAD ":[::sidecars.josh=ci-sidecars.josh,:/]:+compose"

--- a/ci-sidecars.josh
+++ b/ci-sidecars.josh
@@ -1,0 +1,3 @@
+sidecars = :[
+    :#sccache-proxy[:+ws/sccache-proxy]
+]

--- a/ws/build-rust.josh
+++ b/ws/build-rust.josh
@@ -2,9 +2,7 @@
 :#image[:+images/dev-local]
 :$cache="rust"
 
-sidecars = :[
-    :#sccache-proxy[:+ws/sccache-proxy]
-]
+:+sidecars
 
 inputs = :[
     :#fetch[:+ws/fetch]

--- a/ws/test.josh
+++ b/ws/test.josh
@@ -7,9 +7,7 @@ inputs = :[
         :$cache="rust"
         :$cmd="cargo test --workspace --offline --locked"
 
-        sidecars = :[
-            :#sccache-proxy[:+ws/sccache-proxy]
-        ]
+        :+sidecars
 
         inputs = :[
             :#fetch[:+ws/fetch]


### PR DESCRIPTION
Extract compose sidecar definitions to shared CI file

Move sidecar definitions out of workspace files and into ci-sidecars.josh,
composed in from the CI workflow. This lets CI inject its own sidecar
configuration (e.g., the sccache proxy) without that config affecting
local development runs.

Change: extract-ci-sidecars
Change-Series: compose-ci
Change-Series: fix-compose-stored
Assisted-By: deepseek-v4-pro[1m]