### PR TITLE
Fetch CI check status from GitHub and display it in the change list

### DIFF
--- a/forges/josh-github-codegen-graphql/src/get_pr_comments.graphql
+++ b/forges/josh-github-codegen-graphql/src/get_pr_comments.graphql
@@ -17,6 +17,9 @@ query GetPrComments($owner: String!, $name: String!, $number: Int!) {
       changedFiles
       baseRefName
       headRefName
+      statusCheckRollup {
+        state
+      }
       reviewDecision
       labels(first: 20) {
         nodes { name color }

--- a/forges/josh-github-graphql/src/operations/pull_request.rs
+++ b/forges/josh-github-graphql/src/operations/pull_request.rs
@@ -49,6 +49,7 @@ pub struct PrData {
     pub base_ref_name: String,
     pub head_ref_name: String,
     pub review_decision: Option<String>,
+    pub check_status: Option<String>,
     pub labels: Vec<PrLabel>,
     #[serde(skip)]
     pub comments: Vec<PrComment>,
@@ -394,6 +395,7 @@ impl GithubApiConnection {
             base_ref_name: pr.base_ref_name,
             head_ref_name: pr.head_ref_name,
             review_decision: pr.review_decision.map(|r| format!("{:?}", r)),
+            check_status: pr.status_check_rollup.map(|r| format!("{:?}", r.state)),
             labels,
             comments,
         })

--- a/josh-gui/src/common.rs
+++ b/josh-gui/src/common.rs
@@ -20,6 +20,26 @@ pub fn review_decision_display(rd: &str) -> &'static str {
     }
 }
 
+pub fn check_status_label(cs: &str) -> &'static str {
+    match cs {
+        "Success" => "success",
+        "Failure" | "Error" => "failure",
+        "Pending" | "Expected" => "pending",
+        _ => "",
+    }
+}
+
+pub fn check_status_display(cs: &str) -> &'static str {
+    match cs {
+        "Success" => "Passed",
+        "Failure" => "Failed",
+        "Error" => "Error",
+        "Pending" => "Pending",
+        "Expected" => "Expected",
+        _ => "",
+    }
+}
+
 pub fn repo_name() -> String {
     static HOME: OnceLock<Option<String>> = OnceLock::new();
     let home = HOME.get_or_init(|| std::env::home_dir().map(|p| p.display().to_string()));

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -3,7 +3,9 @@ use std::collections::{HashMap, HashSet};
 use dioxus::prelude::*;
 
 use crate::Page;
-use crate::common::{review_decision_display, review_decision_label};
+use crate::common::{
+    check_status_display, check_status_label, review_decision_display, review_decision_label,
+};
 
 #[derive(Clone)]
 pub struct Row {
@@ -13,6 +15,7 @@ pub struct Row {
     pub author: String,
     pub series: String,
     pub review_decision: String,
+    pub check_status: String,
 }
 
 pub struct ListData {
@@ -75,6 +78,7 @@ pub fn list_view(
                                 th { "Author" }
                                 th { "Series" }
                                 th { "Review" }
+                                th { "Checks" }
                             }
                         }
                         tbody {
@@ -108,6 +112,10 @@ pub fn list_view(
                                             td {
                                                 class: "review-{review_decision_label(&row.review_decision)}",
                                                 "{review_decision_display(&row.review_decision)}"
+                                            }
+                                            td {
+                                                class: "check-{check_status_label(&row.check_status)}",
+                                                "{check_status_display(&row.check_status)}"
                                             }
                                         }
                                     }
@@ -153,13 +161,23 @@ pub fn load_rows() -> anyhow::Result<ListData> {
 
         let change_id = change.id().unwrap_or("").to_string();
 
-        let review_decision = josh_changes::read_pr_data(&repo, &change_id)
+        let (review_decision, check_status) = josh_changes::read_pr_data(&repo, &change_id)
             .ok()
             .flatten()
             .and_then(|json| {
                 serde_json::from_str::<serde_json::Value>(&json)
                     .ok()
-                    .and_then(|v| v["review_decision"].as_str().map(|s| s.to_string()))
+                    .map(|v| {
+                        let rd = v["review_decision"]
+                            .as_str()
+                            .map(|s| s.to_string())
+                            .unwrap_or_default();
+                        let cs = v["check_status"]
+                            .as_str()
+                            .map(|s| s.to_string())
+                            .unwrap_or_default();
+                        (rd, cs)
+                    })
             })
             .unwrap_or_default();
 
@@ -170,6 +188,7 @@ pub fn load_rows() -> anyhow::Result<ListData> {
             author: change.author().to_string(),
             series: change.series().join(", "),
             review_decision,
+            check_status,
         });
 
         let mut deps: Vec<String> = Vec::new();

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -561,3 +561,15 @@ td.review-review-required {
     color: #d19a66;
 }
 
+td.check-success {
+    color: #7ec699;
+}
+
+td.check-failure {
+    color: #e06c75;
+}
+
+td.check-pending {
+    color: #d19a66;
+}
+


### PR DESCRIPTION
Fetch CI check status from GitHub and display it in the change list

Query statusCheckRollup from the GitHub GraphQL API and show it as a
"Checks" column on the list page, with color-coded pass/fail/pending states.

Change: ci-check-status-column
Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>