### PR TITLE
Move cargo build dir out of the shared cache volume

### DIFF
--- a/images/dev-local/Dockerfile
+++ b/images/dev-local/Dockerfile
@@ -5,14 +5,14 @@ FROM ${BASE_IMAGE}
 
 RUN <<EOF
 set -eux
-mkdir -p /opt/cache /opt/target
-chmod 777 /opt/cache /opt/target
+mkdir -p /opt/cache /opt/target /opt/build
+chmod 777 /opt/cache /opt/target /opt/build
 EOF
 
 VOLUME /opt/cache
 
 ENV CARGO_TARGET_DIR=/opt/target/cargo-target
-ENV CARGO_BUILD_BUILD_DIR=/opt/cache/cargo-build
+ENV CARGO_BUILD_BUILD_DIR=/opt/build/cargo-build
 ENV CARGO_HOME=/opt/cache/cargo-cache
 ENV RUSTC_WRAPPER=sccache
 ENV SCCACHE_DIR=/opt/cache/sccache


### PR DESCRIPTION
Move cargo build dir out of the shared cache volume

Sharing cargo's build directory across runs is unreliable: mismatched
crate versions between runs leave the incremental build dir in a state
cargo can't recover from. Point CARGO_BUILD_BUILD_DIR at a fresh
/opt/build path that is not on the persistent /opt/cache volume, so
sccache and the cargo registry stay cached but the build dir does not.

Change: cargo-build-dir-off-cache-volume
Assisted-By: claude-opus-4-7