### PR TITLE
Post local comments to GitHub via josh changes sync --push

### DIFF
--- a/forges/josh-github-changes/src/lib.rs
+++ b/forges/josh-github-changes/src/lib.rs
@@ -235,6 +235,10 @@ fn write_pr_comments(
             Some(&comment.timestamp),
             blob_commit.as_deref(),
         )?;
+        // Record the GitHub node ID so this comment is tracked as "already posted".
+        if let Some(change_id) = change.id() {
+            josh_changes::store_github_id(repo, change_id, &hash, &comment.id)?;
+        }
         id_map.insert(comment.id.clone(), hash);
     }
 
@@ -301,4 +305,114 @@ pub async fn sync_change_comments_by_pr_number(
     josh_changes::store_pr_data(repo, change_id, &json)?;
 
     write_pr_comments(repo, change, &pr_data)
+}
+
+/// Post local comments (those without a `github_id`) to a GitHub PR.
+/// Returns the number of comments successfully posted.
+pub async fn post_local_comments(
+    connection: &GithubApiConnection,
+    repo: &git2::Repository,
+    change: &josh_changes::Change,
+    pr_node_id: &str,
+) -> anyhow::Result<usize> {
+    let change_id = match change.id() {
+        Some(id) => id,
+        None => return Ok(0),
+    };
+
+    let comments = josh_changes::read_comments(repo, change)?;
+    if comments.is_empty() {
+        return Ok(0);
+    }
+
+    let github_ids = josh_changes::read_github_ids(repo, change_id)?;
+
+    // Collect unposted comments (no github_id mapping yet).
+    let mut unposted: Vec<&josh_changes::Comment> = comments
+        .iter()
+        .filter(|c| !github_ids.contains_key(&c.id))
+        .collect();
+    if unposted.is_empty() {
+        return Ok(0);
+    }
+
+    // Topological sort: post parents before children that reply to them.
+    let mut posted_count = 0usize;
+    let mut new_ids: std::collections::HashMap<String, String> = github_ids;
+
+    while !unposted.is_empty() {
+        let mut progressed = false;
+        let mut remaining = Vec::new();
+
+        for comment in unposted.drain(..) {
+            let can_post = match &comment.reply_to {
+                Some(parent_hash) => new_ids.contains_key(parent_hash.as_str()),
+                None => true,
+            };
+            if !can_post {
+                remaining.push(comment);
+                continue;
+            }
+
+            let github_id = if let Some(ref file) = comment.file {
+                if let Some(parent_hash) = &comment.reply_to {
+                    let parent_gh_id = match new_ids.get(parent_hash.as_str()) {
+                        Some(id) => id,
+                        None => {
+                            remaining.push(comment);
+                            continue;
+                        }
+                    };
+                    connection
+                        .add_pull_request_review_thread_reply(parent_gh_id, &comment.message)
+                        .await?
+                } else {
+                    let line = comment
+                        .location
+                        .as_ref()
+                        .map_or(1, |loc| loc.start_line as i64);
+                    connection
+                        .add_pull_request_review_thread(pr_node_id, &comment.message, file, line)
+                        .await?
+                }
+            } else {
+                connection.add_comment(pr_node_id, &comment.message).await?
+            };
+
+            josh_changes::store_github_id(repo, change_id, &comment.id, &github_id)?;
+            new_ids.insert(comment.id.clone(), github_id);
+            posted_count += 1;
+            progressed = true;
+        }
+
+        if !progressed {
+            // Orphan reply_to references — post remaining as standalone.
+            for comment in remaining.drain(..) {
+                let github_id = if comment.file.is_some() {
+                    let line = comment
+                        .location
+                        .as_ref()
+                        .map_or(1, |loc| loc.start_line as i64);
+                    connection
+                        .add_pull_request_review_thread(
+                            pr_node_id,
+                            &comment.message,
+                            comment.file.as_deref().unwrap_or(""),
+                            line,
+                        )
+                        .await?
+                } else {
+                    connection.add_comment(pr_node_id, &comment.message).await?
+                };
+                josh_changes::store_github_id(repo, change_id, &comment.id, &github_id)?;
+                new_ids.insert(comment.id.clone(), github_id);
+                posted_count += 1;
+            }
+            break;
+        }
+
+        unposted = remaining;
+    }
+
+    Ok(posted_count)
 }

