### PR TITLE
Remove path from Location, use CommentMeta.file instead

### DIFF
--- a/forges/josh-github-changes/src/lib.rs
+++ b/forges/josh-github-changes/src/lib.rs
@@ -234,8 +234,7 @@ pub async fn sync_change_comments(
                 .path
                 .as_ref()
                 .zip(comment.line)
-                .map(|(path, line)| josh_changes::Location {
-                    path: path.clone(),
+                .map(|(_, line)| josh_changes::Location {
                     start_line: line as u32,
                     end_line: line as u32,
                     start_col: 1,

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -479,7 +479,6 @@ pub fn diff_id(repo: &git2::Repository, commit_oid: git2::Oid) -> anyhow::Result
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Location {
-    pub path: String,
     pub start_line: u32,
     pub end_line: u32,
     pub start_col: u32,

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -81,18 +81,15 @@ pub fn handle_list(
             println!();
             for c in &comments {
                 let cid = &c.id[..8.min(c.id.len())];
-                let loc = c
+                let file = c.file.as_deref().unwrap_or("");
+                let line = c
                     .location
                     .as_ref()
-                    .map(|l| format!(" {}:{}", l.path, l.start_line))
+                    .map(|l| format!(":{}", l.start_line))
                     .unwrap_or_default();
-                let file = c.file.as_deref().unwrap_or("");
                 print!("    {} {}", cid, c.message.lines().next().unwrap_or(""));
                 if !file.is_empty() {
-                    print!(" ({})", file);
-                }
-                if !loc.is_empty() {
-                    print!("{}", loc);
+                    print!(" ({}{})", file, line);
                 }
                 println!();
             }

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -53,19 +53,25 @@ pub fn handle_comment(
     let repo = transaction.repo();
     let head = repo.head()?.peel_to_commit()?.id();
 
-    let short_location = args.location.as_ref().and_then(|s| {
-        let (path, line) = s.rsplit_once(':')?;
-        let line: u32 = line.parse().ok()?;
-        Some(josh_changes::Location {
-            path: path.to_string(),
-            start_line: line,
-            end_line: line,
-            start_col: 1,
-            end_col: u32::MAX,
+    let (short_file, short_location) = args
+        .location
+        .as_ref()
+        .and_then(|s| {
+            let (path, line) = s.rsplit_once(':')?;
+            let line: u32 = line.parse().ok()?;
+            Some((
+                Some(path.to_string()),
+                Some(josh_changes::Location {
+                    start_line: line,
+                    end_line: line,
+                    start_col: 1,
+                    end_col: u32::MAX,
+                }),
+            ))
         })
-    });
+        .unwrap_or((None, None));
 
-    let location = if args.location_path.is_some()
+    let (file, location) = if args.location_path.is_some()
         || args.location_start_line.is_some()
         || args.location_end_line.is_some()
         || args.location_start_col.is_some()
@@ -86,21 +92,23 @@ pub fn handle_comment(
         let end_col = args.location_end_col.ok_or_else(|| {
             anyhow::anyhow!("--location-end-col is required when using long-form location flags")
         })?;
-        Some(josh_changes::Location {
-            path: path.to_string(),
-            start_line,
-            end_line,
-            start_col,
-            end_col,
-        })
+        (
+            Some(path.to_string()),
+            Some(josh_changes::Location {
+                start_line,
+                end_line,
+                start_col,
+                end_col,
+            }),
+        )
     } else {
-        short_location
+        (short_file, short_location)
     };
 
     let change = josh_changes::resolve_change(repo, head, &args.change)?;
     let meta = josh_changes::CommentMeta {
         message: args.message.clone(),
-        file: args.file.clone(),
+        file: file.or(args.file.clone()),
         location,
         reply_to: args.reply_to.clone(),
         update_of: args.update_of.clone(),

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -606,10 +606,11 @@ fn render_threads(
                             span { class: "comment-id", "{&c.id[..8]}" }
                         }
                         pre { class: "comment-body", "{c.message}" }
-                        if let Some(ref loc) = c.location {
-                            span { class: "comment-meta", "{loc.path}:{loc.start_line}" }
-                        } else if let Some(ref f) = c.file {
+                        if let Some(ref f) = c.file {
                             span { class: "comment-meta", "{f}" }
+                            if let Some(ref loc) = c.location {
+                                span { class: "comment-meta", ":{loc.start_line}" }
+                            }
                         }
                     }
                     {render_threads(all, &children, depth + 1)}


### PR DESCRIPTION
Remove path from Location, use CommentMeta.file instead

Location now carries only line/col ranges. The file path is stored
in CommentMeta.file. This avoids storing the file path twice.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: location-no-path