### PR TITLE
Add `josh compose list-images` to enumerate needed images

### DIFF
--- a/josh-cli/src/commands/run.rs
+++ b/josh-cli/src/commands/run.rs
@@ -10,6 +10,8 @@ pub struct ComposeArgs {
 pub enum ComposeCommand {
     /// Run a workspace in a container
     Run(RunArgs),
+    /// List every image (as `ws_image_<oid>`) a `run` with the same args would need
+    ListImages(ListImagesArgs),
 }
 
 pub fn handle_compose(
@@ -18,6 +20,7 @@ pub fn handle_compose(
 ) -> anyhow::Result<()> {
     match &args.command {
         ComposeCommand::Run(run_args) => handle_run(run_args, transaction),
+        ComposeCommand::ListImages(list_args) => handle_list_images(list_args, transaction),
     }
 }
 
@@ -60,4 +63,39 @@ pub fn handle_run(
             clean,
         },
     )
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct ListImagesArgs {
+    /// Ignore the local job cache and list every image a fresh run would build
+    #[arg(long = "all")]
+    pub all: bool,
+
+    /// Git revision to use as input: "." (working tree), "+" (index), or any rev (e.g. "HEAD", "HEAD~1", "main")
+    #[arg(default_value = ".")]
+    pub reference: String,
+
+    /// Filter spec to apply, e.g. ":+ws/test" (defaults to ":+compose")
+    #[arg(default_value = ":+compose")]
+    pub filter: String,
+}
+
+pub fn handle_list_images(
+    args: &ListImagesArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let oids = josh_compose::plan_images(
+        transaction,
+        RunOptions {
+            filter_spec: args.filter.clone(),
+            input_ref: args.reference.clone(),
+            clean: CleanMode::None,
+        },
+        args.all,
+    )?;
+
+    for oid in oids {
+        println!("ws_image_{oid}");
+    }
+    Ok(())
 }

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -5,6 +5,7 @@ pub mod filter;
 pub mod image;
 pub mod job_cache;
 pub mod meta;
+pub mod plan;
 pub mod podman;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -55,4 +56,31 @@ pub fn run(transaction: &josh_core::cache::Transaction, opts: RunOptions) -> any
     container::run_container(repo, ws_tree, &mut attempted)?;
 
     Ok(())
+}
+
+/// Enumerate every image build-tree OID that a `run` with the same options would
+/// require, bases-first and deduplicated.
+///
+/// When `ignore_cache` is false, workspaces whose run is already cached successful and
+/// whose output volume still exists are pruned from the walk (mirroring
+/// `container::run_container`'s early-return). When `ignore_cache` is true, the full
+/// set is reported regardless of cache state.
+pub fn plan_images(
+    transaction: &josh_core::cache::Transaction,
+    opts: RunOptions,
+    ignore_cache: bool,
+) -> anyhow::Result<Vec<git2::Oid>> {
+    josh_filter::check_experimental_features_enabled("josh compose images")?;
+
+    let filter_spec = opts.filter_spec.trim().to_string();
+    let repo = transaction.repo();
+    let _mempack = repo.odb()?.add_new_mempack_backend(1000)?;
+
+    let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
+    let version = filter::git_version(repo);
+
+    let (ws_tree, _safe_name) =
+        filter::compute_ws_tree(transaction, &filter_spec, source_commit, &version)?;
+
+    plan::collect_image_oids(repo, ws_tree, ignore_cache)
 }

