### PR TITLE
Stop injecting VERSION_STRING into josh compose workspace trees

### DIFF
--- a/josh-compose/src/filter.rs
+++ b/josh-compose/src/filter.rs
@@ -7,48 +7,19 @@ pub fn resolve_input(repo: &git2::Repository, input_ref: &str) -> anyhow::Result
         .with_context(|| format!("failed to resolve input ref: {input_ref:?}"))
 }
 
-/// Get a version string for the repo using `git describe --tags --always`.
-pub fn git_version(repo: &git2::Repository) -> String {
-    let mut opts = git2::DescribeOptions::new();
-    opts.describe_tags();
-    repo.describe(&opts)
-        .and_then(|d| d.format(None))
-        .unwrap_or_else(|_| {
-            repo.head()
-                .ok()
-                .and_then(|h| h.target())
-                .map(|oid| oid.to_string()[..12].to_string())
-                .unwrap_or_else(|| "unknown".to_string())
-        })
-}
-
 /// Compute the workspace tree OID and safe name for the given filter spec.
 ///
-/// Constructs the filter:
-///   :SQUASH:#X[:/,:\$VERSION_STRING="<ver>"]:#/X<user_filter>
+/// Constructs the filter `:SQUASH<user_filter>` and applies it to `source_commit`.
 ///
 /// Returns (ws_tree_oid, safe_name).
 pub fn compute_ws_tree(
     transaction: &josh_core::cache::Transaction,
     filter_spec: &str,
     source_commit: git2::Oid,
-    version_string: &str,
 ) -> anyhow::Result<(git2::Oid, String)> {
     let repo = transaction.repo();
 
-    // Escape the version string for embedding in a filter spec
-    let version_escaped = version_string.replace('\\', "\\\\").replace('"', "\\\"");
-
-    // Build the filter string: :SQUASH:#X[:/,:\$VERSION_STRING="<ver>"]:#/X<filter>
-    // Use push('$') to avoid Rust string escaping ambiguity with the :$ blob operator.
-    let full_filter = {
-        let mut s = ":SQUASH:#X[:/,:".to_string();
-        s.push('$');
-        s.push_str(&format!(
-            "VERSION_STRING=\"{version_escaped}\"]:#/X{filter_spec}"
-        ));
-        s
-    };
+    let full_filter = format!(":SQUASH{filter_spec}");
 
     let filterobj = josh_core::filter::parse(&full_filter)
         .with_context(|| format!("failed to parse filter: {full_filter:?}"))?;

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -47,10 +47,8 @@ pub fn run(transaction: &josh_core::cache::Transaction, opts: RunOptions) -> any
     let _mempack = repo.odb()?.add_new_mempack_backend(1000)?;
 
     let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
-    let version = filter::git_version(repo);
 
-    let (ws_tree, _safe_name) =
-        filter::compute_ws_tree(transaction, &filter_spec, source_commit, &version)?;
+    let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
     let mut attempted = std::collections::HashSet::new();
     let extract_to_workdir = opts.input_ref == ".";
@@ -78,10 +76,8 @@ pub fn plan_images(
     let _mempack = repo.odb()?.add_new_mempack_backend(1000)?;
 
     let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
-    let version = filter::git_version(repo);
 
-    let (ws_tree, _safe_name) =
-        filter::compute_ws_tree(transaction, &filter_spec, source_commit, &version)?;
+    let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
     plan::collect_image_oids(repo, ws_tree, ignore_cache)
 }
@@ -105,10 +101,8 @@ pub fn plan_jobs(
     let _mempack = repo.odb()?.add_new_mempack_backend(1000)?;
 
     let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
-    let version = filter::git_version(repo);
 
-    let (ws_tree, _safe_name) =
-        filter::compute_ws_tree(transaction, &filter_spec, source_commit, &version)?;
+    let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
     plan::collect_job_hashes(repo, ws_tree, ignore_cache)
 }

--- a/tests/proxy/get_version.t
+++ b/tests/proxy/get_version.t
@@ -2,7 +2,7 @@
   $ cd ${TESTTMP}
 
   $ curl -s http://localhost:8002/version
-  Version: r* (glob)
+  Version: * (glob)
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   .

--- a/tests/proxy/version_flag.t
+++ b/tests/proxy/version_flag.t
@@ -1,2 +1,2 @@
   $ josh-proxy --version
-  josh-proxy r* (glob)
+  josh-proxy * (glob)

--- a/ws/build-rust.josh
+++ b/ws/build-rust.josh
@@ -9,7 +9,6 @@ inputs = :[
 ]
 
 env = :[
-    ::JOSH_VERSION=VERSION_STRING
     :$CARGO_HOME="/fetch/cargo-cache"
 ]
 


### PR DESCRIPTION
Stop injecting VERSION_STRING into josh compose workspace trees

`compute_ws_tree` was wrapping every run's source with
`:SQUASH:#X[:/,:$VERSION_STRING="<ver>"]:#/X<user_filter>`, where
`<ver>` was `git describe --tags --always` against HEAD. That
embedded a top-level `VERSION_STRING` blob into the squashed tree
every nested workspace was filtered from, so the blob's content —
which changes on every commit because git describe includes the
commit count and short SHA — flowed into every workspace tree OID.
The compose job cache keys on that OID, so every commit busted the
cache for every workspace even when no filtered source had changed.

The only consumer was `ws/build-rust.josh` (`::JOSH_VERSION=VERSION_STRING`),
which forwarded the blob into the build container so cargo baked
it into the binaries via `git_version!` /
`option_env!("JOSH_VERSION")`. These are test/dev builds — a real
version string isn't needed; the macro already falls back to
"unknown" when neither `git describe` (no .git in the container) nor
the env var resolves. Release builds go through
`images/build/Dockerfile`, which sets `JOSH_VERSION` via its own
ARG and is unaffected.

Delete the mechanism end-to-end:

- `filter::compute_ws_tree` drops the `version_string` parameter
  and the `:#X[...]:#/X` wrapping; the filter becomes
  `:SQUASH<user_filter>`.
- `filter::git_version` is removed (no callers).
- `lib::run`, `lib::plan_images`, `lib::plan_jobs` no longer
  compute or pass a version.
- `ws/build-rust.josh` drops the `::JOSH_VERSION=VERSION_STRING`
  env entry; compose-built `josh-proxy` now reports `unknown`.
- `tests/proxy/version_flag.t` and `tests/proxy/get_version.t`
  loosen their `r* (glob)` (which matched the `r26.5.8`-style
  tag format) to `* (glob)` — the assertion still verifies a
  version string is printed without pinning the specific shape.

Verified by capturing `josh compose list-jobs --all` before and
after touching a file outside every workspace filter — the 13-job
hash set is identical (the regression we're fixing). Full
`josh compose run` passes including all prysk suites, and an
immediate repeat run hits the test-suite cache marker for every
workspace.

Change: drop-compose-version-injection

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>