### PR TITLE
Reimplement stack downstacking as a :_=<sha> filter op

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1,4 +1,5 @@
 use anyhow::anyhow;
+pub use josh_core::trailers::{commit_change_meta, parse_change_meta};
 
 #[derive(Debug, Clone)]
 pub struct Change {
@@ -63,57 +64,6 @@ impl Change {
         }
         Ok(oids)
     }
-}
-
-fn is_trailer_line(line: &str) -> bool {
-    let key_len = line
-        .bytes()
-        .take_while(|&b| b.is_ascii_alphanumeric() || b == b'-')
-        .count();
-    key_len > 0 && line[key_len..].starts_with(": ")
-}
-
-/// Extract change-id metadata from a commit, preferring jj/gitbutler's custom
-/// `change-id` commit-object header over any `Change:` / `Change-Id:` trailer
-/// in the message body. The series list comes from message trailers regardless.
-pub fn commit_change_meta(commit: &git2::Commit) -> (Option<String>, Vec<String>) {
-    let (mut id, series) = parse_change_meta(commit.message().unwrap_or(""));
-    if let Ok(buf) = commit.header_field_bytes("change-id") {
-        if let Ok(s) = std::str::from_utf8(&buf) {
-            let s = s.trim();
-            if !s.is_empty() {
-                id = Some(s.to_string());
-            }
-        }
-    }
-    (id, series)
-}
-
-pub fn parse_change_meta(message: &str) -> (Option<String>, Vec<String>) {
-    let lines: Vec<&str> = message.lines().collect();
-    let mut footer_start = lines.len();
-    for (i, line) in lines.iter().enumerate().rev() {
-        if line.is_empty() || is_trailer_line(line) {
-            footer_start = i;
-        } else {
-            break;
-        }
-    }
-
-    let mut id: Option<String> = None;
-    let mut series: Vec<String> = Vec::new();
-    for line in &lines[footer_start..] {
-        if let Some(v) = line.strip_prefix("Change: ") {
-            id = Some(v.to_string());
-        }
-        if let Some(v) = line.strip_prefix("Change-Id: ") {
-            id = Some(v.to_string());
-        }
-        if let Some(v) = line.strip_prefix("Change-Series: ") {
-            series.push(v.to_string());
-        }
-    }
-    (id, series)
 }
 
 pub fn encode_change_id_path(id: &str) -> String {
@@ -193,133 +143,24 @@ pub fn baseref_and_options(
 
 fn split_changes(
     repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     changes: std::collections::HashMap<git2::Oid, Change>,
 ) -> anyhow::Result<Vec<Change>> {
     if changes.values().next().map(|c| c.base) == Some(git2::Oid::zero()) {
         return Ok(changes.into_values().collect());
     }
 
-    changes.iter().map(|(_, c)| downstack(repo, c)).collect()
-}
-
-fn changed_paths(
-    repo: &git2::Repository,
-    commit: &git2::Commit,
-) -> anyhow::Result<std::collections::HashSet<String>> {
-    let parent_tree = if commit.parent_count() > 0 {
-        Some(commit.parent(0)?.tree()?)
-    } else {
-        None
-    };
-    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
-    let mut paths = std::collections::HashSet::new();
-    for delta in diff.deltas() {
-        if let Some(p) = delta.old_file().path().and_then(|p| p.to_str()) {
-            paths.insert(p.to_string());
-        }
-        if let Some(p) = delta.new_file().path().and_then(|p| p.to_str()) {
-            paths.insert(p.to_string());
-        }
-    }
-    Ok(paths)
-}
-
-fn downstack(repo: &git2::Repository, change: &Change) -> anyhow::Result<Change> {
-    let change_oid = change.commit;
-    if !repo.graph_descendant_of(change_oid, change.base)? {
-        return Err(anyhow!(
-            "change {} is not a descendant of base {}",
-            change_oid,
-            change.base
-        ));
-    }
-
-    // Collect commits from base to change (exclusive of base, inclusive of change)
-    let mut walk = repo.revwalk()?;
-    walk.simplify_first_parent()?;
-    walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
-    walk.push(change_oid)?;
-    walk.hide(change.base)?;
-
-    let oids: Vec<git2::Oid> = walk.collect::<Result<Vec<_>, _>>()?;
-
-    if oids.is_empty() {
-        return Ok(change.clone());
-    }
-
-    let mut commits: Vec<git2::Commit> = oids
-        .into_iter()
-        .map(|oid| repo.find_commit(oid))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    // The last commit is `change`; split it off from the intermediates
-    let change_commit = commits.pop().unwrap();
-    let change_parent = change_commit.parent(0)?;
-
-    // Seed the affected path set with the change's own modified paths, then
-    // walk intermediates backwards, keeping any commit whose paths intersect.
-    let change_meta = Change::new(repo, &change_commit);
-    let mut affected_paths = changed_paths(repo, &change_commit)?;
-    for s in &change_meta.series {
-        affected_paths.insert(format!("\x00series:{}", s));
-    }
-    let mut needed: Vec<bool> = vec![false; commits.len()];
-    for (i, intermediate) in commits.iter().enumerate().rev() {
-        let meta = Change::new(repo, intermediate);
-        let mut paths = changed_paths(repo, intermediate)?;
-        for s in &meta.series {
-            paths.insert(format!("\x00series:{}", s));
-        }
-        if !paths.is_disjoint(&affected_paths) {
-            needed[i] = true;
-            affected_paths.extend(paths);
-        }
-    }
-
-    // Rebase needed intermediates forward onto current_base.
-    let mut current_base = repo.find_commit(change.base)?;
-    for (intermediate, is_needed) in commits.iter().zip(needed.iter()) {
-        if !is_needed {
-            continue;
-        }
-        let inter_parent = intermediate.parent(0)?;
-        let mut index = repo.merge_trees(
-            &inter_parent.tree()?,
-            &current_base.tree()?,
-            &intermediate.tree()?,
-            None,
-        )?;
-        let new_tree = repo.find_tree(index.write_tree_to(repo)?)?;
-        let new_oid = josh_core::history::rewrite_commit(
-            repo,
-            intermediate,
-            &[&current_base],
-            josh_core::filter::Rewrite::from_tree(new_tree),
-            josh_core::history::GpgsigMode::Preserve,
-        )?;
-        current_base = repo.find_commit(new_oid)?;
-    }
-
-    // Apply the change on top of the minimal base via 3-way merge.
-    let mut index = repo.merge_trees(
-        &change_parent.tree()?,
-        &current_base.tree()?,
-        &change_commit.tree()?,
-        None,
-    )?;
-    let new_tree = repo.find_tree(index.write_tree_to(repo)?)?;
-
-    let new_oid = josh_core::history::rewrite_commit(
-        repo,
-        &change_commit,
-        &[&current_base],
-        josh_core::filter::Rewrite::from_tree(new_tree),
-        josh_core::history::GpgsigMode::Preserve,
-    )?;
-
-    let mut result = change.clone();
-    result.commit = new_oid;
-    Ok(result)
+    changes
+        .into_values()
+        .map(|c| {
+            let filter = josh_core::filter::Filter::new().downstack(c.base);
+            let commit = repo.find_commit(c.commit)?;
+            let new_oid = josh_core::filter::apply_to_commit(filter, &commit, transaction)?;
+            let mut result = c;
+            result.commit = new_oid;
+            Ok(result)
+        })
+        .collect()
 }
 
 fn changes_to_refs(
@@ -411,6 +252,7 @@ fn get_changes(
 
 pub fn build_to_push(
     repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     push_mode: &PushMode,
     baseref: &str,
     ref_with_options: &str,
@@ -420,7 +262,7 @@ pub fn build_to_push(
     match push_mode {
         PushMode::Publish(author) => {
             let changes = get_changes(repo, oid_to_push, base_oid)?;
-            let changes = split_changes(repo, changes)?;
+            let changes = split_changes(repo, transaction, changes)?;
 
             let mut push_refs = changes_to_refs(repo, baseref, author, changes)?;
 
@@ -451,11 +293,12 @@ pub fn build_to_push(
 
 pub fn sync_changes(
     repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<Vec<Change>> {
     let changes = get_changes(repo, tip, base)?;
-    let changes = split_changes(repo, changes)?;
+    let changes = split_changes(repo, transaction, changes)?;
     for c in &changes {
         let _ = store_diff_data(repo, c);
     }
@@ -1486,69 +1329,4 @@ pub fn list_votes(
         }
     }
     Ok(votes)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn footer_in_body_is_ignored() {
-        let (id, series) =
-            parse_change_meta("Subject\n\nbody mentions Change: not-a-trailer\nmore body\n");
-        assert_eq!(id, None);
-        assert!(series.is_empty());
-    }
-
-    #[test]
-    fn real_trailing_footer_is_parsed() {
-        let (id, _) = parse_change_meta("Subject\n\nBody.\n\nChange: real-id\n");
-        assert_eq!(id.as_deref(), Some("real-id"));
-    }
-
-    #[test]
-    fn single_line_message_is_its_own_footer() {
-        let (id, _) = parse_change_meta("Change: only-line");
-        assert_eq!(id.as_deref(), Some("only-line"));
-    }
-
-    #[test]
-    fn footer_followed_by_body_is_ignored() {
-        let (id, _) = parse_change_meta("Subject\n\nChange: middle\n\nBody after.\n");
-        assert_eq!(id, None);
-    }
-
-    #[test]
-    fn other_trailers_in_block_do_not_break_change() {
-        let msg = "Subject\n\nBody.\n\nSigned-off-by: x <x@y>\nChange: real\n\
-                   Reviewed-by: z <z@w>\n";
-        let (id, _) = parse_change_meta(msg);
-        assert_eq!(id.as_deref(), Some("real"));
-    }
-
-    #[test]
-    fn series_in_footer_block_is_collected() {
-        let msg = "Subject\n\nBody.\n\nChange-Series: s1\nChange-Series: s2\nChange: c\n";
-        let (id, series) = parse_change_meta(msg);
-        assert_eq!(id.as_deref(), Some("c"));
-        assert_eq!(series, vec!["s1".to_string(), "s2".to_string()]);
-    }
-
-    #[test]
-    fn series_in_body_is_ignored() {
-        let msg = "Subject\n\nWe discussed Change-Series: bogus here.\nmore body\n";
-        let (_id, series) = parse_change_meta(msg);
-        assert!(series.is_empty());
-    }
-
-    #[test]
-    fn is_trailer_line_basics() {
-        assert!(is_trailer_line("Change: foo"));
-        assert!(is_trailer_line("Change-Id: foo"));
-        assert!(is_trailer_line("Signed-off-by: a <a@b>"));
-        assert!(!is_trailer_line("not a trailer"));
-        assert!(!is_trailer_line("Change:no-space"));
-        assert!(!is_trailer_line(": leading colon"));
-        assert!(!is_trailer_line(""));
-    }
 }

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -166,6 +166,7 @@ fn prepare_push(
 
     let to_push = build_to_push(
         repo,
+        transaction,
         &push_mode,
         remote_ref,
         remote_ref,

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -153,7 +153,7 @@ pub fn handle_sync(
 
             for pr in &prs {
                 let (existing_change_id, _) =
-                    josh_changes::parse_change_meta(&pr.head_commit_message);
+                    josh_core::trailers::parse_change_meta(&pr.head_commit_message);
 
                 let head_oid = match git2::Oid::from_str(&pr.head_oid) {
                     Ok(o) => o,
@@ -279,7 +279,8 @@ pub fn handle_sync(
             let open_change_ids: std::collections::HashSet<String> = prs
                 .iter()
                 .map(|pr| {
-                    let (existing_id, _) = josh_changes::parse_change_meta(&pr.head_commit_message);
+                    let (existing_id, _) =
+                        josh_core::trailers::parse_change_meta(&pr.head_commit_message);
                     existing_id
                         .unwrap_or_else(|| format!("{}/{}/pull/{}", owner, repo_name, pr.number))
                 })
@@ -402,7 +403,8 @@ pub fn handle_sync(
                 let mut total_posted = 0usize;
                 let mut total_votes_posted = 0usize;
                 for pr in &prs {
-                    let (existing_id, _) = josh_changes::parse_change_meta(&pr.head_commit_message);
+                    let (existing_id, _) =
+                        josh_core::trailers::parse_change_meta(&pr.head_commit_message);
                     let change_id = existing_id
                         .unwrap_or_else(|| format!("{}/{}/pull/{}", owner, repo_name, pr.number));
 
@@ -476,7 +478,7 @@ pub fn handle_sync(
             Ok::<_, anyhow::Error>(())
         })?;
     } else {
-        let changes = josh_changes::sync_changes(repo, head.id(), base_oid)?;
+        let changes = josh_changes::sync_changes(repo, transaction, head.id(), base_oid)?;
         if changes.is_empty() {
             println!("No local changes found.");
             return Ok(());

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -224,6 +224,8 @@ fn lazy_refs2(op: &Op) -> Vec<String> {
             }));
             lr
         }
+        Op::Downstack(LazyRef::Lazy(s)) => vec![s.to_owned()],
+        Op::Downstack(_) => vec![],
         _ => vec![],
     };
     lr.sort();
@@ -279,6 +281,13 @@ fn resolve_refs2(refs: &std::collections::HashMap<String, git2::Oid>, op: &Op) -
                 })
                 .collect();
             Op::Squash(Some(lr))
+        }
+        Op::Downstack(LazyRef::Lazy(s)) => {
+            if let Some(res) = refs.get(s) {
+                Op::Downstack(LazyRef::Resolved(*res))
+            } else {
+                op.clone()
+            }
         }
         _ => op.clone(),
     }
@@ -611,6 +620,17 @@ pub fn apply_to_commit2(
                 history::GpgsigMode::Remove,
             ))
             .transpose();
+        }
+        Op::Downstack(LazyRef::Resolved(base)) => {
+            if let Some(oid) = transaction.get(filter, commit.id()) {
+                return Ok(Some(oid));
+            }
+            let new_oid = downstack(repo, commit.id(), *base)?;
+            transaction.insert(filter, commit.id(), new_oid, false);
+            return Ok(Some(new_oid));
+        }
+        Op::Downstack(LazyRef::Lazy(_)) => {
+            return Err(anyhow!("`:_=...` with unresolved base ref"));
         }
         _ => {
             if let Some(oid) = transaction.get(filter, commit.id()) {
@@ -1544,6 +1564,7 @@ pub fn apply<'a>(
             }
         }
         Op::Pin(_) => Ok(x),
+        Op::Downstack(_) => Err(anyhow!("not applicable to tree: downstack")),
         Op::Meta(_, _) => unreachable!(),
     }
 }
@@ -2029,6 +2050,131 @@ fn per_rev_filter(
         commit_filter.into_meta(),
     ))
     .transpose();
+}
+
+/// Rebuild the stack from `base_oid` to `change_oid`, dropping intermediate commits
+/// whose changed paths are disjoint from the tip's changes, then reapply the tip
+/// onto the minimised base via a 3-way merge. Returns the new tip OID.
+pub fn downstack(
+    repo: &git2::Repository,
+    change_oid: git2::Oid,
+    base_oid: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    if !repo.graph_descendant_of(change_oid, base_oid)? {
+        return Err(anyhow!(
+            "change {} is not a descendant of base {}",
+            change_oid,
+            base_oid
+        ));
+    }
+
+    // Collect commits from base to change (exclusive of base, inclusive of change)
+    let mut walk = repo.revwalk()?;
+    walk.simplify_first_parent()?;
+    walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
+    walk.push(change_oid)?;
+    walk.hide(base_oid)?;
+
+    let oids: Vec<git2::Oid> = walk.collect::<Result<Vec<_>, _>>()?;
+
+    if oids.is_empty() {
+        return Ok(change_oid);
+    }
+
+    let mut commits: Vec<git2::Commit> = oids
+        .into_iter()
+        .map(|oid| repo.find_commit(oid))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // The last commit is `change`; split it off from the intermediates
+    let change_commit = commits.pop().unwrap();
+
+    // Seed the affected path set with the change's own modified paths, then
+    // walk intermediates backwards, keeping any commit whose paths intersect.
+    let (_, change_series) =
+        crate::trailers::parse_change_meta(change_commit.message().unwrap_or(""));
+    let mut affected_paths = downstack_changed_paths(repo, &change_commit)?;
+    for s in &change_series {
+        affected_paths.insert(format!("\x00series:{}", s));
+    }
+    let mut needed: Vec<bool> = vec![false; commits.len()];
+    for (i, intermediate) in commits.iter().enumerate().rev() {
+        let (_, series) = crate::trailers::parse_change_meta(intermediate.message().unwrap_or(""));
+        let mut paths = downstack_changed_paths(repo, intermediate)?;
+        for s in &series {
+            paths.insert(format!("\x00series:{}", s));
+        }
+        if !paths.is_disjoint(&affected_paths) {
+            needed[i] = true;
+            affected_paths.extend(paths);
+        }
+    }
+
+    // Rebase needed intermediates forward onto current_base.
+    let mut current_base = repo.find_commit(base_oid)?;
+    for (intermediate, is_needed) in commits.iter().zip(needed.iter()) {
+        if !is_needed {
+            continue;
+        }
+        let inter_parent = intermediate.parent(0)?;
+        let mut index = repo.merge_trees(
+            &inter_parent.tree()?,
+            &current_base.tree()?,
+            &intermediate.tree()?,
+            None,
+        )?;
+        let new_tree = repo.find_tree(index.write_tree_to(repo)?)?;
+        let new_oid = history::rewrite_commit(
+            repo,
+            intermediate,
+            &[&current_base],
+            Rewrite::from_tree(new_tree),
+            history::GpgsigMode::Preserve,
+        )?;
+        current_base = repo.find_commit(new_oid)?;
+    }
+
+    // Apply the change on top of the minimal base via 3-way merge.
+    let change_parent = change_commit.parent(0)?;
+    let mut index = repo.merge_trees(
+        &change_parent.tree()?,
+        &current_base.tree()?,
+        &change_commit.tree()?,
+        None,
+    )?;
+    let new_tree = repo.find_tree(index.write_tree_to(repo)?)?;
+
+    let new_oid = history::rewrite_commit(
+        repo,
+        &change_commit,
+        &[&current_base],
+        Rewrite::from_tree(new_tree),
+        history::GpgsigMode::Preserve,
+    )?;
+
+    Ok(new_oid)
+}
+
+fn downstack_changed_paths(
+    repo: &git2::Repository,
+    commit: &git2::Commit,
+) -> anyhow::Result<std::collections::HashSet<String>> {
+    let parent_tree = if commit.parent_count() > 0 {
+        Some(commit.parent(0)?.tree()?)
+    } else {
+        None
+    };
+    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
+    let mut paths = std::collections::HashSet::new();
+    for delta in diff.deltas() {
+        if let Some(p) = delta.old_file().path().and_then(|p| p.to_str()) {
+            paths.insert(p.to_string());
+        }
+        if let Some(p) = delta.new_file().path().and_then(|p| p.to_str()) {
+            paths.insert(p.to_string());
+        }
+    }
+    Ok(paths)
 }
 
 #[cfg(test)]

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod history;
 pub mod housekeeping;
 pub mod link;
 pub mod submodules;
+pub mod trailers;
 
 #[derive(
     Clone, Hash, PartialEq, Eq, Copy, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize,

--- a/josh-core/src/trailers.rs
+++ b/josh-core/src/trailers.rs
@@ -1,0 +1,115 @@
+pub fn is_trailer_line(line: &str) -> bool {
+    let key_len = line
+        .bytes()
+        .take_while(|&b| b.is_ascii_alphanumeric() || b == b'-')
+        .count();
+    key_len > 0 && line[key_len..].starts_with(": ")
+}
+
+/// Extract change-id metadata from a commit, preferring jj/gitbutler's custom
+/// `change-id` commit-object header over any `Change:` / `Change-Id:` trailer
+/// in the message body. The series list comes from message trailers regardless.
+pub fn commit_change_meta(commit: &git2::Commit) -> (Option<String>, Vec<String>) {
+    let (mut id, series) = parse_change_meta(commit.message().unwrap_or(""));
+    if let Ok(buf) = commit.header_field_bytes("change-id") {
+        if let Ok(s) = std::str::from_utf8(&buf) {
+            let s = s.trim();
+            if !s.is_empty() {
+                id = Some(s.to_string());
+            }
+        }
+    }
+    (id, series)
+}
+
+pub fn parse_change_meta(message: &str) -> (Option<String>, Vec<String>) {
+    let lines: Vec<&str> = message.lines().collect();
+    let mut footer_start = lines.len();
+    for (i, line) in lines.iter().enumerate().rev() {
+        if line.is_empty() || is_trailer_line(line) {
+            footer_start = i;
+        } else {
+            break;
+        }
+    }
+
+    let mut id: Option<String> = None;
+    let mut series: Vec<String> = Vec::new();
+    for line in &lines[footer_start..] {
+        if let Some(v) = line.strip_prefix("Change: ") {
+            id = Some(v.to_string());
+        }
+        if let Some(v) = line.strip_prefix("Change-Id: ") {
+            id = Some(v.to_string());
+        }
+        if let Some(v) = line.strip_prefix("Change-Series: ") {
+            series.push(v.to_string());
+        }
+    }
+    (id, series)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn footer_in_body_is_ignored() {
+        let (id, series) =
+            parse_change_meta("Subject\n\nbody mentions Change: not-a-trailer\nmore body\n");
+        assert_eq!(id, None);
+        assert!(series.is_empty());
+    }
+
+    #[test]
+    fn real_trailing_footer_is_parsed() {
+        let (id, _) = parse_change_meta("Subject\n\nBody.\n\nChange: real-id\n");
+        assert_eq!(id.as_deref(), Some("real-id"));
+    }
+
+    #[test]
+    fn single_line_message_is_its_own_footer() {
+        let (id, _) = parse_change_meta("Change: only-line");
+        assert_eq!(id.as_deref(), Some("only-line"));
+    }
+
+    #[test]
+    fn footer_followed_by_body_is_ignored() {
+        let (id, _) = parse_change_meta("Subject\n\nChange: middle\n\nBody after.\n");
+        assert_eq!(id, None);
+    }
+
+    #[test]
+    fn other_trailers_in_block_do_not_break_change() {
+        let msg = "Subject\n\nBody.\n\nSigned-off-by: x <x@y>\nChange: real\n\
+                   Reviewed-by: z <z@w>\n";
+        let (id, _) = parse_change_meta(msg);
+        assert_eq!(id.as_deref(), Some("real"));
+    }
+
+    #[test]
+    fn series_in_footer_block_is_collected() {
+        let msg = "Subject\n\nBody.\n\nChange-Series: s1\nChange-Series: s2\nChange: c\n";
+        let (id, series) = parse_change_meta(msg);
+        assert_eq!(id.as_deref(), Some("c"));
+        assert_eq!(series, vec!["s1".to_string(), "s2".to_string()]);
+    }
+
+    #[test]
+    fn series_in_body_is_ignored() {
+        let msg = "Subject\n\nWe discussed Change-Series: bogus here.\nmore body\n";
+        let (_id, series) = parse_change_meta(msg);
+        assert!(series.is_empty());
+    }
+
+    #[test]
+    fn is_trailer_line_basics() {
+        assert!(is_trailer_line("Change: foo"));
+        assert!(is_trailer_line("Change-Id: foo"));
+        assert!(is_trailer_line("Signed-off-by: a <a@b>"));
+        assert!(!is_trailer_line("not a trailer"));
+        assert!(!is_trailer_line("Change:no-space"));
+        assert!(!is_trailer_line(": leading colon"));
+        assert!(!is_trailer_line(""));
+    }
+}

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -208,6 +208,12 @@ impl Filter {
         })
     }
 
+    /// Chain a downstack filter that rebuilds the stack from `base` to the input commit,
+    /// dropping intermediate commits whose paths are disjoint from the tip's changes.
+    pub fn downstack(self, base: git2::Oid) -> Filter {
+        self.chain(to_filter(Op::Downstack(LazyRef::Resolved(base))))
+    }
+
     /// Chain a message filter that transforms commit messages
     pub fn message(self, m: &str) -> Filter {
         self.chain(to_filter(Op::Message(

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -305,6 +305,7 @@ pub(crate) fn spec2(op: &Op) -> String {
         Op::Hook(hook) => {
             format!(":hook={}", parse::quote(hook))
         }
+        Op::Downstack(r) => format!(":_={}", r),
         Op::Meta(meta, filter) => {
             let mut meta_parts = meta
                 .iter()

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -95,6 +95,21 @@ fn make_filter(args: &[&str]) -> anyhow::Result<Filter> {
         ["INVERT"] => Ok(to_filter(Op::Invert)),
         ["FOLD"] => Ok(to_filter(Op::Fold)),
         ["hook", arg] => Ok(f.hook(arg)),
+        ["_", sha] => {
+            check_experimental_features_enabled("downstack filter")?;
+            Ok(to_filter(Op::Downstack(LazyRef::parse(sha)?)))
+        }
+        ["_"] => Err(anyhow!(indoc!(
+            r#"
+            Filter ":_" requires a base SHA argument.
+
+            Note: use "=" to provide the argument value:
+
+              :_=<sha>
+
+            Where `<sha>` is the base commit to rebase against.
+            "#
+        ))),
         _ => Err(anyhow!(formatdoc!(
             r#"
             Invalid filter: ":{0}"

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -128,4 +128,6 @@ pub enum Op {
     Subtract(Filter, Filter),
     Exclude(Filter),
     Pin(Filter),
+
+    Downstack(LazyRef),
 }

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -477,6 +477,10 @@ impl InMemoryBuilder {
                 let params_tree = self.build_str_params(&[hook.as_ref()]);
                 push_tree_entries(&mut entries, [("hook", params_tree)]);
             }
+            Op::Downstack(lazy_ref) => {
+                let params_tree = self.build_str_params(&[lazy_ref.to_string().as_str()]);
+                push_tree_entries(&mut entries, [("downstack", params_tree)]);
+            }
             Op::Meta(meta, filter) => {
                 let mut meta_entries = Vec::new();
                 for (key, value) in meta.iter() {
@@ -1001,6 +1005,17 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
                 replacements.push((regex, replacement));
             }
             Ok(Op::RegexReplace(replacements))
+        }
+        "downstack" => {
+            let inner = repo.find_tree(entry.id())?;
+            let key_blob = repo.find_blob(
+                inner
+                    .get_name("0")
+                    .context("downstack: missing base ref")?
+                    .id(),
+            )?;
+            let key = std::str::from_utf8(key_blob.content())?;
+            Ok(Op::Downstack(LazyRef::parse(key)?))
         }
         "meta" => {
             let meta_tree = repo.find_tree(entry.id())?;

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -495,6 +495,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
 
         let to_push = build_to_push(
             transaction.repo(),
+            &transaction,
             &push_mode,
             &baseref,
             &ref_with_options,

--- a/tests/experimental/downstack_filter.t
+++ b/tests/experimental/downstack_filter.t
@@ -1,0 +1,54 @@
+  $ export RUST_BACKTRACE=1
+  $ git init -q 1> /dev/null
+
+  $ echo base > base
+  $ git add .
+  $ git commit -m "base" 1> /dev/null
+  $ BASE=$(git rev-parse HEAD)
+
+  $ echo a > file_a
+  $ git add .
+  $ git commit -m "add file_a" 1> /dev/null
+
+  $ echo b > file_b
+  $ git add .
+  $ git commit -m "add file_b" 1> /dev/null
+
+  $ echo b2 > file_b
+  $ git add .
+  $ git commit -m "modify file_b" 1> /dev/null
+
+  $ git log --pretty=%s
+  modify file_b
+  add file_b
+  add file_a
+  base
+
+The downstack filter rebuilds the stack from the tip onto $BASE,
+dropping intermediate commits whose paths are disjoint from the tip's changes.
+The tip only touches file_b, so "add file_a" is dropped but "add file_b" is kept.
+
+  $ josh-filter -s ":_=$BASE" --update refs/heads/filtered 1> /dev/null
+  $ git log refs/heads/filtered --pretty=%s
+  modify file_b
+  add file_b
+  base
+
+The resulting tip has the expected tree:
+
+  $ git show refs/heads/filtered:file_b
+  b2
+  $ git ls-tree --name-only refs/heads/filtered
+  base
+  file_b
+
+Roundtrip: filter spec is preserved.
+
+  $ josh-filter -p ":_=$BASE"
+  :_=[0-9a-f]{40} (re)
+
+Error: non-descendant base.
+
+  $ UNRELATED=$(git commit-tree $EMPTY_TREE -m "unrelated")
+  $ josh-filter -s ":_=$UNRELATED" --update refs/heads/foo 2>&1 | grep -i "not a descendant"
+  ERROR: change [0-9a-f]+ is not a descendant of base [0-9a-f]+ (re)

--- a/tests/proxy/push_stacked_split.t
+++ b/tests/proxy/push_stacked_split.t
@@ -181,6 +181,8 @@ Make sure all temporary namespace got removed
       |   |   `-- 693682dba1d7af1cb1eca7c3dcc5128e3ec9c6
       |   |-- 8a
       |   |   `-- 778416d88308bf017cf54f0247e4780765361f
+      |   |-- a0
+      |   |   `-- 18dae3609294bc68eff023fabb96386ec483db
       |   |-- b2
       |   |   `-- dd517c55420a48cb543e0195b4751bf514b941
       |   |-- b7
@@ -198,7 +200,7 @@ Make sure all temporary namespace got removed
           |-- namespaces
           `-- tags
   
-  65 directories, 49 files
+  66 directories, 50 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE


### PR DESCRIPTION
Reimplement stack downstacking as a :_=<sha> filter op

Move the downstack rebase logic out of josh-changes into josh-core's filter
pipeline as a new Op::Downstack, exposed in flang as ":_=<sha>". This lets
the operation participate in the filter cache via the transaction, and lets
the trailer-parsing helpers move alongside it into josh-core::trailers.

Change: downstack-as-filter-op
Assisted-By: claude-opus-4-7