### PR TITLE
Rename view functions to PascalCase for Dioxus 0.7 component scopes

### DIFF
--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -49,7 +49,8 @@ fn vote_state_display(state: &str) -> &'static str {
     }
 }
 
-pub fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
+#[component]
+pub fn DetailView(sha: String, mut page: Signal<Page>) -> Element {
     let data = load_detail(&sha);
     let mut vote_body = use_signal(String::new);
 

--- a/josh-gui/src/diff.rs
+++ b/josh-gui/src/diff.rs
@@ -194,8 +194,14 @@ fn build_diff_with_comments(
     items
 }
 
-pub fn file_diff_view(sha: String, path: String, mut page: Signal<Page>) -> Element {
-    let detail = use_signal(|| detail::load_detail(&sha));
+#[component]
+pub fn FileDiffView(sha: String, path: String, mut page: Signal<Page>) -> Element {
+    let mut detail = use_signal(|| detail::load_detail(&sha));
+    let mut prev_sha = use_signal(|| sha.clone());
+    if *prev_sha.read() != sha {
+        detail.set(detail::load_detail(&sha));
+        prev_sha.set(sha.clone());
+    }
     let (prev_file, next_file) = detail
         .read()
         .as_ref()

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -24,7 +24,8 @@ pub struct ListData {
     pub dependents: HashMap<String, Vec<String>>,
 }
 
-pub fn list_view(
+#[component]
+pub fn ListView(
     list_data: Signal<anyhow::Result<ListData>>,
     mut page: Signal<Page>,
     mut selected_change: Signal<Option<String>>,

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -6,9 +6,9 @@ mod list;
 use dioxus::prelude::*;
 
 use common::breadcrumb;
-use detail::detail_view;
-use diff::file_diff_view;
-use list::{list_view, load_rows};
+use detail::DetailView;
+use diff::FileDiffView;
+use list::{ListView, load_rows};
 
 fn main() {
     dioxus::LaunchBuilder::new()
@@ -117,9 +117,9 @@ fn app() -> Element {
                 {breadcrumb(&page.read(), page, list_data)}
             }
             match &*page.read() {
-                Page::List => list_view(list_data, page, selected_change),
-                Page::Detail { sha } => detail_view(sha.clone(), page),
-                Page::FileDiff { sha, path } => file_diff_view(sha.clone(), path.clone(), page),
+                Page::List => rsx! { ListView { list_data, page, selected_change } },
+                Page::Detail { sha } => rsx! { DetailView { sha: sha.clone(), page } },
+                Page::FileDiff { sha, path } => rsx! { FileDiffView { sha: sha.clone(), path: path.clone(), page } },
             }
         }
     }


### PR DESCRIPTION
Rename view functions to PascalCase for Dioxus 0.7 component scopes

Dioxus 0.7 requires component functions to use PascalCase (e.g. FileDiffView)
in order to be recognized as proper components with their own hook scopes.
The snake_case functions (file_diff_view, detail_view, list_view) were being
treated as regular functions, causing all hooks to leak into the parent app
scope. When navigating between pages with different hook counts, the hook
indices mismatched, panicking with "Unable to retrieve the hook that was
initialized at this index."

Change: pascal-case-components
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>