### PR TITLE
Skip global j/k handler in josh-gui outside the list page

### DIFF
--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -101,6 +101,9 @@ fn app() -> Element {
 
     let on_keydown = move |evt: dioxus::events::KeyboardEvent| {
         use dioxus::prelude::Key;
+        if !matches!(&*page.read(), Page::List) {
+            return;
+        }
         let is_nav = match evt.key() {
             Key::ArrowDown | Key::ArrowUp => true,
             Key::Character(ref c) => c == "j" || c == "k",


### PR DESCRIPTION
Skip global j/k handler in josh-gui outside the list page

The root onkeydown handler called prevent_default() for j/k/Arrow keys
on every page, swallowing those keys before they reached the diff-view
comment textarea, the detail-view vote textarea, and the diff filter
inputs. Gate the handler on Page::List so navigation still works on
the list and other views accept normal keyboard input.

Change: gui-skip-global-keys-outside-list
Assisted-By: anthropic/claude-opus-4-7