### PR TITLE
Bootstrap CI josh binary from a pinned previous commit

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,13 @@ on:
 env:
   CARGO_TERM_COLOR: always
   JOSH_EXPERIMENTAL_FEATURES: "1"
+  # Bootstrap `josh` binary used by CI to drive `josh compose run` and to
+  # pull/push job markers, volumes, and images from R2. Pinned to a known-good
+  # commit that is already merged into `master` (so the build is reproducible
+  # for any branch and the binary is not rebuilt for every PR / merge-queue
+  # run). Bump when a backward-incompatible change to `josh compose` requires
+  # it; the new SHA must also already be on `origin/master`.
+  JOSH_BOOTSTRAP_SHA: caf2143216c07d2775fe566e52989fcb1b9d417c
 
 jobs:
   test:
@@ -47,16 +54,11 @@ jobs:
       run: .github/workflows/scripts/install-podman.sh
     - name: Install Rust toolchain
       uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-    - name: Cache josh binary
-      id: cache-josh
-      if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-      with:
-        path: target/release/josh
-        key: josh-binary-${{ runner.os }}-${{ hashFiles('Cargo.lock', 'rust-toolchain.toml', 'josh-cli/**/*.rs', 'josh-core/**/*.rs', 'josh-filter/**/*.rs', 'josh-run/**/*.rs', 'josh-changes/**/*.rs', 'josh-compose/**/*.rs', 'forges/**/*.rs') }}
-    - name: Build josh binary
-      if: steps.cache-josh.outputs.cache-hit != 'true'
-      run: cargo build --release -p josh-cli
+    - name: Bootstrap josh binary
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      run: .github/workflows/scripts/bootstrap-josh.sh
     - name: Pull cached job markers and volumes from R2
       if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
       env:

--- a/.github/workflows/scripts/bootstrap-josh.sh
+++ b/.github/workflows/scripts/bootstrap-josh.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Provide the CI bootstrap `josh` binary at target/release/josh, used by the
+# workflow to drive `josh compose run` and the R2 pull/push scripts.
+#
+# Strategy:
+#   1. If R2 credentials are present, try to download a binary built from the
+#      pinned `JOSH_BOOTSTRAP_SHA` commit. Hit means seconds; miss falls
+#      through to build.
+#   2. On miss (or no credentials), check out the pinned SHA into a separate
+#      worktree, build `josh-cli`, and place the binary at target/release/josh.
+#   3. If R2 credentials are present after a build, upload so the next run on
+#      any branch finds the object.
+#
+# Branch scope is not relevant: R2 objects are visible to every workflow run
+# with the credentials, which sidesteps the GitHub Actions cache-scope problem
+# that caused PR runs and merge_group runs to each rebuild the binary.
+
+BUCKET="josh-project-cache"
+ENDPOINT="https://19f2dfdd7c93980184be5e5809e8b252.r2.cloudflarestorage.com"
+
+if [[ -z "${JOSH_BOOTSTRAP_SHA:-}" ]]; then
+    echo "bootstrap-josh: JOSH_BOOTSTRAP_SHA is not set" >&2
+    exit 1
+fi
+
+KEY="bootstrap/josh-${JOSH_BOOTSTRAP_SHA}-linux-amd64"
+DEST="target/release/josh"
+mkdir -p target/release
+
+have_creds=0
+if [[ -n "${AWS_ACCESS_KEY_ID:-}" && -n "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    have_creds=1
+fi
+
+if [[ "$have_creds" == "1" ]]; then
+    if aws s3 cp "s3://${BUCKET}/${KEY}" "${DEST}" \
+            --endpoint-url "$ENDPOINT" \
+            --no-progress 2>/dev/null; then
+        chmod +x "${DEST}"
+        echo "bootstrap-josh: downloaded ${KEY} from R2"
+        exit 0
+    fi
+    echo "bootstrap-josh: ${KEY} not in R2, building from pinned ref"
+else
+    echo "bootstrap-josh: no R2 credentials, building from pinned ref"
+fi
+
+WORKTREE="$(mktemp -d -t josh-bootstrap-XXXXXX)"
+trap 'git worktree remove --force "$WORKTREE" >/dev/null 2>&1 || true; rm -rf "$WORKTREE"' EXIT
+
+# Ensure the pinned SHA is present locally. The CI checkout may not contain it
+# (e.g. PR runs only fetch the PR head). The pin is required to live on
+# `origin/master`, so fetching it from `origin` always succeeds.
+if ! git cat-file -e "${JOSH_BOOTSTRAP_SHA}^{commit}" 2>/dev/null; then
+    git fetch --no-tags --depth=1 origin "$JOSH_BOOTSTRAP_SHA"
+fi
+
+git worktree add --detach "$WORKTREE" "$JOSH_BOOTSTRAP_SHA"
+(cd "$WORKTREE" && cargo build --release -p josh-cli)
+cp "${WORKTREE}/target/release/josh" "${DEST}"
+chmod +x "${DEST}"
+
+if [[ "$have_creds" == "1" ]]; then
+    if aws s3 cp "${DEST}" "s3://${BUCKET}/${KEY}" \
+            --endpoint-url "$ENDPOINT" \
+            --no-progress; then
+        echo "bootstrap-josh: uploaded ${KEY} to R2"
+    else
+        echo "bootstrap-josh: upload to R2 failed (non-fatal)"
+    fi
+fi


### PR DESCRIPTION
Bootstrap CI josh binary from a pinned previous commit

The `Build josh binary` step rebuilt `josh-cli` from the tree under test on
every CI run because the cache key hashed nearly every Rust crate, and
GitHub Actions caches are branch-scoped, so PR runs and merge-queue runs
never shared an artifact. The bootstrap binary only needs to drive
`josh compose run/list-jobs/list-images`, which doesn't depend on the
tree under test, so pin it to a `master` commit and fetch it from R2
instead.

`JOSH_BOOTSTRAP_SHA` in the workflow points at a commit already on
`origin/master`; a new bootstrap-josh.sh downloads
`bootstrap/josh-<sha>-linux-amd64` from R2, falling back to building the
pinned ref in a temporary worktree and uploading on miss. R2 objects are
visible to every run regardless of branch scope.

Change: pin-ci-bootstrap-josh
Assisted-By: Claude Opus 4.7 (claude-opus-4-7)