### PR TITLE
Trim changes list; add changes show and changes deps

### DIFF
--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 use josh_cli::commands::auth::AuthArgs;
 use josh_cli::commands::cache::CacheArgs;
-use josh_cli::commands::changes::ListArgs;
+use josh_cli::commands::changes::{DepsArgs, ListArgs, ShowArgs};
 use josh_cli::commands::comment::CommentArgs;
 use josh_cli::commands::fetch::FetchArgs;
 use josh_cli::commands::link::LinkArgs;
@@ -118,8 +118,12 @@ pub enum ChangesCommand {
     Publish(PublishArgs),
     /// Fetch & integrate from a remote, rebase-style with autostash (stacked changes workflow)
     Pull(PullArgs),
-    /// List local changes that would be published (read-only)
+    /// List stored changes with a one-line summary per change
     List(ListArgs),
+    /// Print full detail for a change, including comments
+    Show(ShowArgs),
+    /// Print the change-ids this change depends on
+    Deps(DepsArgs),
     /// Add a comment to a change
     Comment(CommentArgs),
     /// Sync GitHub PR comments to local change comments
@@ -300,6 +304,12 @@ fn run_repo(cmd: &RepoCommand, distributed_cache: bool) -> anyhow::Result<()> {
             }
             ChangesCommand::Pull(pull_args) => {
                 josh_cli::commands::pull::handle_pull(pull_args, &transaction, distributed_cache)
+            }
+            ChangesCommand::Show(show_args) => {
+                josh_cli::commands::changes::handle_show(show_args, &transaction)
+            }
+            ChangesCommand::Deps(deps_args) => {
+                josh_cli::commands::changes::handle_deps(deps_args, &transaction)
             }
             ChangesCommand::Comment(comment_args) => {
                 josh_cli::commands::comment::handle_comment(comment_args, &transaction)

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 
 use josh_cli::commands::auth::AuthArgs;
 use josh_cli::commands::cache::CacheArgs;
-use josh_cli::commands::changes::ListArgs;
+use josh_cli::commands::changes::{DepsArgs, ListArgs, ShowArgs};
 use josh_cli::commands::comment::CommentArgs;
 use josh_cli::commands::fetch::FetchArgs;
 use josh_cli::commands::link::LinkArgs;
@@ -118,8 +118,12 @@ pub enum ChangesCommand {
     Publish(PublishArgs),
     /// Fetch & integrate from a remote, rebase-style with autostash (stacked changes workflow)
     Pull(PullArgs),
-    /// List local changes that would be published (read-only)
+    /// List stored changes with a one-line summary per change
     List(ListArgs),
+    /// Print full detail for a change, including comments
+    Show(ShowArgs),
+    /// Print the change-ids this change depends on
+    Deps(DepsArgs),
     /// Add a comment to a change
     Comment(CommentArgs),
     /// Sync GitHub PR comments to local change comments
@@ -295,6 +299,12 @@ fn run_repo(cmd: &RepoCommand, distributed_cache: bool) -> anyhow::Result<()> {
             }
             ChangesCommand::Pull(pull_args) => {
                 josh_cli::commands::pull::handle_pull(pull_args, &transaction, distributed_cache)
+            }
+            ChangesCommand::Show(show_args) => {
+                josh_cli::commands::changes::handle_show(show_args, &transaction)
+            }
+            ChangesCommand::Deps(deps_args) => {
+                josh_cli::commands::changes::handle_deps(deps_args, &transaction)
             }
             ChangesCommand::Comment(comment_args) => {
                 josh_cli::commands::comment::handle_comment(comment_args, &transaction)

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -1,3 +1,7 @@
+use std::collections::HashMap;
+
+use anyhow::anyhow;
+
 use crate::commands::scope::ScopeArgs;
 
 /// Arguments for `josh changes list`.
@@ -7,8 +11,29 @@ pub struct ListArgs {
     pub scope: ScopeArgs,
 }
 
-/// Print changes read from the resolved changes ref (Local by default, or the
-/// remote selected by `--remote`). Populated by `josh changes sync`.
+/// Arguments for `josh changes show`.
+#[derive(Debug, clap::Parser)]
+pub struct ShowArgs {
+    /// Change-Id to display.
+    #[arg()]
+    pub change_id: String,
+
+    #[command(flatten)]
+    pub scope: ScopeArgs,
+}
+
+/// Arguments for `josh changes deps`.
+#[derive(Debug, clap::Parser)]
+pub struct DepsArgs {
+    /// Change-Id whose dependencies to print.
+    #[arg()]
+    pub change_id: String,
+
+    #[command(flatten)]
+    pub scope: ScopeArgs,
+}
+
+/// Print one summary row per change stored on the resolved changes ref.
 pub fn handle_list(
     args: &ListArgs,
     transaction: &josh_core::cache::Transaction,
@@ -17,66 +42,345 @@ pub fn handle_list(
     let scope = args.scope.resolve(repo)?;
     let changes = josh_changes::list_changes(repo, &scope)?;
 
-    let scope_label = match &scope {
-        josh_changes::ChangesRef::Local { branch } => format!("Local [{}]", branch),
-        josh_changes::ChangesRef::Remote { remote, branch } => {
-            format!("remote '{}' [{}]", remote, branch)
-        }
-    };
+    let scope_label = scope_label(&scope);
 
     if changes.is_empty() {
         println!("No changes found on {}.", scope_label);
         return Ok(());
     }
 
-    println!("Changes on {}:\n", scope_label);
+    let oid_to_change_id = build_oid_to_change_id(&changes);
 
+    struct Row {
+        id: String,
+        subject: String,
+        deps_count: usize,
+        comments_count: usize,
+        vote: String,
+    }
+
+    let mut rows: Vec<Row> = Vec::with_capacity(changes.len());
     for change in &changes {
+        let id = change.id().unwrap_or("<no-change-id>").to_string();
         let commit = repo.find_commit(change.commit())?;
-        let subject = commit.message().unwrap_or("").lines().next().unwrap_or("");
+        let subject = commit
+            .message()
+            .unwrap_or("")
+            .lines()
+            .next()
+            .unwrap_or("")
+            .to_string();
 
-        let id = change.id().unwrap_or("<no-change-id>");
-        let series = if change.series().is_empty() {
-            String::new()
-        } else {
-            format!(" [{}]", change.series().join(", "))
-        };
+        let deps_count = change
+            .contributing(repo)
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|oid| oid_to_change_id.get(&oid.to_string()).cloned())
+            .filter(|dep_id| dep_id != &id)
+            .count();
 
-        println!("{} {}{} ({})", id, subject, series, change.author());
-
-        let contributing = change.contributing(repo)?;
-        for oid in &contributing {
-            if let Ok(c) = repo.find_commit(*oid) {
-                let c_subject = c.message().unwrap_or("").lines().next().unwrap_or("");
-                let c_short = &oid.to_string()[..8];
-                println!("  {}  {}", c_short, c_subject);
-            }
-        }
-
-        let comments = change
+        let comments_count = change
             .id()
-            .map(|cid| josh_changes::read_comments(repo, cid, &scope).unwrap_or_default())
-            .unwrap_or_default();
-        if !comments.is_empty() {
-            println!();
-            for c in &comments {
-                let cid = &c.id[..8.min(c.id.len())];
-                let file = c.file.as_deref().unwrap_or("");
-                let line = c
-                    .location
-                    .as_ref()
-                    .map(|l| format!(":{}", l.start_line))
-                    .unwrap_or_default();
-                print!("    {} {}", cid, c.message.lines().next().unwrap_or(""));
-                if !file.is_empty() {
-                    print!(" ({}{})", file, line);
-                }
-                println!();
-            }
-        }
+            .map(|cid| {
+                josh_changes::read_comments(repo, cid, &scope)
+                    .map(|v| v.len())
+                    .unwrap_or(0)
+            })
+            .unwrap_or(0);
 
-        println!();
+        let vote = change
+            .id()
+            .and_then(|cid| {
+                josh_changes::read_vote(repo, cid, None, &scope)
+                    .ok()
+                    .flatten()
+            })
+            .map(|v| v.state)
+            .unwrap_or_default();
+
+        rows.push(Row {
+            id,
+            subject,
+            deps_count,
+            comments_count,
+            vote,
+        });
+    }
+
+    // Fewest deps last; tiebreak by subject for deterministic output.
+    rows.sort_by(|a, b| {
+        b.deps_count
+            .cmp(&a.deps_count)
+            .then_with(|| a.subject.cmp(&b.subject))
+    });
+
+    let id_w = rows.iter().map(|r| r.id.len()).max().unwrap_or(8);
+    let vote_w = rows.iter().map(|r| r.vote.len()).max().unwrap_or(0).max(4);
+
+    println!("Changes on {}:\n", scope_label);
+    for r in &rows {
+        println!(
+            "{:<id_w$}  D={:>3}  C={:>3}  V={:<vote_w$}  {}",
+            r.id,
+            r.deps_count,
+            r.comments_count,
+            r.vote,
+            r.subject,
+            id_w = id_w,
+            vote_w = vote_w,
+        );
     }
 
     Ok(())
+}
+
+/// Print full detail for one change: metadata, commit message, file stats, comments.
+pub fn handle_show(
+    args: &ShowArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+    let scope = args.scope.resolve(repo)?;
+    let change = resolve_change_by_id(repo, &scope, &args.change_id)?;
+
+    let commit = repo.find_commit(change.commit())?;
+    let msg = commit.message().unwrap_or("");
+    let subject = msg.lines().next().unwrap_or("");
+    let author = commit.author().email().unwrap_or("").to_string();
+    let date = chrono::DateTime::from_timestamp(commit.time().seconds(), 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_default();
+
+    println!("Change-Id: {}", args.change_id);
+    println!("Commit:    {}", change.commit());
+    println!("Author:    {}", author);
+    println!("Date:      {}", date);
+    let series = change.series().join(", ");
+    if !series.is_empty() {
+        println!("Series:    {}", series);
+    }
+
+    if let Ok(Some(json)) = josh_changes::read_pr_data(repo, &args.change_id, &scope) {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&json) {
+            let url = v["url"].as_str().unwrap_or("");
+            let title = v["title"].as_str().unwrap_or("");
+            let state = v["state"].as_str().unwrap_or("");
+            let rd = v["review_decision"].as_str().unwrap_or("");
+            print!("PR:        {} [{}]", title, state);
+            if !rd.is_empty() {
+                print!(" {}", rd);
+            }
+            if !url.is_empty() {
+                print!(" {}", url);
+            }
+            println!();
+        }
+    }
+
+    if let Some(vote) = josh_changes::read_vote(repo, &args.change_id, None, &scope)?
+        .map(|v| v.state)
+        .filter(|s| !s.is_empty())
+    {
+        println!("Vote:      {}", vote);
+    }
+
+    println!();
+    println!("Subject:   {}", subject);
+
+    println!();
+    let files = file_stats(repo, &commit)?;
+    let total_adds: usize = files.iter().map(|f| f.adds).sum();
+    let total_dels: usize = files.iter().map(|f| f.dels).sum();
+    println!(
+        "Files ({}, +{} / -{}):",
+        files.len(),
+        total_adds,
+        total_dels
+    );
+    for f in &files {
+        println!("  +{:<4} -{:<4}  {}", f.adds, f.dels, f.path);
+    }
+
+    let comments = josh_changes::read_comments(repo, &args.change_id, &scope).unwrap_or_default();
+    println!();
+    println!("Comments ({}):", comments.len());
+    if comments.is_empty() {
+        return Ok(());
+    }
+    print_comment_threads(&comments);
+
+    Ok(())
+}
+
+/// Print just the change-ids this change depends on (stored changes whose
+/// commits appear in this change's first-parent walk to base).
+pub fn handle_deps(
+    args: &DepsArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+    let scope = args.scope.resolve(repo)?;
+    let changes = josh_changes::list_changes(repo, &scope)?;
+    let oid_to_change_id = build_oid_to_change_id(&changes);
+
+    let change = changes
+        .iter()
+        .find(|c| c.id() == Some(args.change_id.as_str()))
+        .ok_or_else(|| {
+            anyhow!(
+                "change-id '{}' not found on {}",
+                args.change_id,
+                scope_label(&scope)
+            )
+        })?;
+
+    let mut deps: Vec<(String, String)> = Vec::new();
+    for oid in change.contributing(repo)? {
+        let oid_str = oid.to_string();
+        let dep_id = match oid_to_change_id.get(&oid_str) {
+            Some(d) if d != &args.change_id => d.clone(),
+            _ => continue,
+        };
+        let subject = repo
+            .find_commit(oid)
+            .ok()
+            .and_then(|c| {
+                c.message()
+                    .map(|m| m.lines().next().unwrap_or("").to_string())
+            })
+            .unwrap_or_default();
+        deps.push((dep_id, subject));
+    }
+
+    if deps.is_empty() {
+        println!("{} has no dependencies on stored changes.", args.change_id);
+        return Ok(());
+    }
+
+    let w = deps.iter().map(|(id, _)| id.len()).max().unwrap_or(0);
+    println!("Depends on:");
+    for (id, subject) in &deps {
+        println!("  {:<w$}  {}", id, subject, w = w);
+    }
+    Ok(())
+}
+
+fn scope_label(scope: &josh_changes::ChangesRef) -> String {
+    match scope {
+        josh_changes::ChangesRef::Local { branch } => format!("Local [{}]", branch),
+        josh_changes::ChangesRef::Remote { remote, branch } => {
+            format!("remote '{}' [{}]", remote, branch)
+        }
+    }
+}
+
+fn build_oid_to_change_id(changes: &[josh_changes::Change]) -> HashMap<String, String> {
+    let mut map = HashMap::with_capacity(changes.len());
+    for c in changes {
+        map.insert(c.commit().to_string(), c.id().unwrap_or("").to_string());
+    }
+    map
+}
+
+fn resolve_change_by_id(
+    repo: &git2::Repository,
+    scope: &josh_changes::ChangesRef,
+    change_id: &str,
+) -> anyhow::Result<josh_changes::Change> {
+    josh_changes::list_changes(repo, scope)?
+        .into_iter()
+        .find(|c| c.id() == Some(change_id))
+        .ok_or_else(|| {
+            anyhow!(
+                "change-id '{}' not found on {}",
+                change_id,
+                scope_label(scope)
+            )
+        })
+}
+
+struct FileStat {
+    path: String,
+    adds: usize,
+    dels: usize,
+}
+
+fn file_stats(repo: &git2::Repository, commit: &git2::Commit) -> anyhow::Result<Vec<FileStat>> {
+    let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
+    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
+    let mut files = Vec::with_capacity(diff.deltas().len());
+    for i in 0..diff.deltas().len() {
+        let delta = diff.deltas().nth(i).unwrap();
+        let path = delta
+            .new_file()
+            .path()
+            .or_else(|| delta.old_file().path())
+            .and_then(|p| p.to_str())
+            .unwrap_or("")
+            .to_string();
+        let patch = git2::Patch::from_diff(&diff, i)?;
+        let (_, adds, dels) = patch
+            .as_ref()
+            .map(|p| p.line_stats().unwrap_or((0, 0, 0)))
+            .unwrap_or((0, 0, 0));
+        files.push(FileStat { path, adds, dels });
+    }
+    Ok(files)
+}
+
+fn print_comment_threads(comments: &[josh_changes::Comment]) {
+    let mut roots: Vec<usize> = comments
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| c.reply_to.is_none())
+        .map(|(i, _)| i)
+        .collect();
+    roots.sort_by(|&a, &b| {
+        comments[a]
+            .timestamp
+            .as_deref()
+            .unwrap_or("")
+            .cmp(comments[b].timestamp.as_deref().unwrap_or(""))
+    });
+    for root in roots {
+        print_comment(comments, root, 0);
+    }
+}
+
+fn print_comment(comments: &[josh_changes::Comment], idx: usize, depth: usize) {
+    let c = &comments[idx];
+    let indent = "  ".repeat(depth + 1);
+    let author = c.author.as_deref().unwrap_or("?");
+    let ts = c
+        .timestamp
+        .as_deref()
+        .and_then(|s| s.parse::<i64>().ok())
+        .and_then(|s| chrono::DateTime::from_timestamp(s, 0))
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_default();
+    let loc = c
+        .file
+        .as_deref()
+        .map(|f| {
+            let line = c
+                .location
+                .as_ref()
+                .map(|l| format!(":{}", l.start_line))
+                .unwrap_or_default();
+            format!("  ({}{})", f, line)
+        })
+        .unwrap_or_default();
+    println!("{}[{}] {}{}", indent, author, ts, loc);
+    for line in c.message.lines() {
+        println!("{}  {}", indent, line);
+    }
+    let children: Vec<usize> = comments
+        .iter()
+        .enumerate()
+        .filter(|(_, child)| child.reply_to.as_deref() == Some(&c.id))
+        .map(|(i, _)| i)
+        .collect();
+    for child in children {
+        print_comment(comments, child, depth + 1);
+    }
 }

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -1,3 +1,7 @@
+use std::collections::HashMap;
+
+use anyhow::anyhow;
+
 use crate::commands::scope::ScopeArgs;
 
 /// Arguments for `josh changes list`.
@@ -7,8 +11,29 @@ pub struct ListArgs {
     pub scope: ScopeArgs,
 }
 
-/// Print changes read from the resolved changes ref (Local by default, or the
-/// remote selected by `--remote`). Populated by `josh changes sync`.
+/// Arguments for `josh changes show`.
+#[derive(Debug, clap::Parser)]
+pub struct ShowArgs {
+    /// Change-Id to display.
+    #[arg()]
+    pub change_id: String,
+
+    #[command(flatten)]
+    pub scope: ScopeArgs,
+}
+
+/// Arguments for `josh changes deps`.
+#[derive(Debug, clap::Parser)]
+pub struct DepsArgs {
+    /// Change-Id whose dependencies to print.
+    #[arg()]
+    pub change_id: String,
+
+    #[command(flatten)]
+    pub scope: ScopeArgs,
+}
+
+/// Print one summary row per change stored on the resolved changes ref.
 pub fn handle_list(
     args: &ListArgs,
     transaction: &josh_core::cache::Transaction,
@@ -17,66 +42,347 @@ pub fn handle_list(
     let scope = args.scope.resolve(transaction)?;
     let changes = josh_changes::list_changes(transaction, &scope)?;
 
-    let scope_label = match &scope {
-        josh_changes::ChangesRef::Local { branch } => format!("Local [{}]", branch),
-        josh_changes::ChangesRef::Remote { remote, branch } => {
-            format!("remote '{}' [{}]", remote, branch)
-        }
-    };
+    let scope_label = scope_label(&scope);
 
     if changes.is_empty() {
         println!("No changes found on {}.", scope_label);
         return Ok(());
     }
 
-    println!("Changes on {}:\n", scope_label);
+    let oid_to_change_id = build_oid_to_change_id(&changes);
 
+    struct Row {
+        id: String,
+        subject: String,
+        deps_count: usize,
+        comments_count: usize,
+        vote: String,
+    }
+
+    let mut rows: Vec<Row> = Vec::with_capacity(changes.len());
     for change in &changes {
+        let id = change.id().unwrap_or("<no-change-id>").to_string();
         let commit = repo.find_commit(change.commit())?;
-        let subject = commit.message().unwrap_or("").lines().next().unwrap_or("");
+        let subject = commit
+            .message()
+            .unwrap_or("")
+            .lines()
+            .next()
+            .unwrap_or("")
+            .to_string();
 
-        let id = change.id().unwrap_or("<no-change-id>");
-        let series = if change.series().is_empty() {
-            String::new()
-        } else {
-            format!(" [{}]", change.series().join(", "))
-        };
+        let deps_count = change
+            .contributing(transaction)
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|oid| oid_to_change_id.get(&oid.to_string()).cloned())
+            .filter(|dep_id| dep_id != &id)
+            .count();
 
-        println!("{} {}{} ({})", id, subject, series, change.author());
-
-        let contributing = change.contributing(transaction)?;
-        for oid in &contributing {
-            if let Ok(c) = repo.find_commit(*oid) {
-                let c_subject = c.message().unwrap_or("").lines().next().unwrap_or("");
-                let c_short = &oid.to_string()[..8];
-                println!("  {}  {}", c_short, c_subject);
-            }
-        }
-
-        let comments = change
+        let comments_count = change
             .id()
-            .map(|cid| josh_changes::read_comments(transaction, cid, &scope).unwrap_or_default())
-            .unwrap_or_default();
-        if !comments.is_empty() {
-            println!();
-            for c in &comments {
-                let cid = &c.id[..8.min(c.id.len())];
-                let file = c.file.as_deref().unwrap_or("");
-                let line = c
-                    .location
-                    .as_ref()
-                    .map(|l| format!(":{}", l.start_line))
-                    .unwrap_or_default();
-                print!("    {} {}", cid, c.message.lines().next().unwrap_or(""));
-                if !file.is_empty() {
-                    print!(" ({}{})", file, line);
-                }
-                println!();
-            }
-        }
+            .map(|cid| {
+                josh_changes::read_comments(transaction, cid, &scope)
+                    .map(|v| v.len())
+                    .unwrap_or(0)
+            })
+            .unwrap_or(0);
 
-        println!();
+        let vote = change
+            .id()
+            .and_then(|cid| {
+                josh_changes::read_vote(transaction, cid, None, &scope)
+                    .ok()
+                    .flatten()
+            })
+            .map(|v| v.state)
+            .unwrap_or_default();
+
+        rows.push(Row {
+            id,
+            subject,
+            deps_count,
+            comments_count,
+            vote,
+        });
+    }
+
+    // Fewest deps last; tiebreak by subject for deterministic output.
+    rows.sort_by(|a, b| {
+        b.deps_count
+            .cmp(&a.deps_count)
+            .then_with(|| a.subject.cmp(&b.subject))
+    });
+
+    let id_w = rows.iter().map(|r| r.id.len()).max().unwrap_or(8);
+    let vote_w = rows.iter().map(|r| r.vote.len()).max().unwrap_or(0).max(4);
+
+    println!("Changes on {}:\n", scope_label);
+    for r in &rows {
+        println!(
+            "{:<id_w$}  D={:>3}  C={:>3}  V={:<vote_w$}  {}",
+            r.id,
+            r.deps_count,
+            r.comments_count,
+            r.vote,
+            r.subject,
+            id_w = id_w,
+            vote_w = vote_w,
+        );
     }
 
     Ok(())
+}
+
+/// Print full detail for one change: metadata, commit message, file stats, comments.
+pub fn handle_show(
+    args: &ShowArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+    let scope = args.scope.resolve(transaction)?;
+    let change = resolve_change_by_id(transaction, &scope, &args.change_id)?;
+
+    let commit = repo.find_commit(change.commit())?;
+    let msg = commit.message().unwrap_or("");
+    let subject = msg.lines().next().unwrap_or("");
+    let author = commit.author().email().unwrap_or("").to_string();
+    let date = chrono::DateTime::from_timestamp(commit.time().seconds(), 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_default();
+
+    println!("Change-Id: {}", args.change_id);
+    println!("Commit:    {}", change.commit());
+    println!("Author:    {}", author);
+    println!("Date:      {}", date);
+    let series = change.series().join(", ");
+    if !series.is_empty() {
+        println!("Series:    {}", series);
+    }
+
+    if let Ok(Some(json)) = josh_changes::read_pr_data(transaction, &args.change_id, &scope) {
+        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&json) {
+            let url = v["url"].as_str().unwrap_or("");
+            let title = v["title"].as_str().unwrap_or("");
+            let state = v["state"].as_str().unwrap_or("");
+            let rd = v["review_decision"].as_str().unwrap_or("");
+            print!("PR:        {} [{}]", title, state);
+            if !rd.is_empty() {
+                print!(" {}", rd);
+            }
+            if !url.is_empty() {
+                print!(" {}", url);
+            }
+            println!();
+        }
+    }
+
+    if let Some(vote) = josh_changes::read_vote(transaction, &args.change_id, None, &scope)?
+        .map(|v| v.state)
+        .filter(|s| !s.is_empty())
+    {
+        println!("Vote:      {}", vote);
+    }
+
+    println!();
+    println!("Subject:   {}", subject);
+
+    println!();
+    let files = file_stats(repo, &commit)?;
+    let total_adds: usize = files.iter().map(|f| f.adds).sum();
+    let total_dels: usize = files.iter().map(|f| f.dels).sum();
+    println!(
+        "Files ({}, +{} / -{}):",
+        files.len(),
+        total_adds,
+        total_dels
+    );
+    for f in &files {
+        println!("  +{:<4} -{:<4}  {}", f.adds, f.dels, f.path);
+    }
+
+    let comments =
+        josh_changes::read_comments(transaction, &args.change_id, &scope).unwrap_or_default();
+    println!();
+    println!("Comments ({}):", comments.len());
+    if comments.is_empty() {
+        return Ok(());
+    }
+    print_comment_threads(&comments);
+
+    Ok(())
+}
+
+/// Print just the change-ids this change depends on (stored changes whose
+/// commits appear in this change's first-parent walk to base).
+pub fn handle_deps(
+    args: &DepsArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+    let scope = args.scope.resolve(transaction)?;
+    let changes = josh_changes::list_changes(transaction, &scope)?;
+    let oid_to_change_id = build_oid_to_change_id(&changes);
+
+    let change = changes
+        .iter()
+        .find(|c| c.id() == Some(args.change_id.as_str()))
+        .ok_or_else(|| {
+            anyhow!(
+                "change-id '{}' not found on {}",
+                args.change_id,
+                scope_label(&scope)
+            )
+        })?;
+
+    let mut deps: Vec<(String, String)> = Vec::new();
+    for oid in change.contributing(transaction)? {
+        let oid_str = oid.to_string();
+        let dep_id = match oid_to_change_id.get(&oid_str) {
+            Some(d) if d != &args.change_id => d.clone(),
+            _ => continue,
+        };
+        let subject = repo
+            .find_commit(oid)
+            .ok()
+            .and_then(|c| {
+                c.message()
+                    .ok()
+                    .map(|m| m.lines().next().unwrap_or("").to_string())
+            })
+            .unwrap_or_default();
+        deps.push((dep_id, subject));
+    }
+
+    if deps.is_empty() {
+        println!("{} has no dependencies on stored changes.", args.change_id);
+        return Ok(());
+    }
+
+    let w = deps.iter().map(|(id, _)| id.len()).max().unwrap_or(0);
+    println!("Depends on:");
+    for (id, subject) in &deps {
+        println!("  {:<w$}  {}", id, subject, w = w);
+    }
+    Ok(())
+}
+
+fn scope_label(scope: &josh_changes::ChangesRef) -> String {
+    match scope {
+        josh_changes::ChangesRef::Local { branch } => format!("Local [{}]", branch),
+        josh_changes::ChangesRef::Remote { remote, branch } => {
+            format!("remote '{}' [{}]", remote, branch)
+        }
+    }
+}
+
+fn build_oid_to_change_id(changes: &[josh_changes::Change]) -> HashMap<String, String> {
+    let mut map = HashMap::with_capacity(changes.len());
+    for c in changes {
+        map.insert(c.commit().to_string(), c.id().unwrap_or("").to_string());
+    }
+    map
+}
+
+fn resolve_change_by_id(
+    transaction: &josh_core::cache::Transaction,
+    scope: &josh_changes::ChangesRef,
+    change_id: &str,
+) -> anyhow::Result<josh_changes::Change> {
+    josh_changes::list_changes(transaction, scope)?
+        .into_iter()
+        .find(|c| c.id() == Some(change_id))
+        .ok_or_else(|| {
+            anyhow!(
+                "change-id '{}' not found on {}",
+                change_id,
+                scope_label(scope)
+            )
+        })
+}
+
+struct FileStat {
+    path: String,
+    adds: usize,
+    dels: usize,
+}
+
+fn file_stats(repo: &git2::Repository, commit: &git2::Commit) -> anyhow::Result<Vec<FileStat>> {
+    let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
+    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
+    let mut files = Vec::with_capacity(diff.deltas().len());
+    for i in 0..diff.deltas().len() {
+        let delta = diff.deltas().nth(i).unwrap();
+        let path = delta
+            .new_file()
+            .path()
+            .or_else(|| delta.old_file().path())
+            .and_then(|p| p.to_str())
+            .unwrap_or("")
+            .to_string();
+        let patch = git2::Patch::from_diff(&diff, i)?;
+        let (_, adds, dels) = patch
+            .as_ref()
+            .map(|p| p.line_stats().unwrap_or((0, 0, 0)))
+            .unwrap_or((0, 0, 0));
+        files.push(FileStat { path, adds, dels });
+    }
+    Ok(files)
+}
+
+fn print_comment_threads(comments: &[josh_changes::Comment]) {
+    let mut roots: Vec<usize> = comments
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| c.reply_to.is_none())
+        .map(|(i, _)| i)
+        .collect();
+    roots.sort_by(|&a, &b| {
+        comments[a]
+            .timestamp
+            .as_deref()
+            .unwrap_or("")
+            .cmp(comments[b].timestamp.as_deref().unwrap_or(""))
+    });
+    for root in roots {
+        print_comment(comments, root, 0);
+    }
+}
+
+fn print_comment(comments: &[josh_changes::Comment], idx: usize, depth: usize) {
+    let c = &comments[idx];
+    let indent = "  ".repeat(depth + 1);
+    let author = c.author.as_deref().unwrap_or("?");
+    let ts = c
+        .timestamp
+        .as_deref()
+        .and_then(|s| s.parse::<i64>().ok())
+        .and_then(|s| chrono::DateTime::from_timestamp(s, 0))
+        .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
+        .unwrap_or_default();
+    let loc = c
+        .file
+        .as_deref()
+        .map(|f| {
+            let line = c
+                .location
+                .as_ref()
+                .map(|l| format!(":{}", l.start_line))
+                .unwrap_or_default();
+            format!("  ({}{})", f, line)
+        })
+        .unwrap_or_default();
+    println!("{}[{}] {}{}", indent, author, ts, loc);
+    for line in c.message.lines() {
+        println!("{}  {}", indent, line);
+    }
+    let children: Vec<usize> = comments
+        .iter()
+        .enumerate()
+        .filter(|(_, child)| child.reply_to.as_deref() == Some(&c.id))
+        .map(|(i, _)| i)
+        .collect();
+    for child in children {
+        print_comment(comments, child, depth + 1);
+    }
 }

--- a/tests/cli/changes_cli.t
+++ b/tests/cli/changes_cli.t
@@ -1,0 +1,134 @@
+`josh changes list / show / deps` sanity tests.
+
+Setup
+
+  $ export TESTTMP=${PWD}
+
+  $ mkdir remote
+  $ cd remote
+  $ git init -q --bare -b master
+  $ cd ..
+
+Seed a single-commit master, push it, then clone so refs/remotes/origin/master
+points at the seed commit. `josh changes sync` (Local) needs that ref so it
+knows where the stack starts.
+
+  $ mkdir seed
+  $ cd seed
+  $ git init -q -b master
+  $ echo "seed" > seed.txt
+  $ git add seed.txt
+  $ git commit -q -m "seed"
+  $ git remote add origin ${TESTTMP}/remote
+  $ git push -q origin master
+  $ cd ..
+
+  $ git clone -q ${TESTTMP}/remote local
+  $ cd local
+  $ git config user.email "josh@example.com"
+  $ git config user.name "Josh Test"
+
+Build a three-commit stack:
+
+  $ echo "first revision of A" > fileA
+  $ git add fileA
+  $ printf "A change\n\nChange-Id: c1\n" | git commit -q -F -
+
+  $ echo "second revision of A" > fileA
+  $ git add fileA
+  $ printf "B change\n\nChange-Id: c2\n" | git commit -q -F -
+
+  $ echo "brand new file B" > fileB
+  $ git add fileB
+  $ printf "C change\n\nChange-Id: c3\n" | git commit -q -F -
+
+Populate the Local changes ref (refs/josh/changes/master).
+
+  $ josh changes sync
+
+list: one summary row per change, sorted by deps descending. c2 depends on c1
+(both edit fileA); c1 and c3 have no deps so they land at the bottom, with
+the subject as the tiebreaker.
+
+  $ josh changes list
+  Changes on Local [master]:
+  
+  c2  D=  1  C=  0  V=      B change
+  c1  D=  0  C=  0  V=      A change
+  c3  D=  0  C=  0  V=      C change
+
+Add two private comments to c1. The C= column for c1 should pick them up.
+
+  $ josh changes comment c1 -m "hello on c1"
+  Comment saved (private to local ref).
+  $ josh changes comment c1 -m "another comment"
+  Comment saved (private to local ref).
+
+  $ josh changes list
+  Changes on Local [master]:
+  
+  c2  D=  1  C=  0  V=      B change
+  c1  D=  0  C=  2  V=      A change
+  c3  D=  0  C=  0  V=      C change
+
+deps: c2 depends on c1; c1 and c3 depend on nothing on the ref.
+
+  $ josh changes deps c2
+  Depends on:
+    c1  A change
+
+  $ josh changes deps c1
+  c1 has no dependencies on stored changes.
+
+  $ josh changes deps c3
+  c3 has no dependencies on stored changes.
+
+show: full detail for c1 including its two comments. SHA stays a glob; the
+comment-line timestamp uses `repo.signature()` at write time, which honors
+the GIT_*_DATE env, but the per-comment author/time is later resolved from
+the ref's history walk so we glob it too for robustness.
+
+  $ josh changes show c1
+  Change-Id: c1
+  Commit:    * (glob)
+  Author:    josh@example.com
+  Date:      2005-04-07 22:13
+  
+  Subject:   A change
+  
+  Files (1, +1 / -0):
+    +1    -0     fileA
+  
+  Comments (2):
+    [josh@example.com] * (glob)
+      hello on c1
+    [josh@example.com] * (glob)
+      another comment
+
+show: an id with no comments still prints a "Comments (0):" header.
+
+  $ josh changes show c3
+  Change-Id: c3
+  Commit:    * (glob)
+  Author:    josh@example.com
+  Date:      2005-04-07 22:13
+  
+  Subject:   C change
+  
+  Files (1, +1 / -0):
+    +1    -0     fileB
+  
+  Comments (0):
+
+Error cases: bogus change-ids exit non-zero with a message naming the id and
+the resolved scope.
+
+  $ josh changes show bogus 2>&1
+  Error: change-id 'bogus' not found on Local [master]
+  change-id 'bogus' not found on Local [master]
+  [1]
+
+  $ josh changes deps bogus 2>&1
+  Error: change-id 'bogus' not found on Local [master]
+  change-id 'bogus' not found on Local [master]
+  [1]


### PR DESCRIPTION
Trim changes list; add changes show and changes deps

`josh changes list` used to dump every change with its full stack of
contributing commits and every comment, which made it unscannable beyond
a handful of changes. Rework it as one summary row per change with the
metrics the user actually wants when triaging a stack, and move the
per-change detail and dependency view to dedicated subcommands.

list now prints one row per stored change:

  <change-id>  D=<deps>  C=<comments>  V=<vote>  <subject>

sorted by deps count descending so the bottom-of-stack rows land last
(subject is the tiebreaker for determinism). Comment count comes from
read_comments on the resolved scope; vote from read_vote; deps count
from intersecting Change::contributing oids with the stored
change-id map, the same way josh-gui builds its dependency graph.

show <change-id> prints the full per-change detail: change-id, commit
sha, author, date, optional Series/PR/Vote, subject, file stats
(+adds/-dels), then every stored comment rendered as a thread (roots
sorted by timestamp, replies indented).

deps <change-id> prints just the direct dependencies as
"<dep-id> <subject>" lines, or "<id> has no dependencies on stored
changes." when nothing maps.

All three accept the same --branch / --remote flags via the shared
ScopeArgs and operate on exactly one ChangesRef. Wired into
ChangesCommand via two new Show/Deps variants.

tests/cli/changes_cli.t covers the happy paths (sort order across
deps/comment changes, deps for the dependent / for a leaf, show with
and without comments) plus the error path for bogus change-ids; SHAs
and the per-comment timestamps use (glob) so the test survives
rewriting and the wall-clock signature time at comment-write.

Change: trim-list-add-show-deps
Assisted-By: anthropic/claude-opus-4-7