### PR TITLE
Add write_comment to josh-changes and josh changes comment CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,6 +2942,7 @@ dependencies = [
  "anyhow",
  "git2",
  "josh-core",
+ "serde_json",
 ]
 
 [[package]]

--- a/josh-changes/Cargo.toml
+++ b/josh-changes/Cargo.toml
@@ -11,5 +11,6 @@ keywords = ["git", "monorepo", "workflow", "scm"]
 [dependencies]
 anyhow.workspace = true
 git2.workspace = true
+serde_json.workspace = true
 
 josh-core.workspace = true

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -420,6 +420,60 @@ pub fn diff_id(repo: &git2::Repository, commit_oid: git2::Oid) -> anyhow::Result
     Ok(git2::Oid::hash_object(git2::ObjectType::Blob, &buf)?.to_string())
 }
 
+pub fn write_comment(
+    repo: &git2::Repository,
+    commit_oid: git2::Oid,
+    message: &str,
+) -> anyhow::Result<()> {
+    if message.trim().is_empty() {
+        return Err(anyhow::anyhow!("comment message must not be empty"));
+    }
+
+    let commit = repo.find_commit(commit_oid)?;
+    let (change_id, _) = parse_change_meta(commit.message().unwrap_or(""));
+    let change_id =
+        change_id.ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", commit_oid))?;
+    let diff_id = diff_id(repo, commit_oid)?;
+
+    let content = serde_json::json!({"message": message}).to_string();
+    let comment_hash =
+        git2::Oid::hash_object(git2::ObjectType::Blob, content.as_bytes())?.to_string();
+    let blob_oid = repo.blob(content.as_bytes())?;
+
+    let base_tree = repo
+        .find_reference("refs/josh/changes")
+        .ok()
+        .and_then(|r| r.peel_to_tree().ok())
+        .unwrap_or_else(|| repo.find_tree(josh_core::filter::tree::empty_id()).unwrap());
+    let path = std::path::Path::new("comments")
+        .join(&change_id)
+        .join(&diff_id)
+        .join(&comment_hash);
+    let tree = josh_core::filter::tree::insert(
+        repo,
+        &base_tree,
+        &path,
+        blob_oid,
+        git2::FileMode::Blob.into(),
+    )?;
+
+    let sig = repo.signature()?;
+    let parent_commit = repo
+        .find_reference("refs/josh/changes")
+        .ok()
+        .and_then(|r| r.peel_to_commit().ok());
+    let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
+    repo.commit(
+        Some("refs/josh/changes"),
+        &sig,
+        &sig,
+        &format!("comment on change {}\n", change_id),
+        &tree,
+        &parents,
+    )?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use josh_cli::commands::auth::AuthArgs;
 use josh_cli::commands::cache::CacheArgs;
 use josh_cli::commands::changes::ListArgs;
+use josh_cli::commands::comment::CommentArgs;
 use josh_cli::commands::link::LinkArgs;
 use josh_cli::commands::push::{PublishArgs, PushArgs};
 use josh_cli::commands::run::ComposeArgs;
@@ -137,6 +138,8 @@ pub enum ChangesCommand {
     Publish(PublishArgs),
     /// List local changes that would be published (read-only)
     List(ListArgs),
+    /// Add a comment to a change
+    Comment(CommentArgs),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -268,6 +271,9 @@ fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
             }
             ChangesCommand::List(list_args) => {
                 josh_cli::commands::changes::handle_list(list_args, &transaction)
+            }
+            ChangesCommand::Comment(comment_args) => {
+                josh_cli::commands::comment::handle_comment(comment_args, &transaction)
             }
         },
         RepoCommand::Remote(args) => handle_remote(args, &transaction),

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -1,0 +1,61 @@
+use anyhow::{Context, anyhow};
+
+/// Arguments for `josh changes comment`.
+#[derive(Debug, clap::Parser)]
+pub struct CommentArgs {
+    /// Change to comment on (Change-Id, ref, or SHA).
+    #[arg()]
+    pub change: String,
+
+    /// Comment message.
+    #[arg(short = 'm', long = "message")]
+    pub message: String,
+}
+
+pub fn handle_comment(
+    args: &CommentArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+
+    let oid = resolve_change(repo, &args.change)?;
+    josh_changes::write_comment(repo, oid, &args.message)?;
+
+    println!("Comment saved.");
+    Ok(())
+}
+
+fn resolve_change(repo: &git2::Repository, spec: &str) -> anyhow::Result<git2::Oid> {
+    // Try as a full OID first.
+    if let Ok(oid) = git2::Oid::from_str(spec) {
+        if repo.find_commit(oid).is_ok() {
+            return Ok(oid);
+        }
+    }
+
+    // Try as a revparse (branch, tag, short SHA).
+    if let Ok(obj) = repo.revparse_single(spec) {
+        if let Ok(commit) = obj.peel_to_commit() {
+            return Ok(commit.id());
+        }
+    }
+
+    // Walk HEAD to find a commit with matching Change-Id.
+    let head = repo.head().context("no HEAD; cannot search by Change-Id")?;
+    let tip = head.peel_to_commit()?.id();
+    let mut walk = repo.revwalk()?;
+    walk.simplify_first_parent()?;
+    walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+    walk.push(tip)?;
+    for oid in walk {
+        let oid = oid?;
+        if let Ok(c) = repo.find_commit(oid) {
+            let (id, _) = josh_changes::parse_change_meta(c.message().unwrap_or(""));
+            if id.as_deref() == Some(spec) {
+                return Ok(oid);
+            }
+        }
+    }
+
+    Err(anyhow!("could not resolve '{}' to a commit", spec))
+}

--- a/josh-cli/src/commands/mod.rs
+++ b/josh-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod cache;
 pub mod changes;
+pub mod comment;
 pub mod link;
 pub mod push;
 pub mod run;


### PR DESCRIPTION
Add write_comment to josh-changes and josh changes comment CLI

write_comment stores a JSON comment blob at
refs/josh/changes:comments/<change-id>/<diff-id>/<hash>
using josh_core::filter::tree::insert to merge into the existing tree.
The josh changes comment command resolves a change specifier and
writes the comment.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-changes-comment