### PR TITLE
Warn instead of failing on missing sccache remote cache

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,15 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-      run: target/release/josh compose run HEAD ":[::sidecars.josh=ci-sidecars.josh,:/]:+compose"
+      run: |
+        set -o pipefail
+        target/release/josh compose run HEAD \
+          ":[::sidecars.josh=ci-sidecars.josh,:/]:+compose" 2>&1 \
+          | tee /tmp/compose-run.log
+        if grep -q SCCACHE_REMOTE_CACHE_MISSING /tmp/compose-run.log; then
+          echo "::error::sccache remote cache was not used during the build"
+          exit 1
+        fi
     - name: Push job markers and volumes to R2
       if: success() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
       env:

--- a/ws/check-sccache.sh
+++ b/ws/check-sccache.sh
@@ -4,14 +4,15 @@ stats=$(sccache --show-stats --stats-format json)
 echo "$stats" | jq .
 
 # sccache silently falls back to the local disk cache when the configured remote
-# backend can't be reached. Fail loudly so a broken R2/proxy setup doesn't pass as a
-# green build. The S3-backed cache reports a cache_location like "S3, bucket: ...".
+# backend can't be reached. On dev machines without R2 credentials this is expected,
+# so emit a grepable warning instead of failing — CI greps for the marker and turns
+# it back into a hard failure. The S3-backed cache reports a cache_location like
+# "S3, bucket: ...".
 if echo "$stats" | jq -e '.cache_location | ascii_downcase | startswith("s3")' >/dev/null
 then
     echo "sccache: confirmed S3-backed cache"
 else
-    echo "ERROR: sccache is not using the S3 remote cache" >&2
+    echo "SCCACHE_REMOTE_CACHE_MISSING: sccache is not using the S3 remote cache" >&2
     echo "cache_location: $(echo "$stats" | jq -r '.cache_location')" >&2
     env | grep -E '^(SCCACHE|RUSTC_WRAPPER|CARGO)' | sort >&2
-    exit 1
 fi


### PR DESCRIPTION
Warn instead of failing on missing sccache remote cache

`ws/check-sccache.sh` used to `exit 1` whenever sccache's cache_location
wasn't S3-backed. The intent was to catch a broken R2/proxy setup before
it silently passed as a green build. The side effect was that every
`josh compose run` on a dev machine without `AWS_ACCESS_KEY_ID` /
`AWS_SECRET_ACCESS_KEY` failed at the cargo step, even though the build
itself was fine — sccache had just transparently fallen back to the
local disk cache.

Soften the check so the script prints a grepable marker
(`SCCACHE_REMOTE_CACHE_MISSING`) on stderr and exits 0. The CI "Run
tests" step in `.github/workflows/rust.yml` now `tee`s
`josh compose run` output to a log file under `pipefail` and fails
with an `::error::` annotation if the marker appears, so a broken
remote cache is still caught in CI without breaking local runs.

Change: warn-on-missing-sccache-remote-cache

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>