### PR TITLE
Replace back buttons with clickable breadcrumb navigation

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -39,7 +39,7 @@ fn app() -> Element {
                         fill: "#E62200",
                     }
                 }
-                span { class: "header-dir", {breadcrumb(&page.read(), &rows.read())} }
+                {breadcrumb(&page.read(), page, rows)}
             }
             match &*page.read() {
                 Page::List => list_view(rows, page),
@@ -81,19 +81,58 @@ fn subject_from_rows(rows: &anyhow::Result<Vec<Row>>, sha: &str) -> String {
         .unwrap_or_default()
 }
 
-fn breadcrumb(page: &Page, rows: &anyhow::Result<Vec<Row>>) -> String {
-    let mut parts = vec![repo_name()];
+fn breadcrumb(
+    page: &Page,
+    mut page_signal: Signal<Page>,
+    rows: Signal<anyhow::Result<Vec<Row>>>,
+) -> Element {
+    let repo = repo_name();
+    let subject = match page {
+        Page::List => String::new(),
+        Page::Detail { sha } | Page::FileDiff { sha, .. } => subject_from_rows(&rows.read(), sha),
+    };
+
     match page {
-        Page::List => {}
-        Page::Detail { sha } => {
-            parts.push(subject_from_rows(rows, sha));
-        }
+        Page::List => rsx! {
+            span { class: "header-dir",
+                span { class: "breadcrumb-seg-last", "{repo}" }
+            }
+        },
+        Page::Detail { .. } => rsx! {
+            span { class: "header-dir",
+                span {
+                    class: "breadcrumb-seg",
+                    onclick: move |_| page_signal.set(Page::List),
+                    "{repo}"
+                }
+                span { class: "breadcrumb-sep", " \u{203A} " }
+                span { class: "breadcrumb-seg-last", "{subject}" }
+            }
+        },
         Page::FileDiff { sha, path } => {
-            parts.push(subject_from_rows(rows, sha));
-            parts.push(path.clone());
+            let sha_c = sha.clone();
+            rsx! {
+                span { class: "header-dir",
+                    span {
+                        class: "breadcrumb-seg",
+                        onclick: move |_| page_signal.set(Page::List),
+                        "{repo}"
+                    }
+                    span { class: "breadcrumb-sep", " \u{203A} " }
+                    span {
+                        class: "breadcrumb-seg",
+                        onclick: {
+                            let s = sha_c.clone();
+                            move |_| page_signal.set(Page::Detail { sha: s.clone() })
+                        },
+                        "{subject}"
+                    }
+                    span { class: "breadcrumb-sep", " \u{203A} " }
+                    span { class: "breadcrumb-seg-last", "{path}" }
+                }
+            }
         }
     }
-    parts.join(" \u{203A} ")
 }
 
 fn list_view(rows: Signal<anyhow::Result<Vec<Row>>>, mut page: Signal<Page>) -> Element {
@@ -157,16 +196,8 @@ struct FileStat {
 fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
     let data = load_detail(&sha);
 
-    let back = rsx! {
-        button { class: "back",
-            onclick: move |_| page.set(Page::List),
-            "\u{2190} Back to list"
-        }
-    };
-
     match &data {
         Err(e) => rsx! {
-            {back}
             p { class: "error", "Error: {e}" }
         },
         Ok(data) => {
@@ -177,7 +208,6 @@ fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
                 data.files.iter().map(|f| f.dels).sum::<usize>(),
             );
             rsx! {
-                {back}
                 div { class: "scroll-table detail-layout",
                     div { class: "detail-left",
                         table { class: "detail-meta",
@@ -232,14 +262,6 @@ fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
 }
 
 fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element {
-    let detail_sha = sha.clone();
-    let back = rsx! {
-        button { class: "back",
-            onclick: move |_| page.set(Page::Detail { sha: detail_sha.clone() }),
-            "\u{2190} Back to change"
-        }
-    };
-
     let detail = load_detail(&sha);
     let (prev_file, next_file) = detail
         .as_ref()
@@ -295,7 +317,6 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
 
     match &all_lines {
         Err(e) => rsx! {
-            {back}
             p { class: "error", "Error: {e}" }
         },
         Ok(lines) => {
@@ -315,7 +336,6 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
 
             rsx! {
                 div { class: "diff-page",
-                    {back}
                     {nav}
                     div { class: "diff-toolbar",
                         label {
@@ -342,7 +362,6 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
                             " Show all"
                         }
                     }
-                    h2 { "{path}" }
                     div {
                         class: "diff-container",
                         tabindex: "0",

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -81,19 +81,20 @@ code.muted {
     color: #e06c75;
 }
 
-button.back {
-    background: #333;
-    color: #ccc;
-    border: 1px solid #444;
-    padding: 0.35rem 0.75rem;
-    border-radius: 4px;
+span.breadcrumb-seg {
     cursor: pointer;
-    margin-bottom: 1rem;
 }
 
-button.back:hover {
-    background: #444;
+span.breadcrumb-seg:hover {
     color: #fff;
+}
+
+span.breadcrumb-sep {
+    color: #555;
+}
+
+span.breadcrumb-seg-last {
+    cursor: default;
 }
 
 table.detail-meta {


### PR DESCRIPTION
Replace back buttons with clickable breadcrumb navigation

Each breadcrumb segment is clickable: repo name returns to list,
subject returns to detail, filename returns to file diff. Removed
the old "Back to list" and "Back to change" buttons.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-gui-breadcrumb-nav