### PR TITLE
Pin git-lfs to v3.7.1 SHA in image builds

### DIFF
--- a/images/dev/Dockerfile
+++ b/images/dev/Dockerfile
@@ -68,10 +68,12 @@ RUN cd lfs-test-server && GOPATH=/opt/git-lfs go install
 
 ENV PATH=${PATH}:/opt/git-lfs/bin
 
+ARG GIT_LFS_SHA=b84b33847fe6458f36ef521534dc0eac953cb379
 RUN <<EOF
 set -eux
 git clone https://github.com/git-lfs/git-lfs.git /usr/src/git-lfs
 cd /usr/src/git-lfs
+git checkout "${GIT_LFS_SHA}"
 make
 cp bin/git-lfs /opt/git-lfs/bin
 EOF

--- a/images/prysk-test/Dockerfile
+++ b/images/prysk-test/Dockerfile
@@ -75,10 +75,12 @@ RUN cd lfs-test-server && GOPATH=/opt/git-lfs go install
 
 ENV PATH=${PATH}:/opt/git-lfs/bin
 
+ARG GIT_LFS_SHA=b84b33847fe6458f36ef521534dc0eac953cb379
 RUN <<EOF
 set -eux
 git clone https://github.com/git-lfs/git-lfs.git /usr/src/git-lfs
 cd /usr/src/git-lfs
+git checkout "${GIT_LFS_SHA}"
 make
 cp bin/git-lfs /opt/git-lfs/bin
 EOF


### PR DESCRIPTION
Pin git-lfs to v3.7.1 SHA in image builds

The prysk-test and dev images clone git-lfs from main and run `make`.
Upstream bumped go.mod to `go 1.25.0` on 2026-06-08 (commit 942a95d1),
but alpine:3.22.0's `apk add go` ships Go 1.24.13, so `make` now fails
with `go.mod requires go >= 1.25.0 (GOTOOLCHAIN=local)` and the image
build aborts before any tests run.

Pin both Dockerfiles to b84b33847fe6458f36ef521534dc0eac953cb379, the
v3.7.1 release commit (2025-10-16). Its go.mod still requests `go
1.23.0` with `toolchain go1.24.0`, which the Alpine Go satisfies. Use a
SHA rather than the tag name so the build is reproducible even if the
tag is ever moved or replaced upstream.

Expose the SHA as `ARG GIT_LFS_SHA` so future bumps are a single-line
change at the top of each RUN block.

Change: pin-git-lfs-sha
Assisted-By: Claude Opus 4.7