### PR TITLE
Move comments to third column in josh-gui detail page

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -221,19 +221,6 @@ fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
                             }
                         }
                         pre { class: "commit-message", "{data.message}" }
-                        if !data.comments.is_empty() {
-                            h2 { "Comments" }
-                            div { class: "comments",
-                                {
-                                    let roots: Vec<&josh_changes::Comment> = data
-                                        .comments
-                                        .iter()
-                                        .filter(|c| c.reply_to.is_none())
-                                        .collect();
-                                    render_threads(&data.comments, &roots, 0)
-                                }
-                            }
-                        }
                     }
                     div { class: "detail-right",
                         h2 { "Changed files" }
@@ -266,6 +253,21 @@ fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
                                     }
                                 }
                             }
+                    }
+                    if !data.comments.is_empty() {
+                        div { class: "detail-comments",
+                            h2 { "Comments" }
+                            div { class: "comments",
+                                {
+                                    let roots: Vec<&josh_changes::Comment> = data
+                                        .comments
+                                        .iter()
+                                        .filter(|c| c.reply_to.is_none())
+                                        .collect();
+                                    render_threads(&data.comments, &roots, 0)
+                                }
+                            }
+                        }
                     }
                     }
                 }

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -110,18 +110,24 @@ table.detail-meta td {
 .detail-layout {
     display: flex;
     gap: 2rem;
+    overflow: hidden;
 }
 
 .detail-left {
     flex: 0 0 auto;
-    min-width: 18rem;
-    max-width: 30rem;
+    min-width: 16rem;
+    max-width: 28rem;
 }
 
 .detail-right {
     flex: 1;
-    min-width: 0;
+    min-width: 10rem;
     overflow-x: auto;
+}
+
+.detail-comments {
+    flex: 0 0 18rem;
+    overflow-y: auto;
 }
 
 .comments {


### PR DESCRIPTION
Move comments to third column in josh-gui detail page

Detail layout is now three columns: metadata/message (left), changed
files (middle), discussions (right). Comments moved from left column
to new detail-comments column.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-gui-detail-three-columns