### PR TITLE
Split cargo test into build + run to drop git from rust-dev

### DIFF
--- a/images/rust-dev/Dockerfile
+++ b/images/rust-dev/Dockerfile
@@ -5,8 +5,6 @@ FROM ${BASE_IMAGE}
 
 RUN apk add --no-cache \
     bash \
-    git \
-    git-daemon \
     jq \
     zlib-static \
     zlib-dev \

--- a/images/rust-test-runner-local.josh
+++ b/images/rust-test-runner-local.josh
@@ -1,0 +1,4 @@
+bases = :[
+    :#BASE_IMAGE[:+images/rust-test-runner]
+]
+context = :/images/rust-test-runner-local

--- a/images/rust-test-runner-local/Dockerfile
+++ b/images/rust-test-runner-local/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.23.0@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+RUN <<EOF
+set -eux
+mkdir -p /opt/cache /opt/target /opt/build
+chmod 777 /opt/cache /opt/target /opt/build
+EOF
+
+VOLUME /opt/cache
+
+ARG USER_GID
+ARG USER_UID
+
+RUN <<EOF
+set -eux
+
+if [ ! $(getent group ${USER_GID}) ] ; then
+    addgroup -g ${USER_GID} dev
+fi
+
+adduser \
+    -u ${USER_UID} \
+    -G $(getent group ${USER_GID} | cut -d: -f1) \
+    -D \
+    -H \
+    -g '' \
+    dev
+EOF

--- a/images/rust-test-runner.josh
+++ b/images/rust-test-runner.josh
@@ -1,0 +1,1 @@
+context = :/images/rust-test-runner

--- a/images/rust-test-runner/Dockerfile
+++ b/images/rust-test-runner/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1.23.0@sha256:2780b5c3bab67f1f76c781860de469442999ed1a0d7992a5efdf2cffc0e3d769
+
+ARG ALPINE_VERSION=3.22.0
+
+FROM alpine:${ALPINE_VERSION}
+
+RUN apk add --no-cache \
+    bash \
+    ca-certificates \
+    git \
+    git-daemon \
+    libgcc \
+    libcurl \
+    openssl \
+    zlib

--- a/ws/cargo-test-build.josh
+++ b/ws/cargo-test-build.josh
@@ -1,0 +1,30 @@
+:$label="cargo test build"
+:#image[:+images/rust-dev-local]
+:$cache="sccache"
+
+:+sidecars
+
+inputs = :[
+    :#fetch[:+ws/fetch]
+]
+
+env = :[
+    :$RUSTFLAGS="-D warnings -Ctarget-feature=-crt-static"
+    :$CARGO_HOME="/fetch/cargo-cache"
+]
+
+worktree = :[
+    ::run.sh=ws/cargo-test-build.sh
+    ::check-sccache.sh=ws/check-sccache.sh
+    ::Cargo.toml
+    ::Cargo.lock
+    ::rust-toolchain.toml
+    ::rustfmt.toml
+    ::axum-cgi/
+    ::axum-cgi-server/
+    ::hyper-reverse-proxy/
+    ::josh-*/**/*
+    ::cq/
+    ::forges/
+    ::deployment/
+]

--- a/ws/cargo-test-build.sh
+++ b/ws/cargo-test-build.sh
@@ -1,0 +1,14 @@
+set -e
+
+cargo test --workspace --offline --locked --no-run --message-format=json \
+    > /tmp/cargo.json
+
+sh check-sccache.sh
+
+mkdir -p /out/test-bins
+
+jq -r 'select(.executable != null) | .executable | select(contains("/debug/deps/"))' \
+    /tmp/cargo.json \
+    | while read -r bin; do
+        cp "$bin" /out/test-bins/
+    done

--- a/ws/cargo-test-run.josh
+++ b/ws/cargo-test-run.josh
@@ -1,0 +1,10 @@
+:$label="cargo test run"
+:#image[:+images/rust-test-runner-local]
+
+inputs = :[
+    :#test-build[:+ws/cargo-test-build]
+]
+
+worktree = :[
+    ::run.sh=ws/cargo-test-run.sh
+]

