### PR TITLE
Drop _on_branch wrappers in favor of _in_scopes

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1616,19 +1616,12 @@ pub fn read_github_ids_union(
 }
 
 // =========================================================================
-// `_on_branch` helpers: same merge semantics as the corresponding `_union`
-// variants, but only over refs whose target branch matches.
+// `_in_scopes` helpers: same merge semantics as the corresponding `_union`
+// variants, but restricted to a caller-supplied scope list (typically the
+// output of `refs_on_branch`). Callers that touch metadata for many changes
+// should resolve scopes once and reuse them.
 // =========================================================================
 
-pub fn list_changes_on_branch(
-    repo: &git2::Repository,
-    branch: &str,
-) -> anyhow::Result<Vec<Change>> {
-    list_changes_in_scopes(repo, &refs_on_branch(repo, branch)?)
-}
-
-/// Like `list_changes_on_branch`, but reuses a precomputed scope list to avoid
-/// re-scanning every repository reference on each call.
 pub fn list_changes_in_scopes(
     repo: &git2::Repository,
     scopes: &[ChangesRef],
@@ -1650,15 +1643,6 @@ pub fn list_changes_in_scopes(
     Ok(out)
 }
 
-pub fn read_pr_data_on_branch(
-    repo: &git2::Repository,
-    change_id: &str,
-    branch: &str,
-) -> anyhow::Result<Option<String>> {
-    read_pr_data_in_scopes(repo, change_id, &refs_on_branch(repo, branch)?)
-}
-
-/// Like `read_pr_data_on_branch`, but takes a precomputed scope list.
 pub fn read_pr_data_in_scopes(
     repo: &git2::Repository,
     change_id: &str,
@@ -1675,15 +1659,6 @@ pub fn read_pr_data_in_scopes(
     Ok(None)
 }
 
-pub fn read_comments_on_branch(
-    repo: &git2::Repository,
-    change_id: &str,
-    branch: &str,
-) -> anyhow::Result<Vec<Comment>> {
-    read_comments_in_scopes(repo, change_id, &refs_on_branch(repo, branch)?)
-}
-
-/// Like `read_comments_on_branch`, but takes a precomputed scope list.
 pub fn read_comments_in_scopes(
     repo: &git2::Repository,
     change_id: &str,
@@ -1706,16 +1681,6 @@ pub fn read_comments_in_scopes(
         .collect())
 }
 
-pub fn read_vote_on_branch(
-    repo: &git2::Repository,
-    change_id: &str,
-    user: Option<&str>,
-    branch: &str,
-) -> anyhow::Result<Option<VoteData>> {
-    read_vote_in_scopes(repo, change_id, user, &refs_on_branch(repo, branch)?)
-}
-
-/// Like `read_vote_on_branch`, but takes a precomputed scope list.
 pub fn read_vote_in_scopes(
     repo: &git2::Repository,
     change_id: &str,
@@ -1728,23 +1693,4 @@ pub fn read_vote_in_scopes(
         }
     }
     Ok(None)
-}
-
-pub fn list_votes_on_branch(
-    repo: &git2::Repository,
-    change_id: &str,
-    branch: &str,
-) -> anyhow::Result<Vec<(String, VoteData)>> {
-    use std::collections::HashSet;
-    let mut seen: HashSet<(String, String, String)> = HashSet::new();
-    let mut out: Vec<(String, VoteData)> = Vec::new();
-    for scope in refs_on_branch(repo, branch)? {
-        for (user, data) in list_votes(repo, change_id, &scope)? {
-            let key = (user.clone(), data.sha.clone(), data.state.clone());
-            if seen.insert(key) {
-                out.push((user, data));
-            }
-        }
-    }
-    Ok(out)
 }

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -18,7 +18,8 @@ pub fn handle_list(
         None => josh_changes::head_branch(repo)?,
     };
 
-    let changes = josh_changes::list_changes_on_branch(repo, &branch)?;
+    let scopes = josh_changes::refs_on_branch(repo, &branch)?;
+    let changes = josh_changes::list_changes_in_scopes(repo, &scopes)?;
 
     if changes.is_empty() {
         println!("No local changes found for branch '{}'.", branch);
@@ -52,7 +53,7 @@ pub fn handle_list(
         let comments = change
             .id()
             .map(|cid| {
-                josh_changes::read_comments_on_branch(repo, cid, &branch).unwrap_or_default()
+                josh_changes::read_comments_in_scopes(repo, cid, &scopes).unwrap_or_default()
             })
             .unwrap_or_default();
         if !comments.is_empty() {

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -293,6 +293,7 @@ pub fn DetailView(sha: String, branch: String, mut page: Signal<Page>) -> Elemen
 
 pub fn load_detail(sha: &str, branch: &str) -> anyhow::Result<DetailData> {
     let repo = git2::Repository::discover(".")?;
+    let scopes = josh_changes::refs_on_branch(&repo, branch)?;
     let oid = git2::Oid::from_str(sha)?;
     let commit = repo.find_commit(oid)?;
 
@@ -334,7 +335,7 @@ pub fn load_detail(sha: &str, branch: &str) -> anyhow::Result<DetailData> {
     let mut stack: Vec<StackCommit> = Vec::new();
     let mut pr_info: Option<PrInfo> = None;
     if let Some(ref cid) = change_id {
-        pr_info = josh_changes::read_pr_data_on_branch(&repo, cid, branch)
+        pr_info = josh_changes::read_pr_data_in_scopes(&repo, cid, &scopes)
             .ok()
             .flatten()
             .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok())
@@ -346,8 +347,8 @@ pub fn load_detail(sha: &str, branch: &str) -> anyhow::Result<DetailData> {
             });
 
         // Pick the base oid from whichever ref on this branch has diff data
-        // for the change-id (Local wins per `list_changes_on_branch` precedence).
-        if let Ok(all) = josh_changes::list_changes_on_branch(&repo, branch) {
+        // for the change-id (Local wins per `list_changes_in_scopes` precedence).
+        if let Ok(all) = josh_changes::list_changes_in_scopes(&repo, &scopes) {
             if let Some(c) = all.iter().find(|c| c.id() == Some(cid.as_str())) {
                 let base = c.base();
                 if base != git2::Oid::zero() {
@@ -373,12 +374,12 @@ pub fn load_detail(sha: &str, branch: &str) -> anyhow::Result<DetailData> {
 
     let comments = change_id
         .as_deref()
-        .map(|cid| josh_changes::read_comments_on_branch(&repo, cid, branch).unwrap_or_default())
+        .map(|cid| josh_changes::read_comments_in_scopes(&repo, cid, &scopes).unwrap_or_default())
         .unwrap_or_default();
     let revisions = josh_changes::read_revisions_union(&repo, &change).unwrap_or_default();
     let local_vote = change_id
         .as_ref()
-        .and_then(|cid| josh_changes::read_vote_on_branch(&repo, cid, None, branch).ok())
+        .and_then(|cid| josh_changes::read_vote_in_scopes(&repo, cid, None, &scopes).ok())
         .flatten();
 
     Ok(DetailData {


### PR DESCRIPTION
Drop _on_branch wrappers in favor of _in_scopes

The detail view and `josh changes list` were the remaining callers of
list_changes_on_branch / read_pr_data_on_branch / read_comments_on_branch /
read_vote_on_branch, each of which re-scanned every repository reference to
derive the scope list. Resolve scopes once via refs_on_branch and call the
_in_scopes variants directly; this gives the detail view the same caching
the list view already got and lets the list CLI command share scopes
between list_changes and per-change read_comments. list_votes_on_branch
had no callers and is removed too.

Change: drop-on-branch-wrappers
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>