### PR TITLE
Sync local votes to GitHub as pull request reviews

### DIFF
--- a/forges/josh-github-changes/src/lib.rs
+++ b/forges/josh-github-changes/src/lib.rs
@@ -312,15 +312,10 @@ pub async fn sync_change_comments_by_pr_number(
 pub async fn post_local_comments(
     connection: &GithubApiConnection,
     repo: &git2::Repository,
-    change: &josh_changes::Change,
+    change_id: &str,
     pr_node_id: &str,
 ) -> anyhow::Result<usize> {
-    let change_id = match change.id() {
-        Some(id) => id,
-        None => return Ok(0),
-    };
-
-    let comments = josh_changes::read_comments(repo, change)?;
+    let comments = josh_changes::read_comments(repo, change_id)?;
     if comments.is_empty() {
         return Ok(0);
     }
@@ -415,4 +410,41 @@ pub async fn post_local_comments(
     }
 
     Ok(posted_count)
+}
+
+/// Post local votes (those not yet pushed to GitHub) as pull request reviews.
+pub async fn post_local_votes(
+    connection: &GithubApiConnection,
+    repo: &git2::Repository,
+    change_id: &str,
+    pr_node_id: &str,
+    commit_oid: &str,
+) -> anyhow::Result<usize> {
+    let votes = josh_changes::list_votes(repo, change_id)?;
+    if votes.is_empty() {
+        return Ok(0);
+    }
+
+    let tracked = josh_changes::read_github_vote_ids(repo, change_id)?;
+
+    let mut posted = 0usize;
+    for (user, vote_data) in &votes {
+        if let Some(tracked_data) = tracked.get(user) {
+            if tracked_data.state == vote_data.state && tracked_data.sha == vote_data.sha {
+                continue;
+            }
+        }
+
+        let event = josh_changes::vote_state_to_github_review(&vote_data.state);
+        let body = format!("josh vote: {}", vote_data.state);
+
+        let _review_id = connection
+            .add_pull_request_review(pr_node_id, event, Some(&body), Some(commit_oid))
+            .await?;
+
+        josh_changes::store_github_vote_id(repo, change_id, user, vote_data)?;
+        posted += 1;
+    }
+
+    Ok(posted)
 }

--- a/forges/josh-github-codegen-graphql/src/add_pull_request_review.graphql
+++ b/forges/josh-github-codegen-graphql/src/add_pull_request_review.graphql
@@ -1,0 +1,17 @@
+mutation AddPullRequestReview(
+  $pullRequestId: ID!,
+  $event: PullRequestReviewEvent!,
+  $body: String,
+  $commitOID: GitObjectID
+) {
+  addPullRequestReview(input: {
+    pullRequestId: $pullRequestId,
+    event: $event,
+    body: $body,
+    commitOID: $commitOID
+  }) {
+    pullRequestReview {
+      id
+    }
+  }
+}

--- a/forges/josh-github-codegen-graphql/src/manifest.toml
+++ b/forges/josh-github-codegen-graphql/src/manifest.toml
@@ -42,4 +42,6 @@ fragments = ["collaborator_edge_info"]
 
 [queries.add_pull_request_review_thread_reply]
 
+[queries.add_pull_request_review]
+
 [queries.list_open_prs]

--- a/forges/josh-github-graphql/src/operations/pull_request.rs
+++ b/forges/josh-github-graphql/src/operations/pull_request.rs
@@ -3,10 +3,11 @@ use anyhow::anyhow;
 use serde::Serialize;
 
 use josh_github_codegen_graphql::{
-    add_comment, add_pull_request_review_thread, add_pull_request_review_thread_reply,
-    close_pull_request, convert_pull_request_to_draft, create_pull_request, get_pr_by_head,
-    get_pr_comments, list_open_p_rs, mark_pull_request_ready_for_review, update_pull_request,
-    AddComment, AddPullRequestReviewThread, AddPullRequestReviewThreadReply, ClosePullRequest,
+    add_comment, add_pull_request_review, add_pull_request_review_thread,
+    add_pull_request_review_thread_reply, close_pull_request, convert_pull_request_to_draft,
+    create_pull_request, get_pr_by_head, get_pr_comments, list_open_p_rs,
+    mark_pull_request_ready_for_review, update_pull_request, AddComment, AddPullRequestReview,
+    AddPullRequestReviewThread, AddPullRequestReviewThreadReply, ClosePullRequest,
     ConvertPullRequestToDraft, CreatePullRequest, GetPrByHead, GetPrComments, ListOpenPRs,
     MarkPullRequestReadyForReview, UpdatePullRequest,
 };
@@ -481,5 +482,35 @@ impl GithubApiConnection {
             .comment
             .ok_or_else(|| anyhow!("addPullRequestReviewThreadReply comment is null"))?;
         Ok(comment.id)
+    }
+
+    /// Submit a pull request review (approve, comment, or request changes).
+    /// Returns the review node ID.
+    pub async fn add_pull_request_review(
+        &self,
+        pull_request_id: &str,
+        event: &str,
+        body: Option<&str>,
+        commit_oid: Option<&str>,
+    ) -> anyhow::Result<String> {
+        let event = match event {
+            "APPROVE" => add_pull_request_review::PullRequestReviewEvent::Approve,
+            "COMMENT" => add_pull_request_review::PullRequestReviewEvent::Comment,
+            "REQUEST_CHANGES" => add_pull_request_review::PullRequestReviewEvent::RequestChanges,
+            other => return Err(anyhow!("unknown review event: {}", other)),
+        };
+        let variables = add_pull_request_review::Variables {
+            pull_request_id: pull_request_id.to_string(),
+            event,
+            body: body.map(String::from),
+            commit_oid: commit_oid.map(String::from),
+        };
+        let response = self.make_request::<AddPullRequestReview>(variables).await?;
+        let review = response
+            .add_pull_request_review
+            .ok_or_else(|| anyhow!("addPullRequestReview returned null"))?
+            .pull_request_review
+            .ok_or_else(|| anyhow!("addPullRequestReview pullRequestReview is null"))?;
+        Ok(review.id)
     }
 }

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -794,12 +794,7 @@ fn collect_comments_under(
     Ok(comments)
 }
 