--- a/ws/cargo-test-run.sh
+++ b/ws/cargo-test-run.sh
@@ -1,0 +1,14 @@
+set -e
+
+FAILED=0
+for bin in /test-build/test-bins/*; do
+    echo "==> Running $(basename "$bin")"
+    if ! "$bin"; then
+        FAILED=$((FAILED + 1))
+    fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "==> $FAILED test binar(ies) failed"
+    exit 1
+fi

--- a/ws/test.josh
+++ b/ws/test.josh
@@ -1,38 +1,7 @@
 :$label="test suite"
 :$output="none"
 inputs = :[
-    :#cargo-test[
-        :$label="cargo test"
-        :#image[:+images/rust-dev-local]
-        :$cache="sccache"
-        :$cmd="cargo test --workspace --offline --locked && sh check-sccache.sh"
-
-        :+sidecars
-
-        inputs = :[
-            :#fetch[:+ws/fetch]
-        ]
-
-        env = :[
-            :$RUSTFLAGS="-D warnings -Ctarget-feature=-crt-static"
-            :$CARGO_HOME="/fetch/cargo-cache"
-        ]
-
-        worktree = :[
-            ::check-sccache.sh=ws/check-sccache.sh
-            ::Cargo.toml
-            ::Cargo.lock
-            ::rust-toolchain.toml
-            ::rustfmt.toml
-            ::axum-cgi/
-            ::axum-cgi-server/
-            ::hyper-reverse-proxy/
-            ::josh-*/**/*
-            ::cq/
-            ::forges/
-            ::deployment/
-        ]
-    ]
+    :#cargo-test-run[:+ws/cargo-test-run]
     :#fmt[
         :$label="cargo fmt"
         :#image[:+images/rust-dev-local]


### PR DESCRIPTION
Split cargo test into build + run to drop git from rust-dev

After the per-language image split (d069a9d8d), `rust-dev` still
carried alpine's `git` + `git-daemon` packages solely because one
unit test — `josh-proxy::serve::tests::test_git_cap_discovery` —
shells out to `git http-backend` to verify capability discovery.
No other rust unit/integration test in the workspace spawns a git
child process and no `build.rs` invokes git. Fetch, rust build,
and fmt never need git either.

Split the existing single cargo-test workspace into two phases:

- `ws/cargo-test-build` runs `cargo test --workspace --offline
  --locked --no-run --message-format=json` in `rust-dev-local`,
  extracts every `executable` path under `/debug/deps/` from the
  JSON-lines output, copies them to `/out/test-bins/`. The path
  filter excludes example binaries (which cargo also builds and
  reports under `executable` but lives in `/debug/examples/` and
  would panic when run without their expected env vars).
- `ws/cargo-test-run` consumes `cargo-test-build` as a read-only
  input, iterates `/test-build/test-bins/*`, executes each binary,
  accumulates failures, and exits non-zero if any failed. Runs in
  a new dedicated `rust-test-runner-local` image.

The new `rust-test-runner` image is minimal alpine 3.22.0 + bash,
ca-certificates, git, git-daemon (the alpine package containing
`git-http-backend`), and the runtime libs the cargo binaries link
against (libgcc, libcurl, openssl, zlib). Both `rust-dev` and
`rust-test-runner` are alpine 3.22.0 so library ABIs match across
the build/run boundary.

With the test runner gone, `rust-dev`'s `apk add` line loses `git`
and `git-daemon`. A git package bump no longer invalidates the
rust-dev image used by fetch, build, and fmt.

The orchestrator needed no changes — `ws/test.josh` was already
declaring inputs via `:+ws/<file>` references, so swapping the
inline `:#cargo-test[...]` block for `:+ws/cargo-test-run` pulls
the build phase in transitively just like `build-rust` pulls in
`fetch`.

Verified with `josh compose run`: cargo-test-build copies the
expected binaries (one per crate test target), cargo-test-run
executes them all green including `test_git_cap_discovery` (which
exercises the runner image's `git http-backend`), and the full
pipeline through prysk tests passes.

Change: split-cargo-test-build-run

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>