### PR TITLE
Prune closed changes from refs/josh/changes during sync

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1127,6 +1127,61 @@ pub fn store_pr_data(repo: &git2::Repository, change_id: &str, json: &str) -> an
     Ok(())
 }
 
+/// Read stored GitHub PR data JSON for a change, if it exists.
+pub fn read_pr_data(repo: &git2::Repository, change_id: &str) -> anyhow::Result<Option<String>> {
+    let tree = match repo.find_reference("refs/josh/changes") {
+        Ok(r) => r.peel_to_tree()?,
+        Err(_) => return Ok(None),
+    };
+    let gh_path = std::path::Path::new("gh").join(encode_change_id_path(change_id));
+    let subtree = match get_tree(repo, &tree, &gh_path) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+    for entry in subtree.iter() {
+        if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
+            return Ok(Some(String::from_utf8_lossy(blob.content()).to_string()));
+        }
+    }
+    Ok(None)
+}
+
+/// Delete all stored data for a change from refs/josh/changes.
+/// Removes entries from diffs/, comments/C/, comments/F/, gh/, and gh_ids/ subtrees.
+pub fn delete_change(repo: &git2::Repository, change_id: &str) -> anyhow::Result<()> {
+    let encoded = encode_change_id_path(change_id);
+
+    let base_tree = match repo.find_reference("refs/josh/changes") {
+        Ok(r) => r.peel_to_tree()?,
+        Err(_) => return Ok(()),
+    };
+
+    let mut tree = base_tree;
+    for prefix in &["diffs", "comments/C", "comments/F", "gh", "gh_ids"] {
+        let path = std::path::Path::new(prefix).join(&encoded);
+        if tree.get_path(&path).is_ok() {
+            tree = josh_core::filter::tree::insert(repo, &tree, &path, git2::Oid::zero(), 0)?;
+        }
+    }
+
+    let sig = repo.signature()?;
+    let parent_commit = repo
+        .find_reference("refs/josh/changes")
+        .ok()
+        .and_then(|r| r.peel_to_commit().ok());
+    let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
+    repo.commit(
+        Some("refs/josh/changes"),
+        &sig,
+        &sig,
+        "update refs/josh/changes\n",
+        &tree,
+        &parents,
+    )?;
+
+    Ok(())
+}
+
 /// Store a GitHub node ID for a local comment, marking it as posted.
 pub fn store_github_id(
     repo: &git2::Repository,

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -5,6 +5,7 @@ use josh_core::git::normalize_repo_path;
 use crate::config::read_remote_config;
 use crate::forge::Forge;
 use crate::forge::github;
+use serde_json;
 
 /// Arguments for `josh changes sync`.
 #[derive(Debug, clap::Parser)]
@@ -274,6 +275,129 @@ pub fn handle_sync(
                 total_comments, synced, skipped
             );
 
+            // Build the set of open change IDs from the PRs we just synced.
+            let open_change_ids: std::collections::HashSet<String> = prs
+                .iter()
+                .map(|pr| {
+                    let (existing_id, _) = josh_changes::parse_change_meta(&pr.head_commit_message);
+                    existing_id
+                        .unwrap_or_else(|| format!("{}/{}/pull/{}", owner, repo_name, pr.number))
+                })
+                .collect();
+
+            let all_changes = josh_changes::list_changes(repo)?;
+            let mut cleaned = 0usize;
+
+            for change in &all_changes {
+                let change_id = match change.id() {
+                    Some(id) => id,
+                    None => continue,
+                };
+
+                if open_change_ids.contains(change_id) {
+                    continue;
+                }
+
+                // Determine the PR number for this change.
+                let pr_number: i64 =
+                    match parse_pr_number_from_change_id(change_id, &owner, &repo_name) {
+                        Some(n) => n,
+                        None => {
+                            // Custom Change-Id; try reading stored PR data.
+                            match josh_changes::read_pr_data(repo, change_id) {
+                                Ok(Some(json)) => {
+                                    match serde_json::from_str::<serde_json::Value>(&json) {
+                                        Ok(v) => match v.get("number").and_then(|n| n.as_i64()) {
+                                            Some(n) => n,
+                                            None => {
+                                                eprintln!(
+                                                    "  Change '{}': no PR number in stored data \
+                                                 -- skipping",
+                                                    change_id
+                                                );
+                                                continue;
+                                            }
+                                        },
+                                        Err(e) => {
+                                            eprintln!(
+                                                "  Change '{}': invalid stored PR data: {} \
+                                             -- skipping",
+                                                change_id, e
+                                            );
+                                            continue;
+                                        }
+                                    }
+                                }
+                                Ok(None) => {
+                                    // Purely local change with no PR data at all.
+                                    continue;
+                                }
+                                Err(e) => {
+                                    eprintln!(
+                                        "  Change '{}': failed to read PR data: {} -- skipping",
+                                        change_id, e
+                                    );
+                                    continue;
+                                }
+                            }
+                        }
+                    };
+
+                // Fetch the current PR data from GitHub.
+                let pr_data = match api.get_pr_comments(&owner, &repo_name, pr_number).await {
+                    Ok(d) => d,
+                    Err(e) => {
+                        eprintln!(
+                            "  Change '{}' (PR #{}): failed to fetch PR data: {} -- skipping",
+                            change_id, pr_number, e
+                        );
+                        continue;
+                    }
+                };
+
+                // Guard: if the PR is still open, do not delete the change.
+                if pr_data.state == "OPEN" {
+                    // Record the current state even if unexpectedly open.
+                    let json = serde_json::to_string(&pr_data)?;
+                    josh_changes::store_pr_data(repo, change_id, &json)?;
+                    eprintln!(
+                        "  Change '{}' (PR #{}): unexpectedly still OPEN on GitHub \
+                         -- skipping deletion",
+                        change_id, pr_number
+                    );
+                    continue;
+                }
+
+                // Commit 1: store the updated PR data (final CLOSED/MERGED state).
+                let json = serde_json::to_string(&pr_data)?;
+                if let Err(e) = josh_changes::store_pr_data(repo, change_id, &json) {
+                    eprintln!(
+                        "  Change '{}' (PR #{}): failed to store updated PR data: {} \
+                         -- skipping deletion",
+                        change_id, pr_number, e
+                    );
+                    continue;
+                }
+
+                // Commit 2: delete the change from refs/josh/changes.
+                if let Err(e) = josh_changes::delete_change(repo, change_id) {
+                    eprintln!(
+                        "  Change '{}' (PR #{}): failed to delete: {}",
+                        change_id, pr_number, e
+                    );
+                } else {
+                    println!(
+                        "  Cleaned up '{}' (PR #{}: {})",
+                        change_id, pr_number, pr_data.state
+                    );
+                    cleaned += 1;
+                }
+            }
+
+            if cleaned > 0 {
+                println!("Cleaned up {} closed/merged changes.", cleaned);
+            }
+
             if args.push {
                 let mut total_posted = 0usize;
                 for pr in &prs {
@@ -385,4 +509,10 @@ fn parse_changes_target(head_ref_name: &str) -> Option<&str> {
         end += part.len() + 1;
     }
     None
+}
+
+/// Extract the PR number from a synthetic change ID of the form `{owner}/{repo}/pull/{N}`.
+fn parse_pr_number_from_change_id(change_id: &str, owner: &str, repo: &str) -> Option<i64> {
+    let prefix = format!("{}/{}/pull/", owner, repo);
+    change_id.strip_prefix(&prefix)?.parse().ok()
 }


### PR DESCRIPTION
Prune closed changes from refs/josh/changes during sync

After syncing open PRs, iterate local changes not in the open set.
For each: fetch final PR data, store it, verify it is no longer open,
then delete its entry from the tree. Two commits per closed change.
Change: sync-cleanup-closed-changes
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>