### PR TITLE
Add josh changes sync command for GitHub PR comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2940,6 +2940,7 @@ name = "josh-changes"
 version = "26.6.11"
 dependencies = [
  "anyhow",
+ "chrono",
  "git2",
  "josh-core",
  "serde",

--- a/forges/josh-github-changes/src/lib.rs
+++ b/forges/josh-github-changes/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod admission;
-mod repo;
+pub mod repo;
 
 use std::collections::HashMap;
 

--- a/forges/josh-github-codegen-graphql/src/get_pr_comments.graphql
+++ b/forges/josh-github-codegen-graphql/src/get_pr_comments.graphql
@@ -1,0 +1,40 @@
+query GetPrComments($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      title
+      body
+      createdAt
+      author { __typename login }
+      comments(first: 100) {
+        nodes {
+          id
+          body
+          author { __typename login }
+          createdAt
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+      reviews(first: 100) {
+        nodes {
+          id
+          body
+          author { __typename login }
+          createdAt
+          comments(first: 100) {
+            nodes {
+              id
+              body
+              author { __typename login }
+              createdAt
+              path
+              line
+              replyTo { __typename id }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}

--- a/forges/josh-github-codegen-graphql/src/manifest.toml
+++ b/forges/josh-github-codegen-graphql/src/manifest.toml
@@ -15,6 +15,8 @@ fragments = ["check_run_info"]
 
 [queries.get_pr_by_head]
 
+[queries.get_pr_comments]
+
 [queries.create_pull_request]
 
 [queries.update_pull_request]

--- a/forges/josh-github-graphql/src/operations/pull_request.rs
+++ b/forges/josh-github-graphql/src/operations/pull_request.rs
@@ -3,10 +3,30 @@ use anyhow::anyhow;
 
 use josh_github_codegen_graphql::{
     close_pull_request, convert_pull_request_to_draft, create_pull_request, get_pr_by_head,
-    mark_pull_request_ready_for_review, update_pull_request, ClosePullRequest,
-    ConvertPullRequestToDraft, CreatePullRequest, GetPrByHead, MarkPullRequestReadyForReview,
-    UpdatePullRequest,
+    get_pr_comments, mark_pull_request_ready_for_review, update_pull_request, ClosePullRequest,
+    ConvertPullRequestToDraft, CreatePullRequest, GetPrByHead, GetPrComments,
+    MarkPullRequestReadyForReview, UpdatePullRequest,
 };
+
+#[derive(Debug)]
+pub struct PrComment {
+    pub id: String,
+    pub author: String,
+    pub body: String,
+    pub timestamp: String,
+    pub path: Option<String>,
+    pub line: Option<i64>,
+    pub reply_to: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct PrData {
+    pub title: String,
+    pub body: Option<String>,
+    pub author: String,
+    pub timestamp: String,
+    pub comments: Vec<PrComment>,
+}
 
 impl GithubApiConnection {
     /// Find an open PR by head branch name. Returns (node_id, number, is_draft) if found.
@@ -137,6 +157,86 @@ impl GithubApiConnection {
         };
 
         Ok((response.id, response.number))
+    }
+
+    pub async fn get_pr_comments(
+        &self,
+        owner: &str,
+        name: &str,
+        number: i64,
+    ) -> anyhow::Result<PrData> {
+        let variables = get_pr_comments::Variables {
+            owner: owner.to_string(),
+            name: name.to_string(),
+            number,
+        };
+        let response = self.make_request::<GetPrComments>(variables).await?;
+        let repo = response
+            .repository
+            .ok_or_else(|| anyhow!("repository not found"))?;
+        let pr = repo.pull_request.ok_or_else(|| anyhow!("PR not found"))?;
+
+        let mut comments = Vec::new();
+        for node in pr.comments.nodes.unwrap_or_default().into_iter().flatten() {
+            comments.push(PrComment {
+                id: node.id,
+                author: node.author.map(|a| a.login).unwrap_or_default(),
+                body: node.body,
+                timestamp: format!("{}", node.created_at),
+                path: None,
+                line: None,
+                reply_to: None,
+            });
+        }
+
+        for review in pr
+            .reviews
+            .and_then(|r| r.nodes)
+            .unwrap_or_default()
+            .into_iter()
+            .flatten()
+        {
+            if !review.body.is_empty() {
+                comments.push(PrComment {
+                    id: review.id,
+                    author: review
+                        .author
+                        .as_ref()
+                        .map(|a| a.login.clone())
+                        .unwrap_or_default(),
+                    body: review.body,
+                    timestamp: format!("{}", review.created_at),
+                    path: None,
+                    line: None,
+                    reply_to: None,
+                });
+            }
+            for node in review
+                .comments
+                .nodes
+                .unwrap_or_default()
+                .into_iter()
+                .flatten()
+            {
+                comments.push(PrComment {
+                    id: node.id,
+                    author: node.author.map(|a| a.login).unwrap_or_default(),
+                    body: node.body,
+                    timestamp: format!("{}", node.created_at),
+                    path: Some(node.path),
+                    line: node.line,
+                    reply_to: node.reply_to.map(|r| r.id),
+                });
+            }
+        }
+
+        Ok(PrData {
+            title: pr.title,
+            body: Some(pr.body),
+            author: pr.author.map(|a| a.login).unwrap_or_default(),
+            timestamp: format!("{}", pr.created_at),
+            comments,
+        })
     }
 
     pub async fn close_pull_request(

--- a/josh-changes/Cargo.toml
+++ b/josh-changes/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["git", "monorepo", "workflow", "scm"]
 
 [dependencies]
 anyhow.workspace = true
+chrono.workspace = true
 git2.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -492,17 +492,15 @@ pub struct CommentMeta {
     pub reply_to: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub update_of: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub author: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub timestamp: Option<String>,
 }
 
 pub fn write_comment(
     repo: &git2::Repository,
     change: &Change,
     meta: &CommentMeta,
-) -> anyhow::Result<()> {
+    author: Option<&str>,
+    timestamp: Option<&str>,
+) -> anyhow::Result<String> {
     if meta.message.trim().is_empty() {
         return Err(anyhow::anyhow!("comment message must not be empty"));
     }
@@ -521,9 +519,9 @@ pub fn write_comment(
         .join(&change_id)
         .join(&diff_id)
         .join(&content_hash);
-    write_changes_tree(repo, &path, blob_oid)?;
+    write_changes_tree(repo, &path, blob_oid, author, timestamp)?;
 
-    Ok(())
+    Ok(content_hash)
 }
 
 pub fn store_diff_data(repo: &git2::Repository, change: &Change) -> anyhow::Result<()> {
@@ -575,15 +573,27 @@ pub fn store_diff_data(repo: &git2::Repository, change: &Change) -> anyhow::Resu
         .join(&change_id)
         .join(&diff_id)
         .join(&content_hash);
-    write_changes_tree(repo, &path, blob_oid)?;
+    write_changes_tree(repo, &path, blob_oid, None, None)?;
 
     Ok(())
+}
+
+fn parse_timestamp(s: Option<&str>) -> git2::Time {
+    let Some(s) = s else {
+        return git2::Time::new(0, 0);
+    };
+    let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) else {
+        return git2::Time::new(0, 0);
+    };
+    git2::Time::new(dt.timestamp(), dt.offset().local_minus_utc() / 60)
 }
 
 fn write_changes_tree(
     repo: &git2::Repository,
     path: &std::path::Path,
     blob_oid: git2::Oid,
+    author: Option<&str>,
+    timestamp: Option<&str>,
 ) -> anyhow::Result<()> {
     let base_tree = repo
         .find_reference("refs/josh/changes")
@@ -610,7 +620,14 @@ fn write_changes_tree(
         git2::FileMode::Blob.into(),
     )?;
 
-    let sig = repo.signature()?;
+    let sig = match author {
+        Some(name) => {
+            let email = format!("{}@github", name);
+            let time = parse_timestamp(timestamp);
+            git2::Signature::new(name, &email, &time)?
+        }
+        None => repo.signature()?,
+    };
     let parent_commit = repo
         .find_reference("refs/josh/changes")
         .ok()

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -8,6 +8,7 @@ use josh_cli::commands::comment::CommentArgs;
 use josh_cli::commands::link::LinkArgs;
 use josh_cli::commands::push::{PublishArgs, PushArgs};
 use josh_cli::commands::run::ComposeArgs;
+use josh_cli::commands::sync::SyncArgs;
 use josh_cli::config::{RemoteConfig, read_remote_config, write_remote_config};
 use josh_cli::forge::Forge;
 use josh_core::git::{normalize_repo_path, spawn_git_command};
@@ -140,6 +141,8 @@ pub enum ChangesCommand {
     List(ListArgs),
     /// Add a comment to a change
     Comment(CommentArgs),
+    /// Sync GitHub PR comments to local change comments
+    Sync(SyncArgs),
 }
 
 #[derive(Debug, clap::Parser)]
@@ -274,6 +277,9 @@ fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
             }
             ChangesCommand::Comment(comment_args) => {
                 josh_cli::commands::comment::handle_comment(comment_args, &transaction)
+            }
+            ChangesCommand::Sync(sync_args) => {
+                josh_cli::commands::sync::handle_sync(sync_args, &transaction)
             }
         },
         RepoCommand::Remote(args) => handle_remote(args, &transaction),

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -104,10 +104,8 @@ pub fn handle_comment(
         location,
         reply_to: args.reply_to.clone(),
         update_of: args.update_of.clone(),
-        author: None,
-        timestamp: None,
     };
-    josh_changes::write_comment(repo, &change, &meta)?;
+    josh_changes::write_comment(repo, &change, &meta, None, None)?;
 
     println!("Comment saved.");
     Ok(())

--- a/josh-cli/src/commands/mod.rs
+++ b/josh-cli/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod comment;
 pub mod link;
 pub mod push;
 pub mod run;
+pub mod sync;

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -1,0 +1,138 @@
+use anyhow::{Context, anyhow};
+
+use josh_core::git::normalize_repo_path;
+
+use crate::config::read_remote_config;
+use crate::forge::Forge;
+use crate::forge::github;
+
+/// Arguments for `josh changes sync`.
+#[derive(Debug, clap::Parser)]
+pub struct SyncArgs {
+    /// Josh remote name (default: origin).
+    #[arg()]
+    pub remote: Option<String>,
+}
+
+pub fn handle_sync(
+    args: &SyncArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+    let repo_path = normalize_repo_path(repo.path());
+    let remote_name = args.remote.as_deref().unwrap_or("origin");
+
+    let remote_config = read_remote_config(&repo_path, remote_name)
+        .with_context(|| format!("Failed to read remote config for '{}'", remote_name))?;
+
+    if remote_config.forge != Some(Forge::Github) {
+        return Err(anyhow!("sync is only supported for GitHub remotes"));
+    }
+
+    let head = repo.head()?.peel_to_commit()?;
+    let branch = repo.head()?.shorthand().map(|s| s.to_string());
+
+    let base = if let Some(ref name) = branch {
+        let remote_ref = format!("refs/remotes/origin/{}", name);
+        repo.find_reference(&remote_ref).ok().map(|_| name.clone())
+    } else {
+        None
+    };
+    let base_name = base.clone().unwrap_or_else(|| "master".to_string());
+    let base_oid = branch
+        .as_ref()
+        .and_then(|b| {
+            repo.find_reference(&format!("refs/remotes/origin/{}", b))
+                .ok()
+                .and_then(|r| r.peel_to_commit().ok())
+                .map(|c| c.id())
+        })
+        .unwrap_or(git2::Oid::zero());
+
+    let git_config = repo.config()?;
+    let email = git_config.get_string("user.email").unwrap_or_default();
+
+    let changes = josh_changes::list_changes(repo, head.id(), base_oid)?;
+    if changes.is_empty() {
+        println!("No local changes found.");
+        return Ok(());
+    }
+
+    let (owner, repo_name) = josh_github_changes::repo::parse_owner_repo(&remote_config.url)?;
+
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(async {
+        let api = github::make_api_connection()
+            .await
+            .with_context(|| github::api_connection_hint())?;
+
+        for change in &changes {
+            let change_id = match change.id() {
+                Some(id) => id,
+                None => continue,
+            };
+
+            let head_ref = format!("@changes/{}/{}/{}", base_name, email, change_id);
+
+            let pr = match api
+                .find_pull_request_by_head(&owner, &repo_name, &head_ref)
+                .await?
+            {
+                Some((_node_id, number, _draft)) => {
+                    println!("Found PR #{} for change {}", number, change_id);
+                    number
+                }
+                None => {
+                    eprintln!(
+                        "No open PR found for change {} (branch {})",
+                        change_id, head_ref
+                    );
+                    continue;
+                }
+            };
+
+            let pr_data = api.get_pr_comments(&owner, &repo_name, pr).await?;
+
+            // Write each comment and review, building a GitHub ID -> our hash mapping.
+            let mut id_map: std::collections::HashMap<String, String> =
+                std::collections::HashMap::new();
+
+            for comment in &pr_data.comments {
+                let location = comment.path.as_ref().zip(comment.line).map(|(path, line)| {
+                    josh_changes::Location {
+                        path: path.clone(),
+                        start_line: line as u32,
+                        end_line: line as u32,
+                        start_col: 1,
+                        end_col: u32::MAX,
+                    }
+                });
+                let reply_to = comment
+                    .reply_to
+                    .as_ref()
+                    .and_then(|gh_id| id_map.get(gh_id))
+                    .cloned();
+                let meta = josh_changes::CommentMeta {
+                    message: comment.body.clone(),
+                    file: comment.path.clone(),
+                    location,
+                    reply_to,
+                    update_of: None,
+                };
+                let hash = josh_changes::write_comment(
+                    repo,
+                    change,
+                    &meta,
+                    Some(&comment.author),
+                    Some(&comment.timestamp),
+                )?;
+                id_map.insert(comment.id.clone(), hash);
+            }
+        }
+
+        Ok::<_, anyhow::Error>(())
+    })?;
+
+    println!("Sync complete.");
+    Ok(())
+}


### PR DESCRIPTION
Add josh changes sync command for GitHub PR comments

Adds get_pr_comments GraphQL query to fetch PR comments and reviews.
The sync command finds matching open GitHub PRs for outgoing changes
and writes their comments/reviews to refs/josh/changes via
write_comment, preserving author and timestamp metadata.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-changes-sync