### PR TITLE
Use fixed path for container worktree; fix gh cache scope

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: target/release/josh
-        key: josh-binary-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', 'josh-cli/**/*.rs', 'josh-core/**/*.rs', 'josh-filter/**/*.rs', 'josh-run/**/*.rs', 'josh-changes/**/*.rs') }}
+        key: josh-binary-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', 'josh-cli/**/*.rs', 'josh-core/**/*.rs', 'josh-filter/**/*.rs', 'josh-run/**/*.rs', 'josh-changes/**/*.rs', 'josh-compose/**/*.rs', 'forges/**/*.rs') }}
     - name: Build josh binary
       if: steps.cache-josh.outputs.cache-hit != 'true'
       run: cargo build --release -p josh-cli

--- a/josh-compose/src/container.rs
+++ b/josh-compose/src/container.rs
@@ -259,9 +259,9 @@ pub fn run_container(
     let user_str = format!("{uid}:{gid}");
 
     // Assemble all volumes for the run
-    let workdir = format!("/{}", snapshot_vol);
+    let workdir = "/worktree";
     let mut volumes: Vec<(String, String, bool)> = vec![];
-    volumes.push((snapshot_vol.clone(), workdir.clone(), false));
+    volumes.push((snapshot_vol.clone(), workdir.to_string(), false));
 
     if workspace_meta.output != OutputMode::None {
         podman::recreate_volume(&out_vol)?;
@@ -289,7 +289,7 @@ pub fn run_container(
         env_vars,
         user: Some(user_str),
         network,
-        workdir: Some(workdir),
+        workdir: Some(workdir.to_string()),
         rm: true,
     })?;
 


### PR DESCRIPTION
Use fixed path for container worktree; fix gh cache scope

* To prevent cache pollution, we have to fix volume mount path
* Cache key for deciding when to rebuild josh compose was also incomplete

Change-Id: Iee1f79980182100688bad10ee42519e47ad5fb93