### PR TITLE
Polish josh-gui list selection, scrolling, and comment styling

### DIFF
--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -82,8 +82,17 @@ pub fn ListView(
         });
     }
 
+    let mut scroll_el: Signal<Option<std::rc::Rc<MountedData>>> = use_signal(|| None);
+
+    // Only react to selection changes made after mount; on mount the scroll
+    // position is restored from scroll_offset in onmounted instead.
+    let mut last_sel = use_signal(|| selected_change.peek().clone());
     use_effect(move || {
         let sel = selected_change.read();
+        if *last_sel.peek() == *sel {
+            return;
+        }
+        last_sel.set(sel.clone());
         let Some(cid) = sel.as_deref() else {
             return;
         };
@@ -105,11 +114,16 @@ pub fn ListView(
             None
         };
         if let Some(t) = target {
-            let js = format!(
-                "var el=document.getElementById('changes-scroll');if(el)el.scrollTop={};",
-                t
-            );
-            let _ = dioxus::document::eval(&js);
+            if let Some(el) = scroll_el.peek().clone() {
+                spawn(async move {
+                    let _ = el
+                        .scroll(
+                            dioxus::html::geometry::PixelsVector2D::new(0.0, t as f64),
+                            ScrollBehavior::Instant,
+                        )
+                        .await;
+                });
+            }
         }
     });
 
@@ -154,6 +168,21 @@ pub fn ListView(
                 div {
                     class: "scroll-table",
                     id: "changes-scroll",
+                    onmounted: move |evt| {
+                        let el = evt.data();
+                        scroll_el.set(Some(el.clone()));
+                        let offset = *scroll_offset.peek();
+                        if offset > 0 {
+                            spawn(async move {
+                                let _ = el
+                                    .scroll(
+                                        dioxus::html::geometry::PixelsVector2D::new(0.0, offset as f64),
+                                        ScrollBehavior::Instant,
+                                    )
+                                    .await;
+                            });
+                        }
+                    },
                     onscroll: move |e| {
                         scroll_offset.set(e.data.scroll_top() as usize);
                     },
@@ -207,15 +236,15 @@ pub fn ListView(
                                             id: "change-{row.sha}",
                                             class: "{class}",
                                             onclick: {
-                                                let s = sha.clone();
-                                                move |_| page.set(Page::Detail { sha: s.clone() })
+                                                let c = cid.clone();
+                                                move |_| selected_change.set(Some(c.clone()))
                                             },
                                             td {
                                                 onclick: {
-                                                    let c = cid.clone();
+                                                    let s = sha.clone();
                                                     move |evt| {
                                                         evt.stop_propagation();
-                                                        selected_change.set(Some(c.clone()));
+                                                        page.set(Page::Detail { sha: s.clone() });
                                                     }
                                                 },
                                                 "{row.subject}"

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -172,9 +172,9 @@ span.comment-ts {
 
 pre.comment-body {
     margin: 0;
-    font-family: inherit;
-    font-size: 0.85rem;
-    color: #bbb;
+    font-family: -apple-system, system-ui, sans-serif;
+    font-size: 0.95rem;
+    color: #e8a872;
     white-space: pre-wrap;
 }
 
@@ -254,17 +254,47 @@ table.changes tbody tr:hover td {
     background: #2a2a2a;
 }
 
-table.changes tbody tr.selected td,
+table.changes tbody tr.selected td {
+    background: #d8d8d8;
+    color: #1a1a1a;
+}
+
 table.changes tbody tr.selected:hover td {
-    background: #000000;
+    background: #e8e8e8;
+}
+
+table.changes tbody tr.selected td.num {
+    color: #555;
+}
+
+table.changes tbody tr.selected td.loading {
+    color: #888;
+}
+
+table.changes tbody tr.selected td.review-approved,
+table.changes tbody tr.selected td.vote-approve,
+table.changes tbody tr.selected td.check-success {
+    color: #2d6b3a;
+}
+
+table.changes tbody tr.selected td.review-changes-requested,
+table.changes tbody tr.selected td.vote-revise,
+table.changes tbody tr.selected td.check-failure {
+    color: #a02530;
+}
+
+table.changes tbody tr.selected td.review-review-required,
+table.changes tbody tr.selected td.vote-discuss,
+table.changes tbody tr.selected td.check-pending {
+    color: #8c5a23;
 }
 
 table.changes tbody tr.related td {
-    background: #2a2a2a;
+    background: #22303f;
 }
 
 table.changes tbody tr.related:hover td {
-    background: #333333;
+    background: #2d4054;
 }
 
 .diff-nav {
@@ -504,28 +534,6 @@ tr.diff-comment-row td {
 .diff-comment-inline {
     border-left: 2px solid #5a8ab5;
     padding: 0.25rem 0 0.25rem 0.6rem;
-}
-
-.diff-comment-inline .comment-header {
-    margin-bottom: 0.1rem;
-}
-
-.diff-comment-inline .comment-body {
-    margin: 0;
-    font-family: inherit;
-    font-size: 0.82rem;
-    color: #bbb;
-    white-space: pre-wrap;
-}
-
-.diff-comment-inline .comment-author {
-    color: #7ec699;
-    font-size: 0.78rem;
-}
-
-.diff-comment-inline .comment-ts {
-    color: #666;
-    font-size: 0.78rem;
 }
 
 .comment-form {


### PR DESCRIPTION
Polish josh-gui list selection, scrolling, and comment styling

Make a row click select the row instead of navigating, and move the
detail-page navigation onto the Subject cell click (with stopPropagation
so it doesn't fall back to the row handler). Capture the scroll
container's MountedData in onmounted and restore the scroll position
from scroll_offset right there, so navigating back from the detail view
returns to where the user was scrolled. Guard the selected-change effect
with a last-seen-selection signal so it only scrolls the selection into
view when the selection actually changes after mount, and use the
mounted element's typed scroll() API for that instead of a JS eval.

Restyle the selected row as light-on-dark (#d8d8d8 bg, #1a1a1a text) and
override the per-cell color classes (review/vote/check status, num,
loading) so they stay readable against the inverted background. Give
related rows a blue tint (#22303f / #2d4054) so they read as
contextually-linked rather than just hovered. Bump comment bodies to a
0.95rem system font in #e8a872 so they're easier to scan, and drop the
unused .diff-comment-inline rules.

Change: gui-list-selection-polish
Assisted-By: anthropic/claude-opus-4-7
Assisted-By: anthropic/claude-fable-5