--- a/forges/josh-github-codegen-graphql/src/add_comment.graphql
+++ b/forges/josh-github-codegen-graphql/src/add_comment.graphql
@@ -1,0 +1,9 @@
+mutation AddComment($subjectId: ID!, $body: String!) {
+  addComment(input: { subjectId: $subjectId, body: $body }) {
+    commentEdge {
+      node {
+        id
+      }
+    }
+  }
+}

--- a/forges/josh-github-codegen-graphql/src/add_pull_request_review_thread.graphql
+++ b/forges/josh-github-codegen-graphql/src/add_pull_request_review_thread.graphql
@@ -1,0 +1,21 @@
+mutation AddPullRequestReviewThread(
+  $pullRequestId: ID!,
+  $body: String!,
+  $path: String!,
+  $line: Int!,
+  $side: DiffSide!,
+  $subjectType: PullRequestReviewThreadSubjectType!
+) {
+  addPullRequestReviewThread(input: {
+    pullRequestId: $pullRequestId,
+    body: $body,
+    path: $path,
+    line: $line,
+    side: $side,
+    subjectType: $subjectType
+  }) {
+    thread {
+      id
+    }
+  }
+}

--- a/forges/josh-github-codegen-graphql/src/add_pull_request_review_thread_reply.graphql
+++ b/forges/josh-github-codegen-graphql/src/add_pull_request_review_thread_reply.graphql
@@ -1,0 +1,13 @@
+mutation AddPullRequestReviewThreadReply(
+  $pullRequestReviewThreadId: ID!,
+  $body: String!
+) {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: $pullRequestReviewThreadId,
+    body: $body
+  }) {
+    comment {
+      id
+    }
+  }
+}

--- a/forges/josh-github-codegen-graphql/src/manifest.toml
+++ b/forges/josh-github-codegen-graphql/src/manifest.toml
@@ -36,4 +36,10 @@ fragments = ["required_status_checks_info", "status_checks_params"]
 [queries.get_repository_collaborators]
 fragments = ["collaborator_edge_info"]
 
+[queries.add_comment]
+
+[queries.add_pull_request_review_thread]
+
+[queries.add_pull_request_review_thread_reply]
+
 [queries.list_open_prs]

--- a/forges/josh-github-graphql/src/operations/pull_request.rs
+++ b/forges/josh-github-graphql/src/operations/pull_request.rs
@@ -3,10 +3,12 @@ use anyhow::anyhow;
 use serde::Serialize;
 
 use josh_github_codegen_graphql::{
+    add_comment, add_pull_request_review_thread, add_pull_request_review_thread_reply,
     close_pull_request, convert_pull_request_to_draft, create_pull_request, get_pr_by_head,
     get_pr_comments, list_open_p_rs, mark_pull_request_ready_for_review, update_pull_request,
-    ClosePullRequest, ConvertPullRequestToDraft, CreatePullRequest, GetPrByHead, GetPrComments,
-    ListOpenPRs, MarkPullRequestReadyForReview, UpdatePullRequest,
+    AddComment, AddPullRequestReviewThread, AddPullRequestReviewThreadReply, ClosePullRequest,
+    ConvertPullRequestToDraft, CreatePullRequest, GetPrByHead, GetPrComments, ListOpenPRs,
+    MarkPullRequestReadyForReview, UpdatePullRequest,
 };
 
 #[derive(Debug, Serialize)]
@@ -412,5 +414,70 @@ impl GithubApiConnection {
         };
 
         Ok(())
