### PR TITLE
Add josh-command-middleware; layer GitHub auth onto git commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3026,6 +3026,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "josh-command-middleware"
+version = "26.5.8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "josh-compose"
 version = "26.5.8"
 dependencies = [
@@ -3123,9 +3133,11 @@ version = "26.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "chrono",
  "form_urlencoded",
  "http",
+ "josh-command-middleware",
  "jsonwebtoken",
  "mime",
  "reqwest 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
 
     "deployment/josh-test-webhook-client",
     "deployment/josh-test-webhook-service",
+    "deployment/josh-command-middleware",
 ]
 
 exclude = ["josh-gui", "devtools"]
@@ -102,6 +103,7 @@ josh-github-keyring = { path = "forges/josh-github-keyring", version = "26.5.8" 
 # Deployment
 josh-test-webhook-service = { path = "deployment/josh-test-webhook-service", version = "26.5.8" }
 josh-test-webhook-client = { path = "deployment/josh-test-webhook-client", version = "26.5.8" }
+josh-command-middleware = { path = "deployment/josh-command-middleware", version = "26.5.8" }
 
 [workspace.dependencies.git2]
 default-features = false
@@ -185,3 +187,4 @@ josh-github-auth = { path = "forges/josh-github-auth" }
 josh-github-keyring = { path = "forges/josh-github-keyring" }
 josh-test-webhook-service = { path = "deployment/josh-test-webhook-service" }
 josh-test-webhook-client = { path = "deployment/josh-test-webhook-client" }
+josh-command-middleware = { path = "deployment/josh-command-middleware" }

--- a/deployment/josh-command-middleware/Cargo.toml
+++ b/deployment/josh-command-middleware/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "josh-command-middleware"
+version = "26.5.8"
+edition = "2024"
+authors = ["Josh Project authors <contact@josh-project.dev>"]
+description = "Command middleware for josh"
+license-file = "../../LICENSE"
+repository = "https://github.com/josh-project/josh"
+
+[dependencies]
+anyhow.workspace = true
+async-trait.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["process"] }

