### PR TITLE
Compute downstack deps via tree::diff_paths

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2160,21 +2160,22 @@ fn downstack_commit_deps(
     repo: &git2::Repository,
     commit: &git2::Commit,
 ) -> anyhow::Result<std::collections::HashSet<DownstackDep>> {
-    let parent_tree = if commit.parent_count() > 0 {
-        Some(commit.parent(0)?.tree()?)
+    // Use the in-crate `tree::diff_paths` rather than libgit2's full diff
+    // pipeline: it short-circuits subtrees by oid equality, which collapses
+    // the typical "stack of single-file commits" deps walk down to a few
+    // tree lookups per call.
+    let parent_tree_id = if commit.parent_count() > 0 {
+        commit.parent(0)?.tree()?.id()
     } else {
-        None
+        git2::Oid::zero()
     };
-    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
+    let commit_tree_id = commit.tree()?.id();
+
     let mut deps = std::collections::HashSet::new();
-    for delta in diff.deltas() {
-        if let Some(p) = delta.old_file().path().and_then(|p| p.to_str()) {
-            deps.insert(DownstackDep::Path(p.to_string()));
-        }
-        if let Some(p) = delta.new_file().path().and_then(|p| p.to_str()) {
-            deps.insert(DownstackDep::Path(p.to_string()));
-        }
+    for (path, _polarity) in tree::diff_paths(repo, parent_tree_id, commit_tree_id, "")? {
+        deps.insert(DownstackDep::Path(path));
     }
+
     let (_, series) = crate::trailers::parse_change_meta(commit.message().unwrap_or(""));
     for s in series {
         deps.insert(DownstackDep::Series(s));


### PR DESCRIPTION
Compute downstack deps via tree::diff_paths

downstack_commit_deps was the dominant per-call cost inside downstack:
for every intermediate it ran the full libgit2 diff pipeline
(repo.diff_tree_to_tree + delta iteration) just to collect a set of
touched paths. Multiplied by O(N^2) across a deep stack that pipeline's
setup, rename detection, and delta allocation are exactly what makes
`josh changes sync` feel sluggish on a worktree that's far ahead of
origin.

filter::tree::diff_paths already does the cheap version of this work:
it recursively walks two tree oids and short-circuits with
`if input1 == input2 { return Ok(vec![]); }` at every level. For a
typical clean stack each commit only diverges on one subtree, so the
deps walk collapses to a handful of tree lookups per call instead of
several milliseconds of libgit2 diff work.

Swap downstack_commit_deps to call tree::diff_paths(repo, parent_tree_id,
commit_tree_id, ""), discarding the polarity flag and folding each
returned path into the existing HashSet<DownstackDep>. For a root commit
pass git2::Oid::zero() as the parent oid -- diff_paths falls through to
its `Ok(tree2)`-only branch and walks every entry as added, matching
the previous diff_tree_to_tree(None, ...) behaviour. Change-Series
trailer handling is unchanged.

Public API, callers, and the downstack algorithm itself are untouched;
this is a per-call constant-factor win that should noticeably cut
`josh changes sync` time on deep stacks without altering the deps set
or the resulting needed[] mask.

Change: downstack-deps-via-tree-diff-paths
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>