+    }
+
+    /// Post a general comment to a PR. Returns the GitHub comment node ID.
+    pub async fn add_comment(&self, subject_id: &str, body: &str) -> anyhow::Result<String> {
+        let variables = add_comment::Variables {
+            subject_id: subject_id.to_string(),
+            body: body.to_string(),
+        };
+        let response = self.make_request::<AddComment>(variables).await?;
+        let node = response
+            .add_comment
+            .ok_or_else(|| anyhow!("addComment returned null"))?
+            .comment_edge
+            .ok_or_else(|| anyhow!("addComment commentEdge is null"))?
+            .node
+            .ok_or_else(|| anyhow!("addComment node is null"))?;
+        Ok(node.id)
+    }
+
+    /// Post a file-level review thread comment. Returns the review thread node ID.
+    pub async fn add_pull_request_review_thread(
+        &self,
+        pull_request_id: &str,
+        body: &str,
+        path: &str,
+        line: i64,
+    ) -> anyhow::Result<String> {
+        let variables = add_pull_request_review_thread::Variables {
+            pull_request_id: pull_request_id.to_string(),
+            body: body.to_string(),
+            path: path.to_string(),
+            line,
+            side: add_pull_request_review_thread::DiffSide::Right,
+            subject_type: add_pull_request_review_thread::PullRequestReviewThreadSubjectType::Line,
+        };
+        let response = self
+            .make_request::<AddPullRequestReviewThread>(variables)
+            .await?;
+        let thread = response
+            .add_pull_request_review_thread
+            .ok_or_else(|| anyhow!("addPullRequestReviewThread returned null"))?
+            .thread
+            .ok_or_else(|| anyhow!("addPullRequestReviewThread thread is null"))?;
+        Ok(thread.id)
+    }
+
+    /// Reply to an existing review thread. Returns the reply comment node ID.
+    pub async fn add_pull_request_review_thread_reply(
+        &self,
+        thread_id: &str,
+        body: &str,
+    ) -> anyhow::Result<String> {
+        let variables = add_pull_request_review_thread_reply::Variables {
+            pull_request_review_thread_id: thread_id.to_string(),
+            body: body.to_string(),
+        };
+        let response = self
+            .make_request::<AddPullRequestReviewThreadReply>(variables)
+            .await?;
+        let comment = response
+            .add_pull_request_review_thread_reply
+            .ok_or_else(|| anyhow!("addPullRequestReviewThreadReply returned null"))?
+            .comment
+            .ok_or_else(|| anyhow!("addPullRequestReviewThreadReply comment is null"))?;
+        Ok(comment.id)
     }
 }

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1127,6 +1127,48 @@ pub fn store_pr_data(repo: &git2::Repository, change_id: &str, json: &str) -> an
     Ok(())
 }
 
