### PR TITLE
Fix double-scroll: use flex layout for full viewport containment

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -34,7 +34,8 @@ fn list_view(rows: Signal<anyhow::Result<Vec<Row>>>, mut page: Signal<Page>) -> 
             p { "No outgoing changes found." }
         },
         Ok(rows) => rsx! {
-            table { class: "changes",
+            div { class: "scroll-table",
+                table { class: "changes",
                 thead {
                     tr {
                         th { "Change-Id" }
@@ -69,6 +70,7 @@ fn list_view(rows: Signal<anyhow::Result<Vec<Row>>>, mut page: Signal<Page>) -> 
                         }
                     }
                 }
+            }
             }
         },
         Err(e) => rsx! {
@@ -108,41 +110,43 @@ fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
             );
             rsx! {
                 {back}
-                table { class: "detail-meta",
-                    tbody {
-                        tr { td { "Change-Id" } td { code { "{data.change_id}" } } }
-                        tr { td { "SHA" } td { code { "{data.sha}" } } }
-                        tr { td { "Subject" } td { "{data.subject}" } }
-                        tr { td { "Author" } td { "{data.author}" } }
-                        tr { td { "Date" } td { "{data.date}" } }
-                        tr { td { "Series" } td { "{data.series}" } }
-                    }
-                }
-                h2 { "Changed files" }
-                p { class: "diff-summary", "{stats_total}" }
-                table { class: "files",
-                    thead {
-                        tr {
-                            th { "File" }
-                            th { class: "num", "+" }
-                            th { class: "num", "-" }
+                div { class: "scroll-table",
+                    table { class: "detail-meta",
+                        tbody {
+                            tr { td { "Change-Id" } td { code { "{data.change_id}" } } }
+                            tr { td { "SHA" } td { code { "{data.sha}" } } }
+                            tr { td { "Subject" } td { "{data.subject}" } }
+                            tr { td { "Author" } td { "{data.author}" } }
+                            tr { td { "Date" } td { "{data.date}" } }
+                            tr { td { "Series" } td { "{data.series}" } }
                         }
                     }
-                    tbody {
-                        for f in data.files.iter() {
-                            {
-                                let s = data.sha.clone();
-                                let p = f.path.clone();
-                                rsx! {
-                                    tr {
-                                        class: "file-row",
-                                        onclick: move |_| page.set(Page::FileDiff {
-                                            sha: s.clone(),
-                                            path: p.clone(),
-                                        }),
-                                        td { "{f.path}" }
-                                        td { class: "num adds", "{f.adds}" }
-                                        td { class: "num dels", "{f.dels}" }
+                    h2 { "Changed files" }
+                    p { class: "diff-summary", "{stats_total}" }
+                    table { class: "files",
+                        thead {
+                            tr {
+                                th { "File" }
+                                th { class: "num", "+" }
+                                th { class: "num", "-" }
+                            }
+                        }
+                        tbody {
+                            for f in data.files.iter() {
+                                {
+                                    let s = data.sha.clone();
+                                    let p = f.path.clone();
+                                    rsx! {
+                                        tr {
+                                            class: "file-row",
+                                            onclick: move |_| page.set(Page::FileDiff {
+                                                sha: s.clone(),
+                                                path: p.clone(),
+                                            }),
+                                            td { "{f.path}" }
+                                            td { class: "num adds", "{f.adds}" }
+                                            td { class: "num dels", "{f.dels}" }
+                                        }
                                     }
                                 }
                             }
@@ -228,37 +232,47 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
             let ln_ch = format!("{}", total).len() + 1;
 
             rsx! {
-                {back}
-                {nav}
-                h2 { "{path}" }
-                div {
-                    class: "diff-container",
-                    onscroll: move |e| {
-                        scroll_offset.set(e.data.scroll_top() as usize);
-                    },
-                    table { class: "diff-table",
-                        colgroup {
-                            col { style: "width: {ln_ch}ch" }
-                            col { style: "width: 2ch" }
-                            col {}
-                        }
-                        tbody {
-                            if top_spacer_h > 0 {
-                                tr { style: "height: {top_spacer_h}px" }
+                div { class: "diff-page",
+                    {back}
+                    {nav}
+                    h2 { "{path}" }
+                    div {
+                        class: "diff-container",
+                        onscroll: move |e| {
+                            scroll_offset.set(e.data.scroll_top() as usize);
+                        },
+                        table { class: "diff-table",
+                            colgroup {
+                                col { style: "width: {ln_ch}ch" }
+                                col { style: "width: 2ch" }
+                                col {}
                             }
-                            for line in lines[start..end].iter() {
-                                tr {
-                                    class: "diff-line diff-line-{line.kind:?}",
-                                    td { class: "diff-ln", "{line.line_number}" }
-                                    td { class: "diff-sign", {line.kind.sign()} }
-                                    td {
-                                        class: "diff-content",
-                                        pre { "{line.text}" }
+                            tbody {
+                                if top_spacer_h > 0 {
+                                    tr { style: "height: {top_spacer_h}px",
+                                        td {}
+                                        td {}
+                                        td {}
                                     }
                                 }
-                            }
-                            if bottom_spacer_h > 0 {
-                                tr { style: "height: {bottom_spacer_h}px" }
+                                for line in lines[start..end].iter() {
+                                    tr {
+                                        class: "diff-line diff-line-{line.kind:?}",
+                                        td { class: "diff-ln", "{line.line_number}" }
+                                        td { class: "diff-sign", {line.kind.sign()} }
+                                        td {
+                                            class: "diff-content",
+                                            pre { "{line.text}" }
+                                        }
+                                    }
+                                }
+                                if bottom_spacer_h > 0 {
+                                    tr { style: "height: {bottom_spacer_h}px",
+                                        td {}
+                                        td {}
+                                        td {}
+                                    }
+                                }
                             }
                         }
                     }

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -3,15 +3,30 @@ body {
     margin: 0;
     background: #1e1e1e;
     color: #ddd;
+    height: 100vh;
+    overflow: hidden;
 }
 
 .app {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
     padding: 1.5rem 2rem;
+    box-sizing: border-box;
+    overflow: hidden;
 }
 
 h1 {
     margin-top: 0;
+    margin-bottom: 0.5rem;
     color: #f0f0f0;
+    flex-shrink: 0;
+}
+
+.scroll-table {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
 }
 
 table.changes {
@@ -180,8 +195,17 @@ tr.file-row:hover td {
     background: #2a2a2a;
 }
 
+.diff-page {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
 .diff-container {
-    height: calc(100vh - 10rem);
+    flex: 1;
+    min-height: 0;
     overflow-y: scroll;
     border: 1px solid #333;
     border-radius: 4px;
@@ -198,10 +222,11 @@ table.diff-table {
 }
 
 .diff-line td {
-    white-space: pre;
     padding: 0 0.4rem;
     border-bottom: 1px solid #1a1a1a;
     overflow: hidden;
+    height: 20px;
+    line-height: 20px;
 }
 
 td.diff-ln {
@@ -209,22 +234,26 @@ td.diff-ln {
     color: #555;
     user-select: none;
     padding-right: 0.5rem;
+    white-space: pre;
 }
 
 td.diff-sign {
     text-align: center;
     color: #666;
     user-select: none;
+    white-space: pre;
 }
 
 td.diff-content {
-    overflow-x: auto;
+    overflow: hidden;
 }
 
 td.diff-content pre {
     margin: 0;
     font-family: ui-monospace, monospace;
     font-size: inherit;
+    white-space: pre;
+    overflow-x: auto;
 }
 
 tr.diff-line-Add td {


### PR DESCRIPTION
Fix double-scroll: use flex layout for full viewport containment

Set html/body to height:100% with overflow:hidden, make .app a flex
column, and give each page view its own scroll container. Only the
intended area scrolls, never the outer page.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-gui-fix-double-scroll