### PR TITLE
Honor jj/gitbutler change-id commit header in josh-changes

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -27,6 +27,22 @@ fn is_trailer_line(line: &str) -> bool {
     key_len > 0 && line[key_len..].starts_with(": ")
 }
 
+/// Extract change-id metadata from a commit, preferring jj/gitbutler's custom
+/// `change-id` commit-object header over any `Change:` / `Change-Id:` trailer
+/// in the message body. The series list comes from message trailers regardless.
+pub fn commit_change_meta(commit: &git2::Commit) -> (Option<String>, Vec<String>) {
+    let (mut id, series) = parse_change_meta(commit.message().unwrap_or(""));
+    if let Ok(buf) = commit.header_field_bytes("change-id") {
+        if let Ok(s) = std::str::from_utf8(&buf) {
+            let s = s.trim();
+            if !s.is_empty() {
+                id = Some(s.to_string());
+            }
+        }
+    }
+    (id, series)
+}
+
 fn parse_change_meta(message: &str) -> (Option<String>, Vec<String>) {
     let lines: Vec<&str> = message.lines().collect();
     let mut footer_start = lines.len();
@@ -57,7 +73,7 @@ fn parse_change_meta(message: &str) -> (Option<String>, Vec<String>) {
 fn get_change_id(commit: &git2::Commit) -> Change {
     let mut change = Change::new(commit.id());
     change.author = commit.author().email().unwrap_or("").to_string();
-    let (id, series) = parse_change_meta(commit.message().unwrap_or(""));
+    let (id, series) = commit_change_meta(commit);
     change.id = id;
     change.series = series;
     change

--- a/tests/cli/push_stacked_jj_header.t
+++ b/tests/cli/push_stacked_jj_header.t
@@ -1,0 +1,81 @@
+Setup
+
+  $ export TESTTMP=${PWD}
+
+Helper: rewrite HEAD's commit object to add a custom `change-id` header,
+mimicking what jj / gitbutler produce. Takes the change-id value as $1.
+
+  $ add_change_id_header() {
+  >   orig=$(git rev-parse HEAD)
+  >   git cat-file commit "$orig" \
+  >     | awk -v cid="$1" '/^$/ && !done {print "change-id " cid; done=1} {print}' \
+  >     | git hash-object -t commit -w --stdin > .new.oid
+  >   git update-ref HEAD "$(cat .new.oid)"
+  >   rm .new.oid
+  > }
+
+Create a test repository with some content
+
+  $ mkdir remote
+  $ cd remote
+  $ git init -q --bare
+  $ cd ..
+
+  $ mkdir local
+  $ cd local
+  $ git init -q
+  $ mkdir -p sub1
+  $ echo "file1 content" > sub1/file1
+  $ echo "before" > file7
+  $ git add .
+  $ git commit -q -m "add file1"
+  $ git remote add origin ${TESTTMP}/remote
+  $ git push -q origin master
+  $ cd ..
+
+Clone with josh filter
+
+  $ josh clone ${TESTTMP}/remote :/sub1 filtered > /dev/null 2>&1
+  $ cd filtered
+
+Set up git config for author (must match GIT_AUTHOR_EMAIL used at commit time)
+
+  $ git config user.email "josh@example.com"
+  $ git config user.name "Josh Test"
+
+Commit 1: only a custom `change-id` header — no `Change:` / `Change-Id:` trailer
+
+  $ echo "contents2" > file2
+  $ git add file2
+  $ git commit -q -m "add file2"
+  $ add_change_id_header mlqnqnkrxpuvuuxzlzoltostwlwyskpx
+
+Commit 2: custom header AND a conflicting `Change:` trailer — header must win
+
+  $ echo "contents7" > file7
+  $ git add file7
+  $ printf 'update file7\n\nChange: footer-should-lose\n' | git commit -q -F -
+  $ add_change_id_header qpvuntsmwlqxrkokvyzpswuuxmrlnkqz
+
+Confirm the custom headers landed on the commit objects
+
+  $ git cat-file commit HEAD~ | grep '^change-id '
+  change-id mlqnqnkrxpuvuuxzlzoltostwlwyskpx
+  $ git cat-file commit HEAD | grep '^change-id '
+  change-id qpvuntsmwlqxrkokvyzpswuuxmrlnkqz
+
+Publish the stack — refs must carry the header change-ids, not the footer one
+
+  $ josh changes publish > publish.out 2>&1
+  $ grep -o '@changes/master/josh@example.com/[a-z0-9-]*' publish.out | sort -u
+  @changes/master/josh@example.com/mlqnqnkrxpuvuuxzlzoltostwlwyskpx
+  @changes/master/josh@example.com/qpvuntsmwlqxrkokvyzpswuuxmrlnkqz
+  $ grep footer-should-lose publish.out && echo "FAIL: footer leaked into refs" || echo "ok: footer ignored"
+  ok: footer ignored
+
+Verify the refs were created in the remote
+
+  $ cd ${TESTTMP}/remote
+  $ git for-each-ref --format='%(refname)' 'refs/heads/@changes/master/josh@example.com/*' | sort
+  refs/heads/@changes/master/josh@example.com/mlqnqnkrxpuvuuxzlzoltostwlwyskpx
+  refs/heads/@changes/master/josh@example.com/qpvuntsmwlqxrkokvyzpswuuxmrlnkqz


### PR DESCRIPTION
Honor jj/gitbutler change-id commit header in josh-changes

Jujutsu and GitButler attach a stable change identifier to commits as a
custom `change-id` header on the git commit object itself (alongside
tree / parent / author / committer), not as a message-body trailer. Up
to now josh-changes only consulted `Change:` / `Change-Id:` trailers via
parse_change_meta, so jj users had to either maintain a parallel
`Change:` trailer or lose stack-publish.

Add commit_change_meta in josh-core::trailers that wraps
parse_change_meta and, when the commit object carries a `change-id`
header, lets that value override the trailer-derived id. The series
list still comes from trailers since jj has no analogue. Route
Change::new and resolve_change in josh-changes through the new helper.

A prysk test synthesises commits with custom headers via
git cat-file | awk | git hash-object (no jj install required) and
verifies that header-only commits publish under the header change-id
and that the header beats a conflicting `Change:` trailer.

Change: jj-change-id-header
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>