+/// Store a GitHub node ID for a local comment, marking it as posted.
+pub fn store_github_id(
+    repo: &git2::Repository,
+    change_id: &str,
+    local_hash: &str,
+    github_id: &str,
+) -> anyhow::Result<()> {
+    let blob_oid = repo.blob(github_id.as_bytes())?;
+    let path = std::path::Path::new("gh_ids")
+        .join(encode_change_id_path(change_id))
+        .join(local_hash);
+    write_changes_tree(repo, &path, blob_oid, None, None)?;
+    Ok(())
+}
+
+/// Read all GitHub node IDs for a change's comments.
+/// Returns a map from local comment hash → GitHub node ID.
+pub fn read_github_ids(
+    repo: &git2::Repository,
+    change_id: &str,
+) -> anyhow::Result<std::collections::HashMap<String, String>> {
+    let tree = match repo.find_reference("refs/josh/changes") {
+        Ok(r) => r.peel_to_tree()?,
+        Err(_) => return Ok(Default::default()),
+    };
+    let gh_ids_path = std::path::Path::new("gh_ids").join(encode_change_id_path(change_id));
+    let subtree = match get_tree(repo, &tree, &gh_ids_path) {
+        Some(t) => t,
+        None => return Ok(Default::default()),
+    };
+    let mut map = std::collections::HashMap::new();
+    for entry in subtree.iter() {
+        if let Some(name) = entry.name() {
+            if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
+                let github_id = String::from_utf8_lossy(blob.content()).trim().to_string();
+                map.insert(name.to_string(), github_id);
+            }
+        }
+    }
+    Ok(map)
+}
+
 fn parse_timestamp(s: Option<&str>) -> git2::Time {
     let Some(s) = s else {
         return git2::Time::new(0, 0);

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -20,6 +20,10 @@ pub struct SyncArgs {
     /// Skip GitHub comment syncing; only update refs/josh/changes locally.
     #[arg(long = "local")]
     pub local: bool,
+
+    /// Push local comments that haven't been posted to GitHub yet.
+    #[arg(long = "push")]
+    pub push: bool,
 }
 
 pub fn handle_sync(
@@ -269,6 +273,92 @@ pub fn handle_sync(
                 "Synced {} comments across {} PRs ({} skipped).",
                 total_comments, synced, skipped
             );
+
+            if args.push {
+                let mut total_posted = 0usize;
+                for pr in &prs {
+                    let head_oid = match git2::Oid::from_str(&pr.head_oid) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            eprintln!("PR #{}: bad head OID for comment push: {}", pr.number, e);
+                            continue;
+                        }
+                    };
+                    let pr_head = match repo.find_commit(head_oid) {
+                        Ok(c) => c,
+                        Err(_) => {
+                            eprintln!(
+                                "PR #{}: head commit not available — skipping comment push",
+                                pr.number
+                            );
+                            continue;
+                        }
+                    };
+                    let base_oid = match git2::Oid::from_str(&pr.base_ref_oid) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            eprintln!("PR #{}: bad base OID for comment push: {}", pr.number, e);
+                            continue;
+                        }
+                    };
+                    let target = match repo.find_commit(base_oid) {
+                        Ok(c) => c,
+                        Err(_) => {
+                            eprintln!(
+                                "PR #{}: base commit not available — skipping comment push",
+                                pr.number
+                            );
+                            continue;
+                        }
+                    };
+                    let mut change = josh_changes::Change::new(repo, &pr_head);
+                    let base = repo.merge_base(target.id(), pr_head.id())?;
+                    change.set_base(base);
+
+                    match api
+                        .find_pull_request_by_head(&owner, &repo_name, &pr.head_ref_name)
+                        .await
+                    {
+                        Ok(Some((pr_node_id, _, _))) => {
+                            match josh_github_changes::post_local_comments(
+                                &api,
+                                repo,
+                                &change,
+                                &pr_node_id,
+                            )
+                            .await
+                            {
+                                Ok(n) => {
+                                    total_posted += n;
+                                    if n > 0 {
+                                        println!(
+                                            "  PR #{}: posted {} local comments",
+                                            pr.number, n
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    eprintln!(
+                                        "  PR #{}: failed to post comments: {}",
+                                        pr.number, e
+                                    );
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            eprintln!(
+                                "  No open PR found for {} — skipping comment push",
+                                pr.head_ref_name
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!("  Failed to look up PR for {}: {}", pr.head_ref_name, e);
+                        }
+                    }
+                }
+                println!("Posted {} local comments to GitHub.", total_posted);
+            }
+
             Ok::<_, anyhow::Error>(())
         })?;
     } else {


### PR DESCRIPTION
Post local comments to GitHub via josh changes sync --push

Adds bidirectional comment sync: josh changes sync --push now posts
locally-created comments back to GitHub. GitHub node IDs are tracked
in a separate gh_ids/ subtree under refs/josh/changes to avoid
breaking content-addressed reply_to references.

New GitHub GraphQL mutations: addComment, addPullRequestReviewThread,
and addPullRequestReviewThreadReply. Comments are posted in dependency
order (parents before children).

Change: push-local-comments
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>