### PR TITLE
Cache downstack_commit_deps per transaction

### DIFF
--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -75,6 +75,7 @@ struct Transaction2 {
     overlay_map: HashMap<(git2::Oid, git2::Oid), git2::Oid>,
     unapply_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
     legalize_map: HashMap<(crate::filter::Filter, git2::Oid), crate::filter::Filter>,
+    downstack_deps_map: HashMap<git2::Oid, std::collections::HashSet<crate::filter::DownstackDep>>,
 
     cache: std::sync::Arc<CacheStack>,
     path_tree: sled::Tree,
@@ -111,6 +112,7 @@ impl Transaction {
                 overlay_map: HashMap::new(),
                 unapply_map: HashMap::new(),
                 legalize_map: HashMap::new(),
+                downstack_deps_map: HashMap::new(),
                 cache,
                 path_tree,
                 invert_tree,
@@ -166,6 +168,23 @@ impl Transaction {
             return m.get(&from).cloned();
         }
         None
+    }
+
+    pub(crate) fn insert_downstack_deps(
+        &self,
+        oid: git2::Oid,
+        deps: std::collections::HashSet<crate::filter::DownstackDep>,
+    ) {
+        let mut t2 = self.t2.borrow_mut();
+        t2.downstack_deps_map.insert(oid, deps);
+    }
+
+    pub(crate) fn get_downstack_deps(
+        &self,
+        oid: git2::Oid,
+    ) -> Option<std::collections::HashSet<crate::filter::DownstackDep>> {
+        let t2 = self.t2.borrow_mut();
+        t2.downstack_deps_map.get(&oid).cloned()
     }
 
     pub fn insert_subtract(&self, from: (git2::Oid, git2::Oid), to: git2::Oid) {

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -625,7 +625,7 @@ pub fn apply_to_commit2(
             if let Some(oid) = transaction.get(filter, commit.id()) {
                 return Ok(Some(oid));
             }
-            let new_oid = downstack(repo, commit.id(), *base)?;
+            let new_oid = downstack(repo, transaction, commit.id(), *base)?;
             transaction.insert(filter, commit.id(), new_oid, false);
             return Ok(Some(new_oid));
         }
@@ -2078,6 +2078,7 @@ fn per_rev_filter(
 /// onto the minimised base via a 3-way merge. Returns the new tip OID.
 pub fn downstack(
     repo: &git2::Repository,
+    transaction: &cache::Transaction,
     change_oid: git2::Oid,
     base_oid: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
@@ -2112,10 +2113,10 @@ pub fn downstack(
 
     // Seed the affected dependency set with the change's own deps, then walk
     // intermediates backwards, keeping any commit whose deps intersect.
-    let mut affected = downstack_commit_deps(repo, &change_commit)?;
+    let mut affected = downstack_commit_deps(repo, transaction, &change_commit)?;
     let mut needed: Vec<bool> = vec![false; commits.len()];
     for (i, intermediate) in commits.iter().enumerate().rev() {
-        let deps = downstack_commit_deps(repo, intermediate)?;
+        let deps = downstack_commit_deps(repo, transaction, intermediate)?;
         if !deps.is_disjoint(&affected) {
             needed[i] = true;
             affected.extend(deps);
@@ -2172,15 +2173,27 @@ pub fn downstack(
 /// comes from a `Change-Series:` trailer and lets unrelated paths be linked
 /// explicitly.
 #[derive(Clone, Eq, Hash, PartialEq)]
-enum DownstackDep {
+pub(crate) enum DownstackDep {
     Path(String),
     Series(String),
 }
 
+/// Cache deps per commit oid within a single transaction. `split_changes`
+/// asks for the same intermediate's deps O(N) times across the stack, and a
+/// commit's deps set is a pure function of its oid (parent tree + own tree +
+/// trailer block) -- so memoising it collapses the duplicated work. The map
+/// lives on the transaction so `josh-proxy` doesn't accumulate entries
+/// across unrelated operations.
 fn downstack_commit_deps(
     repo: &git2::Repository,
+    transaction: &cache::Transaction,
     commit: &git2::Commit,
 ) -> anyhow::Result<std::collections::HashSet<DownstackDep>> {
+    let oid = commit.id();
+    if let Some(hit) = transaction.get_downstack_deps(oid) {
+        return Ok(hit);
+    }
+
     // Use the in-crate `tree::diff_paths` rather than libgit2's full diff
     // pipeline: it short-circuits subtrees by oid equality, which collapses
     // the typical "stack of single-file commits" deps walk down to a few
@@ -2201,6 +2214,8 @@ fn downstack_commit_deps(
     for s in series {
         deps.insert(DownstackDep::Series(s));
     }
+
+    transaction.insert_downstack_deps(oid, deps.clone());
     Ok(deps)
 }
 


### PR DESCRIPTION
Cache downstack_commit_deps per transaction

After switching the helper to tree::diff_paths, profiling still showed
downstack_commit_deps at ~20% of `josh changes sync` time on a deep
stack. The per-call cost is now small, but split_changes asks for the
same intermediate's deps O(N) times across the stack -- one per tip --
so the work duplicates linearly with stack depth.

The deps set is a pure function of the commit oid (parent tree + own
tree + Change-Series trailers, all immutable for a given oid). Store
the memo on the active `cache::Transaction` rather than in a static
LazyLock: that keeps the within-`split_changes` deduplication (deps for
the same intermediate are still computed once per transaction), while
bounding the map's lifetime to a single operation so josh-proxy, which
holds the process open across many unrelated transactions, doesn't
accumulate entries indefinitely.

`DownstackDep` is now `pub(crate)` so `Transaction2` can name it as the
value type of the new `downstack_deps_map` field, mirroring how
`legalize_map` names `crate::filter::Filter`.

Change: cache-downstack-commit-deps
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>