### PR TITLE
Reset scroll position when navigating between files in diff view

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -410,6 +410,15 @@ fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element 
     let mut scroll_offset = use_signal(|| 0usize);
     let mut selected_line = use_signal(|| None::<usize>);
 
+    // Reset scroll position when navigating to a different file
+    let mut last_path = use_signal(|| String::new());
+    let current_file = format!("{}:{}", sha, path);
+    if *last_path.read() != current_file {
+        scroll_offset.set(0);
+        selected_line.set(None);
+        last_path.set(current_file);
+    }
+
     match &all_lines {
         Err(e) => rsx! {
             p { class: "error", "Error: {e}" }


### PR DESCRIPTION
Reset scroll position when navigating between files in diff view

When switching between files on the diff page, the scroll_offset signal
was preserved from the previous file because Dioxus reuses the component
instance for the same Page variant. Track the current file identity and
reset scroll_offset and selected_line when it changes.

Change: reset-diff-scroll-on-nav
Assisted-By: deepseek-v4-pro