### PR TITLE
Show comments on josh-gui change detail page

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -221,6 +221,25 @@ fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
                             }
                         }
                         pre { class: "commit-message", "{data.message}" }
+                        if !data.comments.is_empty() {
+                            h2 { "Comments" }
+                            div { class: "comments",
+                                for c in &data.comments {
+                                    div { class: "comment",
+                                        div { class: "comment-header",
+                                            span { class: "comment-id", "{&c.id[..8]}" }
+                                        }
+                                        pre { class: "comment-body", "{c.message}" }
+                                        if let Some(ref f) = c.file {
+                                            span { class: "comment-meta", "{f}" }
+                                        }
+                                        if let Some(ref loc) = c.location {
+                                            span { class: "comment-meta", " {loc.path}:{loc.start_line}" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                     div { class: "detail-right",
                         h2 { "Changed files" }
@@ -582,6 +601,7 @@ struct DetailData {
     date: String,
     series: String,
     files: Vec<FileStat>,
+    comments: Vec<josh_changes::Comment>,
 }
 
 fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
@@ -622,6 +642,9 @@ fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
         });
     }
 
+    let change = josh_changes::Change::new(&repo, &commit);
+    let comments = josh_changes::read_comments(&repo, &change).unwrap_or_default();
+
     Ok(DetailData {
         change_id: change_id.unwrap_or_default(),
         sha: sha.to_string(),
@@ -631,6 +654,7 @@ fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
         date,
         series: series.join(", "),
         files,
+        comments,
     })
 }
 

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -124,6 +124,41 @@ table.detail-meta td {
     overflow-x: auto;
 }
 
+.comments {
+    margin-bottom: 1rem;
+}
+
+.comment {
+    margin-bottom: 0.5rem;
+    padding: 0.4rem 0.6rem;
+    background: #222;
+    border: 1px solid #2a2a2a;
+    border-radius: 3px;
+}
+
+.comment-header {
+    margin-bottom: 0.2rem;
+}
+
+span.comment-id {
+    color: #666;
+    font-family: ui-monospace, monospace;
+    font-size: 0.8rem;
+}
+
+pre.comment-body {
+    margin: 0;
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: #bbb;
+    white-space: pre-wrap;
+}
+
+span.comment-meta {
+    color: #555;
+    font-size: 0.8rem;
+}
+
 pre.commit-message {
     white-space: pre-wrap;
     font-family: ui-monospace, monospace;


### PR DESCRIPTION
Show comments on josh-gui change detail page

Load comments via josh_changes::read_comments and display them
in the left column below the commit message, showing the short
comment id, message body, file, and location.

Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>
Change: josh-gui-detail-comments