### PR TITLE
Split josh compose dev image into per-language minimal images

### DIFF
--- a/images/go-dev-local.josh
+++ b/images/go-dev-local.josh
@@ -1,0 +1,4 @@
+bases = :[
+    :#BASE_IMAGE[:+images/go-dev]
+]
+context = :/images/go-dev-local

--- a/images/go-dev-local/Dockerfile
+++ b/images/go-dev-local/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1.23.0@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN <<EOF
+set -eux
+mkdir -p /opt/cache /opt/target /opt/build
+chmod 777 /opt/cache /opt/target /opt/build
+EOF
+
+VOLUME /opt/cache
+
+ENV GOCACHE=/opt/cache/go-cache
+ENV GOPATH=/opt/target/go-path
+ENV GOFLAGS=-buildvcs=false
+
+ARG USER_GID
+ARG USER_UID
+
+RUN <<EOF
+set -eux
+
+if [ ! $(getent group ${USER_GID}) ] ; then
+    addgroup -g ${USER_GID} dev
+fi
+
+adduser \
+    -u ${USER_UID} \
+    -G $(getent group ${USER_GID} | cut -d: -f1) \
+    -D \
+    -H \
+    -g '' \
+    dev
+EOF

--- a/images/go-dev.josh
+++ b/images/go-dev.josh
@@ -1,0 +1,1 @@
+context = :/images/go-dev

--- a/images/go-dev/Dockerfile
+++ b/images/go-dev/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1.23.0@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+ARG ALPINE_VERSION=3.22.0
+
+FROM alpine:${ALPINE_VERSION}
+
+RUN apk add --no-cache bash ca-certificates git go

--- a/images/prysk-test-local.josh
+++ b/images/prysk-test-local.josh
@@ -1,0 +1,4 @@
+bases = :[
+    :#BASE_IMAGE[:+images/prysk-test]
+]
+context = :/images/prysk-test-local

--- a/images/prysk-test-local/Dockerfile
+++ b/images/prysk-test-local/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.23.0@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN <<EOF
+set -eux
+mkdir -p /opt/cache /opt/target /opt/build
+chmod 777 /opt/cache /opt/target /opt/build
+EOF
+
+VOLUME /opt/cache
+
+ARG USER_GID
+ARG USER_UID
+
+RUN <<EOF
+set -eux
+
+if [ ! $(getent group ${USER_GID}) ] ; then
+    addgroup -g ${USER_GID} dev
+fi
+
+adduser \
+    -u ${USER_UID} \
+    -G $(getent group ${USER_GID} | cut -d: -f1) \
+    -D \
+    -H \
+    -g '' \
+    dev
+EOF

--- a/images/prysk-test.josh
+++ b/images/prysk-test.josh
@@ -1,0 +1,7 @@
+bases = :[
+    :#BUILDER_IMAGE[:+images/rust-base]
+]
+context = :[
+    :/images/prysk-test
+    ::lfs-test-server/
+]

--- a/images/prysk-test/Dockerfile
+++ b/images/prysk-test/Dockerfile
@@ -1,0 +1,86 @@
+# syntax=docker/dockerfile:1.23.0@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+ARG ALPINE_VERSION=3.22.0
+ARG BUILDER_IMAGE
+
+FROM ${BUILDER_IMAGE} AS graphql-builder
+
+RUN apk add --no-cache \
+    openssl-dev \
+    openssl-libs-static \
+    zlib-dev \
+    zlib-static \
+    curl-dev
+
+RUN cargo install --verbose --version 0.14.0 graphql_client_cli
+
+FROM alpine:${ALPINE_VERSION}
+
+RUN apk add --no-cache \
+    bash \
+    coreutils \
+    curl \
+    cmake \
+    make \
+    expat-dev \
+    gettext \
+    python3 \
+    python3-dev \
+    libffi-dev \
+    py3-pip \
+    tree \
+    autoconf \
+    libgit2-dev \
+    psmisc \
+    zlib-dev \
+    openssl-dev \
+    curl-dev \
+    openssh-client \
+    patch \
+    go
+
+# Update check: https://github.com/git/git/tags
+ARG GIT_VERSION=2.50.0
+ENV PATH=${PATH}:/opt/git-install/bin
+WORKDIR /usr/src/git
+RUN <<EOF
+set -e
+wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz
+tar --extract --gzip --file git-${GIT_VERSION}.tar.gz
+rm git-${GIT_VERSION}.tar.gz
+cd git-${GIT_VERSION}
+make configure
+./configure \
+    --without-tcltk \
+    --prefix=/opt/git-install \
+    --exec-prefix=/opt/git-install
+make -j$(nproc)
+make install
+mkdir /opt/git-install/etc
+git config -f /opt/git-install/etc/gitconfig --add safe.directory "*"
+git config -f /opt/git-install/etc/gitconfig protocol.file.allow "always"
+EOF
+
+# Update check: https://github.com/prysk/prysk/releases
+ARG PRYSK_VERSION=0.20.0
+
+# This is a Docker image so --break-system-packages is okay
+RUN pip3 install --break-system-packages \
+  git+https://github.com/prysk/prysk.git@${PRYSK_VERSION}
+
+WORKDIR /usr/src/josh
+
+COPY lfs-test-server lfs-test-server
+RUN cd lfs-test-server && GOPATH=/opt/git-lfs go install
+
+ENV PATH=${PATH}:/opt/git-lfs/bin
+
+RUN <<EOF
+set -eux
+git clone https://github.com/git-lfs/git-lfs.git /usr/src/git-lfs
+cd /usr/src/git-lfs
+make
+cp bin/git-lfs /opt/git-lfs/bin
+EOF
+
+COPY --from=graphql-builder /usr/local/cargo/bin/graphql-client /usr/local/bin/graphql-client

