### PR TITLE
Virtualize diff view with table-based rendering

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -204,29 +204,71 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
         }
     };
 
-    match load_file_diff(&sha, &path) {
+    let all_lines = load_file_diff(&sha, &path);
+    let mut scroll_offset = use_signal(|| 0usize);
+
+    match &all_lines {
         Err(e) => rsx! {
             {back}
             p { class: "error", "Error: {e}" }
         },
-        Ok(lines) => rsx! {
-            {back}
-            {nav}
-            h2 { "{path}" }
-            pre { class: "diff-view",
-                for line in lines.iter() {
-                    match line.kind {
-                        DiffLineKind::Add => rsx! { span { class: "diff-add", "{line.text}\n" } },
-                        DiffLineKind::Del => rsx! { span { class: "diff-del", "{line.text}\n" } },
-                        DiffLineKind::Hunk => rsx! { span { class: "diff-hunk", "{line.text}\n" } },
-                        DiffLineKind::Context => rsx! { span { "{line.text}\n" } },
+        Ok(lines) => {
+            let total = lines.len();
+            let row_h = 20;
+            let visible = 40;
+            let overscan = 40;
+
+            let offset = *scroll_offset.read();
+            let start = (offset / row_h).saturating_sub(overscan);
+            let end = ((offset / row_h) + visible + overscan).min(total);
+
+            let top_spacer_h = start * row_h;
+            let bottom_spacer_h = (total.saturating_sub(end)) * row_h;
+
+            let ln_ch = format!("{}", total).len() + 1;
+
+            rsx! {
+                {back}
+                {nav}
+                h2 { "{path}" }
+                div {
+                    class: "diff-container",
+                    onscroll: move |e| {
+                        scroll_offset.set(e.data.scroll_top() as usize);
+                    },
+                    table { class: "diff-table",
+                        colgroup {
+                            col { style: "width: {ln_ch}ch" }
+                            col { style: "width: 2ch" }
+                            col {}
+                        }
+                        tbody {
+                            if top_spacer_h > 0 {
+                                tr { style: "height: {top_spacer_h}px" }
+                            }
+                            for line in lines[start..end].iter() {
+                                tr {
+                                    class: "diff-line diff-line-{line.kind:?}",
+                                    td { class: "diff-ln", "{line.line_number}" }
+                                    td { class: "diff-sign", {line.kind.sign()} }
+                                    td {
+                                        class: "diff-content",
+                                        pre { "{line.text}" }
+                                    }
+                                }
+                            }
+                            if bottom_spacer_h > 0 {
+                                tr { style: "height: {bottom_spacer_h}px" }
+                            }
+                        }
                     }
                 }
             }
-        },
+        }
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum DiffLineKind {
     Context,
     Add,
@@ -234,9 +276,20 @@ enum DiffLineKind {
     Hunk,
 }
 
+impl DiffLineKind {
+    fn sign(&self) -> &str {
+        match self {
+            DiffLineKind::Add => "+",
+            DiffLineKind::Del => "-",
+            _ => "",
+        }
+    }
+}
+
 struct DiffLine {
     kind: DiffLineKind,
     text: String,
+    line_number: usize,
 }
 
 fn load_file_diff(sha: &str, path: &str) -> anyhow::Result<Vec<DiffLine>> {
@@ -267,13 +320,17 @@ fn load_file_diff(sha: &str, path: &str) -> anyhow::Result<Vec<DiffLine>> {
     if let Some(idx) = patch_idx {
         let patch = git2::Patch::from_diff(&diff, idx)?;
         if let Some(patch) = patch {
+            let mut n = 0;
             for h in 0..patch.num_hunks() {
                 let (hunk, hunk_lines) = patch.hunk(h)?;
+                n += 1;
                 lines.push(DiffLine {
                     kind: DiffLineKind::Hunk,
                     text: String::from_utf8_lossy(hunk.header()).to_string(),
+                    line_number: n,
                 });
                 for l in 0..hunk_lines {
+                    n += 1;
                     let line = patch.line_in_hunk(h, l)?;
                     let origin = line.origin();
                     let kind = match origin {
@@ -285,6 +342,7 @@ fn load_file_diff(sha: &str, path: &str) -> anyhow::Result<Vec<DiffLine>> {
                     lines.push(DiffLine {
                         kind,
                         text: String::from_utf8_lossy(line.content()).to_string(),
+                        line_number: n,
                     });
                 }
             }

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -180,33 +180,77 @@ tr.file-row:hover td {
     background: #2a2a2a;
 }
 
-pre.diff-view {
-    background: #1a1a1a;
+.diff-container {
+    height: calc(100vh - 10rem);
+    overflow-y: scroll;
     border: 1px solid #333;
     border-radius: 4px;
-    padding: 0.75rem 1rem;
-    overflow-x: auto;
+    background: #1a1a1a;
+}
+
+table.diff-table {
+    border-collapse: collapse;
+    width: 100%;
+    table-layout: fixed;
     font-family: ui-monospace, monospace;
-    font-size: 0.9rem;
+    font-size: 0.82rem;
     line-height: 1.4;
+}
+
+.diff-line td {
     white-space: pre;
+    padding: 0 0.4rem;
+    border-bottom: 1px solid #1a1a1a;
+    overflow: hidden;
 }
 
-pre.diff-view span {
-    display: block;
+td.diff-ln {
+    text-align: right;
+    color: #555;
+    user-select: none;
+    padding-right: 0.5rem;
 }
 
-span.diff-add {
+td.diff-sign {
+    text-align: center;
+    color: #666;
+    user-select: none;
+}
+
+td.diff-content {
+    overflow-x: auto;
+}
+
+td.diff-content pre {
+    margin: 0;
+    font-family: ui-monospace, monospace;
+    font-size: inherit;
+}
+
+tr.diff-line-Add td {
     background: #1a3a1a;
     color: #b8e6b8;
 }
 
-span.diff-del {
+tr.diff-line-Add td.diff-ln,
+tr.diff-line-Add td.diff-sign {
+    background: #1e4420;
+    color: #7ec699;
+}
+
+tr.diff-line-Del td {
     background: #3a1a1a;
     color: #e6b8b8;
 }
 
-span.diff-hunk {
+tr.diff-line-Del td.diff-ln,
+tr.diff-line-Del td.diff-sign {
+    background: #441e1e;
+    color: #e06c75;
+}
+
+tr.diff-line-Hunk td {
     color: #6ab0f3;
+    background: #1a2530;
 }
 


### PR DESCRIPTION
Virtualize diff view with table-based rendering

Replace the full-render <pre> block with a fixed-height scrollable
table that only renders visible lines plus overscan, using spacer
rows to maintain correct scrollbar dimensions. Handles large diffs
without overloading the DOM.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-gui-virtual-diff