### PR TITLE
Make Change fields private, add accessor methods

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -2,22 +2,46 @@ use anyhow::anyhow;
 
 #[derive(Debug, Clone)]
 pub struct Change {
-    pub author: String,
-    pub id: Option<String>,
-    pub series: Vec<String>,
-    pub commit: git2::Oid,
-    pub base: git2::Oid,
+    author: String,
+    id: Option<String>,
+    series: Vec<String>,
+    commit: git2::Oid,
+    base: git2::Oid,
 }
 
 impl Change {
-    fn new(commit: git2::Oid) -> Self {
-        Self {
-            author: Default::default(),
-            id: Default::default(),
-            series: Default::default(),
-            commit,
+    pub fn new(commit: &git2::Commit) -> Self {
+        let mut change = Self {
+            author: commit.author().email().unwrap_or("").to_string(),
+            id: None,
+            series: Vec::new(),
+            commit: commit.id(),
             base: git2::Oid::zero(),
-        }
+        };
+        let (id, series) = commit_change_meta(commit);
+        change.id = id;
+        change.series = series;
+        change
+    }
+
+    pub fn author(&self) -> &str {
+        &self.author
+    }
+
+    pub fn id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+
+    pub fn series(&self) -> &[String] {
+        &self.series
+    }
+
+    pub fn commit(&self) -> git2::Oid {
+        self.commit
+    }
+
+    pub fn base(&self) -> git2::Oid {
+        self.base
     }
 
     pub fn contributing(&self, repo: &git2::Repository) -> anyhow::Result<Vec<git2::Oid>> {
@@ -85,15 +109,6 @@ pub fn parse_change_meta(message: &str) -> (Option<String>, Vec<String>) {
         }
     }
     (id, series)
-}
-
-fn get_change_id(commit: &git2::Commit) -> Change {
-    let mut change = Change::new(commit.id());
-    change.author = commit.author().email().unwrap_or("").to_string();
-    let (id, series) = commit_change_meta(commit);
-    change.id = id;
-    change.series = series;
-    change
 }
 
 #[derive(PartialEq, Clone, Debug)]
@@ -205,14 +220,14 @@ fn downstack(repo: &git2::Repository, change: &Change) -> anyhow::Result<Change>
 
     // Seed the affected path set with the change's own modified paths, then
     // walk intermediates backwards, keeping any commit whose paths intersect.
-    let change_meta = get_change_id(&change_commit);
+    let change_meta = Change::new(&change_commit);
     let mut affected_paths = changed_paths(repo, &change_commit)?;
     for s in &change_meta.series {
         affected_paths.insert(format!("\x00series:{}", s));
     }
     let mut needed: Vec<bool> = vec![false; commits.len()];
     for (i, intermediate) in commits.iter().enumerate().rev() {
-        let meta = get_change_id(intermediate);
+        let meta = Change::new(intermediate);
         let mut paths = changed_paths(repo, intermediate)?;
         for s in &meta.series {
             paths.insert(format!("\x00series:{}", s));
@@ -345,7 +360,7 @@ fn get_changes(
     let mut changes = std::collections::HashMap::new();
     for rev in walk {
         let commit = repo.find_commit(rev?)?;
-        let mut change = get_change_id(&commit);
+        let mut change = Change::new(&commit);
         if change.id.is_none() {
             continue;
         }

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -55,17 +55,17 @@ pub fn handle_list(
     }
 
     for change in &changes {
-        let commit = repo.find_commit(change.commit)?;
+        let commit = repo.find_commit(change.commit())?;
         let subject = commit.message().unwrap_or("").lines().next().unwrap_or("");
 
-        let id = change.id.as_deref().unwrap_or("<no-change-id>");
-        let series = if change.series.is_empty() {
+        let id = change.id().unwrap_or("<no-change-id>");
+        let series = if change.series().is_empty() {
             String::new()
         } else {
-            format!(" [{}]", change.series.join(", "))
+            format!(" [{}]", change.series().join(", "))
         };
 
-        println!("{} {}{} ({})", id, subject, series, change.author);
+        println!("{} {}{} ({})", id, subject, series, change.author());
 
         let contributing = change.contributing(repo)?;
         for oid in &contributing {

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -535,7 +535,7 @@ fn load_rows() -> anyhow::Result<Vec<Row>> {
 
     let mut groups: Vec<(Row, Vec<Row>)> = Vec::new();
     for change in &changes {
-        let commit = repo.find_commit(change.commit)?;
+        let commit = repo.find_commit(change.commit())?;
         let subject = commit
             .message()
             .unwrap_or("")
@@ -545,11 +545,11 @@ fn load_rows() -> anyhow::Result<Vec<Row>> {
             .to_string();
 
         let change_row = Row::Change {
-            change_id: change.id.clone().unwrap_or_default(),
-            sha: change.commit.to_string(),
+            change_id: change.id().unwrap_or("").to_string(),
+            sha: change.commit().to_string(),
             subject,
-            author: change.author.clone(),
-            series: change.series.join(", "),
+            author: change.author().to_string(),
+            series: change.series().join(", "),
         };
 
         let mut contrib_rows = Vec::new();


### PR DESCRIPTION
Make Change fields private, add accessor methods

Change::new(&Commit) is now the sole constructor and is pub. All
fields are private with pub accessor methods (author, id, series,
commit, base), ensuring consistent creation through new().

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: change-private-fields