### PR TITLE
Skip actions/cache for pull requests from forks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,7 @@ jobs:
       uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
     - name: Cache josh binary
       id: cache-josh
+      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: target/release/josh


### PR DESCRIPTION
Skip actions/cache for pull requests from forks

Fork PRs cannot safely populate the cache, and skipping the cache step
entirely avoids the security risk of cache poisoning. Same-repo PRs,
pushes, and merge_group events continue to use the cache normally.

Change: skip-fork-cache
Assisted-By: deepseek-v4-pro[1m]