### PR TITLE
Fix sccache remote r2 access

### DIFF
--- a/images/dev/Dockerfile
+++ b/images/dev/Dockerfile
@@ -22,6 +22,7 @@ RUN apk add --no-cache \
     make \
     expat-dev \
     gettext \
+    jq \
     python3 \
     python3-dev \
     libffi-dev \

--- a/images/rust-dev/Dockerfile
+++ b/images/rust-dev/Dockerfile
@@ -7,6 +7,7 @@ RUN apk add --no-cache \
     bash \
     git \
     git-daemon \
+    jq \
     zlib-static \
     zlib-dev \
     openssl-libs-static \

--- a/images/sccache-proxy/entrypoint.sh
+++ b/images/sccache-proxy/entrypoint.sh
@@ -1,11 +1,12 @@
 #!/bin/sh
 set -eu
 
-# Extract hostname from the full endpoint URL.
+# Extract hostname from the full upstream endpoint URL.
 # e.g. https://xxx.r2.cloudflarestorage.com -> xxx.r2.cloudflarestorage.com
-host=$(echo "$SCCACHE_ENDPOINT" | awk -F/ '{print $3}')
+host=$(echo "$UPSTREAM_ENDPOINT" | awk -F/ '{print $3}')
 
 exec aws-sigv4-proxy \
     --name s3 \
     --region "auto" \
+    --port ":${PORT}" \
     --host "$host"

--- a/ws/build-rust.josh
+++ b/ws/build-rust.josh
@@ -14,6 +14,7 @@ env = :[
 
 worktree = :[
     ::run.sh=ws/build-rust.sh
+    ::check-sccache.sh=ws/check-sccache.sh
     :+ws/patched-cargo
     ::Cargo.lock
     ::rust-toolchain.toml

--- a/ws/build-rust.sh
+++ b/ws/build-rust.sh
@@ -11,4 +11,4 @@ cp ${CARGO_TARGET_DIR}/debug/josh-filter /out/debug/
 cp ${CARGO_TARGET_DIR}/debug/josh-ssh-shell /out/debug/
 cp ${CARGO_TARGET_DIR}/debug/axum-cgi-server /out/debug/
 
-sccache --show-stats
+sh check-sccache.sh

--- a/ws/check-sccache.sh
+++ b/ws/check-sccache.sh
@@ -1,0 +1,17 @@
+set -eu
+
+stats=$(sccache --show-stats --stats-format json)
+echo "$stats" | jq .
+
+# sccache silently falls back to the local disk cache when the configured remote
+# backend can't be reached. Fail loudly so a broken R2/proxy setup doesn't pass as a
+# green build. The S3-backed cache reports a cache_location like "S3, bucket: ...".
+if echo "$stats" | jq -e '.cache_location | ascii_downcase | startswith("s3")' >/dev/null
+then
+    echo "sccache: confirmed S3-backed cache"
+else
+    echo "ERROR: sccache is not using the S3 remote cache" >&2
+    echo "cache_location: $(echo "$stats" | jq -r '.cache_location')" >&2
+    env | grep -E '^(SCCACHE|RUSTC_WRAPPER|CARGO)' | sort >&2
+    exit 1
+fi

--- a/ws/sccache-proxy.josh
+++ b/ws/sccache-proxy.josh
@@ -1,9 +1,14 @@
+# The `env` vars configure the proxy itself; `inject` vars configure the build
+# container's sccache. Names must not collide between the two blocks: josh compose
+# dedupes identically-named blobs across sibling subtrees, which would silently drop
+# the colliding `inject` vars from the build container.
+
 :#image[:+images/sccache-proxy]
 :$port="3000"
 
 env = :[
-    :$SCCACHE_BUCKET="josh-project-cache"
-    :$SCCACHE_ENDPOINT="https://19f2dfdd7c93980184be5e5809e8b252.r2.cloudflarestorage.com"
+    :$PORT="3000"
+    :$UPSTREAM_ENDPOINT="https://19f2dfdd7c93980184be5e5809e8b252.r2.cloudflarestorage.com"
 ]
 
 passthrough = :[
@@ -14,5 +19,7 @@ passthrough = :[
 inject = :[
     :$SCCACHE_BUCKET="josh-project-cache"
     :$SCCACHE_ENDPOINT="http://{SIDECAR_IP}:3000"
+    :$SCCACHE_REGION="auto"
     :$SCCACHE_S3_USE_SSL="false"
+    :$SCCACHE_S3_NO_CREDENTIALS="true"
 ]

--- a/ws/test.josh
+++ b/ws/test.josh
@@ -5,7 +5,7 @@ inputs = :[
         :$label="cargo test"
         :#image[:+images/rust-dev-local]
         :$cache="sccache"
-        :$cmd="cargo test --workspace --offline --locked && sccache --show-stats"
+        :$cmd="cargo test --workspace --offline --locked && sh check-sccache.sh"
 
         :+sidecars
 
@@ -19,6 +19,7 @@ inputs = :[
         ]
 
         worktree = :[
+            ::check-sccache.sh=ws/check-sccache.sh
             ::Cargo.toml
             ::Cargo.lock
             ::rust-toolchain.toml


### PR DESCRIPTION
Fix sccache remote r2 access

Point the aws-sigv4-proxy sidecar at port 3000 (its default is :8080) so the
build container's sccache can reach it, and tell sccache to send anonymous S3
requests against the right bucket/region.

Rename the proxy's own endpoint var to UPSTREAM_ENDPOINT (and drop the unused
SCCACHE_BUCKET from the proxy env) so the sidecar's `env` block shares no blob
names with its `inject` block. josh compose dedupes identically-named blobs
across sibling subtrees, which was silently dropping SCCACHE_BUCKET and
SCCACHE_ENDPOINT from the build container so sccache fell back to disk.

Add ws/check-sccache.sh (run after the build and cargo test stages) that parses
'sccache --show-stats --stats-format json' with jq and fails the build unless
cache_location is S3-backed, so a broken proxy/R2 setup can no longer pass as a
green build. Install jq in the rust-dev and dev images.

Change: fix-sccache-remote-r2-access
Assisted-By: Claude Opus 4.8
Change-Id: I99b5a3fc4d3de90959d933810ef964f5378ebacd