### PR TITLE
Compile Cargo dependencies in their own compose step

### DIFF
--- a/ws/build-rust.josh
+++ b/ws/build-rust.josh
@@ -6,6 +6,7 @@
 
 inputs = :[
     :#fetch[:+ws/fetch]
+    :#cargo-deps-build[:+ws/cargo-deps-build]
 ]
 
 env = :[

--- a/ws/build-rust.sh
+++ b/ws/build-rust.sh
@@ -1,5 +1,8 @@
 set -e
 
+cp -a --reflink=auto /cargo-deps-build/target/. "${CARGO_TARGET_DIR}/"
+cp -a --reflink=auto /cargo-deps-build/build/. "${CARGO_BUILD_BUILD_DIR}/"
+
 export RUSTFLAGS="-D warnings -Ctarget-feature=-crt-static"
 cargo build --workspace $CARGO_BUILD_FEATURES --offline --locked
 

--- a/ws/cargo-deps-build.josh
+++ b/ws/cargo-deps-build.josh
@@ -1,0 +1,33 @@
+:$label="cargo deps build"
+:#image[:+images/rust-dev-local]
+:$cache="sccache"
+
+:+sidecars
+
+inputs = :[
+    :#fetch[:+ws/fetch]
+]
+
+env = :[
+    :$RUSTFLAGS="-D warnings -Ctarget-feature=-crt-static"
+    :$CARGO_HOME="/fetch/cargo-cache"
+]
+
+worktree = :[
+    ::run.sh=ws/cargo-deps-build.sh
+    ::check-sccache.sh=ws/check-sccache.sh
+    :+ws/patched-cargo
+    ::**/Cargo.toml
+    ::Cargo.lock
+    ::rust-toolchain.toml
+    ::**/.cargo/
+    :[
+        ::**/lib.rs
+        ::**/benches/**/*.rs
+    ]:replace("(?s).+":"")
+    :[
+        ::**/main.rs
+        ::**/src/bin/**/*.rs
+        ::**/build.rs
+    ]:replace("(?s).+":"fn main(){}")
+]

--- a/ws/cargo-deps-build.sh
+++ b/ws/cargo-deps-build.sh
@@ -1,0 +1,20 @@
+set -e
+
+cargo build --workspace --tests --offline --locked
+cargo build --workspace --offline --locked
+
+# Workspace members were compiled against stub sources, so their rlibs and
+# fingerprints must NOT leak into the downstream build -- otherwise cargo would
+# treat the stub rlibs as fresh and link broken empty modules into the real
+# build. Strip them; external rlibs and the registry cache remain.
+cargo metadata --format-version 1 --no-deps --offline --locked \
+    | jq -r '.packages[].name' \
+    | while read -r name; do
+        cargo clean --offline --locked -p "$name" 2>/dev/null || true
+    done
+
+mkdir -p /out/target /out/build
+cp -a --reflink=auto "${CARGO_TARGET_DIR}/." /out/target/
+cp -a --reflink=auto "${CARGO_BUILD_BUILD_DIR}/." /out/build/
+
+sh check-sccache.sh

--- a/ws/cargo-test-build.josh
+++ b/ws/cargo-test-build.josh
@@ -6,6 +6,7 @@
 
 inputs = :[
     :#fetch[:+ws/fetch]
+    :#cargo-deps-build[:+ws/cargo-deps-build]
 ]
 
 env = :[

--- a/ws/cargo-test-build.sh
+++ b/ws/cargo-test-build.sh
@@ -1,5 +1,8 @@
 set -e
 
+cp -a --reflink=auto /cargo-deps-build/target/. "${CARGO_TARGET_DIR}/"
+cp -a --reflink=auto /cargo-deps-build/build/. "${CARGO_BUILD_BUILD_DIR}/"
+
 cargo test --workspace --offline --locked --no-run --message-format=json \
     > /tmp/cargo.json
 


### PR DESCRIPTION
Compile Cargo dependencies in their own compose step

The rust build steps (cargo-test-build, build-rust) used to depend
directly on fetch, then compile the entire dep graph -- externals and
workspace members -- inside one container. Their job-cache key was the
workspace tree OID, which includes all josh-*/src/**, so any source
edit busted the cache and forced cargo to re-walk every external dep.
sccache hid most of the compile cost, but the container start, cargo
metadata pass, and rustc invocations still ran for each external on
every edit.

Split that work into a new cargo-deps-build step that sits between
fetch and the downstream build steps. Its worktree contains only
Cargo.{toml,lock}, rust-toolchain.toml, .cargo/, plus stubbed entry
points (lib.rs/benches emptied, main.rs/bin/build.rs replaced with
"fn main(){}") -- the same :replace trick already used in fetch.josh.
The container runs cargo build --workspace --tests --offline --locked,
then publishes CARGO_TARGET_DIR and the populated cargo-cache to /out.

cargo-test-build and build-rust now mount that output and copy
/cargo-deps-build/target into CARGO_TARGET_DIR before invoking cargo
(cp -a --reflink=auto avoids duplicating disk space on reflink-capable
filesystems). When only source changes, the deps-build tree OID is
unchanged, so the job cache short-circuits the whole container start;
downstream cargo only recompiles the workspace members whose source
moved and reuses the external rlibs straight from the deps-build
mount.

Change: compose-cargo-deps-build

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>