--- a/deployment/josh-command-middleware/src/lib.rs
+++ b/deployment/josh-command-middleware/src/lib.rs
@@ -1,0 +1,136 @@
+use async_trait::async_trait;
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Middleware(#[from] anyhow::Error),
+    #[error(transparent)]
+    Command(#[from] std::io::Error),
+}
+
+/// A command builder whose args and env can be inspected and mutated by middleware.
+pub struct Command {
+    program: String,
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    current_dir: Option<std::path::PathBuf>,
+}
+
+impl Command {
+    pub fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            env: Vec::new(),
+            current_dir: None,
+        }
+    }
+
+    /// Set the working directory the command runs in.
+    pub fn current_dir(&mut self, dir: impl Into<std::path::PathBuf>) -> &mut Self {
+        self.current_dir = Some(dir.into());
+        self
+    }
+
+    pub fn arg(&mut self, arg: impl Into<String>) -> &mut Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    pub fn args(&mut self, args: impl IntoIterator<Item = impl Into<String>>) -> &mut Self {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn env(&mut self, key: impl Into<String>, val: impl Into<String>) -> &mut Self {
+        self.env.push((key.into(), val.into()));
+        self
+    }
+
+    pub fn envs(
+        &mut self,
+        vars: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> &mut Self {
+        self.env
+            .extend(vars.into_iter().map(|(k, v)| (k.into(), v.into())));
+        self
+    }
+
+    /// Mutable access to the program for middleware
+    pub fn program_mut(&mut self) -> &mut String {
+        &mut self.program
+    }
+
+    /// Mutable access to the argument list for middleware.
+    pub fn args_mut(&mut self) -> &mut Vec<String> {
+        &mut self.args
+    }
+
+    /// Mutable access to the env list for middleware.
+    pub fn env_mut(&mut self) -> &mut Vec<(String, String)> {
+        &mut self.env
+    }
+
+    /// Materialize into a [`tokio::process::Command`].
+    pub fn into_tokio(self) -> tokio::process::Command {
+        let mut cmd = tokio::process::Command::new(&self.program);
+        cmd.args(&self.args);
+        for (k, v) in &self.env {
+            cmd.env(k, v);
+        }
+        if let Some(dir) = &self.current_dir {
+            cmd.current_dir(dir);
+        }
+        cmd
+    }
+}
+
+/// Middleware that modifies a [`Command`] before it is spawned.
+#[async_trait]
+pub trait CommandMiddleware: Send + Sync {
+    async fn apply(&self, cmd: &mut Command) -> anyhow::Result<()>;
+}
+
+/// Lets a shared `Arc<dyn CommandMiddleware>` be used wherever a middleware is
+/// expected, so the same instance can be layered here and used elsewhere.
+#[async_trait]
+impl<T: CommandMiddleware + ?Sized> CommandMiddleware for std::sync::Arc<T> {
+    async fn apply(&self, cmd: &mut Command) -> anyhow::Result<()> {
+        (**self).apply(cmd).await
+    }
+}
+
+/// A stack of [`CommandMiddleware`] layers, applied in order.
+pub struct CommandStack {
+    layers: Vec<Box<dyn CommandMiddleware>>,
+}
+
+impl CommandStack {
+    pub fn new() -> Self {
+        Self { layers: Vec::new() }
+    }
+
+    /// Add a middleware layer to the stack.
+    pub fn layer<M: CommandMiddleware + 'static>(mut self, middleware: M) -> Self {
+        self.layers.push(Box::new(middleware));
+        self
+    }
+
+    /// Apply all middleware and run the command, returning its output.
+    pub async fn run(&self, mut cmd: Command) -> Result<std::process::Output> {
+        for layer in &self.layers {
+            layer.apply(&mut cmd).await?;
+        }
+
+        Ok(cmd.into_tokio().output().await?)
+    }
+}
+
+impl Default for CommandStack {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/forges/josh-github-auth/Cargo.toml
+++ b/forges/josh-github-auth/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["git", "github", "monorepo", "workflow"]
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+base64.workspace = true
 http.workspace = true
 reqwest.workspace = true
 reqwest-middleware.workspace = true
@@ -25,6 +26,8 @@ url.workspace = true
 secret-vault-value.workspace = true
 jsonwebtoken.workspace = true
 chrono.workspace = true
+
+josh-command-middleware.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/forges/josh-github-auth/src/middleware.rs
+++ b/forges/josh-github-auth/src/middleware.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use base64::engine::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use reqwest::header;
 use reqwest_middleware::{Middleware, Next};
 use secret_vault_value::SecretValue;
@@ -143,5 +145,36 @@ impl Middleware for GithubAuthMiddleware {
         );
 
         next.run(req, extensions).await
+    }
+}
+
+#[async_trait::async_trait]
+impl josh_command_middleware::CommandMiddleware for GithubAuthMiddleware {
+    async fn apply(&self, cmd: &mut josh_command_middleware::Command) -> anyhow::Result<()> {
+        let token = self.get_token().await.map_err(|e| {
+            josh_command_middleware::Error::Middleware(anyhow::anyhow!(
+                "failed to get auth token: {}",
+                e
+            ))
+        })?;
+
+        if cmd.program_mut().as_str() != "git" {
+            return Err(anyhow::anyhow!(
+                "Can't attach auth to anything other than git"
+            ));
+        }
+
+        // Git-over-HTTPS to GitHub authenticates via HTTP Basic auth, with the
+        // token supplied as the password (the username is ignored by GitHub, but
+        // `x-access-token` is the conventional value for app/installation tokens).
+        // The REST/GraphQL API uses `Bearer`, but git does not accept it.
+        let credentials = BASE64.encode(format!("x-access-token:{}", token));
+        let header = format!("http.extraHeader=Authorization: Basic {}", credentials);
+
+        let args = cmd.args_mut();
+        args.insert(0, header);
+        args.insert(0, "-c".to_string());
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Add josh-command-middleware; layer GitHub auth onto git commands

Introduce a josh-command-middleware crate providing an inspectable
Command builder and a CommandStack of async CommandMiddleware layers
applied before a command is spawned. This lets callers (e.g. the merge
queue) attach cross-cutting behavior to git subprocess invocations.

This means we can use the same auth sources for both GraphQL API
and git-http access.

The command wrapper was necessary because neither std process command
nor tokio command provide enough flexibility when it comes to modifying
the existing command (we need to insert http.extraHeader arg for git).

This way of passing credentials to git is also more secure as it doesn't
depend on environment variables, and doesn't require a shell or shell
function provided as auth helper.

The sensitive auth headers are still redacted by git:

https://github.com/git/git/commit/b66c77a64e696eb5e5994a58c0d50073f8e93bf1

Co-Authored-By: DeepSeek v4 Pro <noreply@deepseek.com>
Change-Id: I8674b7082a695cd26022973dbf0fe3589a05a335