### PR TITLE
Scope josh changes metadata by target branch

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -3,45 +3,97 @@ pub use josh_core::trailers::{commit_change_meta, parse_change_meta};
 
 /// Which `refs/josh/...` ref holds a piece of change metadata.
 ///
-/// `Local` is data the user authored or discovered from their working tree
-/// (drafts, diff data for HEAD-reachable Change-Ids).
-/// `Remote(name)` is data fetched from / posted to a specific remote.
+/// Scoped by the target branch of the change, so a single repo can host
+/// changes against multiple branches without collisions.
+///
+/// `Local { branch }` is data the user authored or discovered from their
+/// working tree, targeting `branch`.
+/// `Remote { remote, branch }` is data fetched from / posted to `remote`
+/// for changes targeting `branch`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ChangesRef {
-    Local,
-    Remote(String),
+    Local { branch: String },
+    Remote { remote: String, branch: String },
 }
 
 impl ChangesRef {
     pub fn ref_name(&self) -> String {
         match self {
-            ChangesRef::Local => "refs/josh/changes".to_string(),
-            ChangesRef::Remote(r) => format!("refs/josh/remotes/{}/changes", r),
+            ChangesRef::Local { branch } => format!("refs/josh/changes/{}", branch),
+            ChangesRef::Remote { remote, branch } => {
+                format!("refs/josh/remotes/{}/changes/{}", remote, branch)
+            }
+        }
+    }
+
+    pub fn branch(&self) -> &str {
+        match self {
+            ChangesRef::Local { branch } => branch,
+            ChangesRef::Remote { branch, .. } => branch,
+        }
+    }
+
+    pub fn remote(&self) -> Option<&str> {
+        match self {
+            ChangesRef::Local { .. } => None,
+            ChangesRef::Remote { remote, .. } => Some(remote),
         }
     }
 }
 
