### PR TITLE
Add `josh compose list-jobs` to enumerate workspace cache hashes

### DIFF
--- a/josh-cli/src/commands/run.rs
+++ b/josh-cli/src/commands/run.rs
@@ -12,6 +12,8 @@ pub enum ComposeCommand {
     Run(RunArgs),
     /// List every image (as `ws_image_<oid>`) a `run` with the same args would need
     ListImages(ListImagesArgs),
+    /// List the job hash of every workspace a `run` with the same args would touch
+    ListJobs(ListJobsArgs),
 }
 
 pub fn handle_compose(
@@ -21,6 +23,7 @@ pub fn handle_compose(
     match &args.command {
         ComposeCommand::Run(run_args) => handle_run(run_args, transaction),
         ComposeCommand::ListImages(list_args) => handle_list_images(list_args, transaction),
+        ComposeCommand::ListJobs(list_args) => handle_list_jobs(list_args, transaction),
     }
 }
 
@@ -96,6 +99,41 @@ pub fn handle_list_images(
 
     for oid in oids {
         println!("ws_image_{oid}");
+    }
+    Ok(())
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct ListJobsArgs {
+    /// Ignore the local job cache and list every job a fresh run would touch
+    #[arg(long = "all")]
+    pub all: bool,
+
+    /// Git revision to use as input: "." (working tree), "+" (index), or any rev (e.g. "HEAD", "HEAD~1", "main")
+    #[arg(default_value = ".")]
+    pub reference: String,
+
+    /// Filter spec to apply, e.g. ":+ws/test" (defaults to ":+compose")
+    #[arg(default_value = ":+compose")]
+    pub filter: String,
+}
+
+pub fn handle_list_jobs(
+    args: &ListJobsArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let oids = josh_compose::plan_jobs(
+        transaction,
+        RunOptions {
+            filter_spec: args.filter.clone(),
+            input_ref: args.reference.clone(),
+            clean: CleanMode::None,
+        },
+        args.all,
+    )?;
+
+    for oid in oids {
+        println!("{oid}");
     }
     Ok(())
 }

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -85,3 +85,30 @@ pub fn plan_images(
 
     plan::collect_image_oids(repo, ws_tree, ignore_cache)
 }
+
+/// Enumerate every job hash (workspace tree OID) that a `run` with the same options
+/// would touch, in dependency order (dependencies first).
+///
+/// When `ignore_cache` is false, workspaces whose run is already cached successful and
+/// whose output volume still exists are pruned from the walk (mirroring
+/// `container::run_container`'s early-return). When `ignore_cache` is true, the full
+/// set is reported regardless of cache state.
+pub fn plan_jobs(
+    transaction: &josh_core::cache::Transaction,
+    opts: RunOptions,
+    ignore_cache: bool,
+) -> anyhow::Result<Vec<git2::Oid>> {
+    josh_filter::check_experimental_features_enabled("josh compose jobs")?;
+
+    let filter_spec = opts.filter_spec.trim().to_string();
+    let repo = transaction.repo();
+    let _mempack = repo.odb()?.add_new_mempack_backend(1000)?;
+
+    let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
+    let version = filter::git_version(repo);
+
+    let (ws_tree, _safe_name) =
+        filter::compute_ws_tree(transaction, &filter_spec, source_commit, &version)?;
+
+    plan::collect_job_hashes(repo, ws_tree, ignore_cache)
+}

--- a/josh-compose/src/plan.rs
+++ b/josh-compose/src/plan.rs
@@ -33,6 +33,25 @@ pub fn collect_image_oids(
     Ok(out)
 }
 
+/// Walk the workspace tree and collect the job hash (ws_tree OID) of every workspace
+/// a run would touch, including orchestrator workspaces that don't build an image —
+/// those still write a `job_cache` entry, so they belong in the listing.
+///
+/// Cache semantics mirror `collect_image_oids`: when `ignore_cache` is false, a
+/// workspace whose run is already cached successful AND whose output volume is still
+/// present is pruned from the walk. When true, every job a fresh-cache run would
+/// touch is reported.
+pub fn collect_job_hashes(
+    repo: &git2::Repository,
+    ws_tree: git2::Oid,
+    ignore_cache: bool,
+) -> anyhow::Result<Vec<git2::Oid>> {
+    let mut out: Vec<git2::Oid> = vec![];
+    let mut ws_seen: HashSet<git2::Oid> = HashSet::new();
+    walk_workspace_jobs(repo, ws_tree, ignore_cache, &mut out, &mut ws_seen)?;
+    Ok(out)
+}
+
 fn walk_workspace(
     repo: &git2::Repository,
     ws_tree: git2::Oid,
@@ -68,6 +87,33 @@ fn walk_workspace(
         collect_image_with_bases(repo, spec.image, out, image_seen)?;
     }
 
+    Ok(())
+}
+
+fn walk_workspace_jobs(
+    repo: &git2::Repository,
+    ws_tree: git2::Oid,
+    ignore_cache: bool,
+    out: &mut Vec<git2::Oid>,
+    ws_seen: &mut HashSet<git2::Oid>,
+) -> anyhow::Result<()> {
+    if !ws_seen.insert(ws_tree) {
+        return Ok(());
+    }
+
+    let workspace_meta = meta::read_meta(repo, ws_tree)?;
+
+    if !ignore_cache && workspace_is_skippable(ws_tree, &workspace_meta)? {
+        return Ok(());
+    }
+
+    for (dep_name, dep_sha) in meta::read_blob_entries(repo, ws_tree, "inputs") {
+        let dep_tree = git2::Oid::from_str(dep_sha.trim())
+            .map_err(|_| anyhow::anyhow!("dependency {dep_name}: invalid tree SHA {dep_sha:?}"))?;
+        walk_workspace_jobs(repo, dep_tree, ignore_cache, out, ws_seen)?;
+    }
+
+    out.push(ws_tree);
     Ok(())
 }
 


### PR DESCRIPTION
Add `josh compose list-jobs` to enumerate workspace cache hashes

Precursor to caching workspace run results in R2, mirroring the image
cache added in cache-podman-images-in-r2. Each container run already
writes a `.josh/success/<hash>` marker keyed by the workspace tree OID
(`job_cache::write_result`), but those markers don't survive across CI
runs, so every workspace re-executes from scratch on a cold CI start.

`list-jobs` walks the workspace tree the same way `list-images` does
and prints one hash per line. With `--all` every job a fresh-cache run
would touch is reported; without it, workspaces that are already
cached-success AND whose output volume is still present are pruned via
the existing `workspace_is_skippable` helper — the same condition
`container::run_container` uses for its early-return.

Output is bare hashes (no prefix), matching `.josh/success/<hash>`
filenames so a follow-up `pull-jobs.sh` / `push-jobs.sh` can drive
`aws s3 cp` directly. Orchestrator workspaces with no image are
included; they also produce a `job_cache` entry.

Change: add-compose-list-jobs
Change-Series: compose-job-cache

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>