### PR TITLE
Refresh josh-gui when the changes ref moves

### DIFF
--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -44,6 +44,15 @@ impl ChangesRef {
     }
 }
 
+/// Return the current OID of the changes ref under `scope`, or `None` if the
+/// ref doesn't exist yet. Used by callers that need a single value to compare
+/// against to detect ref changes.
+pub fn read_ref_oid(repo: &git2::Repository, scope: &ChangesRef) -> Option<git2::Oid> {
+    repo.find_reference(&scope.ref_name())
+        .ok()
+        .and_then(|r| r.target())
+}
+
 /// Read `repo.head()` and return the current branch shorthand. Errors on a
 /// detached HEAD with a message asking the caller to pass an explicit branch.
 pub fn head_branch(repo: &git2::Repository) -> anyhow::Result<String> {

--- a/josh-changes/src/refs.rs
+++ b/josh-changes/src/refs.rs
@@ -255,6 +255,13 @@ impl ChangesRef {
     }
 }
 
+/// Return the changes ref's target OID, if it exists.
+pub fn read_ref_oid(repo: &git2::Repository, scope: &ChangesRef) -> Option<git2::Oid> {
+    repo.find_reference(&scope.ref_name())
+        .ok()
+        .and_then(|r| r.target())
+}
+
 /// Read HEAD and return the current branch shorthand. Errors on a
 /// detached HEAD with a message asking the caller to pass an explicit branch.
 pub fn head_branch(transaction: &josh_core::cache::Transaction) -> anyhow::Result<String> {

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -4416,6 +4416,7 @@ dependencies = [
  "josh-github-changes",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -3477,6 +3477,7 @@ dependencies = [
  "git2",
  "josh-changes",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/josh-gui/Cargo.toml
+++ b/josh-gui/Cargo.toml
@@ -20,6 +20,7 @@ josh-changes = { path = "../josh-changes" }
 josh-core = { path = "../josh-core" }
 josh-github-changes = { path = "../forges/josh-github-changes" }
 git2 = { version = "0.21.0", default-features = false, features = ["vendored-libgit2"] }
+tokio = { version = "1", features = ["time"] }
 
 # Same as the root workspace: use the vendored glob fork, which keeps the
 # Pattern token APIs public that josh-filter relies on.

--- a/josh-gui/Cargo.toml
+++ b/josh-gui/Cargo.toml
@@ -17,6 +17,7 @@ dioxus = { version = "0.7", features = ["desktop"] }
 serde_json = "1.0"
 josh-changes = { path = "../josh-changes" }
 git2 = { version = "0.21.0", default-features = false, features = ["vendored-libgit2"] }
+tokio = { version = "1", features = ["time"] }
 
 # Same as the root workspace: use the vendored glob fork, which keeps the
 # Pattern token APIs public that josh-filter relies on.

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -46,6 +46,10 @@ pub struct PrInfo {
 
 #[component]
 pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal<Page>) -> Element {
+    let changes_ref_oid = use_context::<Signal<Option<git2::Oid>>>();
+    // Subscribe so this view re-renders (and load_detail re-runs) whenever the
+    // changes ref's OID changes — locally after save, or via background poll.
+    let _ = changes_ref_oid.read();
     let data = load_detail(&sha, &scope);
     let mut vote_body = use_signal(String::new);
 
@@ -232,13 +236,10 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
                                             class: "vote-btn approve",
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
-                                                let _ = save_vote(
-                                                    &sha, "approve", &body, &scope,
-                                                );
+                                                if save_vote(&sha, "approve", &body, &scope).is_ok() {
+                                                    bump_changes_ref_oid(changes_ref_oid, &scope);
+                                                }
                                                 vote_body.set(String::new());
-                                                page.set(Page::Detail {
-                                                    sha: sha.clone(),
-                                                });
                                             },
                                             "Approve"
                                         }
@@ -252,13 +253,10 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
                                             class: "vote-btn discuss",
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
-                                                let _ = save_vote(
-                                                    &sha, "discuss", &body, &scope,
-                                                );
+                                                if save_vote(&sha, "discuss", &body, &scope).is_ok() {
+                                                    bump_changes_ref_oid(changes_ref_oid, &scope);
+                                                }
                                                 vote_body.set(String::new());
-                                                page.set(Page::Detail {
-                                                    sha: sha.clone(),
-                                                });
                                             },
                                             "Discuss"
                                         }
@@ -272,13 +270,10 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
                                             class: "vote-btn revise",
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
-                                                let _ = save_vote(
-                                                    &sha, "revise", &body, &scope,
-                                                );
+                                                if save_vote(&sha, "revise", &body, &scope).is_ok() {
+                                                    bump_changes_ref_oid(changes_ref_oid, &scope);
+                                                }
                                                 vote_body.set(String::new());