-/// Return `[Local, Remote(r1), Remote(r2), ...]` for every changes ref that
-/// currently exists. Remote names are sorted for deterministic iteration.
+/// Read `repo.head()` and return the current branch shorthand. Errors on a
+/// detached HEAD with a message asking the caller to pass an explicit branch.
+pub fn head_branch(repo: &git2::Repository) -> anyhow::Result<String> {
+    let head = repo
+        .head()
+        .map_err(|e| anyhow!("failed to read HEAD: {}", e))?;
+    if !head.is_branch() {
+        return Err(anyhow!(
+            "HEAD is detached -- pass --branch to select a target branch explicitly"
+        ));
+    }
+    head.shorthand()
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow!("HEAD has no valid shorthand"))
+}
+
+/// Return every changes ref that currently exists, as `ChangesRef` values.
+/// `(remote, branch)` pairs are sorted for deterministic iteration; Local
+/// entries come first.
 pub fn all_changes_refs(repo: &git2::Repository) -> anyhow::Result<Vec<ChangesRef>> {
-    let mut remotes: Vec<String> = Vec::new();
-    for r in repo.references_glob("refs/josh/remotes/*/changes")? {
+    let mut locals: Vec<String> = Vec::new();
+    let mut remotes: Vec<(String, String)> = Vec::new();
+    for r in repo.references()? {
         let r = r?;
-        if let Some(name) = r.name() {
-            if let Some(rest) = name.strip_prefix("refs/josh/remotes/") {
-                if let Some(remote) = rest.strip_suffix("/changes") {
-                    if !remote.is_empty() && !remote.contains('/') {
-                        remotes.push(remote.to_string());
-                    }
+        let name = match r.name() {
+            Some(n) => n,
+            None => continue,
+        };
+        if let Some(branch) = name.strip_prefix("refs/josh/changes/") {
+            if !branch.is_empty() {
+                locals.push(branch.to_string());
+            }
+        } else if let Some(rest) = name.strip_prefix("refs/josh/remotes/") {
+            // `<remote>/changes/<branch>` -- branch may contain `/`, so split
+            // on the literal `/changes/` separator.
+            if let Some((remote, branch)) = rest.split_once("/changes/") {
+                if !remote.is_empty() && !branch.is_empty() {
+                    remotes.push((remote.to_string(), branch.to_string()));
                 }
             }
         }
     }
+    locals.sort();
+    locals.dedup();
     remotes.sort();
-    let mut out = Vec::with_capacity(remotes.len() + 1);
-    out.push(ChangesRef::Local);
-    for r in remotes {
-        out.push(ChangesRef::Remote(r));
+    remotes.dedup();
+
+    let mut out = Vec::with_capacity(locals.len() + remotes.len());
+    for branch in locals {
+        out.push(ChangesRef::Local { branch });
+    }
+    for (remote, branch) in remotes {
+        out.push(ChangesRef::Remote { remote, branch });
     }
     Ok(out)
 }
@@ -341,11 +393,15 @@ pub fn sync_changes(
     transaction: &josh_core::cache::Transaction,
     tip: git2::Oid,
     base: git2::Oid,
+    branch: &str,
 ) -> anyhow::Result<Vec<Change>> {
     let changes = get_changes(repo, tip, base)?;
     let changes = split_changes(repo, transaction, changes)?;
+    let scope = ChangesRef::Local {
+        branch: branch.to_string(),
+    };
     for c in &changes {
-        let _ = store_diff_data(repo, c, &ChangesRef::Local);
+        let _ = store_diff_data(repo, c, &scope);
     }
     Ok(changes)
 }
@@ -1414,9 +1470,19 @@ pub fn list_votes(
 }
 
 // =========================================================================
-// Union helpers: read across `refs/josh/changes` + every
-// `refs/josh/remotes/*/changes` and merge results.
+// Union helpers: read across `refs/josh/changes/*` + every
+// `refs/josh/remotes/*/changes/*` and merge results. The `_union` variants
+// merge across every discovered (scope, branch) combination; the
+// `_on_branch` variants restrict the merge to a single target branch.
 // =========================================================================
+
+/// Like `all_changes_refs`, but filtered to refs targeting `branch`.
+fn refs_on_branch(repo: &git2::Repository, branch: &str) -> anyhow::Result<Vec<ChangesRef>> {
+    Ok(all_changes_refs(repo)?
+        .into_iter()
+        .filter(|r| r.branch() == branch)
+        .collect())
+}
 
 /// List changes across the local ref and every per-remote ref. Deduped by
 /// change-id; if a change-id appears in multiple refs, the Local entry's
@@ -1446,7 +1512,7 @@ pub fn read_pr_data_union(
     change_id: &str,
 ) -> anyhow::Result<Option<String>> {
     for scope in all_changes_refs(repo)? {
-        if matches!(scope, ChangesRef::Local) {
+        if matches!(scope, ChangesRef::Local { .. }) {
             continue;
         }
         if let Some(json) = read_pr_data(repo, change_id, &scope)? {
@@ -1544,6 +1610,103 @@ pub fn read_github_ids_union(
     for scope in all_changes_refs(repo)? {
         for (k, v) in read_github_ids(repo, change_id, &scope)? {
             out.entry(k).or_insert(v);
+        }
+    }
+    Ok(out)
+}
+
+// =========================================================================
+// `_on_branch` helpers: same merge semantics as the corresponding `_union`
+// variants, but only over refs whose target branch matches.
+// =========================================================================
+
+pub fn list_changes_on_branch(
+    repo: &git2::Repository,
+    branch: &str,
+) -> anyhow::Result<Vec<Change>> {
+    use std::collections::HashSet;
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<Change> = Vec::new();
+    for scope in refs_on_branch(repo, branch)? {
+        for c in list_changes(repo, &scope)? {
+            let id = match c.id() {
+                Some(id) => id.to_string(),
+                None => continue,
+            };
+            if seen.insert(id) {
+                out.push(c);
+            }
+        }
+    }
+    Ok(out)
+}
+
+pub fn read_pr_data_on_branch(
+    repo: &git2::Repository,
+    change_id: &str,
+    branch: &str,
+) -> anyhow::Result<Option<String>> {
+    for scope in refs_on_branch(repo, branch)? {
+        if matches!(scope, ChangesRef::Local { .. }) {
+            continue;
+        }
+        if let Some(json) = read_pr_data(repo, change_id, &scope)? {
+            return Ok(Some(json));
+        }
+    }
+    Ok(None)
+}
+
+pub fn read_comments_on_branch(
+    repo: &git2::Repository,
+    change_id: &str,
+    branch: &str,
+) -> anyhow::Result<Vec<Comment>> {
+    use std::collections::HashMap;
+    let mut by_id: HashMap<String, Comment> = HashMap::new();
+    let mut order: Vec<String> = Vec::new();
+    for scope in refs_on_branch(repo, branch)? {
+        for c in read_comments(repo, change_id, &scope)? {
+            if !by_id.contains_key(&c.id) {
+                order.push(c.id.clone());
+            }
+            by_id.insert(c.id.clone(), c);
+        }
+    }
+    Ok(order
+        .into_iter()
+        .filter_map(|id| by_id.remove(&id))
+        .collect())
+}
+
+pub fn read_vote_on_branch(
+    repo: &git2::Repository,
+    change_id: &str,
+    user: Option<&str>,
+    branch: &str,
+) -> anyhow::Result<Option<VoteData>> {
+    for scope in refs_on_branch(repo, branch)? {
+        if let Some(v) = read_vote(repo, change_id, user, &scope)? {
+            return Ok(Some(v));
+        }
+    }
+    Ok(None)
+}
+
+pub fn list_votes_on_branch(
+    repo: &git2::Repository,
+    change_id: &str,
+    branch: &str,
+) -> anyhow::Result<Vec<(String, VoteData)>> {
+    use std::collections::HashSet;
+    let mut seen: HashSet<(String, String, String)> = HashSet::new();
+    let mut out: Vec<(String, VoteData)> = Vec::new();
+    for scope in refs_on_branch(repo, branch)? {
+        for (user, data) in list_votes(repo, change_id, &scope)? {
+            let key = (user.clone(), data.sha.clone(), data.state.clone());
+            if seen.insert(key) {
+                out.push((user, data));
+            }
         }
     }
     Ok(out)

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -1,20 +1,31 @@
 /// Arguments for `josh changes list`.
 #[derive(Debug, clap::Parser)]
-pub struct ListArgs {}
+pub struct ListArgs {
+    /// Target branch to list changes for (defaults to HEAD's branch).
+    #[arg(short = 'b', long = "branch")]
+    pub branch: Option<String>,
+}
 
-/// Print changes read from refs/josh/changes (populated by `josh changes sync`).
+/// Print changes read from refs/josh/changes/<branch> + refs/josh/remotes/*/changes/<branch>
+/// (populated by `josh changes sync`).
 pub fn handle_list(
-    _args: &ListArgs,
+    args: &ListArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
+    let branch = match &args.branch {
+        Some(b) => b.clone(),
+        None => josh_changes::head_branch(repo)?,
+    };
 
-    let changes = josh_changes::list_all_changes(repo)?;
+    let changes = josh_changes::list_changes_on_branch(repo, &branch)?;
 
     if changes.is_empty() {
-        println!("No local changes found.");
+        println!("No local changes found for branch '{}'.", branch);
         return Ok(());
     }
+
+    println!("Changes targeting '{}':\n", branch);
 
     for change in &changes {
         let commit = repo.find_commit(change.commit())?;
@@ -40,7 +51,9 @@ pub fn handle_list(
 
         let comments = change
             .id()
-            .map(|cid| josh_changes::read_comments_union(repo, cid).unwrap_or_default())
+            .map(|cid| {
+                josh_changes::read_comments_on_branch(repo, cid, &branch).unwrap_or_default()
+            })
             .unwrap_or_default();
         if !comments.is_empty() {
             println!();

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -44,6 +44,10 @@ pub struct CommentArgs {
     /// Hash of a previous comment to update/replace.
     #[arg(long = "update-of")]
     pub update_of: Option<String>,
+
+    /// Target branch for the comment (defaults to HEAD's branch).
+    #[arg(short = 'b', long = "branch")]
+    pub branch: Option<String>,
 }
 
 pub fn handle_comment(
@@ -113,13 +117,17 @@ pub fn handle_comment(
         reply_to: args.reply_to.clone(),
         update_of: args.update_of.clone(),
     };
+    let branch = match &args.branch {
+        Some(b) => b.clone(),
+        None => josh_changes::head_branch(repo)?,
+    };
     josh_changes::write_comment(
         repo,
         &change,
         &meta,
         None,
         None,
-        &josh_changes::ChangesRef::Local,
+        &josh_changes::ChangesRef::Local { branch },
     )?;
 
     println!("Comment saved.");

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -47,17 +47,24 @@ pub fn handle_sync(
         .unwrap_or(git2::Oid::zero());
 
     let remote_name = args.remote.as_deref().unwrap_or("origin").to_string();
-    let remote_scope = josh_changes::ChangesRef::Remote(remote_name.clone());
-    let local_scope = josh_changes::ChangesRef::Local;
 
     if args.clean {
-        let target = if args.local {
-            local_scope.ref_name()
-        } else {
-            remote_scope.ref_name()
-        };
-        if let Ok(mut r) = repo.find_reference(&target) {
-            r.delete()?;
+        // Delete every changes ref under the targeted scope, across all branches.
+        let mut to_delete: Vec<josh_changes::ChangesRef> = Vec::new();
+        for scope in josh_changes::all_changes_refs(repo)? {
+            let keep = match (&scope, args.local) {
+                (josh_changes::ChangesRef::Local { .. }, true) => true,
+                (josh_changes::ChangesRef::Remote { remote, .. }, false) => remote == &remote_name,
+                _ => false,
+            };
+            if keep {
+                to_delete.push(scope);
+            }
+        }
+        for scope in to_delete {
+            if let Ok(mut r) = repo.find_reference(&scope.ref_name()) {
+                r.delete()?;
+            }
         }
     }
 
@@ -220,6 +227,17 @@ pub fn handle_sync(
                     );
                 }
 
+                // Target branch for scoping: stacked changes encode the ultimate target
+                // in the head ref (@changes/<target>/...); otherwise fall back to the
+                // PR's immediate base.
+                let target_branch = parse_changes_target(&pr.head_ref_name)
+                    .unwrap_or_else(|| pr.base_ref_name.trim_start_matches("refs/heads/"))
+                    .to_string();
+                let remote_scope = josh_changes::ChangesRef::Remote {
+                    remote: remote_name.clone(),
+                    branch: target_branch.clone(),
+                };
+
                 let result = (|| -> anyhow::Result<(josh_changes::Change, i64)> {
                     let change = if existing_change_id.is_some() {
                         let mut change = josh_changes::Change::new(repo, &pr_head);
@@ -301,10 +319,22 @@ pub fn handle_sync(
                 })
                 .collect();
 
-            let all_changes = josh_changes::list_changes(repo, &remote_scope)?;
+            // Iterate every (change, scope) pair under this remote -- changes may live
+            // under multiple target-branch refs.
+            let remote_scopes: Vec<josh_changes::ChangesRef> =
+                josh_changes::all_changes_refs(repo)?
+                    .into_iter()
+                    .filter(|r| r.remote() == Some(&remote_name))
+                    .collect();
+            let mut all_changes: Vec<(josh_changes::Change, josh_changes::ChangesRef)> = Vec::new();
+            for scope in &remote_scopes {
+                for c in josh_changes::list_changes(repo, scope)? {
+                    all_changes.push((c, scope.clone()));
+                }
+            }
             let mut cleaned = 0usize;
 
-            for change in &all_changes {
+            for (change, remote_scope) in &all_changes {
                 let change_id = match change.id() {
                     Some(id) => id,
                     None => continue,
@@ -320,7 +350,7 @@ pub fn handle_sync(
                         Some(n) => n,
                         None => {
                             // Custom Change-Id; try reading stored PR data.
-                            match josh_changes::read_pr_data(repo, change_id, &remote_scope) {
+                            match josh_changes::read_pr_data(repo, change_id, remote_scope) {
                                 Ok(Some(json)) => {
                                     match serde_json::from_str::<serde_json::Value>(&json) {
                                         Ok(v) => match v.get("number").and_then(|n| n.as_i64()) {
@@ -375,7 +405,7 @@ pub fn handle_sync(
                 if pr_data.state == "OPEN" {
                     // Record the current state even if unexpectedly open.
                     let json = serde_json::to_string(&pr_data)?;
-                    josh_changes::store_pr_data(repo, change_id, &json, &remote_scope)?;
+                    josh_changes::store_pr_data(repo, change_id, &json, remote_scope)?;
                     eprintln!(
                         "  Change '{}' (PR #{}): unexpectedly still OPEN on GitHub \
                          -- skipping deletion",
@@ -386,7 +416,7 @@ pub fn handle_sync(
 
                 // Commit 1: store the updated PR data (final CLOSED/MERGED state).
                 let json = serde_json::to_string(&pr_data)?;
-                if let Err(e) = josh_changes::store_pr_data(repo, change_id, &json, &remote_scope) {
+                if let Err(e) = josh_changes::store_pr_data(repo, change_id, &json, remote_scope) {
                     eprintln!(
                         "  Change '{}' (PR #{}): failed to store updated PR data: {} \
                          -- skipping deletion",
@@ -396,7 +426,7 @@ pub fn handle_sync(
                 }
 
                 // Commit 2: delete the change from the remote changes ref.
-                if let Err(e) = josh_changes::delete_change(repo, change_id, &remote_scope) {
+                if let Err(e) = josh_changes::delete_change(repo, change_id, remote_scope) {
                     eprintln!(
                         "  Change '{}' (PR #{}): failed to delete: {}",
                         change_id, pr_number, e
@@ -422,6 +452,18 @@ pub fn handle_sync(
                         josh_core::trailers::parse_change_meta(&pr.head_commit_message);
                     let change_id = existing_id
                         .unwrap_or_else(|| format!("{}/{}/pull/{}", owner, repo_name, pr.number));
+
+                    // Same target-branch derivation as the per-PR sync above.
+                    let target_branch = parse_changes_target(&pr.head_ref_name)
+                        .unwrap_or_else(|| pr.base_ref_name.trim_start_matches("refs/heads/"))
+                        .to_string();
+                    let local_scope = josh_changes::ChangesRef::Local {
+                        branch: target_branch.clone(),
+                    };
+                    let remote_scope = josh_changes::ChangesRef::Remote {
+                        remote: remote_name.clone(),
+                        branch: target_branch.clone(),
+                    };
 
                     match api
                         .find_pull_request_by_head(&owner, &repo_name, &pr.head_ref_name)
@@ -497,7 +539,10 @@ pub fn handle_sync(
             Ok::<_, anyhow::Error>(())
         })?;
     } else {
-        let changes = josh_changes::sync_changes(repo, transaction, head.id(), base_oid)?;
+        let branch = branch.as_deref().ok_or_else(|| {
+            anyhow!("HEAD is detached -- check out a branch to sync local changes")
+        })?;
+        let changes = josh_changes::sync_changes(repo, transaction, head.id(), base_oid, branch)?;
         if changes.is_empty() {
             println!("No local changes found.");
             return Ok(());

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -43,8 +43,8 @@ pub struct PrInfo {
 }
 
 #[component]
-pub fn DetailView(sha: String, mut page: Signal<Page>) -> Element {
-    let data = load_detail(&sha);
+pub fn DetailView(sha: String, branch: String, mut page: Signal<Page>) -> Element {
+    let data = load_detail(&sha, &branch);
     let mut vote_body = use_signal(String::new);
 
     match &data {
@@ -224,13 +224,14 @@ pub fn DetailView(sha: String, mut page: Signal<Page>) -> Element {
                             div { class: "vote-actions",
                                 {
                                     let sha = sha.clone();
+                                    let branch = branch.clone();
                                     rsx! {
                                         button {
                                             class: "vote-btn approve",
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
                                                 let _ = save_vote(
-                                                    &sha, "approve", &body,
+                                                    &sha, "approve", &body, &branch,
                                                 );
                                                 vote_body.set(String::new());
                                                 page.set(Page::Detail {
@@ -243,13 +244,14 @@ pub fn DetailView(sha: String, mut page: Signal<Page>) -> Element {
                                 }
                                 {
                                     let sha = sha.clone();
+                                    let branch = branch.clone();
                                     rsx! {
                                         button {
                                             class: "vote-btn discuss",
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
                                                 let _ = save_vote(
-                                                    &sha, "discuss", &body,
+                                                    &sha, "discuss", &body, &branch,
                                                 );
                                                 vote_body.set(String::new());
                                                 page.set(Page::Detail {
@@ -262,13 +264,14 @@ pub fn DetailView(sha: String, mut page: Signal<Page>) -> Element {
                                 }
                                 {
                                     let sha = sha.clone();
+                                    let branch = branch.clone();
                                     rsx! {
                                         button {
                                             class: "vote-btn revise",
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
                                                 let _ = save_vote(
-                                                    &sha, "revise", &body,
+                                                    &sha, "revise", &body, &branch,
                                                 );
                                                 vote_body.set(String::new());
                                                 page.set(Page::Detail {
@@ -288,7 +291,7 @@ pub fn DetailView(sha: String, mut page: Signal<Page>) -> Element {
     }
 }
 
-pub fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
+pub fn load_detail(sha: &str, branch: &str) -> anyhow::Result<DetailData> {
     let repo = git2::Repository::discover(".")?;
     let oid = git2::Oid::from_str(sha)?;
     let commit = repo.find_commit(oid)?;
@@ -331,7 +334,7 @@ pub fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
     let mut stack: Vec<StackCommit> = Vec::new();
     let mut pr_info: Option<PrInfo> = None;
     if let Some(ref cid) = change_id {
-        pr_info = josh_changes::read_pr_data_union(&repo, cid)
+        pr_info = josh_changes::read_pr_data_on_branch(&repo, cid, branch)
             .ok()
             .flatten()
             .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok())
@@ -342,9 +345,9 @@ pub fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
                 review_decision: v["review_decision"].as_str().unwrap_or("").to_string(),
             });
 
-        // Pick the base oid from whichever ref has diff data for this change-id,
-        // with Local winning per `list_all_changes` precedence.
-        if let Ok(all) = josh_changes::list_all_changes(&repo) {
+        // Pick the base oid from whichever ref on this branch has diff data
+        // for the change-id (Local wins per `list_changes_on_branch` precedence).
+        if let Ok(all) = josh_changes::list_changes_on_branch(&repo, branch) {
             if let Some(c) = all.iter().find(|c| c.id() == Some(cid.as_str())) {
                 let base = c.base();
                 if base != git2::Oid::zero() {
@@ -370,12 +373,12 @@ pub fn load_detail(sha: &str) -> anyhow::Result<DetailData> {
 
     let comments = change_id
         .as_deref()
-        .map(|cid| josh_changes::read_comments_union(&repo, cid).unwrap_or_default())
+        .map(|cid| josh_changes::read_comments_on_branch(&repo, cid, branch).unwrap_or_default())
         .unwrap_or_default();
     let revisions = josh_changes::read_revisions_union(&repo, &change).unwrap_or_default();
     let local_vote = change_id
         .as_ref()
-        .and_then(|cid| josh_changes::read_vote_union(&repo, cid, None).ok())
+        .and_then(|cid| josh_changes::read_vote_on_branch(&repo, cid, None, branch).ok())
         .flatten();
 
     Ok(DetailData {
@@ -400,6 +403,7 @@ pub fn save_comment(
     file_path: &str,
     line_num: u32,
     message: &str,
+    branch: &str,
 ) -> anyhow::Result<String> {
     let repo = git2::Repository::discover(".")?;
     let oid = git2::Oid::from_str(sha)?;
@@ -425,15 +429,20 @@ pub fn save_comment(
         &meta,
         None,
         None,
-        &josh_changes::ChangesRef::Local,
+        &josh_changes::ChangesRef::Local {
+            branch: branch.to_string(),
+        },
     )
 }
 
-pub fn save_vote(sha: &str, state: &str, body: &str) -> anyhow::Result<String> {
+pub fn save_vote(sha: &str, state: &str, body: &str, branch: &str) -> anyhow::Result<String> {
     let repo = git2::Repository::discover(".")?;
     let oid = git2::Oid::from_str(sha)?;
     let commit = repo.find_commit(oid)?;
     let change = josh_changes::Change::new(&repo, &commit);
+    let scope = josh_changes::ChangesRef::Local {
+        branch: branch.to_string(),
+    };
 
     if !body.trim().is_empty() {
         let meta = josh_changes::CommentMeta {
@@ -443,22 +452,8 @@ pub fn save_vote(sha: &str, state: &str, body: &str) -> anyhow::Result<String> {
             reply_to: None,
             update_of: None,
         };
-        josh_changes::write_comment(
-            &repo,
-            &change,
-            &meta,
-            None,
-            None,
-            &josh_changes::ChangesRef::Local,
-        )?;
+        josh_changes::write_comment(&repo, &change, &meta, None, None, &scope)?;
     }
 
-    josh_changes::write_vote(
-        &repo,
-        &change,
-        state,
-        None,
-        None,
-        &josh_changes::ChangesRef::Local,
-    )
+    josh_changes::write_vote(&repo, &change, state, None, None, &scope)
 }

--- a/josh-gui/src/diff.rs
+++ b/josh-gui/src/diff.rs
@@ -195,11 +195,11 @@ fn build_diff_with_comments(
 }
 
 #[component]
-pub fn FileDiffView(sha: String, path: String, mut page: Signal<Page>) -> Element {
-    let mut detail = use_signal(|| detail::load_detail(&sha));
+pub fn FileDiffView(sha: String, path: String, branch: String, mut page: Signal<Page>) -> Element {
+    let mut detail = use_signal(|| detail::load_detail(&sha, &branch));
     let mut prev_sha = use_signal(|| sha.clone());
     if *prev_sha.read() != sha {
-        detail.set(detail::load_detail(&sha));
+        detail.set(detail::load_detail(&sha, &branch));
         prev_sha.set(sha.clone());
     }
     let (prev_file, next_file) = detail
@@ -510,6 +510,7 @@ pub fn FileDiffView(sha: String, path: String, mut page: Signal<Page>) -> Elemen
                             let ln = selected_file_line(&items, *selected_line.read());
                             let sha_for_save = sha.clone();
                             let path_for_save = path.clone();
+                            let branch_for_save = branch.clone();
                             rsx! {
                                 div { class: "comment-form",
                                     div { class: "comment-form-header",
@@ -540,6 +541,7 @@ pub fn FileDiffView(sha: String, path: String, mut page: Signal<Page>) -> Elemen
                                                 let mut detail_sig = detail;
                                                 let sha_save = sha_for_save.clone();
                                                 let path_save = path_for_save.clone();
+                                                let branch_save = branch_for_save.clone();
                                                 move |_| {
                                                     let msg = comment_text.read().trim().to_string();
                                                     if msg.is_empty() {
@@ -554,11 +556,14 @@ pub fn FileDiffView(sha: String, path: String, mut page: Signal<Page>) -> Elemen
                                                             &path_save,
                                                             line_num,
                                                             &msg,
+                                                            &branch_save,
                                                         )
                                                         .is_ok()
                                                         {
-                                                            detail_sig
-                                                                .set(detail::load_detail(&sha_save));
+                                                            detail_sig.set(detail::load_detail(
+                                                                &sha_save,
+                                                                &branch_save,
+                                                            ));
                                                             commenting.set(false);
                                                             comment_text.set("".to_string());
                                                         }

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -144,10 +144,10 @@ pub fn ListView(
     }
 }
 
-pub fn load_rows() -> anyhow::Result<ListData> {
+pub fn load_rows(branch: &str) -> anyhow::Result<ListData> {
     let repo = git2::Repository::discover(".")?;
 
-    let changes = josh_changes::list_all_changes(&repo)?;
+    let changes = josh_changes::list_changes_on_branch(&repo, branch)?;
 
     let mut oid_to_change_id: HashMap<String, String> = HashMap::new();
     for change in &changes {
@@ -173,27 +173,28 @@ pub fn load_rows() -> anyhow::Result<ListData> {
 
         let change_id = change.id().unwrap_or("").to_string();
 
-        let (review_decision, check_status) = josh_changes::read_pr_data_union(&repo, &change_id)
-            .ok()
-            .flatten()
-            .and_then(|json| {
-                serde_json::from_str::<serde_json::Value>(&json)
-                    .ok()
-                    .map(|v| {
-                        let rd = v["review_decision"]
-                            .as_str()
-                            .map(|s| s.to_string())
-                            .unwrap_or_default();
-                        let cs = v["check_status"]
-                            .as_str()
-                            .map(|s| s.to_string())
-                            .unwrap_or_default();
-                        (rd, cs)
-                    })
-            })
-            .unwrap_or_default();
+        let (review_decision, check_status) =
+            josh_changes::read_pr_data_on_branch(&repo, &change_id, branch)
+                .ok()
+                .flatten()
+                .and_then(|json| {
+                    serde_json::from_str::<serde_json::Value>(&json)
+                        .ok()
+                        .map(|v| {
+                            let rd = v["review_decision"]
+                                .as_str()
+                                .map(|s| s.to_string())
+                                .unwrap_or_default();
+                            let cs = v["check_status"]
+                                .as_str()
+                                .map(|s| s.to_string())
+                                .unwrap_or_default();
+                            (rd, cs)
+                        })
+                })
+                .unwrap_or_default();
 
-        let local_vote = josh_changes::read_vote_union(&repo, &change_id, None)
+        let local_vote = josh_changes::read_vote_on_branch(&repo, &change_id, None, branch)
             .ok()
             .flatten()
             .map(|v| v.state);

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -26,10 +26,41 @@ pub enum Page {
     FileDiff { sha: String, path: String },
 }
 
+fn initial_branch() -> String {
+    git2::Repository::discover(".")
+        .ok()
+        .and_then(|r| josh_changes::head_branch(&r).ok())
+        .unwrap_or_default()
+}
+
+fn available_branches() -> Vec<String> {
+    use std::collections::BTreeSet;
+    let mut set: BTreeSet<String> = BTreeSet::new();
+    if let Ok(repo) = git2::Repository::discover(".") {
+        if let Ok(refs) = josh_changes::all_changes_refs(&repo) {
+            for r in refs {
+                set.insert(r.branch().to_string());
+            }
+        }
+        if let Ok(b) = josh_changes::head_branch(&repo) {
+            set.insert(b);
+        }
+    }
+    set.into_iter().collect()
+}
+
 fn app() -> Element {
-    let list_data = use_signal(load_rows);
+    let current_branch = use_signal(initial_branch);
+    let mut list_data: Signal<anyhow::Result<list::ListData>> =
+        use_signal(|| load_rows(&current_branch.read()));
     let page = use_signal(|| Page::List);
     let mut selected_change = use_signal(|| None::<String>);
+
+    use_effect(move || {
+        let b = current_branch.read().clone();
+        list_data.set(load_rows(&b));
+        selected_change.set(None);
+    });
 
     use_effect(move || {
         if let Ok(data) = &*list_data.read() {
@@ -97,6 +128,10 @@ fn app() -> Element {
         }
     };
 
+    let mut branch_signal = current_branch;
+    let branches = available_branches();
+    let branch_now = current_branch.read().clone();
+
     rsx! {
         style { {include_str!("style.css")} }
         div { class: "app", tabindex: "0", onkeydown: on_keydown,
@@ -115,11 +150,32 @@ fn app() -> Element {
                     }
                 }
                 {breadcrumb(&page.read(), page, list_data)}
+                select {
+                    class: "branch-selector",
+                    value: "{branch_now}",
+                    onchange: move |evt| branch_signal.set(evt.value()),
+                    for b in branches.iter() {
+                        option { value: "{b}", selected: *b == branch_now, "{b}" }
+                    }
+                }
             }
             match &*page.read() {
                 Page::List => rsx! { ListView { list_data, page, selected_change } },
-                Page::Detail { sha } => rsx! { DetailView { sha: sha.clone(), page } },
-                Page::FileDiff { sha, path } => rsx! { FileDiffView { sha: sha.clone(), path: path.clone(), page } },
+                Page::Detail { sha } => rsx! {
+                    DetailView {
+                        sha: sha.clone(),
+                        branch: current_branch.read().clone(),
+                        page,
+                    }
+                },
+                Page::FileDiff { sha, path } => rsx! {
+                    FileDiffView {
+                        sha: sha.clone(),
+                        path: path.clone(),
+                        branch: current_branch.read().clone(),
+                        page,
+                    }
+                },
             }
         }
     }


### PR DESCRIPTION
Scope josh changes metadata by target branch

Extend ChangesRef from Local / Remote(name) to Local { branch } /
Remote { remote, branch } so changes targeting different branches live
under separate refs (refs/josh/changes/<branch> and
refs/josh/remotes/<remote>/changes/<branch>) and never collide. Add
head_branch() to resolve HEAD's shorthand (erroring on detached HEAD)
and *_on_branch read helpers that mirror the *_union variants but
restrict the merge to a single target branch.

Thread the target branch through the call sites: the CLI list/comment
commands and `sync` (local path) default to HEAD's branch with a
-b/--branch override; `sync --push` derives it per-PR from the
@changes/<target>/ head ref or the PR's base ref, so remote scopes match
the branch the PR actually targets. `sync --clean` now deletes every
ref under the targeted scope across all branches.

The GUI carries the selected branch through DetailView / FileDiffView /
save_comment / save_vote, and grows a top-bar branch selector populated
from existing changes refs plus HEAD.

Change: scope-changes-by-target-branch
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>