### PR TITLE
Add line selection to diff view with keyboard and mouse navigation

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -218,6 +218,7 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
     };
     let all_lines = load_file_diff(&sha, &path, ctx);
     let mut scroll_offset = use_signal(|| 0usize);
+    let mut selected_line = use_signal(|| None::<usize>);
 
     match &all_lines {
         Err(e) => rsx! {
@@ -271,8 +272,34 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
                     h2 { "{path}" }
                     div {
                         class: "diff-container",
+                        tabindex: "0",
                         onscroll: move |e| {
                             scroll_offset.set(e.data.scroll_top() as usize);
+                        },
+                        onkeydown: move |e| {
+                            let total = all_lines.as_ref().ok().map(|l| l.len()).unwrap_or(0);
+                            if total == 0 {
+                                return;
+                            }
+                            let cur = selected_line.read().unwrap_or(0);
+                            let new = match e.key() {
+                                Key::ArrowDown => Some((cur + 1).min(total - 1)),
+                                Key::ArrowUp => Some(if cur > 0 { cur - 1 } else { 0 }),
+                                _ => return,
+                            };
+                            if let Some(n) = new {
+                                selected_line.set(Some(n));
+                                let off = *scroll_offset.read();
+                                let vis_start = off / row_h;
+                                let vis_end = vis_start + visible;
+                                if n < vis_start + overscan {
+                                    scroll_offset.set(n.saturating_sub(overscan) * row_h);
+                                } else if n >= vis_end.saturating_sub(overscan) {
+                                    scroll_offset.set(
+                                        (n + overscan + 1).saturating_sub(visible) * row_h,
+                                    );
+                                }
+                            }
                         },
                         table { class: "diff-table",
                             colgroup {
@@ -289,13 +316,22 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
                                     }
                                 }
                                 for line in lines[start..end].iter() {
-                                    tr {
-                                        class: "diff-line diff-line-{line.kind:?}",
-                                        td { class: "diff-ln", "{line.line_number}" }
-                                        td { class: "diff-sign", {line.kind.sign()} }
-                                        td {
-                                            class: "diff-content",
-                                            pre { "{line.text}" }
+                                    {
+                                        let sel = *selected_line.read();
+                                        let is_sel = sel == Some(line.line_number);
+                                        let ln = line.line_number;
+                                        rsx! {
+                                            tr {
+                                                class: "diff-line diff-line-{line.kind:?}",
+                                                class: if is_sel { "diff-line-sel" },
+                                                onclick: move |_| selected_line.set(Some(ln)),
+                                                td { class: "diff-ln", "{line.line_number}" }
+                                                td { class: "diff-sign", {line.kind.sign()} }
+                                                td {
+                                                    class: "diff-content",
+                                                    pre { "{line.text}" }
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -307,3 +307,12 @@ tr.diff-line-Hunk td {
     background: #1a2530;
 }
 
+tr.diff-line-sel td {
+    outline: 1px solid #5a8ab5;
+    outline-offset: -1px;
+}
+
+.diff-container:focus {
+    outline: none;
+}
+


### PR DESCRIPTION
Add line selection to diff view with keyboard and mouse navigation

Arrow keys move the selected line up/down, auto-scrolling to keep it
visible. Clicking a row selects it. The selected row gets an outline
highlight.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-gui-diff-line-selection