### PR TITLE
Make parse_change_meta public, use in josh-gui

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -60,7 +60,7 @@ pub fn commit_change_meta(commit: &git2::Commit) -> (Option<String>, Vec<String>
     (id, series)
 }
 
-fn parse_change_meta(message: &str) -> (Option<String>, Vec<String>) {
+pub fn parse_change_meta(message: &str) -> (Option<String>, Vec<String>) {
     let lines: Vec<&str> = message.lines().collect();
     let mut footer_start = lines.len();
     for (i, line) in lines.iter().enumerate().rev() {

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -36,9 +36,10 @@ fn app() -> Element {
                                             td { "{series}" }
                                         }
                                     },
-                                    Row::Contributing { oid, subject } => rsx! {
+                                    Row::Contributing { change_id, sha, subject } => rsx! {
                                         tr { class: "contributing",
-                                            td { code { "{oid}" } }
+                                            td { code { class: "muted", "{change_id}" } }
+                                            td { code { "{sha}" } }
                                             td { "{subject}" }
                                             td {}
                                             td {}
@@ -66,7 +67,8 @@ enum Row {
         series: String,
     },
     Contributing {
-        oid: String,
+        change_id: String,
+        sha: String,
         subject: String,
     },
 }
@@ -110,15 +112,12 @@ fn load_rows() -> anyhow::Result<Vec<Row>> {
 
         for oid in change.contributing(&repo)? {
             if let Ok(c) = repo.find_commit(oid) {
-                let c_subject = c
-                    .message()
-                    .unwrap_or("")
-                    .lines()
-                    .next()
-                    .unwrap_or("")
-                    .to_string();
+                let msg = c.message().unwrap_or("");
+                let c_subject = msg.lines().next().unwrap_or("").to_string();
+                let c_change_id = josh_changes::parse_change_meta(msg).0.unwrap_or_default();
                 rows.push(Row::Contributing {
-                    oid: oid.to_string()[..8].to_string(),
+                    change_id: c_change_id,
+                    sha: oid.to_string()[..8].to_string(),
                     subject: c_subject,
                 });
             }

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -44,6 +44,10 @@ code {
     font-family: ui-monospace, monospace;
 }
 
+code.muted {
+    color: #666;
+}
+
 .error {
     color: #e06c75;
 }


### PR DESCRIPTION
Make parse_change_meta public, use in josh-gui

Expose parse_change_meta as a public function in josh-changes. josh-gui
uses it to extract Change-Ids from contributing commits, displayed in
muted grey.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: parse-change-meta-public