### PR TITLE
Add author and timestamp optional fields to CommentMeta

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -492,6 +492,10 @@ pub struct CommentMeta {
     pub reply_to: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub update_of: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub author: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub timestamp: Option<String>,
 }
 
 pub fn write_comment(

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -104,6 +104,8 @@ pub fn handle_comment(
         location,
         reply_to: args.reply_to.clone(),
         update_of: args.update_of.clone(),
+        author: None,
+        timestamp: None,
     };
     josh_changes::write_comment(repo, &change, &meta)?;
 


### PR DESCRIPTION
Add author and timestamp optional fields to CommentMeta

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: comment-meta-author-timestamp