### PR TITLE
Add prev/next file navigation to josh-gui diff view

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -163,6 +163,46 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
         }
     };
 
+    let detail = load_detail(&sha);
+    let (prev_file, next_file) = detail
+        .as_ref()
+        .ok()
+        .and_then(|d| {
+            let i = d.files.iter().position(|f| f.path == path)?;
+            let prev = i.checked_sub(1).map(|j| d.files[j].path.clone());
+            let next = d.files.get(i + 1).map(|f| f.path.clone());
+            Some((prev, next))
+        })
+        .unwrap_or((None, None));
+
+    let (prev_clone, next_clone, sha_clone) = (prev_file.clone(), next_file.clone(), sha.clone());
+    let nav = rsx! {
+        div { class: "diff-nav",
+            if let Some(prev) = prev_clone {
+                button {
+                    class: "nav-btn",
+                    onclick: {
+                        let s = sha_clone.clone();
+                        let p = prev.clone();
+                        move |_| page.set(Page::FileDiff { sha: s.clone(), path: p.clone() })
+                    },
+                    "\u{2190} {prev}"
+                }
+            }
+            if let Some(next) = next_clone {
+                button {
+                    class: "nav-btn",
+                    onclick: {
+                        let s = sha_clone.clone();
+                        let n = next.clone();
+                        move |_| page.set(Page::FileDiff { sha: s.clone(), path: n.clone() })
+                    },
+                    "{next} \u{2192}"
+                }
+            }
+        }
+    };
+
     match load_file_diff(&sha, &path) {
         Err(e) => rsx! {
             {back}
@@ -170,6 +210,7 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
         },
         Ok(lines) => rsx! {
             {back}
+            {nav}
             h2 { "{path}" }
             pre { class: "diff-view",
                 for line in lines.iter() {

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -134,6 +134,32 @@ tr.changes tbody tr:hover td {
     background: #2a2a2a;
 }
 
+.diff-nav {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+button.nav-btn {
+    background: #333;
+    color: #ccc;
+    border: 1px solid #444;
+    padding: 0.25rem 0.6rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    max-width: 16rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+button.nav-btn:hover {
+    background: #444;
+    color: #fff;
+}
+
 tr.file-row {
     cursor: pointer;
 }


### PR DESCRIPTION
Add prev/next file navigation to josh-gui diff view

Next/prev file buttons at the top right of the file diff view allow
quick navigation between changed files within the same commit.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-gui-file-diff-nav