### PR TITLE
Add "josh changes list" command

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1,11 +1,12 @@
 use anyhow::anyhow;
 
 #[derive(Debug, Clone)]
-struct Change {
+pub struct Change {
     pub author: String,
     pub id: Option<String>,
     pub series: Vec<String>,
     pub commit: git2::Oid,
+    pub base: git2::Oid,
 }
 
 impl Change {
@@ -15,7 +16,23 @@ impl Change {
             id: Default::default(),
             series: Default::default(),
             commit,
+            base: git2::Oid::zero(),
         }
+    }
+
+    pub fn contributing(&self, repo: &git2::Repository) -> anyhow::Result<Vec<git2::Oid>> {
+        let mut walk = repo.revwalk()?;
+        walk.simplify_first_parent()?;
+        walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+        walk.push(self.commit)?;
+        if self.base != git2::Oid::zero() {
+            walk.hide(self.base)?;
+        }
+        let mut oids: Vec<git2::Oid> = walk.collect::<Result<Vec<_>, _>>()?;
+        if oids.first() == Some(&self.commit) {
+            oids.remove(0);
+        }
+        Ok(oids)
     }
 }
 
@@ -124,16 +141,12 @@ pub fn baseref_and_options(
 fn split_changes(
     repo: &git2::Repository,
     changes: std::collections::HashMap<git2::Oid, Change>,
-    base: git2::Oid,
 ) -> anyhow::Result<Vec<Change>> {
-    if base == git2::Oid::zero() {
+    if changes.values().next().map(|c| c.base) == Some(git2::Oid::zero()) {
         return Ok(changes.into_values().collect());
     }
 
-    changes
-        .iter()
-        .map(|(_, c)| downstack(repo, base, c))
-        .collect()
+    changes.iter().map(|(_, c)| downstack(repo, c)).collect()
 }
 
 fn changed_paths(
@@ -158,13 +171,13 @@ fn changed_paths(
     Ok(paths)
 }
 
-fn downstack(repo: &git2::Repository, base: git2::Oid, change: &Change) -> anyhow::Result<Change> {
+fn downstack(repo: &git2::Repository, change: &Change) -> anyhow::Result<Change> {
     let change_oid = change.commit;
-    if !repo.graph_descendant_of(change_oid, base)? {
+    if !repo.graph_descendant_of(change_oid, change.base)? {
         return Err(anyhow!(
             "change {} is not a descendant of base {}",
             change_oid,
-            base
+            change.base
         ));
     }
 
@@ -173,7 +186,7 @@ fn downstack(repo: &git2::Repository, base: git2::Oid, change: &Change) -> anyho
     walk.simplify_first_parent()?;
     walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
     walk.push(change_oid)?;
-    walk.hide(base)?;
+    walk.hide(change.base)?;
 
     let oids: Vec<git2::Oid> = walk.collect::<Result<Vec<_>, _>>()?;
 
@@ -211,7 +224,7 @@ fn downstack(repo: &git2::Repository, base: git2::Oid, change: &Change) -> anyho
     }
 
     // Rebase needed intermediates forward onto current_base.
-    let mut current_base = repo.find_commit(base)?;
+    let mut current_base = repo.find_commit(change.base)?;
     for (intermediate, is_needed) in commits.iter().zip(needed.iter()) {
         if !is_needed {
             continue;
@@ -332,7 +345,8 @@ fn get_changes(
     let mut changes = std::collections::HashMap::new();
     for rev in walk {
         let commit = repo.find_commit(rev?)?;
-        let change = get_change_id(&commit);
+        let mut change = get_change_id(&commit);
+        change.base = base;
         changes.insert(change.commit, change);
     }
 
@@ -350,7 +364,7 @@ pub fn build_to_push(
     match push_mode {
         PushMode::Publish(author) => {
             let changes = get_changes(repo, oid_to_push, base_oid)?;
-            let changes = split_changes(repo, changes, base_oid)?;
+            let changes = split_changes(repo, changes)?;
 
             let mut push_refs = changes_to_refs(repo, baseref, author, changes)?;
 
@@ -377,6 +391,15 @@ pub fn build_to_push(
             change_id: "JOSH_PUSH".to_string(),
         }]),
     }
+}
+
+pub fn list_changes(
+    repo: &git2::Repository,
+    tip: git2::Oid,
+    base: git2::Oid,
+) -> anyhow::Result<Vec<Change>> {
+    let changes = get_changes(repo, tip, base)?;
+    split_changes(repo, changes)
 }
 
 #[cfg(test)]

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 
 use josh_cli::commands::auth::AuthArgs;
 use josh_cli::commands::cache::CacheArgs;
+use josh_cli::commands::changes::ListArgs;
 use josh_cli::commands::link::LinkArgs;
 use josh_cli::commands::push::{PublishArgs, PushArgs};
 use josh_cli::commands::run::ComposeArgs;
@@ -134,6 +135,8 @@ pub struct ChangesArgs {
 pub enum ChangesCommand {
     /// Push each commit as an independent, minimal diff (stacked changes workflow)
     Publish(PublishArgs),
+    /// List local changes that would be published (read-only)
+    List(ListArgs),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -262,6 +265,9 @@ fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
                     },
                     &transaction,
                 )
+            }
+            ChangesCommand::List(list_args) => {
+                josh_cli::commands::changes::handle_list(list_args, &transaction)
             }
         },
         RepoCommand::Remote(args) => handle_remote(args, &transaction),

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -1,0 +1,83 @@
+use anyhow::Context;
+
+/// Arguments for `josh changes list`.
+#[derive(Debug, clap::Parser)]
+pub struct ListArgs {
+    /// Override the base ref (default: origin/<current-branch>).
+    #[arg(short = 'b', long = "base")]
+    pub base: Option<String>,
+}
+
+/// Print downstacked changes between the current branch tip and its remote
+/// tracking branch.  All authors are included (no author filtering).
+pub fn handle_list(
+    args: &ListArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+
+    // Determine tip and branch name from HEAD.
+    let head = repo.head().context("Failed to get HEAD")?;
+    let branch = head
+        .shorthand()
+        .context("Detached HEAD -- cannot determine current branch")?;
+
+    let tip = head.peel_to_commit().context("HEAD has no target")?.id();
+
+    // Resolve base -- either an explicit --base argument or origin/<branch>.
+    let base = if let Some(base_ref) = &args.base {
+        repo.find_reference(base_ref)
+            .with_context(|| format!("base ref '{}' not found", base_ref))?
+            .peel_to_commit()
+            .context("base ref has no target")?
+            .id()
+    } else {
+        let remote_ref = format!("refs/remotes/origin/{}", branch);
+        repo.find_reference(&remote_ref)
+            .with_context(|| {
+                format!(
+                    "no remote tracking branch '{}' found -- \
+                     has this branch been pushed?\n\
+                     Use --base to specify a base ref",
+                    remote_ref,
+                )
+            })?
+            .peel_to_commit()
+            .context("remote tracking ref has no target")?
+            .id()
+    };
+
+    let changes = josh_changes::list_changes(repo, tip, base)?;
+
+    if changes.is_empty() {
+        println!("No local changes found.");
+        return Ok(());
+    }
+
+    for change in &changes {
+        let commit = repo.find_commit(change.commit)?;
+        let subject = commit.message().unwrap_or("").lines().next().unwrap_or("");
+
+        let id = change.id.as_deref().unwrap_or("<no-change-id>");
+        let series = if change.series.is_empty() {
+            String::new()
+        } else {
+            format!(" [{}]", change.series.join(", "))
+        };
+
+        println!("{} {}{} ({})", id, subject, series, change.author);
+
+        let contributing = change.contributing(repo)?;
+        for oid in &contributing {
+            if let Ok(c) = repo.find_commit(*oid) {
+                let c_subject = c.message().unwrap_or("").lines().next().unwrap_or("");
+                let c_short = &oid.to_string()[..8];
+                println!("  {}  {}", c_short, c_subject);
+            }
+        }
+
+        println!();
+    }
+
+    Ok(())
+}

--- a/josh-cli/src/commands/mod.rs
+++ b/josh-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod auth;
 pub mod cache;
+pub mod changes;
 pub mod link;
 pub mod push;
 pub mod run;


### PR DESCRIPTION
Add "josh changes list" command

Introduce a read-only subcommand that prints the downstacked changes between
HEAD and its remote tracking branch (or an explicit --base ref), showing the
change id, subject, series and contributing commits for each.

To support this, Change gains a base field so split_changes/downstack no longer
need it threaded as a separate argument, and a new contributing() helper walks
the first-parent commits between base and tip.

Change: josh-changes-list
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>