### PR TITLE
Filter out changes without a Change-Id in get_changes

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -346,6 +346,9 @@ fn get_changes(
     for rev in walk {
         let commit = repo.find_commit(rev?)?;
         let mut change = get_change_id(&commit);
+        if change.id.is_none() {
+            continue;
+        }
         change.base = base;
         changes.insert(change.commit, change);
     }

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -262,8 +262,6 @@ Make sure all temporary namespace got removed
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
       |   |-- 72
       |   |   `-- 7902c81346e29c4f75e0913bd62d7b85d7033f
-      |   |-- 7a
-      |   |   `-- d74e7fd19fdee5fc3adf14739e8d207f87a575
       |   |-- 96
       |   |   `-- 539577d449c8e5446b5339c20436a13ec51f41
       |   |-- 9a
@@ -274,8 +272,6 @@ Make sure all temporary namespace got removed
       |   |   `-- a557394ce29f000108607abd97f19fed4d1b7c
       |   |-- b2
       |   |   `-- dd517c55420a48cb543e0195b4751bf514b941
-      |   |-- e0
-      |   |   `-- 293732533356a16d0d2dd4ed7a0088ce9742a6
       |   |-- ec
       |   |   `-- 41aad70b4b898baf48efeb795a7753d9674152
       |   |-- ed
@@ -289,7 +285,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  70 directories, 53 files
+  68 directories, 51 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -245,8 +245,6 @@ Make sure all temporary namespace got removed
       |   |   `-- 06a6f09b169109f5ebd17428219142c67e84b9
       |   |-- 1d
       |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
-      |   |-- 1f
-      |   |   `-- be805c76d465aee056156b8cab015701cb08a0
       |   |-- 24
       |   |   `-- 4c0b793d0e21897e97d9898256f14734726faa
       |   |-- 2b
@@ -261,8 +259,6 @@ Make sure all temporary namespace got removed
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
       |   |-- 88
       |   |   `-- 2b84c5d3241087bc41982a744b72b7a174c49e
-      |   |-- 98
-      |   |   `-- 94b72f2bd0c6b9d468ae4c059b6de2628d9c14
       |   |-- a2
       |   |   `-- 8c68e091a9e9d04c154061018f168f7096caa9
       |   |-- a3
@@ -278,8 +274,6 @@ Make sure all temporary namespace got removed
       |   |   `-- 33ab805ad4ef7ddda5b51e4a78ec0fac6b699a
       |   |-- c6
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
-      |   |-- d7
-      |   |   `-- eff8aebe26179face2d6fc0fc37682a6b83ee6
       |   |-- e3
       |   |   `-- a269743538338b0d059eda2f72976ec29220a8
       |   |-- info
@@ -289,7 +283,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  78 directories, 62 files
+  75 directories, 59 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE


### PR DESCRIPTION
Filter out changes without a Change-Id in get_changes

A commit without a Change-Id is not a change and should not be turned
into one in the first place, rather than being constructed and then
filtered out at the call site.

Assisted-By: Claude claude-opus-4-7 <noreply@anthropic.com>
Change: list-changes-filter-no-id