### PR TITLE
Move resolve_change to josh-changes, take head and return Change

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -420,6 +420,43 @@ pub fn list_changes(
     split_changes(repo, changes)
 }
 
+pub fn resolve_change(
+    repo: &git2::Repository,
+    head: git2::Oid,
+    spec: &str,
+) -> anyhow::Result<Change> {
+    // Try as a full OID first.
+    if let Ok(oid) = git2::Oid::from_str(spec) {
+        if let Ok(commit) = repo.find_commit(oid) {
+            return Ok(Change::new(&commit));
+        }
+    }
+
+    // Try as a revparse (branch, tag, short SHA).
+    if let Ok(obj) = repo.revparse_single(spec) {
+        if let Ok(commit) = obj.peel_to_commit() {
+            return Ok(Change::new(&commit));
+        }
+    }
+
+    // Walk from head to find a commit with matching Change-Id.
+    let mut walk = repo.revwalk()?;
+    walk.simplify_first_parent()?;
+    walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+    walk.push(head)?;
+    for oid in walk {
+        let oid = oid?;
+        if let Ok(c) = repo.find_commit(oid) {
+            let (id, _) = parse_change_meta(c.message().unwrap_or(""));
+            if id.as_deref() == Some(spec) {
+                return Ok(Change::new(&c));
+            }
+        }
+    }
+
+    Err(anyhow!("could not resolve '{}' to a commit", spec))
+}
+
 pub fn diff_id(repo: &git2::Repository, commit_oid: git2::Oid) -> anyhow::Result<String> {
     let commit = repo.find_commit(commit_oid)?;
     let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
@@ -437,18 +474,17 @@ pub fn diff_id(repo: &git2::Repository, commit_oid: git2::Oid) -> anyhow::Result
 
 pub fn write_comment(
     repo: &git2::Repository,
-    commit_oid: git2::Oid,
+    change: &Change,
     message: &str,
 ) -> anyhow::Result<()> {
     if message.trim().is_empty() {
         return Err(anyhow::anyhow!("comment message must not be empty"));
     }
 
-    let commit = repo.find_commit(commit_oid)?;
-    let (change_id, _) = parse_change_meta(commit.message().unwrap_or(""));
-    let change_id =
-        change_id.ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", commit_oid))?;
-    let diff_id = diff_id(repo, commit_oid)?;
+    let change_id = change
+        .id()
+        .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
+    let diff_id = diff_id(repo, change.commit())?;
 
     let content = serde_json::json!({"message": message}).to_string();
     let comment_hash =

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -1,5 +1,3 @@
-use anyhow::{Context, anyhow};
-
 /// Arguments for `josh changes comment`.
 #[derive(Debug, clap::Parser)]
 pub struct CommentArgs {
@@ -17,45 +15,11 @@ pub fn handle_comment(
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
+    let head = repo.head()?.peel_to_commit()?.id();
 
-    let oid = resolve_change(repo, &args.change)?;
-    josh_changes::write_comment(repo, oid, &args.message)?;
+    let change = josh_changes::resolve_change(repo, head, &args.change)?;
+    josh_changes::write_comment(repo, &change, &args.message)?;
 
     println!("Comment saved.");
     Ok(())
-}
-
-fn resolve_change(repo: &git2::Repository, spec: &str) -> anyhow::Result<git2::Oid> {
-    // Try as a full OID first.
-    if let Ok(oid) = git2::Oid::from_str(spec) {
-        if repo.find_commit(oid).is_ok() {
-            return Ok(oid);
-        }
-    }
-
-    // Try as a revparse (branch, tag, short SHA).
-    if let Ok(obj) = repo.revparse_single(spec) {
-        if let Ok(commit) = obj.peel_to_commit() {
-            return Ok(commit.id());
-        }
-    }
-
-    // Walk HEAD to find a commit with matching Change-Id.
-    let head = repo.head().context("no HEAD; cannot search by Change-Id")?;
-    let tip = head.peel_to_commit()?.id();
-    let mut walk = repo.revwalk()?;
-    walk.simplify_first_parent()?;
-    walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
-    walk.push(tip)?;
-    for oid in walk {
-        let oid = oid?;
-        if let Ok(c) = repo.find_commit(oid) {
-            let (id, _) = josh_changes::parse_change_meta(c.message().unwrap_or(""));
-            if id.as_deref() == Some(spec) {
-                return Ok(oid);
-            }
-        }
-    }
-
-    Err(anyhow!("could not resolve '{}' to a commit", spec))
 }


### PR DESCRIPTION
Move resolve_change to josh-changes, take head and return Change

resolve_change now takes head_oid as a parameter and returns a
Change struct. write_comment takes &Change instead of Oid.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: resolve-change-in-josh-changes