-pub fn read_comments(repo: &git2::Repository, change: &Change) -> anyhow::Result<Vec<Comment>> {
-    let change_id = match change.id() {
-        Some(id) => id,
-        None => return Ok(Vec::new()),
-    };
-
+pub fn read_comments(repo: &git2::Repository, change_id: &str) -> anyhow::Result<Vec<Comment>> {
     let tree = match repo.find_reference("refs/josh/changes") {
         Ok(r) => r.peel_to_tree()?,
         Err(_) => return Ok(Vec::new()),
@@ -1157,7 +1152,15 @@ pub fn delete_change(repo: &git2::Repository, change_id: &str) -> anyhow::Result
     };
 
     let mut tree = base_tree;
-    for prefix in &["diffs", "comments/C", "comments/F", "gh", "gh_ids"] {
+    for prefix in &[
+        "diffs",
+        "comments/C",
+        "comments/F",
+        "gh",
+        "gh_ids",
+        "votes",
+        "gh_vote_ids",
+    ] {
         let path = std::path::Path::new(prefix).join(&encoded);
         if tree.get_path(&path).is_ok() {
             tree = josh_core::filter::tree::insert(repo, &tree, &path, git2::Oid::zero(), 0)?;
@@ -1218,6 +1221,47 @@ pub fn read_github_ids(
             if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
                 let github_id = String::from_utf8_lossy(blob.content()).trim().to_string();
                 map.insert(name.to_string(), github_id);
+            }
+        }
+    }
+    Ok(map)
+}
+
+pub fn store_github_vote_id(
+    repo: &git2::Repository,
+    change_id: &str,
+    user: &str,
+    vote_data: &VoteData,
+) -> anyhow::Result<()> {
+    let json = serde_json::to_string(vote_data)?;
+    let blob_oid = repo.blob(json.as_bytes())?;
+    let path = std::path::Path::new("gh_vote_ids")
+        .join(encode_change_id_path(change_id))
+        .join(user);
+    write_changes_tree(repo, &path, blob_oid, None, None)?;
+    Ok(())
+}
+
+pub fn read_github_vote_ids(
+    repo: &git2::Repository,
+    change_id: &str,
+) -> anyhow::Result<std::collections::HashMap<String, VoteData>> {
+    let tree = match repo.find_reference("refs/josh/changes") {
+        Ok(r) => r.peel_to_tree()?,
+        Err(_) => return Ok(Default::default()),
+    };
+    let path = std::path::Path::new("gh_vote_ids").join(encode_change_id_path(change_id));
+    let subtree = match get_tree(repo, &tree, &path) {
+        Some(t) => t,
+        None => return Ok(Default::default()),
+    };
+    let mut map = std::collections::HashMap::new();
+    for entry in subtree.iter() {
+        if let Some(user) = entry.name() {
+            if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
+                if let Ok(data) = serde_json::from_slice::<VoteData>(blob.content()) {
+                    map.insert(user.to_string(), data);
+                }
             }
         }
     }
@@ -1290,18 +1334,18 @@ fn write_changes_tree(
     Ok(())
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct VoteData {
     pub state: String,
-    pub body: String,
+    pub sha: String,
 }
 
 pub fn vote_state_to_github_review(state: &str) -> &'static str {
     match state {
-        "approve" => "APPROVED",
-        "discuss" => "COMMENTED",
-        "revise" => "CHANGES_REQUESTED",
-        _ => "COMMENTED",
+        "approve" => "APPROVE",
+        "discuss" => "COMMENT",
+        "revise" => "REQUEST_CHANGES",
+        _ => "COMMENT",
     }
 }
 
@@ -1309,7 +1353,6 @@ pub fn write_vote(
     repo: &git2::Repository,
     change: &Change,
     state: &str,
-    body: &str,
     author: Option<&str>,
     timestamp: Option<&str>,
 ) -> anyhow::Result<String> {
@@ -1317,79 +1360,132 @@ pub fn write_vote(
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
 
-    let json = serde_json::json!({"state": state, "body": body});
+    let json = serde_json::json!({"state": state, "sha": change.commit().to_string()});
     let content = json.to_string();
     let content_hash =
         git2::Oid::hash_object(git2::ObjectType::Blob, content.as_bytes())?.to_string();
     let blob_oid = repo.blob(content.as_bytes())?;
 
+    let mut tb = repo.treebuilder(None)?;
+    tb.insert(&blob_oid.to_string(), blob_oid, git2::FileMode::Blob.into())?;
+    let tree_oid = tb.write()?;
+
+    let user = match author {
+        Some(name) => name.to_string(),
+        None => repo.signature()?.email().unwrap_or("unknown").to_string(),
+    };
+
     let path = std::path::Path::new("votes")
         .join(encode_change_id_path(&change_id))
-        .join(&content_hash);
-    write_changes_tree(repo, &path, blob_oid, author, timestamp)?;
+        .join(&user);
+
+    let base_tree = repo
+        .find_reference("refs/josh/changes")
+        .ok()
+        .and_then(|r| r.peel_to_tree().ok())
+        .unwrap_or_else(|| repo.find_tree(josh_core::filter::tree::empty_id()).unwrap());
+
+    if let Some(existing) = base_tree
+        .get_path(&path)
+        .ok()
+        .and_then(|e| e.to_object(repo).ok())
+    {
+        if existing.id() == tree_oid {
+            return Ok(content_hash);
+        }
+    }
+
+    let tree = josh_core::filter::tree::insert(repo, &base_tree, &path, tree_oid, 0o0040000)?;
+
+    let sig = match author {
+        Some(name) => {
+            let email = format!("{}@github", name);
+            let time = parse_timestamp(timestamp);
+            git2::Signature::new(name, &email, &time)?
+        }
+        None => repo.signature()?,
+    };
+    let parent_commit = repo
+        .find_reference("refs/josh/changes")
+        .ok()
+        .and_then(|r| r.peel_to_commit().ok());
+    let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
+    repo.commit(
+        Some("refs/josh/changes"),
+        &sig,
+        &sig,
+        "update refs/josh/changes\n",
+        &tree,
+        &parents,
+    )?;
 
     Ok(content_hash)
 }
 
-pub fn read_vote(repo: &git2::Repository, change_id: &str) -> anyhow::Result<Option<VoteData>> {
-    // Verify the ref exists before proceeding.
-    let _obj = match repo.find_reference("refs/josh/changes") {
-        Ok(r) => r.peel_to_commit()?,
+pub fn read_vote(
+    repo: &git2::Repository,
+    change_id: &str,
+    user: Option<&str>,
+) -> anyhow::Result<Option<VoteData>> {
+    let tree = match repo.find_reference("refs/josh/changes") {
+        Ok(r) => r.peel_to_tree()?,
         Err(_) => return Ok(None),
     };
 
-    let path = std::path::Path::new("votes").join(encode_change_id_path(change_id));
+    let user = match user {
+        Some(name) => name.to_string(),
+        None => repo.signature()?.email().unwrap_or("unknown").to_string(),
+    };
 
-    let mut revwalk = repo.revwalk()?;
-    revwalk.push_ref("refs/josh/changes")?;
+    let path = std::path::Path::new("votes")
+        .join(encode_change_id_path(change_id))
+        .join(&user);
 
-    for oid in revwalk {
-        let commit = repo.find_commit(oid?)?;
-        let tree = commit.tree()?;
-
-        let current_votes = match get_tree(repo, &tree, &path) {
-            Some(t) => t,
-            None => continue,
-        };
-
-        let entries: Vec<String> = current_votes
-            .iter()
-            .filter_map(|e| e.name().map(String::from))
-            .collect();
-
-        if entries.is_empty() {
-            continue;
-        }
-
-        let new_entries: Vec<String> = if let Ok(parent) = commit.parent(0) {
-            let parent_tree = parent.tree()?;
-            let parent_entries: std::collections::HashSet<String> =
-                get_tree(repo, &parent_tree, &path)
-                    .map(|t| {
-                        t.iter()
-                            .filter_map(|e| e.name().map(String::from))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-            entries
-                .into_iter()
-                .filter(|e| !parent_entries.contains(e))
-                .collect()
-        } else {
-            entries
-        };
-
-        if let Some(name) = new_entries.first() {
-            let entry = current_votes
-                .get_name(name)
-                .ok_or_else(|| anyhow!("vote blob not found in tree"))?;
-            let blob = entry.to_object(repo)?.peel_to_blob()?;
+    let subtree = match get_tree(repo, &tree, &path) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+    for entry in subtree.iter() {
+        if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
             let data: VoteData = serde_json::from_slice(blob.content())?;
             return Ok(Some(data));
         }
     }
-
     Ok(None)
+}
+
+pub fn list_votes(
+    repo: &git2::Repository,
+    change_id: &str,
+) -> anyhow::Result<Vec<(String, VoteData)>> {
+    let tree = match repo.find_reference("refs/josh/changes") {
+        Ok(r) => r.peel_to_tree()?,
+        Err(_) => return Ok(Default::default()),
+    };
+    let path = std::path::Path::new("votes").join(encode_change_id_path(change_id));
+    let subtree = match get_tree(repo, &tree, &path) {
+        Some(t) => t,
+        None => return Ok(Default::default()),
+    };
+    let mut votes = Vec::new();
+    for entry in subtree.iter() {
+        let user = match entry.name() {
+            Some(name) => name.to_string(),
+            None => continue,
+        };
+        let user_tree = match entry.to_object(repo).and_then(|o| o.peel_to_tree()) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        for child in user_tree.iter() {
+            if let Ok(blob) = child.to_object(repo).and_then(|o| o.peel_to_blob()) {
+                if let Ok(data) = serde_json::from_slice::<VoteData>(blob.content()) {
+                    votes.push((user.clone(), data));
+                }
+            }
+        }
+    }
+    Ok(votes)
 }
 
 #[cfg(test)]

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -38,7 +38,10 @@ pub fn handle_list(
             }
         }
 
-        let comments = josh_changes::read_comments(repo, change).unwrap_or_default();
+        let comments = change
+            .id()
+            .map(|cid| josh_changes::read_comments(repo, cid).unwrap_or_default())
+            .unwrap_or_default();
         if !comments.is_empty() {
             println!();
             for c in &comments {

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -400,44 +400,11 @@ pub fn handle_sync(
 
             if args.push {
                 let mut total_posted = 0usize;
+                let mut total_votes_posted = 0usize;
                 for pr in &prs {
-                    let head_oid = match git2::Oid::from_str(&pr.head_oid) {
-                        Ok(o) => o,
-                        Err(e) => {
-                            eprintln!("PR #{}: bad head OID for comment push: {}", pr.number, e);
-                            continue;
-                        }
-                    };
-                    let pr_head = match repo.find_commit(head_oid) {
-                        Ok(c) => c,
-                        Err(_) => {
-                            eprintln!(
-                                "PR #{}: head commit not available — skipping comment push",
-                                pr.number
-                            );
-                            continue;
-                        }
-                    };
-                    let base_oid = match git2::Oid::from_str(&pr.base_ref_oid) {
-                        Ok(o) => o,
-                        Err(e) => {
-                            eprintln!("PR #{}: bad base OID for comment push: {}", pr.number, e);
-                            continue;
-                        }
-                    };
-                    let target = match repo.find_commit(base_oid) {
-                        Ok(c) => c,
-                        Err(_) => {
-                            eprintln!(
-                                "PR #{}: base commit not available — skipping comment push",
-                                pr.number
-                            );
-                            continue;
-                        }
-                    };
-                    let mut change = josh_changes::Change::new(repo, &pr_head);
-                    let base = repo.merge_base(target.id(), pr_head.id())?;
-                    change.set_base(base);
+                    let (existing_id, _) = josh_changes::parse_change_meta(&pr.head_commit_message);
+                    let change_id = existing_id
+                        .unwrap_or_else(|| format!("{}/{}/pull/{}", owner, repo_name, pr.number));
 
                     match api
                         .find_pull_request_by_head(&owner, &repo_name, &pr.head_ref_name)
@@ -447,7 +414,7 @@ pub fn handle_sync(
                             match josh_github_changes::post_local_comments(
                                 &api,
                                 repo,
-                                &change,
+                                &change_id,
                                 &pr_node_id,
                             )
                             .await
@@ -468,6 +435,26 @@ pub fn handle_sync(
                                     );
                                 }
                             }
+
+                            match josh_github_changes::post_local_votes(
+                                &api,
+                                repo,
+                                &change_id,
+                                &pr_node_id,
+                                &pr.head_oid,
+                            )
+                            .await
+                            {
+                                Ok(n) => {
+                                    total_votes_posted += n;
+                                    if n > 0 {
+                                        println!("  PR #{}: posted {} votes", pr.number, n);
+                                    }
+                                }
+                                Err(e) => {
+                                    eprintln!("  PR #{}: failed to post votes: {}", pr.number, e);
+                                }
+                            }
                         }
                         Ok(None) => {
                             eprintln!(
@@ -480,7 +467,10 @@ pub fn handle_sync(
                         }
                     }
                 }
-                println!("Posted {} local comments to GitHub.", total_posted);
+                println!(
+                    "Posted {} local comments and {} votes to GitHub.",
+                    total_posted, total_votes_posted
+                );
             }
 
             Ok::<_, anyhow::Error>(())

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -213,9 +213,6 @@ pub fn DetailView(sha: String, mut page: Signal<Page>) -> Element {
                                     span { class: "vote-state vote-{vote.state}",
                                         "{vote_state_display(&vote.state)}"
                                     }
-                                    if !vote.body.is_empty() {
-                                        pre { class: "vote-body", "{vote.body}" }
-                                    }
                                 }
                             }
                             textarea {
@@ -403,11 +400,14 @@ pub fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
         }
     }
 
-    let comments = josh_changes::read_comments(&repo, &change).unwrap_or_default();
+    let comments = change_id
+        .as_deref()
+        .map(|cid| josh_changes::read_comments(&repo, cid).unwrap_or_default())
+        .unwrap_or_default();
     let revisions = josh_changes::read_revisions(&repo, &change).unwrap_or_default();
     let local_vote = change_id
         .as_ref()
-        .and_then(|cid| josh_changes::read_vote(&repo, cid).ok())
+        .and_then(|cid| josh_changes::read_vote(&repo, cid, None).ok())
         .flatten();
 
     Ok(DetailData {
@@ -459,5 +459,17 @@ pub fn save_vote(sha: &str, state: &str, body: &str) -> anyhow::Result<String> {
     let oid = git2::Oid::from_str(sha)?;
     let commit = repo.find_commit(oid)?;
     let change = josh_changes::Change::new(&repo, &commit);
-    josh_changes::write_vote(&repo, &change, state, body, None, None)
+
+    if !body.trim().is_empty() {
+        let meta = josh_changes::CommentMeta {
+            message: body.to_string(),
+            file: None,
+            location: None,
+            reply_to: None,
+            update_of: None,
+        };
+        josh_changes::write_comment(&repo, &change, &meta, None, None)?;
+    }
+
+    josh_changes::write_vote(&repo, &change, state, None, None)
 }

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -193,7 +193,7 @@ pub fn load_rows() -> anyhow::Result<ListData> {
             })
             .unwrap_or_default();
 
-        let local_vote = josh_changes::read_vote(&repo, &change_id)
+        let local_vote = josh_changes::read_vote(&repo, &change_id, None)
             .ok()
             .flatten()
             .map(|v| v.state);


### PR DESCRIPTION
Sync local votes to GitHub as pull request reviews

Add post_local_votes alongside post_local_comments: walks votes/<change-id>/
in refs/josh/changes and submits each as an addPullRequestReview mutation
(approve/comment/request-changes), tracking posted state under gh_vote_ids/
so re-runs dedup.

Restructure vote storage to be keyed by user (votes/<change-id>/<email>/),
using git user.email so the path identifies a stable user rather than a
display name with spaces. read_vote takes an optional user; list_votes
enumerates all users. Vote payload is now {state, sha} (no body); the
review comment, if any, is written as a separate top-level comment.

Fix the push phase of `josh changes sync --push` to derive change_id the
same way the pull phase does -- from the head commit's Change-Id trailer
with a {owner}/{repo}/pull/{N} fallback. Previously it called
Change::new(repo, pr_head) directly, so PRs whose head commit lacks the
trailer (e.g. dependabot bumps) silently posted zero comments and zero
votes. read_comments / post_local_comments / post_local_votes now take
change_id: &str instead of &Change, with call sites updated accordingly.

Change: sync-local-votes-to-github
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>