### PR TITLE
Stub source-target file contents in the cargo fetch worktree

### DIFF
--- a/ws/fetch.josh
+++ b/ws/fetch.josh
@@ -14,10 +14,12 @@ worktree = :[
     ::**/Cargo.lock
     ::**/rust-toolchain.toml
     ::**/.cargo/
-    ::**/lib.rs
-    ::**/main.rs
-    ::**/bin/
-    ::**/build.rs
-    ::**/benches/
-    ::josh-core/benches/
+    :[
+        ::**/lib.rs
+        ::**/main.rs
+        ::**/bin/
+        ::**/build.rs
+        ::**/benches/
+        ::josh-core/benches/
+    ]:replace("(?s).+":"")
 ]


### PR DESCRIPTION
Stub source-target file contents in the cargo fetch worktree

cargo fetch --locked needs each declared/auto-discovered target file to
exist (src/lib.rs, src/main.rs, src/bin/*.rs, build.rs, benches/*.rs)
but it never reads their contents -- it only resolves the dep graph
from Cargo.toml and Cargo.lock. Including the real bodies in the fetch
worktree meant every edit to a .rs file changed the worktree tree OID
and busted the [cargo fetch] job cache, even when no dependency input
had moved.

Wrap the source-target globs in a group and chain :replace("(?s).+":"")
so each matched blob becomes empty. All empty blobs share git's
empty-blob OID, so the worktree tree depends only on the set of paths
the globs match, not on their contents. Adding/removing/renaming a
target still busts the cache (correctly); routine source edits do not.

Change: fetch-stub-source-contents

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>