### PR TITLE
Add workspace-level passthrough for sccache S3 credentials

### DIFF
--- a/josh-compose/src/container.rs
+++ b/josh-compose/src/container.rs
@@ -17,7 +17,7 @@ const SIDECAR_IP_PLACEHOLDER: &str = "{SIDECAR_IP}";
 /// Errors listing every missing variable when any are absent or empty, so that the
 /// developer sees the full set of misconfigured env vars in one go (locally and in CI).
 fn resolve_passthrough(
-    sidecar_name: &str,
+    context: &str,
     passthrough: &[(String, String)],
 ) -> anyhow::Result<Vec<(String, String)>> {
     let mut resolved = vec![];
@@ -32,7 +32,7 @@ fn resolve_passthrough(
     }
     if !missing.is_empty() {
         anyhow::bail!(
-            "sidecar {sidecar_name}: missing required passthrough env vars: {}",
+            "{context}: missing required passthrough env vars: {}",
             missing.join(", ")
         );
     }
@@ -46,7 +46,8 @@ fn resolve_passthrough(
 fn start_sidecar(repo: &git2::Repository, spec: &SidecarSpec) -> anyhow::Result<(String, String)> {
     let image_name = image::ensure_image(repo, spec.image)?;
 
-    let passthrough_env = resolve_passthrough(&spec.name, &spec.passthrough)?;
+    let passthrough_env =
+        resolve_passthrough(&format!("sidecar {}", spec.name), &spec.passthrough)?;
 
     podman::ensure_network_internal(SIDECAR_NETWORK)?;
 
@@ -194,6 +195,13 @@ pub fn run_container(
 
     // Read env vars from env/ subtree
     let mut env_vars = meta::read_blob_entries(repo, ws_tree, "env");
+
+    // Resolve workspace-level passthrough env vars from the host process.
+    if !workspace_meta.passthrough.is_empty() {
+        let passthrough_env =
+            resolve_passthrough(&workspace_meta.label, &workspace_meta.passthrough)?;
+        env_vars.extend(passthrough_env);
+    }
 
     // Start any declared sidecars and inject their IPs into the main container's env.
     // Any sidecar failure (missing creds, start error, readiness timeout) is fatal: tear

--- a/josh-compose/src/meta.rs
+++ b/josh-compose/src/meta.rs
@@ -24,6 +24,7 @@ pub struct WorkspaceMeta {
     pub cmd: String,
     pub cache: Option<String>,
     pub network: NetworkMode,
+    pub passthrough: Vec<(String, String)>,
     /// Tree OID of the image workspace. None for orchestrator-only workspaces.
     pub image: Option<git2::Oid>,
     /// Tree OID of the files to place in the container. None for orchestrator-only workspaces.
@@ -116,12 +117,15 @@ pub fn read_meta(repo: &git2::Repository, ws_tree: git2::Oid) -> anyhow::Result<
 
     let sidecars = read_sidecars(repo, ws_tree)?;
 
+    let passthrough = read_blob_entries(repo, ws_tree, "passthrough");
+
     Ok(WorkspaceMeta {
         label,
         output,
         cmd,
         cache,
         network,
+        passthrough,
         image,
         worktree,
         sidecars,

--- a/ws/build-rust.josh
+++ b/ws/build-rust.josh
@@ -8,8 +8,15 @@ inputs = :[
     :#fetch[:+ws/fetch]
 ]
 
+:+ws/sccache-env
+
 env = :[
     :$CARGO_HOME="/fetch/cargo-cache"
+]
+
+passthrough = :[
+    :$AWS_ACCESS_KEY_ID="AWS_ACCESS_KEY_ID"
+    :$AWS_SECRET_ACCESS_KEY="AWS_SECRET_ACCESS_KEY"
 ]
 
 worktree = :[

--- a/ws/sccache-env.josh
+++ b/ws/sccache-env.josh
@@ -1,0 +1,5 @@
+env = :[
+    :$SCCACHE_BUCKET="josh-project-cache"
+    :$SCCACHE_ENDPOINT="https://19f2dfdd7c93980184be5e5809e8b252.r2.cloudflarestorage.com"
+    :$SCCACHE_REGION="auto"
+]

--- a/ws/test.josh
+++ b/ws/test.josh
@@ -13,9 +13,16 @@ inputs = :[
             :#fetch[:+ws/fetch]
         ]
 
+        :+ws/sccache-env
+
         env = :[
             :$RUSTFLAGS="-D warnings -Ctarget-feature=-crt-static"
             :$CARGO_HOME="/fetch/cargo-cache"
+        ]
+
+        passthrough = :[
+            :$AWS_ACCESS_KEY_ID="AWS_ACCESS_KEY_ID"
+            :$AWS_SECRET_ACCESS_KEY="AWS_SECRET_ACCESS_KEY"
         ]
 
         worktree = :[


### PR DESCRIPTION
Add workspace-level passthrough for sccache S3 credentials

Without AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the main
container, sccache falls back to local disk even though SCCACHE_BUCKET
and SCCACHE_ENDPOINT are set via sidecar injection — the inject block
only passes static literals, not host env vars.

Add a passthrough subtree to workspace meta (same pattern as sidecar
passthrough) and wire it up in the cargo-test and build-rust workspaces
so sccache can actually reach the R2 backend.

Also extract shared SCCACHE_* env vars into ws/sccache-env.josh and
include it from both workspaces, providing a direct R2 endpoint as a
fallback when the sidecar proxy chain doesn't deliver them.

Change: workspace-passthrough
Requires: I66c7d2b6316e08c4ed6be32c295f4d450b0585ab
Assisted-By: deepseek-v4-pro[1m]
Change-Id: Ie4e90515bac4ae746e48f8048270f415bb5c9886