### PR TITLE
Add --version flag to josh-proxy

### DIFF
--- a/josh-proxy/src/cli.rs
+++ b/josh-proxy/src/cli.rs
@@ -15,7 +15,7 @@ fn parse_remote(s: &str) -> Result<Remote, &'static str> {
 }
 
 #[derive(clap::Parser, Debug)]
-#[command(name = "josh-proxy")]
+#[command(name = "josh-proxy", version = josh_core::VERSION)]
 pub struct Args {
     #[arg(long, required = true, value_parser = parse_remote)]
     pub remote: Vec<Remote>,

--- a/tests/proxy/shell.t
+++ b/tests/proxy/shell.t
@@ -16,6 +16,7 @@
         --filter-prefix <FILTER_PREFIX>    Filter to be prefixed to all queries of this instance
         --http-retry <HTTP_RETRY>          Number of retries for HTTP server errors [default: 3]
     -h, --help                             Print help
+    -V, --version                          Print version
 
   $ josh-proxy --port=8002 --local=../../tmp --remote=http://localhost:8001 > proxy.out 2>&1 &
   $ sleep 1

--- a/tests/proxy/version_flag.t
+++ b/tests/proxy/version_flag.t
@@ -1,0 +1,2 @@
+  $ josh-proxy --version
+  josh-proxy r* (glob)


### PR DESCRIPTION
Add --version flag to josh-proxy

josh-proxy already exposed a /version HTTP endpoint but had no CLI flag,
so operators inspecting a deployed binary on disk had to start the
server and hit the endpoint to learn its version. Wire josh_core::VERSION
into the clap Args definition so the derive macro auto-generates
--version (and -V) handling, matching the pattern josh-cli already uses.
The shared constant keeps the CLI flag and the HTTP endpoint in sync.

A new prysk test covers `josh-proxy --version`, and the existing
shell.t --help golden output picks up the new -V / --version line.

Change: josh-proxy-version-flag
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>