--- a/josh-compose/src/plan.rs
+++ b/josh-compose/src/plan.rs
@@ -1,0 +1,109 @@
+use std::collections::HashSet;
+
+use crate::job_cache;
+use crate::meta::{self, OutputMode, WorkspaceMeta};
+use crate::podman;
+
+/// Walk the workspace tree and collect every image build-tree OID a run would touch.
+///
+/// The returned vector is deduplicated and ordered bases-first (a base image's OID
+/// always appears before any image that uses it as a base). This is the order in which
+/// images would need to be pulled/built for a run to succeed.
+///
+/// When `ignore_cache` is false (the default), workspaces whose run is already cached
+/// successful AND whose output volume is still present are skipped — matching the
+/// early-return path in `container::run_container`. When `ignore_cache` is true, every
+/// image a fresh-cache run would build is reported.
+pub fn collect_image_oids(
+    repo: &git2::Repository,
+    ws_tree: git2::Oid,
+    ignore_cache: bool,
+) -> anyhow::Result<Vec<git2::Oid>> {
+    let mut out: Vec<git2::Oid> = vec![];
+    let mut image_seen: HashSet<git2::Oid> = HashSet::new();
+    let mut ws_seen: HashSet<git2::Oid> = HashSet::new();
+    walk_workspace(
+        repo,
+        ws_tree,
+        ignore_cache,
+        &mut out,
+        &mut image_seen,
+        &mut ws_seen,
+    )?;
+    Ok(out)
+}
+
+fn walk_workspace(
+    repo: &git2::Repository,
+    ws_tree: git2::Oid,
+    ignore_cache: bool,
+    out: &mut Vec<git2::Oid>,
+    image_seen: &mut HashSet<git2::Oid>,
+    ws_seen: &mut HashSet<git2::Oid>,
+) -> anyhow::Result<()> {
+    if !ws_seen.insert(ws_tree) {
+        return Ok(());
+    }
+
+    let workspace_meta = meta::read_meta(repo, ws_tree)?;
+
+    if !ignore_cache && workspace_is_skippable(ws_tree, &workspace_meta)? {
+        eprintln!(
+            "[{}] Using cached output ({})",
+            workspace_meta.label, ws_tree
+        );
+        return Ok(());
+    }
+
+    for (dep_name, dep_sha) in meta::read_blob_entries(repo, ws_tree, "inputs") {
+        let dep_tree = git2::Oid::from_str(dep_sha.trim())
+            .map_err(|_| anyhow::anyhow!("dependency {dep_name}: invalid tree SHA {dep_sha:?}"))?;
+        walk_workspace(repo, dep_tree, ignore_cache, out, image_seen, ws_seen)?;
+    }
+
+    if let Some(image_oid) = workspace_meta.image {
+        collect_image_with_bases(repo, image_oid, out, image_seen)?;
+    }
+    for spec in &workspace_meta.sidecars {
+        collect_image_with_bases(repo, spec.image, out, image_seen)?;
+    }
+
+    Ok(())
+}
+
+/// Mirror `container::run_container`'s early-return condition, tightened to also
+/// require the output volume when the workspace produces one. A skippable workspace
+/// won't be executed by a run, so its image and sidecar images are not needed.
+fn workspace_is_skippable(ws_tree: git2::Oid, meta: &WorkspaceMeta) -> anyhow::Result<bool> {
+    let hash = ws_tree.to_string();
+    if !job_cache::is_cached_success(&hash) {
+        return Ok(false);
+    }
+    if meta.output == OutputMode::None {
+        return Ok(true);
+    }
+    let out_vol = format!("out_{ws_tree}");
+    podman::volume_exists(&out_vol)
+}
+
+fn collect_image_with_bases(
+    repo: &git2::Repository,
+    image_oid: git2::Oid,
+    out: &mut Vec<git2::Oid>,
+    image_seen: &mut HashSet<git2::Oid>,
+) -> anyhow::Result<()> {
+    if image_seen.contains(&image_oid) {
+        return Ok(());
+    }
+
+    for (base_name, base_sha) in meta::read_blob_entries(repo, image_oid, "bases") {
+        let base_oid = git2::Oid::from_str(base_sha.trim())
+            .map_err(|_| anyhow::anyhow!("invalid base SHA for {base_name}: {base_sha:?}"))?;
+        collect_image_with_bases(repo, base_oid, out, image_seen)?;
+    }
+
+    if image_seen.insert(image_oid) {
+        out.push(image_oid);
+    }
+    Ok(())
+}


### PR DESCRIPTION
Add `josh compose list-images` to enumerate needed images

Walks the workspace tree the same way `run_container` does and prints
every image OID (as `ws_image_<oid>`) a run would build, bases-first and
deduped. Sidecar images are included.

By default, workspaces whose run is already cached successful and whose
output volume still exists are pruned — mirroring `run_container`'s
early-return path. `--all` disables the filter to report every image a
fresh-cache run would build, useful for pushing the full set to a
registry after a successful local run.

This is the first step toward storing images in a registry so CI can
pull instead of rebuild.

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>
Change: josh-compose-list-images
Change-Series: compose-image-cache