### PR TITLE
Extract dependency container outputs to workdir

### DIFF
--- a/josh-compose/src/container.rs
+++ b/josh-compose/src/container.rs
@@ -152,7 +152,7 @@ pub fn run_container(
                 continue;
             }
         };
-        if let Err(e) = run_container(repo, dep_tree, attempted, false) {
+        if let Err(e) = run_container(repo, dep_tree, attempted, extract_to_workdir) {
             dep_errors.push(format!("dependency {dep_name} failed: {e}"));
             continue;
         }


### PR DESCRIPTION
Extract dependency container outputs to workdir

Pass the inherited `extract_to_workdir` flag to recursive dependency calls so
that when the top-level container is invoked with input_ref ".", dependency
containers also extract their output volumes. Reverts the dependency-side
change from skip-dep-workdir-extract while keeping the top-level gate.

Change: extract-dep-workdir
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>