### PR TITLE
Bundle publish/push refs into a single git push

### DIFF
--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -76,9 +76,7 @@ pub struct PublishArgs {
 }
 
 struct PreparedPush {
-    remote_name: String,
     to_push: Vec<PushRef>,
-    push_mode: PushMode,
     pr_infos: Vec<josh_github_changes::PrInfo>,
 }
 
@@ -88,7 +86,7 @@ fn prepare_push(
     base: Option<&str>,
     transaction: &josh_core::cache::Transaction,
     filter: josh_core::filter::Filter,
-    push_mode: PushMode,
+    push_mode: &PushMode,
     forge: &Option<Forge>,
 ) -> anyhow::Result<PreparedPush> {
     let repo = transaction.repo();
@@ -183,82 +181,91 @@ fn prepare_push(
         vec![]
     };
 
-    Ok(PreparedPush {
-        remote_name: remote_name.to_string(),
-        to_push,
-        push_mode,
-        pr_infos,
-    })
+    Ok(PreparedPush { to_push, pr_infos })
 }
 
-fn execute_push(
-    prepared: &PreparedPush,
+/// Push all refs to the remote in a single bundled `git push` invocation.
+///
+/// Every ref shares one remote URL and a uniform set of flags, so they are pushed together
+/// rather than one process per ref. This also makes `--atomic` meaningful across the whole
+/// set instead of applying to a single ref at a time.
+fn push_refs(
+    remote_name: &str,
+    to_push: &[PushRef],
     repo_path: &std::path::Path,
     url: &str,
     force: bool,
     atomic: bool,
     dry_run: bool,
 ) -> anyhow::Result<()> {
-    for push_ref in &prepared.to_push {
-        let mut git_push_args = vec!["push"];
-
-        if force || matches!(prepared.push_mode, PushMode::Split(_)) {
-            git_push_args.push("--force");
-        }
-
-        if atomic {
-            git_push_args.push("--atomic");
-        }
-
-        if dry_run {
-            git_push_args.push("--dry-run");
-        }
-
-        let target_remote = url.to_string();
-        let push_refspec = format!("{}:{}", push_ref.oid, push_ref.ref_name);
-
-        git_push_args.push(&target_remote);
-        git_push_args.push(&push_refspec);
-
-        if let Err(e) = spawn_git_command(repo_path, &git_push_args, &[]) {
-            eprintln!(
-                "Failed to push {} to {}/{}",
-                push_ref.oid, prepared.remote_name, push_ref.ref_name
-            );
-            eprintln!("{}", e);
-        } else {
-            eprintln!(
-                "Pushed {} to {}/{}",
-                push_ref.oid, prepared.remote_name, push_ref.ref_name
-            );
-        }
+    if to_push.is_empty() {
+        return Ok(());
     }
 
-    if !prepared.pr_infos.is_empty() {
-        use crate::forge::github;
+    let mut git_push_args = vec!["push"];
 
-        let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
+    if force {
+        git_push_args.push("--force");
+    }
 
-        if let Err(e) = rt.block_on(async {
-            let api_connection = github::make_api_connection().await;
-            let api_connection = api_connection.with_context(|| github::api_connection_hint())?;
+    if atomic {
+        git_push_args.push("--atomic");
+    }
 
-            josh_github_changes::create_or_update_prs(
-                &api_connection,
-                url,
-                &prepared.pr_infos,
-                dry_run,
-            )
-            .await
-        }) {
-            eprintln!("Warning: failed to create/update GitHub PRs: {}", e);
-        }
+    if dry_run {
+        git_push_args.push("--dry-run");
+    }
+
+    git_push_args.push(url);
+
+    for push_ref in to_push {
+        eprintln!(
+            "Pushing {} to {}/{}",
+            push_ref.oid, remote_name, push_ref.ref_name
+        );
+    }
+
+    let refspecs: Vec<String> = to_push
+        .iter()
+        .map(|push_ref| format!("{}:{}", push_ref.oid, push_ref.ref_name))
+        .collect();
+    git_push_args.extend(refspecs.iter().map(String::as_str));
+
+    spawn_git_command(repo_path, &git_push_args, &[])
+        .with_context(|| format!("Failed to push to {}", remote_name))?;
+
+    eprintln!("Pushed {} ref(s) to {}", to_push.len(), remote_name);
+
+    Ok(())
+}
+
+/// Create or update GitHub PRs for the collected push refs.
+fn create_prs(
+    pr_infos: &[josh_github_changes::PrInfo],
+    url: &str,
+    dry_run: bool,
+) -> anyhow::Result<()> {
+    if pr_infos.is_empty() {
+        return Ok(());
+    }
+
+    use crate::forge::github;
+
+    let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
+
+    if let Err(e) = rt.block_on(async {
+        let api_connection = github::make_api_connection().await;
+        let api_connection = api_connection.with_context(|| github::api_connection_hint())?;
+
+        josh_github_changes::create_or_update_prs(&api_connection, url, pr_infos, dry_run).await
+    }) {
+        eprintln!("Warning: failed to create/update GitHub PRs: {}", e);
     }
 
     Ok(())
 }
 
-fn run_push(
+fn orchestrate_push(
     remote: Option<&str>,
     refspecs_arg: &[String],
     base: Option<&str>,
@@ -293,7 +300,7 @@ fn run_push(
         refspecs_arg.to_vec()
     };
 
-    // Phase 1: Prepare all pushes (pure computation)
+    // Phase 1: Prepare all pushes (pure computation).
     let prepared_pushes: Vec<PreparedPush> = refspecs
         .iter()
         .map(|refspec| {
@@ -303,16 +310,43 @@ fn run_push(
                 base,
                 transaction,
                 filter,
-                push_mode.clone(),
+                &push_mode,
                 &forge,
             )
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    // Phase 2: Execute all pushes (side effects)
-    for prepared in &prepared_pushes {
-        execute_push(prepared, repo.path(), &url, force, atomic, dry_run)?;
+    // Phase 2: Flatten the prepared pushes into one bundled set. Dedup by destination ref
+    // name (keep first) to tolerate duplicate or colliding refspec arguments, which an
+    // atomic push would otherwise reject.
+    let mut seen = std::collections::HashSet::new();
+    let mut to_push: Vec<PushRef> = Vec::new();
+    let mut pr_infos: Vec<josh_github_changes::PrInfo> = Vec::new();
+
+    for prepared in prepared_pushes {
+        for push_ref in prepared.to_push {
+            if seen.insert(push_ref.ref_name.clone()) {
+                to_push.push(push_ref);
+            }
+        }
+        pr_infos.extend(prepared.pr_infos);
     }
+
+    // Split mode always force-updates its per-change refs.
+    let force = force || matches!(push_mode, PushMode::Split(_));
+
+    // Phase 3: Execute the side effects.
+    push_refs(
+        remote_name,
+        &to_push,
+        repo.path(),
+        &url,
+        force,
+        atomic,
+        dry_run,
+    )?;
+
+    create_prs(&pr_infos, &url, dry_run)?;
 
     Ok(())
 }
@@ -321,7 +355,7 @@ pub fn handle_push(
     args: &PushArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    run_push(
+    orchestrate_push(
         args.remote.as_deref(),
         &args.refspecs,
         args.base.as_deref(),
@@ -341,7 +375,7 @@ pub fn handle_publish(
     let config = repo.config().context("Failed to get git config")?;
     let push_mode = PushMode::Split(config.get_string("user.email").unwrap_or_default());
 
-    run_push(
+    orchestrate_push(
         args.remote.as_deref(),
         &args.refspecs,
         args.base.as_deref(),

--- a/tests/cli/push.t
+++ b/tests/cli/push.t
@@ -58,14 +58,16 @@ Make a change in the filtered repository
 Push the change back
 
   $ josh push origin HEAD:refs/heads/master -f
+  Pushing 33f0c009c43980ba5e76995b53f9615a4d880a08 to origin/refs/heads/master
   To file://${TESTTMP}/remote
      14ecb7c..33f0c00  33f0c009c43980ba5e76995b53f9615a4d880a08 -> master
   
-  Pushed 33f0c009c43980ba5e76995b53f9615a4d880a08 to origin/refs/heads/master
+  Pushed 1 ref(s) to origin
   $ josh push
+  Pushing 33f0c009c43980ba5e76995b53f9615a4d880a08 to origin/refs/heads/master
   Everything up-to-date
   
-  Pushed 33f0c009c43980ba5e76995b53f9615a4d880a08 to origin/refs/heads/master
+  Pushed 1 ref(s) to origin
 
 Verify the change was pushed to the original repository
 
@@ -89,10 +91,11 @@ reverse filtering. Without --base the unfiltered base would be zero;
   $ git add file3
   $ git commit -q -m "add file3"
   $ josh push origin HEAD:refs/heads/feature --base=master
+  Pushing 0902bcdb4ce9d12071408a716f1e34c5cfeb6d8e to origin/refs/heads/feature
   To file://${TESTTMP}/remote
   * (glob)
   
-  Pushed * to origin/refs/heads/feature (glob)
+  Pushed 1 ref(s) to origin
 
 --base must resolve to an existing remote-tracking ref.
 

--- a/tests/cli/push_stacked.t
+++ b/tests/cli/push_stacked.t
@@ -73,26 +73,19 @@ Push with stacked changes (should create multiple refs)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/remotes/origin/HEAD (esc)
   5f2928c89c4dcc7f5a8c59ef65734a83620cefee\trefs/remotes/origin/master (esc)
   $ josh publish
+  Pushing c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
+  Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/1234
+  Pushing c1b55ea7e5f27f82d3565c1f5d64113adf635c2c to origin/refs/heads/@changes/master/josh@example.com/foo7
+  Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/foo7
+  Pushing 2cbfa8cb8d9a9f1de029fcba547a6e56c742733f to origin/refs/heads/@heads/master/josh@example.com
   To file://${TESTTMP}/remote
    * [new branch]      c61c37f4a3d5eb447f41dde15620eee1a181d60b -> @changes/master/josh@example.com/1234
-  
-  Pushed c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
-  To file://${TESTTMP}/remote
    * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/1234
-  
-  Pushed 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/1234
-  To file://${TESTTMP}/remote
    * [new branch]      c1b55ea7e5f27f82d3565c1f5d64113adf635c2c -> @changes/master/josh@example.com/foo7
-  
-  Pushed c1b55ea7e5f27f82d3565c1f5d64113adf635c2c to origin/refs/heads/@changes/master/josh@example.com/foo7
-  To file://${TESTTMP}/remote
    * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/foo7
-  
-  Pushed 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/foo7
-  To file://${TESTTMP}/remote
    * [new branch]      2cbfa8cb8d9a9f1de029fcba547a6e56c742733f -> @heads/master/josh@example.com
   
-  Pushed 2cbfa8cb8d9a9f1de029fcba547a6e56c742733f to origin/refs/heads/@heads/master/josh@example.com
+  Pushed 5 ref(s) to origin
 
   $ git ls-remote .
   da80e49d24d110866ce2ec7a5c21112696fd165b\tHEAD (esc)
@@ -129,10 +122,11 @@ Test normal push (without --split) - create a new commit
   * Change-Id: 1234:43d6fcc9e7a81452d7343c78c0102f76027717fb
   * add file1:5f2928c89c4dcc7f5a8c59ef65734a83620cefee
   $ josh push
+  Pushing d3e371f8c637c91b59e05aae1066cf0adbe0da93 to origin/refs/heads/master
   To file://${TESTTMP}/remote
      6ed6c1c..d3e371f  d3e371f8c637c91b59e05aae1066cf0adbe0da93 -> master
   
-  Pushed d3e371f8c637c91b59e05aae1066cf0adbe0da93 to origin/refs/heads/master
+  Pushed 1 ref(s) to origin
 
 Verify normal push worked
 

--- a/tests/cli/push_stacked_binary.t
+++ b/tests/cli/push_stacked_binary.t
@@ -53,26 +53,19 @@ Set up git config for author
 Push with stacked changes containing binary files
 
   $ josh publish
+  Pushing 61d809929bf6b7a29d194f43368936fc82b033db to origin/refs/heads/@changes/master/josh@example.com/bin1
+  Pushing 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/bin1
+  Pushing a4f8ccd2c1cf12aaf3b46eae73e38c71185867e7 to origin/refs/heads/@changes/master/josh@example.com/bin2
+  Pushing 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/bin2
+  Pushing bcf10470382d693f9188a7a75872bcf3cd117dbc to origin/refs/heads/@heads/master/josh@example.com
   To file://${TESTTMP}/remote
    * [new branch]      61d809929bf6b7a29d194f43368936fc82b033db -> @changes/master/josh@example.com/bin1
-  
-  Pushed 61d809929bf6b7a29d194f43368936fc82b033db to origin/refs/heads/@changes/master/josh@example.com/bin1
-  To file://${TESTTMP}/remote
    * [new branch]      115b269a011d493259a125fa941fd790b903175f -> @base/master/josh@example.com/bin1
-  
-  Pushed 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/bin1
-  To file://${TESTTMP}/remote
    * [new branch]      a4f8ccd2c1cf12aaf3b46eae73e38c71185867e7 -> @changes/master/josh@example.com/bin2
-  
-  Pushed a4f8ccd2c1cf12aaf3b46eae73e38c71185867e7 to origin/refs/heads/@changes/master/josh@example.com/bin2
-  To file://${TESTTMP}/remote
    * [new branch]      115b269a011d493259a125fa941fd790b903175f -> @base/master/josh@example.com/bin2
+   * [new branch]      bcf10470382d693f9188a7a75872bcf3cd117dbc -> @heads/master/josh@example.com
   
-  Pushed 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/bin2
-  To file://${TESTTMP}/remote
-   * [new branch]      * -> @heads/master/josh@example.com (glob)
-  
-  Pushed * to origin/refs/heads/@heads/master/josh@example.com (glob)
+  Pushed 5 ref(s) to origin
 
 
 Verify binary content is preserved on the change branches

--- a/tests/cli/push_stacked_split.t
+++ b/tests/cli/push_stacked_split.t
@@ -71,34 +71,23 @@ Set up git config for author
 Publish changes (josh publish should create multiple refs for each change)
 
   $ josh publish
+  Pushing c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
+  Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/1234
+  Pushing 955da8395478e58213ad4ae975d9d885f87fdcec to origin/refs/heads/@changes/master/josh@example.com/foo7
+  Pushing 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/foo7
+  Pushing ef7c3c85ad4c5875f308003d42a6e11d9b14aeb9 to origin/refs/heads/@changes/master/josh@example.com/1235
+  Pushing c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@base/master/josh@example.com/1235
+  Pushing 929b441481dc5e1a946004a5615592d837ad564b to origin/refs/heads/@heads/master/josh@example.com
   To file://${TESTTMP}/remote
    * [new branch]      c61c37f4a3d5eb447f41dde15620eee1a181d60b -> @changes/master/josh@example.com/1234
-  
-  Pushed c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@changes/master/josh@example.com/1234
-  To file://${TESTTMP}/remote
    * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/1234
-  
-  Pushed 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/1234
-  To file://${TESTTMP}/remote
    * [new branch]      955da8395478e58213ad4ae975d9d885f87fdcec -> @changes/master/josh@example.com/foo7
-  
-  Pushed 955da8395478e58213ad4ae975d9d885f87fdcec to origin/refs/heads/@changes/master/josh@example.com/foo7
-  To file://${TESTTMP}/remote
    * [new branch]      6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d -> @base/master/josh@example.com/foo7
-  
-  Pushed 6ed6c1ca90cb15fe4edf8d133f0e2e44562aa77d to origin/refs/heads/@base/master/josh@example.com/foo7
-  To file://${TESTTMP}/remote
    * [new branch]      ef7c3c85ad4c5875f308003d42a6e11d9b14aeb9 -> @changes/master/josh@example.com/1235
-  
-  Pushed ef7c3c85ad4c5875f308003d42a6e11d9b14aeb9 to origin/refs/heads/@changes/master/josh@example.com/1235
-  To file://${TESTTMP}/remote
    * [new branch]      c61c37f4a3d5eb447f41dde15620eee1a181d60b -> @base/master/josh@example.com/1235
-  
-  Pushed c61c37f4a3d5eb447f41dde15620eee1a181d60b to origin/refs/heads/@base/master/josh@example.com/1235
-  To file://${TESTTMP}/remote
    * [new branch]      929b441481dc5e1a946004a5615592d837ad564b -> @heads/master/josh@example.com
   
-  Pushed 929b441481dc5e1a946004a5615592d837ad564b to origin/refs/heads/@heads/master/josh@example.com
+  Pushed 7 ref(s) to origin
 
 Verify the refs were created in the remote
 
@@ -176,10 +165,11 @@ Test normal push still works
   $ git add file2
   $ git commit -q -m "add file4" -m "Change-Id: 1236"
   $ josh push
+  Pushing b653cac206c6317b8acebacae76017cf683456c8 to origin/refs/heads/master
   To file://${TESTTMP}/remote
      6ed6c1c..b653cac  b653cac206c6317b8acebacae76017cf683456c8 -> master
   
-  Pushed b653cac206c6317b8acebacae76017cf683456c8 to origin/refs/heads/master
+  Pushed 1 ref(s) to origin
 
 Verify normal push worked
 


### PR DESCRIPTION
Bundle publish/push refs into a single git push

Previously push and publish ran one `git push` process per ref: an outer
loop over refspec arguments and an inner loop over each computed PushRef.
Since every ref shares one remote URL and a uniform set of flags, they can
all go out in a single `git push <url> <oid1>:<ref1> <oid2>:<ref2> ...`
invocation. This also makes `--atomic` meaningful across the whole set
rather than applying to one ref at a time.

Flatten the prepared pushes into one bundled set, deduplicating by
destination ref name (keep first) so duplicate or colliding refspec
arguments do not make an atomic push reject a repeated destination.

Refactor the surrounding structure to match: rename `run_push` to
`orchestrate_push`, split GitHub PR creation out of the old `execute_push`
into `create_prs`, and reduce the git push itself to `push_refs`. Output
now prints one `Pushing <oid> to <remote>/<ref>` line per ref followed by a
`Pushed N ref(s) to <remote>` summary gated on success.

Assisted-By: claude-opus-4-8
Change: bundle-push-refspecs
Change-Id: Ia6772925cb6f786d7ff6ecfabe6b3c3a30664df3