-                                                page.set(Page::Detail {
-                                                    sha: sha.clone(),
-                                                });
                                             },
                                             "Revise"
                                         }
@@ -431,6 +426,22 @@ pub fn save_comment(
         josh_changes::ChangesRef::Local { .. } => {
             josh_changes::write_comment(&repo, &change, &meta, None, None, scope)
         }
+    }
+}
+
+/// Re-read the OID of the changes ref under `scope` and write it into the
+/// shared signal if it changed. Call this after a local mutation so all views
+/// that subscribe to the OID refresh immediately, without waiting for the
+/// background poll.
+pub fn bump_changes_ref_oid(
+    mut changes_ref_oid: Signal<Option<git2::Oid>>,
+    scope: &josh_changes::ChangesRef,
+) {
+    let new_oid = git2::Repository::discover(".")
+        .ok()
+        .and_then(|r| josh_changes::read_ref_oid(&r, scope));
+    if new_oid != *changes_ref_oid.peek() {
+        changes_ref_oid.set(new_oid);
     }
 }
 

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -46,6 +46,9 @@ pub struct PrInfo {
 
 #[component]
 pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal<Page>) -> Element {
+    let changes_ref_oid = use_context::<Signal<Option<git2::Oid>>>();
+    // Establish a reactive dependency on ref changes.
+    let _ = changes_ref_oid.read();
     let data = load_detail(&sha, &scope);
     let mut vote_body = use_signal(String::new);
 
@@ -232,13 +235,10 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
                                             class: "vote-btn approve",
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
-                                                let _ = save_vote(
-                                                    &sha, "approve", &body, &scope,
-                                                );
+                                                if save_vote(&sha, "approve", &body, &scope).is_ok() {
+                                                    bump_changes_ref_oid(changes_ref_oid, &scope);
+                                                }
                                                 vote_body.set(String::new());
-                                                page.set(Page::Detail {
-                                                    sha: sha.clone(),
-                                                });
                                             },
                                             "Approve"
                                         }
@@ -252,13 +252,10 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
                                             class: "vote-btn discuss",
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
-                                                let _ = save_vote(
-                                                    &sha, "discuss", &body, &scope,
-                                                );
+                                                if save_vote(&sha, "discuss", &body, &scope).is_ok() {
+                                                    bump_changes_ref_oid(changes_ref_oid, &scope);
+                                                }
                                                 vote_body.set(String::new());
-                                                page.set(Page::Detail {
-                                                    sha: sha.clone(),
-                                                });
                                             },
                                             "Discuss"
                                         }
@@ -272,13 +269,10 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
                                             class: "vote-btn revise",
                                             onclick: move |_| {
                                                 let body = vote_body.read().clone();
-                                                let _ = save_vote(
-                                                    &sha, "revise", &body, &scope,
-                                                );
+                                                if save_vote(&sha, "revise", &body, &scope).is_ok() {
+                                                    bump_changes_ref_oid(changes_ref_oid, &scope);
+                                                }
                                                 vote_body.set(String::new());
-                                                page.set(Page::Detail {
-                                                    sha: sha.clone(),
-                                                });
                                             },
                                             "Revise"
                                         }
