### PR TITLE
Pass fetched cargo/go deps as RO outputs, not via shared cache

### DIFF
--- a/images/dev-local/Dockerfile
+++ b/images/dev-local/Dockerfile
@@ -13,11 +13,9 @@ VOLUME /opt/cache
 
 ENV CARGO_TARGET_DIR=/opt/target/cargo-target
 ENV CARGO_BUILD_BUILD_DIR=/opt/build/cargo-build
-ENV CARGO_HOME=/opt/cache/cargo-cache
 ENV RUSTC_WRAPPER=sccache
 ENV SCCACHE_DIR=/opt/cache/sccache
 ENV GOCACHE=/opt/cache/go-cache
-ENV GOMODCACHE=/opt/cache/go-mod-cache
 ENV GOPATH=/opt/target/go-path
 ENV GOFLAGS=-buildvcs=false
 

--- a/ws/build-go.josh
+++ b/ws/build-go.josh
@@ -1,9 +1,14 @@
 :$label="go build"
 :#image[:+images/dev-local]
-:$cache="go"
+:$cache="go-build"
 
 inputs = :[
     :#go-fetch[:+ws/fetch-go]
+]
+
+env = :[
+    :$GOMODCACHE="/go-fetch/go-mod-cache"
+    :$GOFLAGS="-buildvcs=false -mod=readonly"
 ]
 
 worktree = :[

--- a/ws/build-rust.josh
+++ b/ws/build-rust.josh
@@ -1,6 +1,6 @@
 :$label="rust build"
 :#image[:+images/dev-local]
-:$cache="rust"
+:$cache="sccache"
 
 :+sidecars
 
@@ -10,6 +10,7 @@ inputs = :[
 
 env = :[
     ::JOSH_VERSION=VERSION_STRING
+    :$CARGO_HOME="/fetch/cargo-cache"
 ]
 
 worktree = :[

--- a/ws/fetch-go.josh
+++ b/ws/fetch-go.josh
@@ -1,9 +1,12 @@
 :$label="go mod download"
 :#image[:+images/dev-local]
-:$cache="go"
 :$network="host"
 
 :$cmd="cd josh-ssh-dev-server && go mod download"
+
+env = :[
+    :$GOMODCACHE="/out/go-mod-cache"
+]
 
 worktree = :[
     ::josh-ssh-dev-server/go.mod

--- a/ws/fetch.josh
+++ b/ws/fetch.josh
@@ -1,9 +1,12 @@
 :$label="cargo fetch"
 :#image[:+images/dev-local]
-:$cache="rust"
 :$network="host"
 
 :$cmd="cargo fetch --locked"
+
+env = :[
+    :$CARGO_HOME="/out/cargo-cache"
+]
 
 worktree = :[
     :+ws/patched-cargo

--- a/ws/test.josh
+++ b/ws/test.josh
@@ -4,7 +4,7 @@ inputs = :[
     :#cargo-test[
         :$label="cargo test"
         :#image[:+images/dev-local]
-        :$cache="rust"
+        :$cache="sccache"
         :$cmd="cargo test --workspace --offline --locked"
 
         :+sidecars
@@ -15,6 +15,7 @@ inputs = :[
 
         env = :[
             :$RUSTFLAGS="-D warnings -Ctarget-feature=-crt-static"
+            :$CARGO_HOME="/fetch/cargo-cache"
         ]
 
         worktree = :[


### PR DESCRIPTION
Pass fetched cargo/go deps as RO outputs, not via shared cache

The fetch workspaces (ws/fetch.josh, ws/fetch-go.josh) were smuggling
the cargo registry / go module cache through the `:$cache` mechanism:
both wrote into a shared RW named volume mounted at /opt/cache, and
every downstream consumer mounted the same volume RW to pick the deps
up. The volume was dual-purpose — fetched deps plus genuine RW build
caches (sccache, GOCACHE) — and any consumer could quietly mutate the
dep store.

Fetched deps are conceptually outputs (immutable per fetch-tree hash),
so model them that way:

- fetch.josh overrides CARGO_HOME=/out/cargo-cache and drops :$cache.
  `cargo fetch --locked` populates the output volume, which is now its
  real product.
- fetch-go.josh does the same with GOMODCACHE=/out/go-mod-cache.
- Consumers (build-rust, build-go, test.josh's cargo-test) already
  listed the matching fetch as an `inputs` dep, so the dep store is
  already mounted RO at /fetch or /go-fetch. They now point CARGO_HOME
  / GOMODCACHE at those mounts and rely on the existing `--offline
  --locked` (rust) and a new `GOFLAGS=-mod=readonly` (go) to refuse any
  write.
- The remaining `:$cache` is renamed from "rust" / "go" to "sccache" /
  "go-build" to reflect that the volume now only holds the genuine RW
  build cache (SCCACHE_DIR / GOCACHE — both still live on /opt/cache).
- images/dev-local/Dockerfile loses the now-misleading CARGO_HOME and
  GOMODCACHE defaults; each workspace sets its own.

Old `rust_cache` / `go_cache` named volumes become orphan after this
change and disposal is covered by `josh compose run --clean-all`.

Verified end-to-end via `josh compose run --clean-all` followed by
`josh compose run`: every workspace ran fresh, the fetch output
volumes contain `cargo-cache/` and `go-mod-cache/` respectively, a
second run cache-skips everything, and `touch /fetch/probe` on the dep
mount fails with EROFS.

Change: split-fetched-deps-from-cache
Change-Series: compose-job-cache

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>