### PR TITLE
Show full commit message on josh-gui change detail page

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -148,6 +148,7 @@ fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
                             tr { td { "Series" } td { "{data.series}" } }
                         }
                     }
+                    pre { class: "commit-message", "{data.message}" }
                     h2 { "Changed files" }
                     p { class: "diff-summary", "{stats_total}" }
                     table { class: "files",
@@ -469,6 +470,7 @@ struct DetailData {
     change_id: String,
     sha: String,
     subject: String,
+    message: String,
     author: String,
     date: String,
     series: String,
@@ -482,6 +484,7 @@ fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
 
     let msg = commit.message().unwrap_or("");
     let subject = msg.lines().next().unwrap_or("").to_string();
+    let message = msg.to_string();
     let author = commit.author().email().unwrap_or("").to_string();
     let date = chrono::DateTime::from_timestamp(commit.time().seconds(), 0)
         .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
@@ -516,6 +519,7 @@ fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
         change_id: change_id.unwrap_or_default(),
         sha: sha.to_string(),
         subject,
+        message,
         author,
         date,
         series: series.join(", "),

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -106,6 +106,20 @@ table.detail-meta td {
     vertical-align: top;
 }
 
+pre.commit-message {
+    white-space: pre-wrap;
+    font-family: ui-monospace, monospace;
+    font-size: 0.85rem;
+    color: #bbb;
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.75rem;
+    background: #222;
+    border: 1px solid #333;
+    border-radius: 4px;
+    max-height: 12rem;
+    overflow-y: auto;
+}
+
 table.detail-meta td:first-child {
     color: #888;
     white-space: nowrap;


### PR DESCRIPTION
Show full commit message on josh-gui change detail page

Add a scrollable pre block with the full commit message below the
meta table.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-gui-detail-message