@@ -435,6 +429,19 @@ pub fn save_comment(
     // surface flush errors) before reporting success.
     transaction.flush_mem_odb()?;
     Ok(content_hash)
+}
+
+/// Refresh the shared OID after a local ref mutation.
+pub fn bump_changes_ref_oid(
+    mut changes_ref_oid: Signal<Option<git2::Oid>>,
+    scope: &josh_changes::ChangesRef,
+) {
+    let new_oid = git2::Repository::discover(".")
+        .ok()
+        .and_then(|r| josh_changes::read_ref_oid(&r, scope));
+    if new_oid != *changes_ref_oid.peek() {
+        changes_ref_oid.set(new_oid);
+    }
 }
 
 pub fn save_vote(

--- a/josh-gui/src/diff.rs
+++ b/josh-gui/src/diff.rs
@@ -202,11 +202,15 @@ pub fn FileDiffView(
     scope: josh_changes::ChangesRef,
     mut page: Signal<Page>,
 ) -> Element {
+    let changes_ref_oid = use_context::<Signal<Option<git2::Oid>>>();
     let mut detail = use_signal(|| detail::load_detail(&sha, &scope));
     let mut prev_sha = use_signal(|| sha.clone());
-    if *prev_sha.read() != sha {
+    let mut prev_oid = use_signal(|| *changes_ref_oid.peek());
+    let cur_oid = *changes_ref_oid.read();
+    if *prev_sha.read() != sha || *prev_oid.read() != cur_oid {
         detail.set(detail::load_detail(&sha, &scope));
         prev_sha.set(sha.clone());
+        prev_oid.set(cur_oid);
     }
     let (prev_file, next_file) = detail
         .read()
@@ -544,7 +548,6 @@ pub fn FileDiffView(
                                             class: "nav-btn",
                                             disabled: comment_text.read().trim().is_empty(),
                                             onclick: {
-                                                let mut detail_sig = detail;
                                                 let sha_save = sha_for_save.clone();
                                                 let path_save = path_for_save.clone();
                                                 let scope_save = scope_for_save.clone();
@@ -566,10 +569,10 @@ pub fn FileDiffView(
                                                         )
                                                         .is_ok()
                                                         {
-                                                            detail_sig.set(detail::load_detail(
-                                                                &sha_save,
+                                                            detail::bump_changes_ref_oid(
+                                                                changes_ref_oid,
                                                                 &scope_save,
-                                                            ));
+                                                            );
                                                             commenting.set(false);
                                                             comment_text.set("".to_string());
                                                         }

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -39,18 +39,30 @@ pub struct ListData {
 #[component]
 pub fn ListView(
     list_data: Signal<anyhow::Result<ListData>>,
-    metadata_cache: Signal<HashMap<String, RowMetadata>>,
+    mut metadata_cache: Signal<HashMap<String, RowMetadata>>,
     mut scroll_offset: Signal<usize>,
     scope: josh_changes::ChangesRef,
     mut page: Signal<Page>,
     mut selected_change: Signal<Option<String>>,
 ) -> Element {
+    let changes_ref_oid = use_context::<Signal<Option<git2::Oid>>>();
+    let mut prev_metadata_oid = use_signal(|| None::<Option<git2::Oid>>);
+
     {
         let scope_for_meta = scope.clone();
         use_effect(move || {
+            let cur_oid = *changes_ref_oid.read();
             let offset = *scroll_offset.read() as u32;
             let viewport_px = VISIBLE_ROWS * ROW_HEIGHT;
             let overscan_px = OVERSCAN_ROWS * ROW_HEIGHT;
+
+            // If the changes ref has changed since we last populated the cache,
+            // the cached metadata is stale — drop it and refetch.
+            if prev_metadata_oid.peek().as_ref() != Some(&cur_oid) {
+                metadata_cache.write().clear();
+                prev_metadata_oid.set(Some(cur_oid));
+            }
+
             let data_ref = list_data.peek();
             let Ok(data) = &*data_ref else {
                 return;

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -39,18 +39,28 @@ pub struct ListData {
 #[component]
 pub fn ListView(
     list_data: Signal<anyhow::Result<ListData>>,
-    metadata_cache: Signal<HashMap<String, RowMetadata>>,
+    mut metadata_cache: Signal<HashMap<String, RowMetadata>>,
     mut scroll_offset: Signal<usize>,
     scope: josh_changes::ChangesRef,
     mut page: Signal<Page>,
     mut selected_change: Signal<Option<String>>,
 ) -> Element {
+    let changes_ref_oid = use_context::<Signal<Option<git2::Oid>>>();
+    let mut prev_metadata_oid = use_signal(|| None::<Option<git2::Oid>>);
+
     {
         let scope_for_meta = scope.clone();
         use_effect(move || {
+            let cur_oid = *changes_ref_oid.read();
             let offset = *scroll_offset.read() as u32;
             let viewport_px = VISIBLE_ROWS * ROW_HEIGHT;
             let overscan_px = OVERSCAN_ROWS * ROW_HEIGHT;
+
+            if prev_metadata_oid.peek().as_ref() != Some(&cur_oid) {
+                metadata_cache.write().clear();
+                prev_metadata_oid.set(Some(cur_oid));
+            }
+
             let data_ref = list_data.peek();
             let Ok(data) = &*data_ref else {
                 return;

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -73,12 +73,60 @@ pub enum Page {
 fn app() -> Element {
     let initial_scope = use_context::<josh_changes::ChangesRef>();
     let current_scope = use_signal(|| initial_scope.clone());
-    let list_data: Signal<anyhow::Result<list::ListData>> =
+
+    // Single source of truth for "what state is the changes ref in right now".
+    // Bumped by local mutations (save_comment / save_vote) and by a background
+    // poll that detects external changes (fetches, other processes). Loaders
+    // across the app subscribe to this signal so a bump triggers a refresh
+    // everywhere derived data is shown.
+    let mut changes_ref_oid: Signal<Option<git2::Oid>> = use_signal(|| {
+        git2::Repository::discover(".")
+            .ok()
+            .and_then(|r| josh_changes::read_ref_oid(&r, &current_scope.read()))
+    });
+    use_context_provider(|| changes_ref_oid);
+
+    let mut list_data: Signal<anyhow::Result<list::ListData>> =
         use_signal(|| load_rows(&current_scope.read()));
     let metadata_cache: Signal<HashMap<String, RowMetadata>> = use_signal(HashMap::new);
     let scroll_offset = use_signal(|| 0usize);
     let page = use_signal(|| Page::List);
     let mut selected_change = use_signal(|| None::<String>);
+
+    // Reload the list whenever the ref OID or scope changes.
+    use_effect(move || {
+        let _ = changes_ref_oid.read();
+        let scope = current_scope.read().clone();
+        list_data.set(load_rows(&scope));
+    });
+
+    // When the scope changes, re-read the OID immediately so we don't have to
+    // wait for the next poll tick.
+    use_effect(move || {
+        let scope = current_scope.read().clone();
+        let new_oid = git2::Repository::discover(".")
+            .ok()
+            .and_then(|r| josh_changes::read_ref_oid(&r, &scope));
+        if new_oid != *changes_ref_oid.peek() {
+            changes_ref_oid.set(new_oid);
+        }
+    });
+
+    // Poll the ref's OID once a second to pick up external changes. Reading a
+    // ref is a tiny disk read; we only write the signal (and trigger reloads)
+    // when the OID actually changes, so an idle GUI stays idle.
+    use_future(move || async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            let scope = current_scope.peek().clone();
+            let new_oid = git2::Repository::discover(".")
+                .ok()
+                .and_then(|r| josh_changes::read_ref_oid(&r, &scope));
+            if new_oid != *changes_ref_oid.peek() {
+                changes_ref_oid.set(new_oid);
+            }
+        }
+    });
 
     use_effect(move || {
         if let Ok(data) = &*list_data.read() {

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -74,12 +74,52 @@ pub enum Page {
 fn app() -> Element {
     let initial_scope = use_context::<josh_changes::ChangesRef>();
     let current_scope = use_signal(|| initial_scope.clone());
-    let list_data: Signal<anyhow::Result<list::ListData>> =
+
+    // Views subscribe to this signal to invalidate ref-derived data.
+    let mut changes_ref_oid: Signal<Option<git2::Oid>> = use_signal(|| {
+        git2::Repository::discover(".")
+            .ok()
+            .and_then(|r| josh_changes::read_ref_oid(&r, &current_scope.read()))
+    });
+    use_context_provider(|| changes_ref_oid);
+
+    let mut list_data: Signal<anyhow::Result<list::ListData>> =
         use_signal(|| load_rows(&current_scope.read()));
     let metadata_cache: Signal<HashMap<String, RowMetadata>> = use_signal(HashMap::new);
     let scroll_offset = use_signal(|| 0usize);
     let page = use_signal(|| Page::List);
     let mut selected_change = use_signal(|| None::<String>);
+
+    use_effect(move || {
+        let _ = changes_ref_oid.read();
+        let scope = current_scope.read().clone();
+        list_data.set(load_rows(&scope));
+    });
+
+    // Avoid waiting for the poll after switching scopes.
+    use_effect(move || {
+        let scope = current_scope.read().clone();
+        let new_oid = git2::Repository::discover(".")
+            .ok()
+            .and_then(|r| josh_changes::read_ref_oid(&r, &scope));
+        if new_oid != *changes_ref_oid.peek() {
+            changes_ref_oid.set(new_oid);
+        }
+    });
+
+    // Only publish OID changes to keep idle views from reloading.
+    use_future(move || async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            let scope = current_scope.peek().clone();
+            let new_oid = git2::Repository::discover(".")
+                .ok()
+                .and_then(|r| josh_changes::read_ref_oid(&r, &scope));
+            if new_oid != *changes_ref_oid.peek() {
+                changes_ref_oid.set(new_oid);
+            }
+        }
+    });
 
     use_effect(move || {
         if let Ok(data) = &*list_data.read() {


### PR DESCRIPTION
Refresh josh-gui when the changes ref moves

Track the active changes ref OID and reload derived views after local writes or
external updates.

Change: gui-refresh-on-changes-ref-bump
Assisted-By: anthropic/claude-opus-4-7
Assisted-By: openai-codex/gpt-5.6-sol