### PR TITLE
Cache compose job markers and output volumes in R2 around CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,15 @@ jobs:
     - name: Build josh binary
       if: steps.cache-josh.outputs.cache-hit != 'true'
       run: cargo build --release -p josh-cli
+    - name: Pull cached job markers and volumes from R2
+      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      run: |
+        export PATH="$(pwd)/target/release:$PATH"
+        export JOSH_EXPERIMENTAL_FEATURES=1
+        .github/workflows/scripts/pull-jobs.sh HEAD ":[::sidecars.josh=ci-sidecars.josh,:/]:+compose"
     - name: Pull cached images from R2
       if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
       env:
@@ -69,6 +78,15 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       run: target/release/josh compose run HEAD ":[::sidecars.josh=ci-sidecars.josh,:/]:+compose"
+    - name: Push job markers and volumes to R2
+      if: success() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      run: |
+        export PATH="$(pwd)/target/release:$PATH"
+        export JOSH_EXPERIMENTAL_FEATURES=1
+        .github/workflows/scripts/push-jobs.sh HEAD ":[::sidecars.josh=ci-sidecars.josh,:/]:+compose"
     - name: Push built images to R2
       if: success() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
       env:

--- a/.github/workflows/scripts/pull-images.sh
+++ b/.github/workflows/scripts/pull-images.sh
@@ -16,7 +16,7 @@ if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
     exit 0
 fi
 
-mapfile -t images < <(josh compose list-images --all "$@")
+mapfile -t images < <(josh compose list-images "$@")
 
 for image in "${images[@]}"; do
     if podman image exists "$image"; then

--- a/.github/workflows/scripts/pull-jobs.sh
+++ b/.github/workflows/scripts/pull-jobs.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-warm .josh/success markers and out_<hash> volumes from R2 so
+# `josh compose run` cache-skips workspaces whose results already exist.
+# Best-effort: a missing object or transport error just falls through and
+# the corresponding job runs locally.
+#
+# Two passes:
+#   1. Pull every success marker for the universe of jobs the run would touch.
+#   2. After markers land, `list-jobs` (cache-aware) returns hashes that still
+#      aren't fully cached locally. For those, pull the output volume tarball.
+#
+# Usage: pull-jobs.sh [REFERENCE] [FILTER]
+# Extra args are forwarded to `josh compose list-jobs`.
+
+BUCKET="josh-project-cache"
+ENDPOINT="https://19f2dfdd7c93980184be5e5809e8b252.r2.cloudflarestorage.com"
+
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    echo "pull-jobs: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY not set, skipping" >&2
+    exit 0
+fi
+
+mkdir -p .josh/success
+
+# Pass 1: pull every success marker for the universe of jobs.
+mapfile -t universe < <(josh compose list-jobs --all "$@")
+
+for hash in "${universe[@]}"; do
+    if [[ -f ".josh/success/${hash}" ]]; then
+        echo "pull-jobs: marker $hash already present locally"
+        continue
+    fi
+
+    key="job-markers/${hash}"
+    if aws s3 cp "s3://${BUCKET}/${key}" ".josh/success/${hash}" \
+            --endpoint-url "$ENDPOINT" \
+            --no-progress 2>/dev/null; then
+        echo "pull-jobs: marker $hash"
+    else
+        echo "pull-jobs: marker $hash not in R2"
+    fi
+done
+
+# Pass 2: cache-aware list returns hashes still missing volume (or marker).
+# For each, try to pull the volume tarball into a fresh podman volume.
+mapfile -t need < <(josh compose list-jobs "$@")
+
+for hash in "${need[@]}"; do
+    vol="out_${hash}"
+    if podman volume exists "$vol"; then
+        echo "pull-jobs: volume $hash already present locally"
+        continue
+    fi
+
+    key="job-volumes/${hash}.tar"
+    if aws s3 cp "s3://${BUCKET}/${key}" - \
+            --endpoint-url "$ENDPOINT" \
+            --no-progress 2>/dev/null \
+        | { podman volume create "$vol" >/dev/null \
+            && podman volume import "$vol" -; }; then
+        echo "pull-jobs: volume $hash"
+    else
+        # Failed pull -> drop the volume if we partially created it, and drop
+        # the marker so the job re-runs cleanly. The Rust skip-check tightening
+        # would self-heal this anyway, but cleaning up here keeps state tidy.
+        if podman volume exists "$vol"; then
+            podman volume rm --force "$vol" >/dev/null
+        fi
+        rm -f ".josh/success/${hash}"
+        echo "pull-jobs: volume $hash not in R2 (will build locally)"
+    fi
+done

