### PR TITLE
Virtualize the josh-gui changes list and rework its columns

### DIFF
--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -8,6 +8,10 @@ use crate::common::{
     vote_state_display, vote_state_label,
 };
 
+const ROW_HEIGHT: u32 = 32;
+const VISIBLE_ROWS: u32 = 40;
+const OVERSCAN_ROWS: u32 = 20;
+
 #[derive(Clone)]
 pub struct Row {
     pub change_id: String,
@@ -15,9 +19,15 @@ pub struct Row {
     pub subject: String,
     pub author: String,
     pub series: String,
+    pub contributing_count: usize,
+}
+
+#[derive(Clone, Default)]
+pub struct RowMetadata {
     pub review_decision: String,
     pub check_status: String,
     pub local_vote: Option<String>,
+    pub comments_count: usize,
 }
 
 pub struct ListData {
@@ -29,9 +39,80 @@ pub struct ListData {
 #[component]
 pub fn ListView(
     list_data: Signal<anyhow::Result<ListData>>,
+    metadata_cache: Signal<HashMap<String, RowMetadata>>,
+    mut scroll_offset: Signal<usize>,
+    branch: String,
     mut page: Signal<Page>,
     mut selected_change: Signal<Option<String>>,
 ) -> Element {
+    {
+        let branch_for_meta = branch.clone();
+        use_effect(move || {
+            let offset = *scroll_offset.read() as u32;
+            let viewport_px = VISIBLE_ROWS * ROW_HEIGHT;
+            let overscan_px = OVERSCAN_ROWS * ROW_HEIGHT;
+            let data_ref = list_data.peek();
+            let Ok(data) = &*data_ref else {
+                return;
+            };
+            let total = data.rows.len();
+            let start = (offset.saturating_sub(overscan_px) / ROW_HEIGHT) as usize;
+            let start = start.min(total);
+            let end =
+                ((offset + viewport_px + overscan_px).div_ceil(ROW_HEIGHT) as usize).min(total);
+            let needed: Vec<String> = {
+                let cache = metadata_cache.peek();
+                data.rows[start..end]
+                    .iter()
+                    .filter(|r| !cache.contains_key(&r.change_id))
+                    .map(|r| r.change_id.clone())
+                    .collect()
+            };
+            drop(data_ref);
+            if needed.is_empty() {
+                return;
+            }
+            let fetched = load_metadata_batch(&branch_for_meta, &needed);
+            if !fetched.is_empty() {
+                let mut cache = metadata_cache.write();
+                for (cid, meta) in fetched {
+                    cache.insert(cid, meta);
+                }
+            }
+        });
+    }
+
+    use_effect(move || {
+        let sel = selected_change.read();
+        let Some(cid) = sel.as_deref() else {
+            return;
+        };
+        let data_ref = list_data.peek();
+        let Ok(data) = &*data_ref else {
+            return;
+        };
+        let Some(idx) = data.rows.iter().position(|r| r.change_id == cid) else {
+            return;
+        };
+        let viewport_px = VISIBLE_ROWS * ROW_HEIGHT;
+        let top = (idx as u32) * ROW_HEIGHT;
+        let offset = *scroll_offset.peek() as u32;
+        let target = if top < offset {
+            Some(top)
+        } else if top + ROW_HEIGHT > offset + viewport_px {
+            Some((top + ROW_HEIGHT).saturating_sub(viewport_px))
+        } else {
+            None
+        };
+        if let Some(t) = target {
+            let js = format!(
+                "var el=document.getElementById('changes-scroll');if(el)el.scrollTop={};",
+                t
+            );
+            let _ = dioxus::document::eval(&js);
+        }
+    });
+
     match &*list_data.read() {
         Ok(data) if data.rows.is_empty() => rsx! {
             p { "No outgoing changes found." }
@@ -55,43 +136,72 @@ pub fn ListView(
                 HashSet::new()
             };
 
-            let row_items: Vec<(String, String, String)> = data
-                .rows
-                .iter()
-                .map(|row| {
-                    let is_sel = sel_cid.as_deref() == Some(&row.change_id);
-                    let class = if is_sel {
-                        "selected"
-                    } else if related.contains(row.change_id.as_str()) {
-                        "related"
-                    } else {
-                        ""
-                    };
-                    (class.to_string(), row.sha.clone(), row.change_id.clone())
-                })
-                .collect();
+            let total = data.rows.len();
+            let offset = *scroll_offset.read() as u32;
+            let viewport_px = VISIBLE_ROWS * ROW_HEIGHT;
+            let overscan_px = OVERSCAN_ROWS * ROW_HEIGHT;
+            let start = (offset.saturating_sub(overscan_px) / ROW_HEIGHT) as usize;
+            let start = start.min(total);
+            let end =
+                ((offset + viewport_px + overscan_px).div_ceil(ROW_HEIGHT) as usize).min(total);
+
+            let top_h = (start as u32) * ROW_HEIGHT;
+            let bot_h = ((total - end) as u32) * ROW_HEIGHT;
+
+            let cache = metadata_cache.read();
 
             rsx! {
-                div { class: "scroll-table",
+                div {
+                    class: "scroll-table",
+                    id: "changes-scroll",
+                    onscroll: move |e| {
+                        scroll_offset.set(e.data.scroll_top() as usize);
+                    },
                     table { class: "changes",
+                        colgroup {
+                            col {}
+                            col { style: "width: 18ch" }
+                            col { style: "width: 10ch" }
+                            col { style: "width: 12ch" }
+                            col { style: "width: 8ch" }
+                            col { style: "width: 5ch" }
+                            col { style: "width: 10ch" }
+                            col { style: "width: 9ch" }
+                        }
                         thead {
                             tr {
-                                th { "Change-Id" }
                                 th { "Subject" }
                                 th { "Author" }
                                 th { "Series" }
                                 th { "Review" }
                                 th { "Vote" }
+                                th { "Deps" }
+                                th { "Comments" }
                                 th { "Checks" }
                             }
                         }
                         tbody {
-                            for (i, item) in row_items.iter().enumerate() {
+                            if top_h > 0 {
+                                tr { style: "height: {top_h}px",
+                                    td { colspan: "8" }
+                                }
+                            }
+                            for i in start..end {
                                 {
                                     let row = &data.rows[i];
-                                    let class = &item.0;
-                                    let sha = &item.1;
-                                    let cid = &item.2;
+                                    let is_sel = sel_cid.as_deref() == Some(&row.change_id);
+                                    let class = if is_sel {
+                                        "selected"
+                                    } else if related.contains(row.change_id.as_str()) {
+                                        "related"
+                                    } else {
+                                        ""
+                                    };
+                                    let sha = row.sha.clone();
+                                    let cid = row.change_id.clone();
+                                    let meta = cache.get(&row.change_id).cloned();
+                                    let loading = meta.is_none();
+                                    let m = meta.unwrap_or_default();
                                     rsx! {
                                         tr {
                                             id: "change-{row.sha}",
@@ -108,29 +218,44 @@ pub fn ListView(
                                                         selected_change.set(Some(c.clone()));
                                                     }
                                                 },
-                                                code { "{row.change_id}" }
+                                                "{row.subject}"
                                             }
-                                            td { "{row.subject}" }
                                             td { "{row.author}" }
                                             td { "{row.series}" }
                                             td {
-                                                class: "review-{review_decision_label(&row.review_decision)}",
-                                                "{review_decision_display(&row.review_decision)}"
+                                                class: "review-{review_decision_label(&m.review_decision)}",
+                                                class: if loading { "loading" },
+                                                "{review_decision_display(&m.review_decision)}"
                                             }
                                             td {
-                                                class: if let Some(ref v) = row.local_vote {
+                                                class: if let Some(ref v) = m.local_vote {
                                                     "vote-{vote_state_label(v)}"
                                                 },
-                                                if let Some(ref v) = row.local_vote {
+                                                class: if loading { "loading" },
+                                                if let Some(ref v) = m.local_vote {
                                                     "{vote_state_display(v)}"
                                                 }
                                             }
+                                            td { class: "num", "{row.contributing_count}" }
                                             td {
-                                                class: "check-{check_status_label(&row.check_status)}",
-                                                "{check_status_display(&row.check_status)}"
+                                                class: "num",
+                                                class: if loading { "loading" },
+                                                if !loading && m.comments_count > 0 {
+                                                    "{m.comments_count}"
+                                                }
+                                            }
+                                            td {
+                                                class: "check-{check_status_label(&m.check_status)}",
+                                                class: if loading { "loading" },
+                                                "{check_status_display(&m.check_status)}"
                                             }
                                         }
                                     }
+                                }
+                            }
+                            if bot_h > 0 {
+                                tr { style: "height: {bot_h}px",
+                                    td { colspan: "8" }
                                 }
                             }
                         }
@@ -160,7 +285,6 @@ pub fn load_rows(branch: &str) -> anyhow::Result<ListData> {
 
     let mut rows = Vec::new();
     let mut dependencies: HashMap<String, Vec<String>> = HashMap::new();
-    let mut dep_counts: HashMap<String, usize> = HashMap::new();
 
     for change in &changes {
         let commit = repo.find_commit(change.commit())?;
@@ -174,43 +298,6 @@ pub fn load_rows(branch: &str) -> anyhow::Result<ListData> {
 
         let change_id = change.id().unwrap_or("").to_string();
 
-        let (review_decision, check_status) =
-            josh_changes::read_pr_data_in_scopes(&repo, &change_id, &scopes)
-                .ok()
-                .flatten()
-                .and_then(|json| {
-                    serde_json::from_str::<serde_json::Value>(&json)
-                        .ok()
-                        .map(|v| {
-                            let rd = v["review_decision"]
-                                .as_str()
-                                .map(|s| s.to_string())
-                                .unwrap_or_default();
-                            let cs = v["check_status"]
-                                .as_str()
-                                .map(|s| s.to_string())
-                                .unwrap_or_default();
-                            (rd, cs)
-                        })
-                })
-                .unwrap_or_default();
-
-        let local_vote = josh_changes::read_vote_in_scopes(&repo, &change_id, None, &scopes)
-            .ok()
-            .flatten()
-            .map(|v| v.state);
-
-        rows.push(Row {
-            change_id: change_id.clone(),
-            sha: change.commit().to_string(),
-            subject,
-            author: change.author().to_string(),
-            series: change.series().join(", "),
-            review_decision,
-            check_status,
-            local_vote,
-        });
-
         let mut deps: Vec<String> = Vec::new();
         for oid in change.contributing(&repo)? {
             let oid_str = oid.to_string();
@@ -220,9 +307,17 @@ pub fn load_rows(branch: &str) -> anyhow::Result<ListData> {
                 }
             }
         }
-        let count = deps.len();
-        dependencies.insert(change_id.clone(), deps);
-        dep_counts.insert(change_id, count);
+
+        rows.push(Row {
+            change_id: change_id.clone(),
+            sha: change.commit().to_string(),
+            subject,
+            author: change.author().to_string(),
+            series: change.series().join(", "),
+            contributing_count: deps.len(),
+        });
+
+        dependencies.insert(change_id, deps);
     }
 
     let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
@@ -235,11 +330,70 @@ pub fn load_rows(branch: &str) -> anyhow::Result<ListData> {
         }
     }
 
-    rows.sort_by_key(|r| dep_counts.get(&r.change_id).copied().unwrap_or(0));
+    rows.sort_by_key(|r| r.contributing_count);
 
     Ok(ListData {
         rows,
         dependencies,
         dependents,
     })
+}
+
+fn load_metadata_with_scopes(
+    repo: &git2::Repository,
+    scopes: &[josh_changes::ChangesRef],
+    change_id: &str,
+) -> RowMetadata {
+    let (review_decision, check_status) =
+        josh_changes::read_pr_data_in_scopes(repo, change_id, scopes)
+            .ok()
+            .flatten()
+            .and_then(|json| {
+                serde_json::from_str::<serde_json::Value>(&json)
+                    .ok()
+                    .map(|v| {
+                        let rd = v["review_decision"]
+                            .as_str()
+                            .map(|s| s.to_string())
+                            .unwrap_or_default();
+                        let cs = v["check_status"]
+                            .as_str()
+                            .map(|s| s.to_string())
+                            .unwrap_or_default();
+                        (rd, cs)
+                    })
+            })
+            .unwrap_or_default();
+
+    let local_vote = josh_changes::read_vote_in_scopes(repo, change_id, None, scopes)
+        .ok()
+        .flatten()
+        .map(|v| v.state);
+
+    let comments_count = josh_changes::read_comments_in_scopes(repo, change_id, scopes)
+        .map(|c| c.len())
+        .unwrap_or(0);
+
+    RowMetadata {
+        review_decision,
+        check_status,
+        local_vote,
+        comments_count,
+    }
+}
+
+pub fn load_metadata_batch(branch: &str, change_ids: &[String]) -> Vec<(String, RowMetadata)> {
+    if change_ids.is_empty() {
+        return Vec::new();
+    }
+    let Ok(repo) = git2::Repository::discover(".") else {
+        return Vec::new();
+    };
+    let Ok(scopes) = josh_changes::refs_on_branch(&repo, branch) else {
+        return Vec::new();
+    };
+    change_ids
+        .iter()
+        .map(|cid| (cid.clone(), load_metadata_with_scopes(&repo, &scopes, cid)))
+        .collect()
 }

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -3,12 +3,14 @@ mod detail;
 mod diff;
 mod list;
 
+use std::collections::HashMap;
+
 use dioxus::prelude::*;
 
 use common::breadcrumb;
 use detail::DetailView;
 use diff::FileDiffView;
-use list::{ListView, load_rows};
+use list::{ListView, RowMetadata, load_rows};
 
 fn main() {
     dioxus::LaunchBuilder::new()
@@ -53,6 +55,8 @@ fn app() -> Element {
     let current_branch = use_signal(initial_branch);
     let mut list_data: Signal<anyhow::Result<list::ListData>> =
         use_signal(|| load_rows(&current_branch.read()));
+    let mut metadata_cache: Signal<HashMap<String, RowMetadata>> = use_signal(HashMap::new);
+    let mut scroll_offset = use_signal(|| 0usize);
     let page = use_signal(|| Page::List);
     let mut selected_change = use_signal(|| None::<String>);
 
@@ -60,6 +64,8 @@ fn app() -> Element {
         let b = current_branch.read().clone();
         list_data.set(load_rows(&b));
         selected_change.set(None);
+        metadata_cache.write().clear();
+        scroll_offset.set(0);
     });
 
     use_effect(move || {
@@ -78,21 +84,6 @@ fn app() -> Element {
             let _ = dioxus::document::eval(
                 "setTimeout(function(){var el=document.querySelector('.app');if(el)el.focus();},0)",
             );
-        }
-    });
-
-    use_effect(move || {
-        let cid = selected_change.read();
-        if let Some(cid) = cid.as_deref() {
-            if let Ok(data) = &*list_data.read() {
-                if let Some(row) = data.rows.iter().find(|r| r.change_id == cid) {
-                    let js = format!(
-                        "var el=document.getElementById('change-{0}');if(el)el.scrollIntoView({{block:'nearest'}});",
-                        row.sha
-                    );
-                    let _ = dioxus::document::eval(&js);
-                }
-            }
         }
     });
 
@@ -160,7 +151,16 @@ fn app() -> Element {
                 }
             }
             match &*page.read() {
-                Page::List => rsx! { ListView { list_data, page, selected_change } },
+                Page::List => rsx! {
+                    ListView {
+                        list_data,
+                        metadata_cache,
+                        scroll_offset,
+                        branch: current_branch.read().clone(),
+                        page,
+                        selected_change,
+                    }
+                },
                 Page::Detail { sha } => rsx! {
                     DetailView {
                         sha: sha.clone(),

--- a/josh-gui/src/style.css
+++ b/josh-gui/src/style.css
@@ -47,6 +47,13 @@ span.header-dir {
 table.changes {
     border-collapse: collapse;
     width: 100%;
+    table-layout: fixed;
+}
+
+table.changes td.num {
+    text-align: right;
+    color: #999;
+    font-variant-numeric: tabular-nums;
 }
 
 table.changes th {
@@ -58,9 +65,22 @@ table.changes th {
     border-bottom: 1px solid #444;
 }
 
+table.changes tbody tr {
+    height: 32px;
+}
+
 table.changes td {
-    padding: 0.35rem 0.75rem;
+    padding: 0 0.75rem;
     border-bottom: 1px solid #2a2a2a;
+    box-sizing: border-box;
+    height: 32px;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+table.changes td.loading {
+    color: #555;
 }
 
 code {


### PR DESCRIPTION
Virtualize the josh-gui changes list and rework its columns

The changes list rendered every row up front and called read_pr_data_in_scopes
and read_vote_in_scopes per row inside load_rows, so first paint was O(N)
backend ref-searches and DOM nodes. Switch to a windowed render that mirrors
the diff page (top/bottom spacer rows + overscan), drive scroll_offset from
the container's onscroll, and JS-scroll the container when keyboard nav moves
the selection out of the rendered window (replacing the old getElementById /
scrollIntoView use_effect).

Split per-row metadata out of load_rows into a RowMetadata struct (review
decision, check status, local vote, comments count) stored in an app-level
HashMap signal. A use_effect on scroll_offset fetches missing entries for the
current window via load_metadata_batch, which resolves the repo and scope
list once per batch instead of once per row. The branch-change effect now
clears that cache and resets scroll_offset alongside list_data.

Rework the columns now that there's room: drop the Change-Id column (the
selection click moves onto the Subject cell), add a Deps column showing the
number of contributing change-ids per row, sort the list by that count
ascending, and add a Comments column populated lazily from
read_comments_in_scopes. Set table-layout: fixed on table.changes with a
colgroup so widths don't reflow as new rows scroll in, give td a fixed 32px
height for deterministic offset math, and ellipsize overflowing cells.

Change: virtualize-changes-list
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>