### PR TITLE
Strip path+version dual decl from filtered Cargo.toml

### DIFF
--- a/ws/build-rust.josh
+++ b/ws/build-rust.josh
@@ -12,7 +12,7 @@ env = :[
 
 worktree = :[
     ::run.sh=ws/build-rust.sh
-    ::Cargo.toml
+    :+ws/patched-cargo
     ::Cargo.lock
     ::rust-toolchain.toml
     ::rustfmt.toml

--- a/ws/fetch.josh
+++ b/ws/fetch.josh
@@ -6,6 +6,7 @@
 :$cmd="cargo fetch --locked"
 
 worktree = :[
+    :+ws/patched-cargo
     ::**/Cargo.toml
     ::**/Cargo.lock
     ::**/rust-toolchain.toml

--- a/ws/patched-cargo.josh
+++ b/ws/patched-cargo.josh
@@ -1,0 +1,1 @@
+::Cargo.toml:replace("\\{\\s*path\\s*=\\s*\"([^\"]+)\"\\s*,\\s*version\\s*=\\s*\"[^\"]+\"\\s*\\}":"{ path = \"$1\" }")


### PR DESCRIPTION
Strip path+version dual decl from filtered Cargo.toml

In `[workspace.dependencies]` the josh-* crates are declared with both
`path` and `version`. The filtered worktree produced by `ws/fetch.josh`
and `ws/build-rust.josh` lacks .git, and cargo sometimes resolves these
entries against crates.io despite the `path` field, confusing
`cargo fetch` / `cargo build` under `josh compose run`.

Introduce `ws/patched-cargo.josh` containing
`::Cargo.toml:replace(...)` that rewrites `{ path = "X", version = "Y" }`
to `{ path = "X" }`, and reference it via `:+ws/patched-cargo` from the
fetch and build filter compositions. The on-disk Cargo.toml is
untouched -- only the copy inside the build container is patched.

Change: filter-strip-cargo-version-dual
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>