### PR TITLE
Add --clean flag to josh changes sync

### DIFF
--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -12,6 +12,10 @@ pub struct SyncArgs {
     /// Josh remote name (default: origin).
     #[arg()]
     pub remote: Option<String>,
+
+    /// Discard existing refs/josh/changes before syncing.
+    #[arg(long = "clean")]
+    pub clean: bool,
 }
 
 pub fn handle_sync(
@@ -50,6 +54,12 @@ pub fn handle_sync(
     if changes.is_empty() {
         println!("No local changes found.");
         return Ok(());
+    }
+
+    if args.clean {
+        if let Ok(mut r) = repo.find_reference("refs/josh/changes") {
+            r.delete()?;
+        }
     }
 
     let (owner, repo_name) = josh_github_changes::repo::parse_owner_repo(&remote_config.url)?;


### PR DESCRIPTION
Add --clean flag to josh changes sync

When passed, discards the existing refs/josh/changes before fetching
comments from GitHub, giving a fresh start for the sync.

Change: sync-clean-flag
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>