### PR TITLE
Skip output-volume check for compose deps with output="none"

### DIFF
--- a/josh-compose/src/container.rs
+++ b/josh-compose/src/container.rs
@@ -156,11 +156,13 @@ pub fn run_container(
             dep_errors.push(format!("dependency {dep_name} failed: {e}"));
             continue;
         }
+        let dep_meta = meta::read_meta(repo, dep_tree)?;
+        if dep_meta.output == OutputMode::None {
+            continue;
+        }
         let dep_out_vol = format!("out_{dep_tree}");
         if !podman::volume_exists(&dep_out_vol)? {
-            dep_errors.push(format!(
-                "dependency {dep_name} has no output volume (output must not be 'none')"
-            ));
+            dep_errors.push(format!("dependency {dep_name} has no output volume"));
             continue;
         }
         dep_volumes.push((dep_out_vol, format!("/{dep_name}"), true));


### PR DESCRIPTION
Skip output-volume check for compose deps with output="none"

run_container required every dependency to have an out_<oid> volume after
running, which broke orchestrator workspaces like ws/test.josh whose inputs
are side-effect-only sub-workspaces (josh-gui-build, devtools-build) that
declare :$output="none". OutputMode::None is documented as "no output volume
created"; plan.rs already special-cases it for the cache-skip path, but
container.rs did not, so the orchestrator failed with
"dependency X has no output volume (output must not be 'none')".

Read the dep's meta after running it and skip both the volume-existence
check and the dep_volumes push when its output is None. Keep the strict
check for Keep/Workdir deps where a missing volume is a real bug (e.g. R2
marker pulled but volume blob missing).

Change: compose-skip-none-output-dep-volume
Assisted-By: claude-opus-4-7