### PR TITLE
Use correct diff_id from review commit for synced comments

### DIFF
--- a/forges/josh-github-codegen-graphql/src/get_pr_comments.graphql
+++ b/forges/josh-github-codegen-graphql/src/get_pr_comments.graphql
@@ -20,12 +20,14 @@ query GetPrComments($owner: String!, $name: String!, $number: Int!) {
           body
           author { __typename login }
           createdAt
+          commit { oid }
           comments(first: 100) {
             nodes {
               id
               body
               author { __typename login }
               createdAt
+              commit { oid }
               path
               line
               replyTo { __typename id }

--- a/forges/josh-github-graphql/src/operations/pull_request.rs
+++ b/forges/josh-github-graphql/src/operations/pull_request.rs
@@ -17,6 +17,7 @@ pub struct PrComment {
     pub path: Option<String>,
     pub line: Option<i64>,
     pub reply_to: Option<String>,
+    pub commit_oid: Option<String>,
 }
 
 #[derive(Debug)]
@@ -179,13 +180,14 @@ impl GithubApiConnection {
         let mut comments = Vec::new();
         for node in pr.comments.nodes.unwrap_or_default().into_iter().flatten() {
             comments.push(PrComment {
-                id: node.id,
+                id: node.id.clone(),
                 author: node.author.map(|a| a.login).unwrap_or_default(),
                 body: node.body,
                 timestamp: format!("{}", node.created_at),
                 path: None,
                 line: None,
                 reply_to: None,
+                commit_oid: None,
             });
         }
 
@@ -196,9 +198,10 @@ impl GithubApiConnection {
             .into_iter()
             .flatten()
         {
+            let review_commit = review.commit.as_ref().map(|c| c.oid.clone());
             if !review.body.is_empty() {
                 comments.push(PrComment {
-                    id: review.id,
+                    id: review.id.clone(),
                     author: review
                         .author
                         .as_ref()
@@ -209,6 +212,7 @@ impl GithubApiConnection {
                     path: None,
                     line: None,
                     reply_to: None,
+                    commit_oid: review_commit.clone(),
                 });
             }
             for node in review
@@ -218,14 +222,16 @@ impl GithubApiConnection {
                 .into_iter()
                 .flatten()
             {
+                let node_commit = node.commit.as_ref().map(|c| c.oid.clone());
                 comments.push(PrComment {
-                    id: node.id,
+                    id: node.id.clone(),
                     author: node.author.map(|a| a.login).unwrap_or_default(),
                     body: node.body,
                     timestamp: format!("{}", node.created_at),
                     path: Some(node.path),
                     line: node.line,
                     reply_to: node.reply_to.map(|r| r.id),
+                    commit_oid: node_commit.or(review_commit.clone()),
                 });
             }
         }

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -501,6 +501,17 @@ pub fn write_comment(
     author: Option<&str>,
     timestamp: Option<&str>,
 ) -> anyhow::Result<String> {
+    write_comment_with_diff(repo, change, meta, author, timestamp, None)
+}
+
+pub fn write_comment_with_diff(
+    repo: &git2::Repository,
+    change: &Change,
+    meta: &CommentMeta,
+    author: Option<&str>,
+    timestamp: Option<&str>,
+    diff_id_override: Option<&str>,
+) -> anyhow::Result<String> {
     if meta.message.trim().is_empty() {
         return Err(anyhow::anyhow!("comment message must not be empty"));
     }
@@ -508,7 +519,10 @@ pub fn write_comment(
     let change_id = change
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
-    let diff_id = diff_id(repo, change.commit())?;
+    let diff_id = match diff_id_override {
+        Some(d) => d.to_string(),
+        None => diff_id(repo, change.commit())?,
+    };
 
     let content = serde_json::to_string(meta)?;
     let content_hash =

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -119,12 +119,20 @@ pub fn handle_sync(
                     reply_to,
                     update_of: None,
                 };
-                let hash = josh_changes::write_comment(
+
+                let diff_id = comment
+                    .commit_oid
+                    .as_ref()
+                    .and_then(|oid| git2::Oid::from_str(oid).ok())
+                    .and_then(|oid| josh_changes::diff_id(repo, oid).ok());
+
+                let hash = josh_changes::write_comment_with_diff(
                     repo,
                     change,
                     &meta,
                     Some(&comment.author),
                     Some(&comment.timestamp),
+                    diff_id.as_deref(),
                 )?;
                 id_map.insert(comment.id.clone(), hash);
             }


### PR DESCRIPTION
Use correct diff_id from review commit for synced comments

Add commit.oid to GraphQL query for reviews and review comments.
When syncing, compute diff_id from the review's commit OID instead
of the current downstacked commit, so each comment is stored under
the diff it was actually made against. Expose write_comment_with_diff
for callers that need to override the diff_id.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: sync-correct-diff-id