### PR TITLE
Rename vote states to approve/discuss/revise

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1296,6 +1296,15 @@ pub struct VoteData {
     pub body: String,
 }
 
+pub fn vote_state_to_github_review(state: &str) -> &'static str {
+    match state {
+        "approve" => "APPROVED",
+        "discuss" => "COMMENTED",
+        "revise" => "CHANGES_REQUESTED",
+        _ => "COMMENTED",
+    }
+}
+
 pub fn write_vote(
     repo: &git2::Repository,
     change: &Change,

--- a/josh-gui/src/common.rs
+++ b/josh-gui/src/common.rs
@@ -2,6 +2,24 @@ use std::sync::OnceLock;
 
 use dioxus::prelude::*;
 
+pub fn vote_state_label(state: &str) -> &'static str {
+    match state {
+        "approve" => "approve",
+        "discuss" => "discuss",
+        "revise" => "revise",
+        _ => "",
+    }
+}
+
+pub fn vote_state_display(state: &str) -> &'static str {
+    match state {
+        "approve" => "Approve",
+        "discuss" => "Discuss",
+        "revise" => "Revise",
+        _ => "",
+    }
+}
+
 pub fn review_decision_label(rd: &str) -> &'static str {
     match rd {
         "Approved" => "approved",

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -1,7 +1,9 @@
 use dioxus::prelude::*;
 
 use crate::Page;
-use crate::common::{render_threads, review_decision_display, review_decision_label};
+use crate::common::{
+    render_threads, review_decision_display, review_decision_label, vote_state_display,
+};
 
 #[derive(Clone)]
 pub struct FileStat {
@@ -38,15 +40,6 @@ pub struct PrInfo {
     pub title: String,
     pub state: String,
     pub review_decision: String,
-}
-
-fn vote_state_display(state: &str) -> &'static str {
-    match state {
-        "approved" => "Approved",
-        "neutral" => "Neutral",
-        "changes_requested" => "Changes requested",
-        _ => "",
-    }
 }
 
 #[component]
@@ -240,7 +233,7 @@ pub fn DetailView(sha: String, mut page: Signal<Page>) -> Element {
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
                                                 let _ = save_vote(
-                                                    &sha, "approved", &body,
+                                                    &sha, "approve", &body,
                                                 );
                                                 vote_body.set(String::new());
                                                 page.set(Page::Detail {
@@ -255,18 +248,18 @@ pub fn DetailView(sha: String, mut page: Signal<Page>) -> Element {
                                     let sha = sha.clone();
                                     rsx! {
                                         button {
-                                            class: "vote-btn neutral",
+                                            class: "vote-btn discuss",
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
                                                 let _ = save_vote(
-                                                    &sha, "neutral", &body,
+                                                    &sha, "discuss", &body,
                                                 );
                                                 vote_body.set(String::new());
                                                 page.set(Page::Detail {
                                                     sha: sha.clone(),
                                                 });
                                             },
-                                            "Neutral"
+                                            "Discuss"
                                         }
                                     }
                                 }
@@ -278,7 +271,7 @@ pub fn DetailView(sha: String, mut page: Signal<Page>) -> Element {
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
                                                 let _ = save_vote(
-                                                    &sha, "changes_requested", &body,
+                                                    &sha, "revise", &body,
                                                 );
                                                 vote_body.set(String::new());
                                                 page.set(Page::Detail {

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -5,6 +5,7 @@ use dioxus::prelude::*;
 use crate::Page;
 use crate::common::{
     check_status_display, check_status_label, review_decision_display, review_decision_label,
+    vote_state_display, vote_state_label,
 };
 
 #[derive(Clone)]
@@ -16,6 +17,7 @@ pub struct Row {
     pub series: String,
     pub review_decision: String,
     pub check_status: String,
+    pub local_vote: Option<String>,
 }
 
 pub struct ListData {
@@ -79,6 +81,7 @@ pub fn ListView(
                                 th { "Author" }
                                 th { "Series" }
                                 th { "Review" }
+                                th { "Vote" }
                                 th { "Checks" }
                             }
                         }
@@ -113,6 +116,14 @@ pub fn ListView(
                                             td {
                                                 class: "review-{review_decision_label(&row.review_decision)}",
                                                 "{review_decision_display(&row.review_decision)}"
+                                            }
+                                            td {
+                                                class: if let Some(ref v) = row.local_vote {
+                                                    "vote-{vote_state_label(v)}"
+                                                },
+                                                if let Some(ref v) = row.local_vote {
+                                                    "{vote_state_display(v)}"
+                                                }
                                             }
                                             td {
                                                 class: "check-{check_status_label(&row.check_status)}",
@@ -182,6 +193,11 @@ pub fn load_rows() -> anyhow::Result<ListData> {
             })
             .unwrap_or_default();
 
+        let local_vote = josh_changes::read_vote(&repo, &change_id)
+            .ok()
+            .flatten()
+            .map(|v| v.state);
+
         rows.push(Row {
             change_id: change_id.clone(),
             sha: change.commit().to_string(),
@@ -190,6 +206,7 @@ pub fn load_rows() -> anyhow::Result<ListData> {
             series: change.series().join(", "),
             review_decision,
             check_status,
+            local_vote,
         });
 
         let mut deps: Vec<String> = Vec::new();

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -561,6 +561,18 @@ td.review-review-required {
     color: #d19a66;
 }
 
+td.vote-approve {
+    color: #7ec699;
+}
+
+td.vote-discuss {
+    color: #d19a66;
+}
+
+td.vote-revise {
+    color: #e06c75;
+}
+
 td.check-success {
     color: #7ec699;
 }
@@ -596,15 +608,15 @@ span.vote-state {
     font-size: 0.9rem;
 }
 
-span.vote-state.vote-approved {
+span.vote-state.vote-approve {
     color: #7ec699;
 }
 
-span.vote-state.vote-neutral {
+span.vote-state.vote-discuss {
     color: #d19a66;
 }
 
-span.vote-state.vote-changes_requested {
+span.vote-state.vote-revise {
     color: #e06c75;
 }
 
@@ -662,12 +674,12 @@ button.vote-btn.approve:hover {
     background: #2a4a2a;
 }
 
-button.vote-btn.neutral {
+button.vote-btn.discuss {
     color: #d19a66;
     border-color: #d19a66;
 }
 
-button.vote-btn.neutral:hover {
+button.vote-btn.discuss:hover {
     background: #3a3020;
 }
 


### PR DESCRIPTION
Rename vote states to approve/discuss/revise

Replace the old approved/neutral/changes_requested terminology with
approve/discuss/revise throughout the UI and backend. The list page now
also displays the local vote state in a new column.

Change: rename-vote-states
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>