### PR TITLE
Add local voting on changes via approve/neutral/revise widget

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1290,6 +1290,99 @@ fn write_changes_tree(
     Ok(())
 }
 
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct VoteData {
+    pub state: String,
+    pub body: String,
+}
+
+pub fn write_vote(
+    repo: &git2::Repository,
+    change: &Change,
+    state: &str,
+    body: &str,
+    author: Option<&str>,
+    timestamp: Option<&str>,
+) -> anyhow::Result<String> {
+    let change_id = change
+        .id()
+        .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
+
+    let json = serde_json::json!({"state": state, "body": body});
+    let content = json.to_string();
+    let content_hash =
+        git2::Oid::hash_object(git2::ObjectType::Blob, content.as_bytes())?.to_string();
+    let blob_oid = repo.blob(content.as_bytes())?;
+
+    let path = std::path::Path::new("votes")
+        .join(encode_change_id_path(&change_id))
+        .join(&content_hash);
+    write_changes_tree(repo, &path, blob_oid, author, timestamp)?;
+
+    Ok(content_hash)
+}
+
+pub fn read_vote(repo: &git2::Repository, change_id: &str) -> anyhow::Result<Option<VoteData>> {
+    // Verify the ref exists before proceeding.
+    let _obj = match repo.find_reference("refs/josh/changes") {
+        Ok(r) => r.peel_to_commit()?,
+        Err(_) => return Ok(None),
+    };
+
+    let path = std::path::Path::new("votes").join(encode_change_id_path(change_id));
+
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push_ref("refs/josh/changes")?;
+
+    for oid in revwalk {
+        let commit = repo.find_commit(oid?)?;
+        let tree = commit.tree()?;
+
+        let current_votes = match get_tree(repo, &tree, &path) {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let entries: Vec<String> = current_votes
+            .iter()
+            .filter_map(|e| e.name().map(String::from))
+            .collect();
+
+        if entries.is_empty() {
+            continue;
+        }
+
+        let new_entries: Vec<String> = if let Ok(parent) = commit.parent(0) {
+            let parent_tree = parent.tree()?;
+            let parent_entries: std::collections::HashSet<String> =
+                get_tree(repo, &parent_tree, &path)
+                    .map(|t| {
+                        t.iter()
+                            .filter_map(|e| e.name().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+            entries
+                .into_iter()
+                .filter(|e| !parent_entries.contains(e))
+                .collect()
+        } else {
+            entries
+        };
+
+        if let Some(name) = new_entries.first() {
+            let entry = current_votes
+                .get_name(name)
+                .ok_or_else(|| anyhow!("vote blob not found in tree"))?;
+            let blob = entry.to_object(repo)?.peel_to_blob()?;
+            let data: VoteData = serde_json::from_slice(blob.content())?;
+            return Ok(Some(data));
+        }
+    }
+
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -3169,6 +3169,7 @@ dependencies = [
  "anyhow",
  "git2",
  "josh-core",
+ "serde",
  "serde_json",
 ]
 

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -30,6 +30,7 @@ pub struct DetailData {
     pub revisions: Vec<josh_changes::Revision>,
     pub stack: Vec<StackCommit>,
     pub pr_info: Option<PrInfo>,
+    pub local_vote: Option<josh_changes::VoteData>,
 }
 
 pub struct PrInfo {
@@ -39,8 +40,18 @@ pub struct PrInfo {
     pub review_decision: String,
 }
 
+fn vote_state_display(state: &str) -> &'static str {
+    match state {
+        "approved" => "Approved",
+        "neutral" => "Neutral",
+        "changes_requested" => "Changes requested",
+        _ => "",
+    }
+}
+
 pub fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
     let data = load_detail(&sha);
+    let mut vote_body = use_signal(String::new);
 
     match &data {
         Err(e) => rsx! {
@@ -81,6 +92,84 @@ pub fn detail_view(sha: String, mut page: Signal<Page>) -> Element {
                                                     " {review_decision_display(&pr.review_decision)}"
                                                 }
                                             }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        div { class: "vote-section",
+                            h2 { "Vote" }
+                            if let Some(ref vote) = data.local_vote {
+                                div { class: "current-vote",
+                                    span { class: "vote-state vote-{vote.state}",
+                                        "{vote_state_display(&vote.state)}"
+                                    }
+                                    if !vote.body.is_empty() {
+                                        pre { class: "vote-body", "{vote.body}" }
+                                    }
+                                }
+                            }
+                            textarea {
+                                class: "vote-textarea",
+                                placeholder: "Review comment (optional)...",
+                                value: "{vote_body}",
+                                oninput: move |evt| vote_body.set(evt.value()),
+                            }
+                            div { class: "vote-actions",
+                                {
+                                    let sha = sha.clone();
+                                    rsx! {
+                                        button {
+                                            class: "vote-btn approve",
+                                            onclick: move |_| {
+                                                let body = vote_body.read().clone();
+                                                let _ = save_vote(
+                                                    &sha, "approved", &body,
+                                                );
+                                                vote_body.set(String::new());
+                                                page.set(Page::Detail {
+                                                    sha: sha.clone(),
+                                                });
+                                            },
+                                            "Approve"
+                                        }
+                                    }
+                                }
+                                {
+                                    let sha = sha.clone();
+                                    rsx! {
+                                        button {
+                                            class: "vote-btn neutral",
+                                            onclick: move |_| {
+                                                let body = vote_body.read().clone();
+                                                let _ = save_vote(
+                                                    &sha, "neutral", &body,
+                                                );
+                                                vote_body.set(String::new());
+                                                page.set(Page::Detail {
+                                                    sha: sha.clone(),
+                                                });
+                                            },
+                                            "Neutral"
+                                        }
+                                    }
+                                }
+                                {
+                                    let sha = sha.clone();
+                                    rsx! {
+                                        button {
+                                            class: "vote-btn revise",
+                                            onclick: move |_| {
+                                                let body = vote_body.read().clone();
+                                                let _ = save_vote(
+                                                    &sha, "changes_requested", &body,
+                                                );
+                                                vote_body.set(String::new());
+                                                page.set(Page::Detail {
+                                                    sha: sha.clone(),
+                                                });
+                                            },
+                                            "Revise"
                                         }
                                     }
                                 }
@@ -322,6 +411,10 @@ pub fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
 
     let comments = josh_changes::read_comments(&repo, &change).unwrap_or_default();
     let revisions = josh_changes::read_revisions(&repo, &change).unwrap_or_default();
+    let local_vote = change_id
+        .as_ref()
+        .and_then(|cid| josh_changes::read_vote(&repo, cid).ok())
+        .flatten();
 
     Ok(DetailData {
         change_id: change_id.unwrap_or_default(),
@@ -336,6 +429,7 @@ pub fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
         revisions,
         stack,
         pr_info,
+        local_vote,
     })
 }
 
@@ -364,4 +458,12 @@ pub fn save_comment(
     };
 
     josh_changes::write_comment(&repo, &change, &meta, None, None)
+}
+
+pub fn save_vote(sha: &str, state: &str, body: &str) -> anyhow::Result<String> {
+    let repo = git2::Repository::discover(".")?;
+    let oid = git2::Oid::from_str(sha)?;
+    let commit = repo.find_commit(oid)?;
+    let change = josh_changes::Change::new(&repo, &commit);
+    josh_changes::write_vote(&repo, &change, state, body, None, None)
 }

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -573,3 +573,110 @@ td.check-pending {
     color: #d19a66;
 }
 
+.vote-section {
+    margin-top: 1.5rem;
+}
+
+.vote-section h2 {
+    font-size: 1.1rem;
+    color: #ddd;
+    margin-bottom: 0.5rem;
+}
+
+.current-vote {
+    margin-bottom: 0.75rem;
+    padding: 0.5rem;
+    background: #2a2a2a;
+    border-radius: 4px;
+    border-left: 3px solid #555;
+}
+
+span.vote-state {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+span.vote-state.vote-approved {
+    color: #7ec699;
+}
+
+span.vote-state.vote-neutral {
+    color: #d19a66;
+}
+
+span.vote-state.vote-changes_requested {
+    color: #e06c75;
+}
+
+pre.vote-body {
+    margin-top: 0.4rem;
+    font-size: 0.85rem;
+    color: #aaa;
+    white-space: pre-wrap;
+}
+
+textarea.vote-textarea {
+    width: 100%;
+    min-height: 4rem;
+    background: #222;
+    color: #ccc;
+    border: 1px solid #444;
+    border-radius: 4px;
+    padding: 0.4rem;
+    font-size: 0.85rem;
+    font-family: inherit;
+    resize: vertical;
+    box-sizing: border-box;
+}
+
+textarea.vote-textarea:focus {
+    border-color: #666;
+    outline: none;
+}
+
+.vote-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+button.vote-btn {
+    padding: 0.25rem 0.75rem;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.85rem;
+    background: #333;
+    border: 1px solid #555;
+}
+
+button.vote-btn:hover {
+    background: #444;
+}
+
+button.vote-btn.approve {
+    color: #7ec699;
+    border-color: #7ec699;
+}
+
+button.vote-btn.approve:hover {
+    background: #2a4a2a;
+}
+
+button.vote-btn.neutral {
+    color: #d19a66;
+    border-color: #d19a66;
+}
+
+button.vote-btn.neutral:hover {
+    background: #3a3020;
+}
+
+button.vote-btn.revise {
+    color: #e06c75;
+    border-color: #e06c75;
+}
+
+button.vote-btn.revise:hover {
+    background: #3a2020;
+}
+


### PR DESCRIPTION
Add local voting on changes via approve/neutral/revise widget

Store votes as blobs under refs/josh/changes/votes/<change-id>/<hash>.
Add a voting section to the detail page with three vote buttons and an
optional review comment, persisted locally via write_vote/read_vote.

Change: local-change-voting
Assisted-By: DeepSeek v4 Pro <noreply@anthropic.com>