### PR TITLE
Cache podman images in R2 via aws-cli around CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,8 +55,26 @@ jobs:
     - name: Build josh binary
       if: steps.cache-josh.outputs.cache-hit != 'true'
       run: cargo build --release -p josh-cli
+    - name: Pull cached images from R2
+      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      run: |
+        export PATH="$(pwd)/target/release:$PATH"
+        export JOSH_EXPERIMENTAL_FEATURES=1
+        .github/workflows/scripts/pull-images.sh HEAD ":[::sidecars.josh=ci-sidecars.josh,:/]:+compose"
     - name: Run tests
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       run: target/release/josh compose run HEAD ":[::sidecars.josh=ci-sidecars.josh,:/]:+compose"
+    - name: Push built images to R2
+      if: success() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      run: |
+        export PATH="$(pwd)/target/release:$PATH"
+        export JOSH_EXPERIMENTAL_FEATURES=1
+        .github/workflows/scripts/push-images.sh HEAD ":[::sidecars.josh=ci-sidecars.josh,:/]:+compose"

--- a/.github/workflows/scripts/pull-images.sh
+++ b/.github/workflows/scripts/pull-images.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-warm podman's local image store from R2 so `josh compose run` skips builds.
+# Best-effort: a missing object or transport error just falls through to a local
+# build later — never fails the script.
+#
+# Usage: pull-images.sh [REFERENCE] [FILTER]
+# Extra args are forwarded to `josh compose list-images`.
+
+BUCKET="josh-project-cache"
+ENDPOINT="https://19f2dfdd7c93980184be5e5809e8b252.r2.cloudflarestorage.com"
+
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    echo "pull-images: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY not set, skipping" >&2
+    exit 0
+fi
+
+mapfile -t images < <(josh compose list-images --all "$@")
+
+for image in "${images[@]}"; do
+    if podman image exists "$image"; then
+        echo "pull-images: $image already present locally"
+        continue
+    fi
+
+    key="images/${image}.tar"
+    echo "pull-images: fetching s3://${BUCKET}/${key}"
+    if aws s3 cp "s3://${BUCKET}/${key}" - \
+            --endpoint-url "$ENDPOINT" \
+            --no-progress 2>/dev/null \
+        | podman load; then
+        echo "pull-images: loaded $image"
+    else
+        echo "pull-images: $image not in R2 (will build locally)"
+    fi
+done

--- a/.github/workflows/scripts/push-images.sh
+++ b/.github/workflows/scripts/push-images.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upload any podman images a run needed to R2, so future runs can pull instead of
+# build. Idempotent: existing objects are detected via head-object and skipped.
+#
+# Usage: push-images.sh [REFERENCE] [FILTER]
+# Extra args are forwarded to `josh compose list-images`.
+
+BUCKET="josh-project-cache"
+ENDPOINT="https://19f2dfdd7c93980184be5e5809e8b252.r2.cloudflarestorage.com"
+
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    echo "push-images: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY not set, skipping" >&2
+    exit 0
+fi
+
+mapfile -t images < <(josh compose list-images --all "$@")
+
+for image in "${images[@]}"; do
+    if ! podman image exists "$image"; then
+        echo "push-images: $image not present locally, skipping"
+        continue
+    fi
+
+    key="images/${image}.tar"
+    if aws s3api head-object \
+            --bucket "$BUCKET" \
+            --key "$key" \
+            --endpoint-url "$ENDPOINT" \
+            >/dev/null 2>&1; then
+        echo "push-images: s3://${BUCKET}/${key} already present, skipping"
+        continue
+    fi
+
+    echo "push-images: uploading $image -> s3://${BUCKET}/${key}"
+    podman save --format=docker-archive "$image" \
+        | aws s3 cp - "s3://${BUCKET}/${key}" \
+            --endpoint-url "$ENDPOINT" \
+            --no-progress
+done


### PR DESCRIPTION
Cache podman images in R2 via aws-cli around CI

Adds pull-images.sh / push-images.sh under .github/workflows/scripts.
Both drive `josh compose list-images --all` to enumerate `ws_image_<oid>`
names, then use `aws s3 cp` (via R2's S3-compatible endpoint) to stream
tarballs to/from `josh-project-cache/images/`. Reuses the same
AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY already wired up for sccache.

Pull is best-effort: a missing object falls through and the image gets
built locally as before. Push uses `head-object` to dedupe uploads, so
re-running is a no-op. Push step is gated to non-fork sources, matching
the existing cache-josh gate.

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>
Change: cache-podman-images-in-r2
Change-Series: compose-image-cache