### PR TITLE
Cache 3-way merge_trees results per transaction

### DIFF
--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -76,6 +76,7 @@ struct Transaction2 {
     unapply_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
     legalize_map: HashMap<(crate::filter::Filter, git2::Oid), crate::filter::Filter>,
     downstack_deps_map: HashMap<git2::Oid, std::collections::HashSet<crate::filter::DownstackDep>>,
+    merge_trees_map: HashMap<(git2::Oid, git2::Oid, git2::Oid), git2::Oid>,
 
     cache: std::sync::Arc<CacheStack>,
     path_tree: sled::Tree,
@@ -113,6 +114,7 @@ impl Transaction {
                 unapply_map: HashMap::new(),
                 legalize_map: HashMap::new(),
                 downstack_deps_map: HashMap::new(),
+                merge_trees_map: HashMap::new(),
                 cache,
                 path_tree,
                 invert_tree,
@@ -185,6 +187,23 @@ impl Transaction {
     ) -> Option<std::collections::HashSet<crate::filter::DownstackDep>> {
         let t2 = self.t2.borrow_mut();
         t2.downstack_deps_map.get(&oid).cloned()
+    }
+
+    pub(crate) fn insert_merge_trees(
+        &self,
+        key: (git2::Oid, git2::Oid, git2::Oid),
+        result: git2::Oid,
+    ) {
+        let mut t2 = self.t2.borrow_mut();
+        t2.merge_trees_map.insert(key, result);
+    }
+
+    pub(crate) fn get_merge_trees(
+        &self,
+        key: (git2::Oid, git2::Oid, git2::Oid),
+    ) -> Option<git2::Oid> {
+        let t2 = self.t2.borrow_mut();
+        t2.merge_trees_map.get(&key).copied()
     }
 
     pub fn insert_subtract(&self, from: (git2::Oid, git2::Oid), to: git2::Oid) {

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2130,13 +2130,14 @@ pub fn downstack(
             continue;
         }
         let inter_parent = intermediate.parent(0)?;
-        let mut index = repo.merge_trees(
-            &inter_parent.tree()?,
-            &current_base.tree()?,
-            &intermediate.tree()?,
-            None,
+        let new_tree_oid = cached_merge_trees(
+            repo,
+            transaction,
+            inter_parent.tree_id(),
+            current_base.tree_id(),
+            intermediate.tree_id(),
         )?;
-        let new_tree = repo.find_tree(index.write_tree_to(repo)?)?;
+        let new_tree = repo.find_tree(new_tree_oid)?;
         let new_oid = history::rewrite_commit(
             repo,
             intermediate,
@@ -2149,13 +2150,14 @@ pub fn downstack(
 
     // Apply the change on top of the minimal base via 3-way merge.
     let change_parent = change_commit.parent(0)?;
-    let mut index = repo.merge_trees(
-        &change_parent.tree()?,
-        &current_base.tree()?,
-        &change_commit.tree()?,
-        None,
+    let new_tree_oid = cached_merge_trees(
+        repo,
+        transaction,
+        change_parent.tree_id(),
+        current_base.tree_id(),
+        change_commit.tree_id(),
     )?;
-    let new_tree = repo.find_tree(index.write_tree_to(repo)?)?;
+    let new_tree = repo.find_tree(new_tree_oid)?;
 
     let new_oid = history::rewrite_commit(
         repo,
@@ -2166,6 +2168,44 @@ pub fn downstack(
     )?;
 
     Ok(new_oid)
+}
+
+/// Memo libgit2's 3-way `merge_trees` + `write_tree_to` pair within the
+/// active transaction. The merged tree oid is a pure function of the three
+/// input tree oids (with `MergeOptions::None`), and `split_changes` issues
+/// many identical triples across per-tip `downstack` calls; turning each
+/// repeat into a hashmap hit is the win. Scoping to the transaction (rather
+/// than process-wide) keeps `josh-proxy` from accumulating entries across
+/// unrelated operations.
+fn cached_merge_trees(
+    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    a: git2::Oid,
+    b: git2::Oid,
+    c: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    // Conventional 3-way identities. When the ancestor matches one side, the
+    // merge result is the other side -- common in a clean linear stack where
+    // the rebuilt parent's tree already equals the original intermediate's
+    // parent tree -- so we skip both the lookup and the merge.
+    if a == b {
+        return Ok(c);
+    }
+    if a == c {
+        return Ok(b);
+    }
+
+    let key = (a, b, c);
+    if let Some(hit) = transaction.get_merge_trees(key) {
+        return Ok(hit);
+    }
+    let tree_a = repo.find_tree(a)?;
+    let tree_b = repo.find_tree(b)?;
+    let tree_c = repo.find_tree(c)?;
+    let mut index = repo.merge_trees(&tree_a, &tree_b, &tree_c, None)?;
+    let oid = index.write_tree_to(repo)?;
+    transaction.insert_merge_trees(key, oid);
+    Ok(oid)
 }
 
 /// A dependency token used by `downstack` to decide whether two commits


### PR DESCRIPTION
Cache 3-way merge_trees results per transaction

`downstack`'s rebase loop calls libgit2's `merge_trees` + `write_tree_to`
pair once per surviving intermediate plus once for the tip. The merged
tree oid is a pure function of the three input tree oids (with
`MergeOptions::None`), and `split_changes` issues many identical triples
across per-tip `downstack` calls -- memoising them collapses the
repeated work to a hashmap hit.

Store the memo on the active `cache::Transaction` rather than a static
LazyLock: that keeps the within-`split_changes` deduplication while
bounding the map's lifetime to a single operation so josh-proxy, which
holds the process open across many unrelated transactions, doesn't
accumulate entries indefinitely.

The 3-way identity fast-paths (`a == b` -> `c`, `a == c` -> `b`) stay
ahead of the cache lookup -- they're cheap and common in a clean linear
stack where the rebuilt parent's tree already equals the original
intermediate's parent tree.

Change: cache-merge-trees-in-downstack
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>