--- a/images/rust-dev-local.josh
+++ b/images/rust-dev-local.josh
@@ -1,0 +1,4 @@
+bases = :[
+    :#BASE_IMAGE[:+images/rust-dev]
+]
+context = :/images/rust-dev-local

--- a/images/rust-dev-local/Dockerfile
+++ b/images/rust-dev-local/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.23.0@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN <<EOF
+set -eux
+mkdir -p /opt/cache /opt/target /opt/build
+chmod 777 /opt/cache /opt/target /opt/build
+EOF
+
+VOLUME /opt/cache
+
+ENV CARGO_TARGET_DIR=/opt/target/cargo-target
+ENV CARGO_BUILD_BUILD_DIR=/opt/build/cargo-build
+ENV RUSTC_WRAPPER=sccache
+ENV SCCACHE_DIR=/opt/cache/sccache
+
+ARG USER_GID
+ARG USER_UID
+
+RUN <<EOF
+set -eux
+
+if [ ! $(getent group ${USER_GID}) ] ; then
+    addgroup -g ${USER_GID} dev
+fi
+
+adduser \
+    -u ${USER_UID} \
+    -G $(getent group ${USER_GID} | cut -d: -f1) \
+    -D \
+    -H \
+    -g '' \
+    dev
+EOF

--- a/images/rust-dev.josh
+++ b/images/rust-dev.josh
@@ -1,0 +1,4 @@
+bases = :[
+    :#BASE_IMAGE[:+images/rust-base]
+]
+context = :/images/rust-dev

--- a/images/rust-dev/Dockerfile
+++ b/images/rust-dev/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1.23.0@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+ARG BASE_IMAGE=josh-rust-base
+FROM ${BASE_IMAGE}
+
+RUN apk add --no-cache \
+    bash \
+    git \
+    git-daemon \
+    zlib-static \
+    zlib-dev \
+    openssl-libs-static \
+    openssl-dev \
+    curl-dev
+
+RUN rustup component add rustfmt
+
+# Update check: https://github.com/mozilla/sccache/releases
+ARG SCCACHE_VERSION=0.14.0
+ARG TARGETARCH
+RUN <<EOF
+set -eux
+
+apk add --no-cache curl
+
+if [ "$TARGETARCH" = amd64 ]; then
+    sccache_arch=x86_64;
+elif [ "$TARGETARCH" = arm64 ]; then
+    sccache_arch=aarch64;
+else
+    echo "Unsupported arch";
+    exit 1
+fi
+
+curl -sSL https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-${sccache_arch}-unknown-linux-musl.tar.gz \
+    -o /tmp/sccache.tar.gz
+tar -xzf /tmp/sccache.tar.gz -C /tmp
+mv /tmp/sccache-v${SCCACHE_VERSION}-${sccache_arch}-unknown-linux-musl/sccache /usr/local/bin/sccache
+chmod +x /usr/local/bin/sccache
+rm -rf /tmp/sccache*
+apk del curl
+EOF

--- a/ws/build-go.josh
+++ b/ws/build-go.josh
@@ -1,5 +1,5 @@
 :$label="go build"
