### PR TITLE
Support git revision syntax in input ref resolution

### DIFF
--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -16,11 +16,10 @@ fn resolve_input_ref(
         oid.to_string()
     } else if git2::Oid::from_str(input_ref).is_ok() {
         input_ref.to_string()
-    } else {
-        let reference = repo
-            .resolve_reference_from_short_name(input_ref)
-            .with_context(|| format!("could not resolve input: {:?}", input_ref))?;
+    } else if let Ok(reference) = repo.resolve_reference_from_short_name(input_ref) {
         reference.name().unwrap().to_string()
+    } else {
+        oid.to_string()
     };
     Ok((ref_string, oid))
 }

--- a/josh-cli/src/commands/run.rs
+++ b/josh-cli/src/commands/run.rs
@@ -31,7 +31,7 @@ pub struct RunArgs {
     #[arg(long = "clean-all")]
     pub clean_all: bool,
 
-    /// Git ref to use as input: "." (working tree), "+" (index), "HEAD", or any ref
+    /// Git revision to use as input: "." (working tree), "+" (index), or any rev (e.g. "HEAD", "HEAD~1", "main")
     #[arg(default_value = ".")]
     pub reference: String,
 

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -34,10 +34,10 @@ pub fn resolve_snapshot_input(
     } else if let Ok(oid) = git2::Oid::from_str(input_ref) {
         Ok(repo.find_object(oid, None)?.peel_to_commit()?.id())
     } else {
-        let reference = repo
-            .resolve_reference_from_short_name(input_ref)
+        let obj = repo
+            .revparse_single(input_ref)
             .with_context(|| format!("could not resolve input: {:?}", input_ref))?;
-        Ok(reference.target().unwrap())
+        Ok(obj.peel_to_commit()?.id())
     }
 }
 


### PR DESCRIPTION
Support git revision syntax in input ref resolution

Replace resolve_reference_from_short_name with revparse_single in the shared
resolve_snapshot_input function so that git revision expressions like HEAD~1
are supported in both "josh compose run" and "josh-filter".

Change: revparse-input-ref
Assisted-By: DeepSeek V4 Pro <noreply@deepseek.com>