--- a/.github/workflows/scripts/push-jobs.sh
+++ b/.github/workflows/scripts/push-jobs.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Upload .josh/success markers and out_<hash> output volumes to R2, so future
+# runs can pull instead of rebuild. Idempotent: existing objects are detected
+# via head-object and skipped. Failed (.josh/failed) markers are not uploaded.
+#
+# Usage: push-jobs.sh [REFERENCE] [FILTER]
+# Extra args are forwarded to `josh compose list-jobs`.
+
+BUCKET="josh-project-cache"
+ENDPOINT="https://19f2dfdd7c93980184be5e5809e8b252.r2.cloudflarestorage.com"
+
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    echo "push-jobs: AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY not set, skipping" >&2
+    exit 0
+fi
+
+head_exists() {
+    aws s3api head-object \
+        --bucket "$BUCKET" \
+        --key "$1" \
+        --endpoint-url "$ENDPOINT" \
+        >/dev/null 2>&1
+}
+
+mapfile -t hashes < <(josh compose list-jobs --all "$@")
+
+for hash in "${hashes[@]}"; do
+    # Marker
+    if [[ -f ".josh/success/${hash}" ]]; then
+        key="job-markers/${hash}"
+        if head_exists "$key"; then
+            echo "push-jobs: marker $hash already in R2"
+        else
+            echo "push-jobs: uploading marker $hash -> s3://${BUCKET}/${key}"
+            aws s3 cp ".josh/success/${hash}" "s3://${BUCKET}/${key}" \
+                --endpoint-url "$ENDPOINT" \
+                --no-progress
+        fi
+    else
+        echo "push-jobs: marker $hash not present locally, skipping"
+    fi
+
+    # Volume (absent for output=none workspaces — naturally skipped)
+    vol="out_${hash}"
+    if podman volume exists "$vol"; then
+        key="job-volumes/${hash}.tar"
+        if head_exists "$key"; then
+            echo "push-jobs: volume $hash already in R2"
+        else
+            echo "push-jobs: uploading volume $hash -> s3://${BUCKET}/${key}"
+            podman volume export "$vol" \
+                | aws s3 cp - "s3://${BUCKET}/${key}" \
+                    --endpoint-url "$ENDPOINT" \
+                    --no-progress
+        fi
+    fi
+done

--- a/josh-compose/src/container.rs
+++ b/josh-compose/src/container.rs
@@ -112,10 +112,16 @@ pub fn run_container(
 ) -> anyhow::Result<()> {
     let workspace_meta = meta::read_meta(repo, ws_tree)?;
 
-    // Cache check: skip only if a previous successful run is recorded.
+    // Cache check: skip only if a previous successful run is recorded AND its
+    // output volume is still present (when one is expected). Mirrors
+    // `plan::workspace_is_skippable` so a stale marker without its volume —
+    // reachable when an R2 volume pull fails after the marker pull succeeded —
+    // self-heals by re-running rather than failing downstream dep-mounts.
     let hash = ws_tree.to_string();
     let out_vol = format!("out_{ws_tree}");
-    if job_cache::is_cached_success(&hash) {
+    if job_cache::is_cached_success(&hash)
+        && (workspace_meta.output == OutputMode::None || podman::volume_exists(&out_vol)?)
+    {
         eprintln!(
             "[{}] Using cached output ({})",
             workspace_meta.label, ws_tree


### PR DESCRIPTION
Cache compose job markers and output volumes in R2 around CI

Extends the cache-around-CI pattern established for podman images
(eb1cf6542) to the workspace run results themselves. After this,
a cold CI box can fully cache-skip every workspace whose filtered
source tree matches a prior successful run — fetch, build, test,
per-category tests — instead of just skipping image rebuilds.

Two new scripts under .github/workflows/scripts:

pull-jobs.sh runs in two passes, both best-effort. Pass 1 pulls every
`.josh/success/<hash>` marker from `s3://josh-project-cache/job-markers/`
for the universe returned by `josh compose list-jobs --all`. Pass 2 then
calls `josh compose list-jobs` cache-aware: those hashes either have a
marker now but are missing their output volume, or have no marker
either. For each, attempt `aws s3 cp s3://.../job-volumes/<hash>.tar`
and pipe into `podman volume import`. Misses on the second pass mean
either the job is genuinely uncached (will run locally) or the volume
upload was incomplete; either way the script also drops the local
marker on volume-pull failure so state stays tidy.

push-jobs.sh enumerates the same universe and uploads markers +
volumes that exist locally and aren't yet in R2, head-object-dedup'd
the same way push-images.sh does. `.josh/failed/<hash>` markers are
not pushed.

rust.yml gains pull-jobs/push-jobs steps. Pull order is jobs first,
images second — by the time pull-images.sh runs, any workspace whose
marker+volume came from R2 is already skippable, so list-images
(cache-aware) prunes its image and we don't waste bandwidth pulling
images for jobs that won't run. pull-images.sh loses its hardcoded
`--all` to enable this; on a fresh box with nothing cached the
behavior is identical, since nothing is skippable yet.

The Rust change in josh-compose/src/container.rs tightens
run_container's early-return to also require the output volume to
exist when `output != None`, matching `plan::workspace_is_skippable`.
Today every run that writes a marker writes its volume too, so the
prior loose check (marker only) was sound. The R2 path breaks that
invariant: a marker pulled while its volume pull failed would leave
the next run hitting `dependency X has no output volume` from the
dep walker. Tightened, a stale marker self-heals — the job re-runs
through `recreate_volume` and writes a fresh marker.

Verified locally end-to-end: pipeline runs green, `out_<fetch_hash>`
deleted while the marker is kept triggers a clean cargo-fetch re-run
(no downstream errors), and after a fully-warm run
`list-images --all` reports 3 while cache-aware `list-images` reports
0, confirming pull-images.sh will skip pulling when jobs are cached.

Change: cache-jobs-in-r2
Change-Series: compose-job-cache

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>