-:#image[:+images/dev-local]
+:#image[:+images/go-dev-local]
 :$cache="go-build"
 
 inputs = :[

--- a/ws/build-rust.josh
+++ b/ws/build-rust.josh
@@ -1,5 +1,5 @@
 :$label="rust build"
-:#image[:+images/dev-local]
+:#image[:+images/rust-dev-local]
 :$cache="sccache"
 
 :+sidecars

--- a/ws/fetch-go.josh
+++ b/ws/fetch-go.josh
@@ -1,5 +1,5 @@
 :$label="go mod download"
-:#image[:+images/dev-local]
+:#image[:+images/go-dev-local]
 :$network="host"
 
 :$cmd="cd josh-ssh-dev-server && go mod download"

--- a/ws/fetch.josh
+++ b/ws/fetch.josh
@@ -1,5 +1,5 @@
 :$label="cargo fetch"
-:#image[:+images/dev-local]
+:#image[:+images/rust-dev-local]
 :$network="host"
 
 :$cmd="cargo fetch --locked"

--- a/ws/test.josh
+++ b/ws/test.josh
@@ -3,7 +3,7 @@
 inputs = :[
     :#cargo-test[
         :$label="cargo test"
-        :#image[:+images/dev-local]
+        :#image[:+images/rust-dev-local]
         :$cache="sccache"
         :$cmd="cargo test --workspace --offline --locked"
 
@@ -33,7 +33,7 @@ inputs = :[
     ]
     :#fmt[
         :$label="cargo fmt"
-        :#image[:+images/dev-local]
+        :#image[:+images/rust-dev-local]
         :$cmd="cargo fmt -- --check"
 
         worktree = :[

--- a/ws/tests-per-category.star
+++ b/ws/tests-per-category.star
@@ -35,7 +35,7 @@ def generate_test_nodes():
         metadata = compose([
             filter.blob("label", category),
             filter.blob("output", "workdir"),
-            filter.treeid("image", filter.stored("images/dev-local")),
+            filter.treeid("image", filter.stored("images/prysk-test-local")),
         ])
 
         if is_experimental:


### PR DESCRIPTION
Split josh compose dev image into per-language minimal images

Every workspace step under `ws/*.josh` previously ran in `images/dev`
(via `images/dev-local`), which carries the rust toolchain, native
build deps, go, git built from source, prysk + python, git-lfs,
lfs-test-server, sccache, and `graphql_client_cli` — even when a step
only needs one of those. The big image meant every toolchain bump
invalidated the entire compose cache and every step paid a fat
image-pull cost.

Split it three ways along language family:

- `rust-dev` — rust-base + bash, git, git-daemon (alpine's package
  containing `git-http-backend`, needed by `josh-proxy` unit tests),
  rust native build deps (zlib/openssl/curl static+dev), rustfmt,
  sccache. Used by cargo fetch, rust build, cargo test, cargo fmt.
- `go-dev` — alpine + bash, ca-certificates, git, go. Used by go mod
  download and go build.
- `prysk-test` — alpine + git built from source + python3 + prysk +
  git-lfs + lfs-test-server + openssh + patch. No rust, no sccache.
  A multi-stage `graphql-builder` based on `rust-base` `cargo install`s
  `graphql_client_cli` and copies just the binary into the final image
  — that's the only rust artifact prysk integration tests actually
  invoke (`graphql-client introspect-schema`).

Each new base image gets its own `*-dev-local` overlay carrying the
user/UID-GID block + `/opt/cache /opt/target /opt/build` VOLUME and
only the env vars relevant to that language. `RUSTC_WRAPPER=sccache`
stays scoped to `rust-dev-local`, `GOCACHE`/`GOPATH`/`GOFLAGS` to
`go-dev-local`. `prysk-test-local` has none — the test runner
doesn't need them.

Scope is limited to compose steps. `images/dev`, `images/dev-local`,
`images/build`, `images/run` are unchanged — they're still consumed
by the release-binary pipeline and will be addressed separately.

The compose orchestrator (`josh-compose/src/image.rs`) needed no
changes: per-step image selection was already a workspace concern
declared via `:#image[:+images/<name>]`, and base images are already
resolved recursively through the `:#BASE_IMAGE[:+...]` filter pattern.

Verified end-to-end with `josh compose run` against the working tree:
all cargo unit tests pass and all 169 prysk tests across cli, cq,
filter, proxy, and experimental categories pass with the new image set.

Change: split-dev-image-per-language

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>