### PR TITLE
Set josh-gui window title to "Josh"

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -1,7 +1,13 @@
 use dioxus::prelude::*;
 
 fn main() {
-    dioxus::launch(app);
+    dioxus::LaunchBuilder::new()
+        .with_cfg(
+            dioxus::desktop::Config::new().with_window(
+                dioxus::desktop::WindowBuilder::new().with_title("Josh"),
+            ),
+        )
+        .launch(app);
 }
 
 #[derive(Clone, PartialEq)]


### PR DESCRIPTION
Set josh-gui window title to "Josh"

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-gui-window-title