### PR TITLE
Add optional fields to write_comment and CLI comment command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,6 +2942,7 @@ dependencies = [
  "anyhow",
  "git2",
  "josh-core",
+ "serde",
  "serde_json",
 ]
 

--- a/josh-changes/Cargo.toml
+++ b/josh-changes/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["git", "monorepo", "workflow", "scm"]
 [dependencies]
 anyhow.workspace = true
 git2.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 
 josh-core.workspace = true

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -472,12 +472,34 @@ pub fn diff_id(repo: &git2::Repository, commit_oid: git2::Oid) -> anyhow::Result
     Ok(git2::Oid::hash_object(git2::ObjectType::Blob, &buf)?.to_string())
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct Location {
+    pub path: String,
+    pub start_line: u32,
+    pub end_line: u32,
+    pub start_col: u32,
+    pub end_col: u32,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct CommentMeta {
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub location: Option<Location>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reply_to: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub update_of: Option<String>,
+}
+
 pub fn write_comment(
     repo: &git2::Repository,
     change: &Change,
-    message: &str,
+    meta: &CommentMeta,
 ) -> anyhow::Result<()> {
-    if message.trim().is_empty() {
+    if meta.message.trim().is_empty() {
         return Err(anyhow::anyhow!("comment message must not be empty"));
     }
 
@@ -486,7 +508,7 @@ pub fn write_comment(
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
     let diff_id = diff_id(repo, change.commit())?;
 
-    let content = serde_json::json!({"message": message}).to_string();
+    let content = serde_json::to_string(meta)?;
     let content_hash =
         git2::Oid::hash_object(git2::ObjectType::Blob, content.as_bytes())?.to_string();
     let blob_oid = repo.blob(content.as_bytes())?;

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -8,6 +8,42 @@ pub struct CommentArgs {
     /// Comment message.
     #[arg(short = 'm', long = "message")]
     pub message: String,
+
+    /// File path the comment relates to.
+    #[arg(long = "file")]
+    pub file: Option<String>,
+
+    /// Location as path:line (shortcut for --location-path PATH --location-start-line N ...).
+    #[arg(long = "location")]
+    pub location: Option<String>,
+
+    /// Location path (file or directory).
+    #[arg(long = "location-path")]
+    pub location_path: Option<String>,
+
+    /// Location start line (1-based).
+    #[arg(long = "location-start-line")]
+    pub location_start_line: Option<u32>,
+
+    /// Location end line (1-based).
+    #[arg(long = "location-end-line")]
+    pub location_end_line: Option<u32>,
+
+    /// Location start column (1-based).
+    #[arg(long = "location-start-col")]
+    pub location_start_col: Option<u32>,
+
+    /// Location end column (1-based).
+    #[arg(long = "location-end-col")]
+    pub location_end_col: Option<u32>,
+
+    /// Hash of a previous comment to reply to.
+    #[arg(long = "reply-to")]
+    pub reply_to: Option<String>,
+
+    /// Hash of a previous comment to update/replace.
+    #[arg(long = "update-of")]
+    pub update_of: Option<String>,
 }
 
 pub fn handle_comment(
@@ -17,8 +53,59 @@ pub fn handle_comment(
     let repo = transaction.repo();
     let head = repo.head()?.peel_to_commit()?.id();
 
+    let short_location = args.location.as_ref().and_then(|s| {
+        let (path, line) = s.rsplit_once(':')?;
+        let line: u32 = line.parse().ok()?;
+        Some(josh_changes::Location {
+            path: path.to_string(),
+            start_line: line,
+            end_line: line,
+            start_col: 1,
+            end_col: u32::MAX,
+        })
+    });
+
+    let location = if args.location_path.is_some()
+        || args.location_start_line.is_some()
+        || args.location_end_line.is_some()
+        || args.location_start_col.is_some()
+        || args.location_end_col.is_some()
+    {
+        let path = args.location_path.as_deref().ok_or_else(|| {
+            anyhow::anyhow!("--location-path is required when using long-form location flags")
+        })?;
+        let start_line = args.location_start_line.ok_or_else(|| {
+            anyhow::anyhow!("--location-start-line is required when using long-form location flags")
+        })?;
+        let end_line = args.location_end_line.ok_or_else(|| {
+            anyhow::anyhow!("--location-end-line is required when using long-form location flags")
+        })?;
+        let start_col = args.location_start_col.ok_or_else(|| {
+            anyhow::anyhow!("--location-start-col is required when using long-form location flags")
+        })?;
+        let end_col = args.location_end_col.ok_or_else(|| {
+            anyhow::anyhow!("--location-end-col is required when using long-form location flags")
+        })?;
+        Some(josh_changes::Location {
+            path: path.to_string(),
+            start_line,
+            end_line,
+            start_col,
+            end_col,
+        })
+    } else {
+        short_location
+    };
+
     let change = josh_changes::resolve_change(repo, head, &args.change)?;
-    josh_changes::write_comment(repo, &change, &args.message)?;
+    let meta = josh_changes::CommentMeta {
+        message: args.message.clone(),
+        file: args.file.clone(),
+        location,
+        reply_to: args.reply_to.clone(),
+        update_of: args.update_of.clone(),
+    };
+    josh_changes::write_comment(repo, &change, &meta)?;
 
     println!("Comment saved.");
     Ok(())


### PR DESCRIPTION
Add optional fields to write_comment and CLI comment command

CommentMeta struct carries message plus optional file, location,
reply_to, and update_of. CLI gets --file, --location, --reply-to,
and --update-of flags.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: comment-optional-fields