### PR TITLE
Add change detail view with file diff stats

### DIFF
--- a/josh-gui/Cargo.toml
+++ b/josh-gui/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0"
+chrono = "^0"
 dioxus = { version = "0.7", features = ["desktop"] }
 josh-changes = { path = "../josh-changes" }
 git2 = { version = "0.20.4", default-features = false, features = ["vendored-libgit2"] }

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -4,64 +4,206 @@ fn main() {
     dioxus::launch(app);
 }
 
+#[derive(Clone, PartialEq)]
+enum Page {
+    List,
+    Detail { sha: String },
+}
+
 fn app() -> Element {
     let rows = use_signal(load_rows);
+    let page = use_signal(|| Page::List);
 
     rsx! {
         style { {include_str!("style.css")} }
         div { class: "app",
             h1 { "josh-gui" }
-            match &*rows.read() {
-                Ok(rows) if rows.is_empty() => rsx! {
-                    p { "No outgoing changes found." }
-                },
-                Ok(rows) => rsx! {
-                    table { class: "changes",
-                        thead {
-                            tr {
-                                th { "Change-Id" }
-                                th { "Subject" }
-                                th { "Author" }
-                                th { "Series" }
-                            }
-                        }
-                        tbody {
-                            for row in rows.iter() {
-                                match row {
-                                    Row::Change { change_id, subject, author, series } => rsx! {
-                                        tr {
-                                            td { code { "{change_id}" } }
-                                            td { "{subject}" }
-                                            td { "{author}" }
-                                            td { "{series}" }
-                                        }
-                                    },
-                                    Row::Contributing { change_id, sha, subject, author, series } => rsx! {
-                                        tr { class: "contributing",
-                                            td { code { class: "muted", "{change_id}" } }
-                                            td { code { "{sha}" } }
-                                            td { "{subject}" }
-                                            td { "{author}" }
-                                            td { "{series}" }
-                                        }
-                                    },
-                                }
-                            }
-                        }
-                    }
-                },
-                Err(e) => rsx! {
-                    p { class: "error", "Error: {e}" }
-                },
+            match &*page.read() {
+                Page::List => list_view(rows, page),
+                Page::Detail { sha } => detail_view(sha.clone(), page),
             }
         }
     }
+}
+
+fn list_view(rows: Signal<anyhow::Result<Vec<Row>>>, mut page: Signal<Page>) -> Element {
+    match &*rows.read() {
+        Ok(rows) if rows.is_empty() => rsx! {
+            p { "No outgoing changes found." }
+        },
+        Ok(rows) => rsx! {
+            table { class: "changes",
+                thead {
+                    tr {
+                        th { "Change-Id" }
+                        th { "Subject" }
+                        th { "Author" }
+                        th { "Series" }
+                    }
+                }
+                tbody {
+                    for row in rows.iter() {
+                        match row {
+                            Row::Change { change_id, sha, subject, author, series } => {
+                                let s = sha.clone();
+                                rsx! {
+                                    tr {
+                                        onclick: move |_| page.set(Page::Detail { sha: s.clone() }),
+                                        td { code { "{change_id}" } }
+                                        td { "{subject}" }
+                                        td { "{author}" }
+                                        td { "{series}" }
+                                    }
+                                }
+                            },
+                            Row::Contributing { change_id, sha: _, subject, author, series } => rsx! {
+                                tr { class: "contributing",
+                                    td { code { class: "muted", "{change_id}" } }
+                                    td { "{subject}" }
+                                    td { "{author}" }
+                                    td { "{series}" }
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        },
+        Err(e) => rsx! {
+            p { class: "error", "Error: {e}" }
+        },
+    }
+}
+
+#[derive(Clone)]
+struct FileStat {
+    path: String,
+    adds: usize,
+    dels: usize,
+}
+
+fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
+    let data = load_detail(&sha);
+
+    let back = rsx! {
+        button { class: "back",
+            onclick: move |_| page.set(Page::List),
+            "\u{2190} Back to list"
+        }
+    };
+
+    match &data {
+        Err(e) => rsx! {
+            {back}
+            p { class: "error", "Error: {e}" }
+        },
+        Ok(data) => {
+            let stats_total = format!(
+                "{} files changed, +{} / -{}",
+                data.files.len(),
+                data.files.iter().map(|f| f.adds).sum::<usize>(),
+                data.files.iter().map(|f| f.dels).sum::<usize>(),
+            );
+            rsx! {
+                {back}
+                table { class: "detail-meta",
+                    tbody {
+                        tr { td { "Change-Id" } td { code { "{data.change_id}" } } }
+                        tr { td { "SHA" } td { code { "{data.sha}" } } }
+                        tr { td { "Subject" } td { "{data.subject}" } }
+                        tr { td { "Author" } td { "{data.author}" } }
+                        tr { td { "Date" } td { "{data.date}" } }
+                        tr { td { "Series" } td { "{data.series}" } }
+                    }
+                }
+                h2 { "Changed files" }
+                p { class: "diff-summary", "{stats_total}" }
+                table { class: "files",
+                    thead {
+                        tr {
+                            th { "File" }
+                            th { class: "num", "+" }
+                            th { class: "num", "-" }
+                        }
+                    }
+                    tbody {
+                        for f in data.files.iter() {
+                            tr {
+                                td { "{f.path}" }
+                                td { class: "num adds", "{f.adds}" }
+                                td { class: "num dels", "{f.dels}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct DetailData {
+    change_id: String,
+    sha: String,
+    subject: String,
+    author: String,
+    date: String,
+    series: String,
+    files: Vec<FileStat>,
+}
+
+fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
+    let repo = git2::Repository::discover(".")?;
+    let oid = git2::Oid::from_str(sha)?;
+    let commit = repo.find_commit(oid)?;
+
+    let msg = commit.message().unwrap_or("");
+    let subject = msg.lines().next().unwrap_or("").to_string();
+    let author = commit.author().email().unwrap_or("").to_string();
+    let date = chrono::DateTime::from_timestamp(commit.time().seconds(), 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_default();
+    let (change_id, series) = josh_changes::parse_change_meta(msg);
+
+    let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
+    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
+
+    let mut files: Vec<FileStat> = Vec::new();
+    for i in 0..diff.deltas().len() {
+        let delta = diff.deltas().nth(i).unwrap();
+        let path = delta
+            .new_file()
+            .path()
+            .or_else(|| delta.old_file().path())
+            .and_then(|p| p.to_str())
+            .unwrap_or("");
+        let patch = git2::Patch::from_diff(&diff, i)?;
+        let (_, adds, dels) = patch
+            .as_ref()
+            .map(|p| p.line_stats().unwrap_or((0, 0, 0)))
+            .unwrap_or((0, 0, 0));
+        files.push(FileStat {
+            path: path.to_string(),
+            adds,
+            dels,
+        });
+    }
+
+    Ok(DetailData {
+        change_id: change_id.unwrap_or_default(),
+        sha: sha.to_string(),
+        subject,
+        author,
+        date,
+        series: series.join(", "),
+        files,
+    })
 }
 
 #[derive(Clone)]
 enum Row {
     Change {
         change_id: String,
+        sha: String,
         subject: String,
         author: String,
         series: String,
@@ -107,6 +249,7 @@ fn load_rows() -> anyhow::Result<Vec<Row>> {
 
         let change_row = Row::Change {
             change_id: change.id.clone().unwrap_or_default(),
+            sha: change.commit.to_string(),
             subject,
             author: change.author.clone(),
             series: change.series.join(", "),
@@ -121,7 +264,7 @@ fn load_rows() -> anyhow::Result<Vec<Row>> {
                 let (c_change_id, c_series) = josh_changes::parse_change_meta(msg);
                 contrib_rows.push(Row::Contributing {
                     change_id: c_change_id.unwrap_or_default(),
-                    sha: oid.to_string()[..8].to_string(),
+                    sha: oid.to_string(),
                     subject: c_subject,
                     author: c_author,
                     series: c_series.join(", "),

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -51,3 +51,85 @@ code.muted {
 .error {
     color: #e06c75;
 }
+
+button.back {
+    background: #333;
+    color: #ccc;
+    border: 1px solid #444;
+    padding: 0.35rem 0.75rem;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-bottom: 1rem;
+}
+
+button.back:hover {
+    background: #444;
+    color: #fff;
+}
+
+table.detail-meta {
+    border-collapse: collapse;
+    margin-bottom: 1.5rem;
+}
+
+table.detail-meta td {
+    padding: 0.25rem 0.75rem 0.25rem 0;
+    vertical-align: top;
+}
+
+table.detail-meta td:first-child {
+    color: #888;
+    white-space: nowrap;
+    padding-right: 1rem;
+}
+
+h2 {
+    color: #f0f0f0;
+    font-size: 1.1rem;
+    margin: 1rem 0 0.5rem;
+}
+
+.diff-summary {
+    color: #888;
+    margin: 0 0 0.5rem;
+}
+
+table.files {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+table.files th {
+    text-align: left;
+    padding: 0.3rem 0.5rem;
+    color: #888;
+    font-weight: 600;
+    font-size: 0.85rem;
+    border-bottom: 1px solid #444;
+}
+
+table.files td {
+    padding: 0.25rem 0.5rem;
+    border-bottom: 1px solid #2a2a2a;
+}
+
+td.num {
+    text-align: right;
+    width: 3rem;
+}
+
+td.adds {
+    color: #7ec699;
+}
+
+td.dels {
+    color: #e06c75;
+}
+
+tr.changes tbody tr {
+    cursor: pointer;
+}
+
+tr.changes tbody tr:hover td {
+    background: #2a2a2a;
+}


### PR DESCRIPTION
Add change detail view with file diff stats

Clicking a change row opens a detail page showing metadata, changed
files with per-file +/- line counts, and a back button to return to
the list view. Navigation uses a simple state-based Page signal.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-gui-detail-view