### PR TITLE
Skip rust CI on draft pull requests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ '**' ]
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
 
 env:
@@ -15,6 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     name: CI
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
     - name: Free up disk space
       shell: bash


### PR DESCRIPTION
Skip rust CI on draft pull requests

GitHub Actions runner capacity is the current bottleneck and deep stacks
turn into many parallel builds. Skip the rust workflow's test job when
the PR is a draft, and add ready_for_review to the pull_request trigger
types so flipping a draft to ready still kicks off CI.

Change: skip-ci-on-draft-prs
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>