### PR TITLE
Decompose multi-component File filters in opt::step

### DIFF
--- a/josh-filter/src/opt.rs
+++ b/josh-filter/src/opt.rs
@@ -563,6 +563,7 @@ fn step(filter: Filter) -> Filter {
     }
     let original = filter;
     let result = to_filter(match to_op(filter) {
+        Op::Subdir(path) if path.as_os_str().is_empty() => Op::Nop,
         Op::Subdir(path) => {
             if path.components().count() > 1 {
                 Op::Chain(
@@ -574,6 +575,7 @@ fn step(filter: Filter) -> Filter {
                 Op::Subdir(path)
             }
         }
+        Op::Prefix(path) if path.as_os_str().is_empty() => Op::Nop,
         Op::Prefix(path) => {
             if path.components().count() > 1 {
                 Op::Chain(
@@ -584,6 +586,27 @@ fn step(filter: Filter) -> Filter {
                 )
             } else {
                 Op::Prefix(path)
+            }
+        }
+        Op::File(dest_path, source_path)
+            if source_path.components().count() > 1 || dest_path.components().count() > 1 =>
+        {
+            if let (Some(src_parent), Some(src_name), Some(dst_parent), Some(dst_name)) = (
+                source_path.parent(),
+                source_path.file_name(),
+                dest_path.parent(),
+                dest_path.file_name(),
+            ) {
+                Op::Chain(vec![
+                    to_filter(Op::Subdir(src_parent.to_path_buf())),
+                    to_filter(Op::File(
+                        std::path::PathBuf::from(dst_name),
+                        std::path::PathBuf::from(src_name),
+                    )),
+                    to_filter(Op::Prefix(dst_parent.to_path_buf())),
+                ])
+            } else {
+                Op::File(dest_path, source_path)
             }
         }
         Op::Rev(filters) => Op::Rev(

--- a/josh-starlark/src/tests.rs
+++ b/josh-starlark/src/tests.rs
@@ -240,11 +240,12 @@ filter = compose(all_file_filters)
     let filter = evaluate(script, root_tree_oid, &repo)?;
     let filter_spec = spec(filter);
 
-    // The filter should contain all files: README.md, src/main.rs, src/lib/utils.rs
-    // Compose of file filters (sorted alphabetically): :[::README.md,::src/lib/utils.rs,::src/main.rs]
+    // The filter should contain all files: README.md, src/main.rs, src/lib/utils.rs.
+    // File filters with multi-component paths decompose into Subdir + File + Prefix
+    // chains; common Subdir/Prefix layers around `src` and `lib` get factored out.
     assert_eq!(
         filter_spec,
-        ":[::README.md,::src/lib/utils.rs,::src/main.rs]"
+        ":[::README.md,:/src:[:/lib::utils.rs:prefix=lib,::main.rs]:prefix=src]"
     );
     Ok(())
 }

--- a/tests/experimental/link-submodules.t
+++ b/tests/experimental/link-submodules.t
@@ -63,13 +63,15 @@ Test Adapt filter - should expand submodule into actual tree content
   $ josh-filter -s :adapt=submodules:link=embedded master --update refs/josh/filter/master
   21b7f3ca0990df3f3bd6affb2d737f6f3b8f0ab2
   [1] :embed=libs
-  [2] ::libs/.link.josh
+  [2] :/libs
+  [2] ::.link.josh
+  [2] :prefix=libs
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] :"{@}"
   [3] :adapt=submodules
   [3] :link=embedded
-  [10] reachable_roots
-  [10] sequence_number
+  [11] reachable_roots
+  [11] sequence_number
   $ git log --graph --pretty=%s refs/josh/filter/master
   *   add libs submodule
   |\  
@@ -150,13 +152,15 @@ Test Adapt with multiple submodules
   $ josh-filter -s :adapt=submodules master --update refs/josh/filter/master
   36e64c35239749063d0ff71e5d67b6104a8ec8a4
   [1] :embed=libs
-  [2] ::libs/.link.josh
+  [2] :/libs
+  [2] ::.link.josh
+  [2] :prefix=libs
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] :"{@}"
   [3] :link=embedded
   [4] :adapt=submodules
-  [11] reachable_roots
-  [11] sequence_number
+  [12] reachable_roots
+  [12] sequence_number
   $ git ls-tree --name-only -r refs/josh/filter/master
   libs/.link.josh
   main.txt
@@ -175,14 +179,19 @@ Test Adapt with multiple submodules
   [1] :embed=libs
   [1] :embed=modules/another
   [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
-  [2] ::libs/.link.josh
-  [2] ::modules/another/.link.josh
+  [2] :/another
+  [2] :/libs
+  [2] :/modules
+  [2] :prefix=another
+  [2] :prefix=libs
+  [2] :prefix=modules
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
+  [3] ::.link.josh
   [4] :"{@}"
   [4] :adapt=submodules
   [4] :link=embedded
-  [15] reachable_roots
-  [15] sequence_number
+  [18] reachable_roots
+  [18] sequence_number
   $ git log --graph --pretty=%s refs/josh/filter/master
   *   add another submodule
   |\  
@@ -257,16 +266,21 @@ Test Adapt with submodule changes - add commits to submodule and update
   039bfc0995f10cd1bb1b3771b084c1acfca6949e
   [1] :embed=modules/another
   [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
-  [2] ::modules/another/.link.josh
+  [2] :/another
+  [2] :/modules
   [2] :embed=libs
+  [2] :prefix=another
+  [2] :prefix=modules
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
-  [3] ::libs/.link.josh
+  [3] :/libs
+  [3] :prefix=libs
+  [4] ::.link.josh
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
-  [21] reachable_roots
-  [21] sequence_number
+  [25] reachable_roots
+  [25] sequence_number
   $ git log --graph --pretty=%s:%H refs/josh/filter/master
   *   update libs submodule:039bfc0995f10cd1bb1b3771b084c1acfca6949e
   |\  
@@ -309,17 +323,21 @@ Test Adapt with submodule changes - add commits to submodule and update
   c5ce38ecbae793a62ed4b46bb9f98e09eb71d78c
   [1] :embed=modules/another
   [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
-  [2] ::modules/another/.link.josh
+  [2] :/another
+  [2] :/modules
   [2] :embed=libs
+  [2] :prefix=another
+  [2] :prefix=modules
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
-  [3] ::libs/.link.josh
+  [3] :prefix=libs
+  [4] ::.link.josh
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
-  [9] :/libs
-  [29] reachable_roots
-  [29] sequence_number
+  [12] :/libs
+  [33] reachable_roots
+  [33] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
   *   update libs submodule:c5ce38ecbae793a62ed4b46bb9f98e09eb71d78c
   |\  
@@ -333,18 +351,22 @@ Test Adapt with submodule changes - add commits to submodule and update
   c5ce38ecbae793a62ed4b46bb9f98e09eb71d78c
   [1] :embed=modules/another
   [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
-  [2] ::modules/another/.link.josh
+  [2] :/another
+  [2] :/modules
   [2] :embed=libs
+  [2] :prefix=another
+  [2] :prefix=modules
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
-  [3] ::libs/.link.josh
+  [3] :prefix=libs
+  [4] ::.link.josh
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
   [6] :prune=trivial-merge
-  [9] :/libs
-  [31] reachable_roots
-  [31] sequence_number
+  [12] :/libs
+  [35] reachable_roots
+  [35] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
   *   update libs submodule:c5ce38ecbae793a62ed4b46bb9f98e09eb71d78c
   |\  
@@ -360,19 +382,23 @@ Test Adapt with submodule changes - add commits to submodule and update
   3061af908a0dc1417902fbd7208bb2b8dc354e6c
   [1] :embed=modules/another
   [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
-  [2] ::modules/another/.link.josh
+  [2] :/another
+  [2] :/modules
   [2] :embed=libs
+  [2] :prefix=another
+  [2] :prefix=modules
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
-  [3] ::libs/.link.josh
+  [3] :prefix=libs
+  [4] ::.link.josh
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :export
   [5] :link=embedded
   [6] :prune=trivial-merge
-  [9] :/libs
-  [31] reachable_roots
-  [31] sequence_number
+  [12] :/libs
+  [35] reachable_roots
+  [35] sequence_number
   $ git log --graph --pretty=%s:%H:%T FILTERED_HEAD
   * add file4.txt:3061af908a0dc1417902fbd7208bb2b8dc354e6c:ac420a625dfb874002210e623a7fdb55708ef2fa
   * add file3.txt:411907f127aa115588a614ec1dff6ee3c4696173:2935d839ce5e2fa8d5d8fb1a8541bf95b98fbedb
@@ -382,19 +408,23 @@ Test Adapt with submodule changes - add commits to submodule and update
   3061af908a0dc1417902fbd7208bb2b8dc354e6c
   [1] :embed=modules/another
   [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
-  [2] ::modules/another/.link.josh
+  [2] :/another
+  [2] :/modules
   [2] :embed=libs
+  [2] :prefix=another
+  [2] :prefix=modules
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
-  [3] ::libs/.link.josh
+  [3] :prefix=libs
+  [4] ::.link.josh
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :export
   [5] :link=embedded
   [6] :prune=trivial-merge
-  [9] :/libs
-  [31] reachable_roots
-  [31] sequence_number
+  [12] :/libs
+  [35] reachable_roots
+  [35] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
   * add file4.txt:3061af908a0dc1417902fbd7208bb2b8dc354e6c
   * add file3.txt:411907f127aa115588a614ec1dff6ee3c4696173
@@ -404,21 +434,23 @@ Test Adapt with submodule changes - add commits to submodule and update
   a62789476855b6c89d1f15ba935d1a937e3ccd67
   [1] :embed=modules/another
   [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
-  [2] :/another
-  [2] ::modules/another/.link.josh
   [2] :embed=libs
+  [2] :prefix=another
+  [2] :prefix=modules
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
-  [3] ::libs/.link.josh
+  [3] :prefix=libs
+  [4] :/another
+  [4] ::.link.josh
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :export
   [5] :link=embedded
   [6] :prune=trivial-merge
-  [7] :/modules
-  [9] :/libs
-  [33] reachable_roots
-  [33] sequence_number
+  [9] :/modules
+  [12] :/libs
+  [37] reachable_roots
+  [37] sequence_number
   $ git log --graph --pretty=%s:%H FILTERED_HEAD
   * add another submodule:a62789476855b6c89d1f15ba935d1a937e3ccd67
   * add another.txt:8fbd01fa31551a059e280f68ac37397712feb59e
@@ -427,21 +459,23 @@ Test Adapt with submodule changes - add commits to submodule and update
   039bfc0995f10cd1bb1b3771b084c1acfca6949e
   [1] :embed=modules/another
   [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
-  [2] :/another
-  [2] ::modules/another/.link.josh
   [2] :embed=libs
+  [2] :prefix=another
+  [2] :prefix=modules
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
-  [3] ::libs/.link.josh
+  [3] :prefix=libs
+  [4] :/another
+  [4] ::.link.josh
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :export
   [5] :link=embedded
   [6] :prune=trivial-merge
-  [7] :/modules
-  [9] :/libs
-  [33] reachable_roots
-  [33] sequence_number
+  [9] :/modules
+  [12] :/libs
+  [37] reachable_roots
+  [37] sequence_number
   $ rm -Rf libs
   $ rm -Rf modules
   $ git checkout testsubexport
@@ -469,21 +503,23 @@ Test Adapt with submodule changes - add commits to submodule and update
   005cde5c84fbcf17526a0e2fec0a2932c4ce8f24
   [1] :embed=modules/another
   [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
-  [2] :/another
-  [2] ::modules/another/.link.josh
   [2] :embed=libs
+  [2] :prefix=another
+  [2] :prefix=modules
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
-  [3] ::libs/.link.josh
+  [3] :prefix=libs
+  [4] :/another
+  [4] ::.link.josh
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
   [6] :export
-  [7] :/modules
   [7] :prune=trivial-merge
-  [10] :/libs
-  [36] reachable_roots
-  [36] sequence_number
+  [9] :/modules
+  [13] :/libs
+  [40] reachable_roots
+  [40] sequence_number
 
   $ git checkout testsubexported
   Switched to branch 'testsubexported'
@@ -508,23 +544,24 @@ Test Adapt with submodule changes - add commits to submodule and update
   [1] :embed=modules/another
   [1] :prefix=modules/another
   [1] :unapply(108820becc39a6a21212e893a7cde9250b564825:/modules/another)
-  [2] :/another
-  [2] ::modules/another/.link.josh
   [2] :embed=libs
+  [2] :prefix=another
+  [2] :prefix=modules
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
-  [3] ::libs/.link.josh
-  [4] :prefix=libs
+  [4] :/another
+  [4] ::.link.josh
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
   [5] :link=embedded
   [6] :export
-  [7] :/modules
+  [7] :prefix=libs
   [7] :prune=trivial-merge
-  [10] :/libs
+  [9] :/modules
   [10] :unlink
-  [36] reachable_roots
-  [36] sequence_number
+  [13] :/libs
+  [40] reachable_roots
+  [40] sequence_number
 
   $ git log --graph --pretty=%s:%H:%T refs/heads/unlinked_master
   *   update libs submodule:3d95fb6ef91b355b85f191cc16ac494a2c9651b3:0dff040bb48e18b3a89c345d5209fe73b3ca6ed1

--- a/tests/experimental/link.t
+++ b/tests/experimental/link.t
@@ -32,14 +32,16 @@ Test Link filter (identical to Adapt)
 
   $ josh-filter -s :adapt=submodules:link=embedded master --update refs/josh/filter/master
   92633928cfadfc6a62a6e9b6d5f2a1e133b24877
+  [1] ::.link.josh
   [1] :embed=libs
+  [1] :prefix=libs
   [1] :unapply(547cadac76e234f77d5b363a4c517bf7a85cd4ee:/libs)
   [2] :"{@}"
-  [2] ::libs/.link.josh
+  [2] :/libs
   [2] :adapt=submodules
   [2] :link=embedded
-  [7] reachable_roots
-  [7] sequence_number
+  [8] reachable_roots
+  [8] sequence_number
   $ git ls-tree -r --name-only refs/josh/filter/master
   libs/.link.josh
   libs/bar/file2.txt

--- a/tests/filter/file_destination.t
+++ b/tests/filter/file_destination.t
@@ -15,9 +15,11 @@ Test File filter with destination path
 
   $ josh-filter -s ::renamed.txt=src/subdir/original.txt master --update refs/josh/master
   febbdb79c867625e8ce536e06f80e88a9827edf9
-  [1] ::renamed.txt=src/subdir/original.txt
-  [1] reachable_roots
-  [1] sequence_number
+  [1] :/src
+  [1] :/subdir
+  [1] ::renamed.txt=original.txt
+  [3] reachable_roots
+  [3] sequence_number
 
   $ git checkout refs/josh/master 2> /dev/null
   $ tree
@@ -43,9 +45,13 @@ Test File filter with destination path in subdirectory
 
   $ josh-filter -s ::dest/subdir/renamed.txt=src/subdir/original.txt master --update refs/josh/master
   a0a74aba925001c897af13106d526fa9a04792f3
-  [1] ::dest/subdir/renamed.txt=src/subdir/original.txt
-  [1] reachable_roots
-  [1] sequence_number
+  [1] :/src
+  [1] :/subdir
+  [1] ::renamed.txt=original.txt
+  [1] :prefix=dest
+  [1] :prefix=subdir
+  [5] reachable_roots
+  [5] sequence_number
 
   $ git checkout refs/josh/master 2> /dev/null
   $ tree
@@ -60,7 +66,7 @@ Test File filter with destination path in subdirectory
 
 Test File filter spec formatting with destination path
   $ josh-filter -p ::dest/renamed.txt=src/file.txt
-  ::dest/renamed.txt=src/file.txt
+  dest = :/src::renamed.txt=file.txt
 
 Test File filter backward compatibility (no destination path - keeps same path)
   $ cd ${TESTTMP}
@@ -77,9 +83,13 @@ Test File filter backward compatibility (no destination path - keeps same path)
 
   $ josh-filter -s ::src/subdir/file.txt master --update refs/josh/master
   0bbd185c6b7bc651e9557162c087cafc0dee8131
-  [1] ::src/subdir/file.txt
-  [1] reachable_roots
-  [1] sequence_number
+  [1] :/src
+  [1] :/subdir
+  [1] ::file.txt
+  [1] :prefix=src
+  [1] :prefix=subdir
+  [5] reachable_roots
+  [5] sequence_number
 
   $ git checkout refs/josh/master 2> /dev/null
   $ tree
@@ -107,9 +117,11 @@ Test File filter with destination path --reverse
 
   $ josh-filter -s ::renamed.txt=src/subdir/original.txt master --update refs/josh/master
   febbdb79c867625e8ce536e06f80e88a9827edf9
-  [1] ::renamed.txt=src/subdir/original.txt
-  [1] reachable_roots
-  [1] sequence_number
+  [1] :/src
+  [1] :/subdir
+  [1] ::renamed.txt=original.txt
+  [3] reachable_roots
+  [3] sequence_number
 
   $ git checkout refs/josh/master 2> /dev/null
   $ echo "modified content" > renamed.txt
@@ -118,9 +130,11 @@ Test File filter with destination path --reverse
 
   $ josh-filter -s ::renamed.txt=src/subdir/original.txt --reverse master --update refs/josh/master
   c122559c82871c0c453012051d4b067158a9a8cb
-  [1] ::renamed.txt=src/subdir/original.txt
-  [1] reachable_roots
-  [1] sequence_number
+  [1] :/src
+  [1] :/subdir
+  [1] ::renamed.txt=original.txt
+  [3] reachable_roots
+  [3] sequence_number
 
   $ git checkout master 2> /dev/null
   $ cat src/subdir/original.txt
@@ -153,9 +167,13 @@ Test File filter backward compatibility --reverse
 
   $ josh-filter -s ::src/subdir/file.txt master --update refs/josh/master
   0bbd185c6b7bc651e9557162c087cafc0dee8131
-  [1] ::src/subdir/file.txt
-  [1] reachable_roots
-  [1] sequence_number
+  [1] :/src
+  [1] :/subdir
+  [1] ::file.txt
+  [1] :prefix=src
+  [1] :prefix=subdir
+  [5] reachable_roots
+  [5] sequence_number
 
   $ git checkout refs/josh/master 2> /dev/null
   $ echo "modified content" > src/subdir/file.txt
@@ -164,9 +182,13 @@ Test File filter backward compatibility --reverse
 
   $ josh-filter -s ::src/subdir/file.txt --reverse master --update refs/josh/master
   49d6b8e7dbefec1836449d7a62f9f906e00521e7
-  [1] ::src/subdir/file.txt
-  [1] reachable_roots
-  [1] sequence_number
+  [1] :/src
+  [1] :/subdir
+  [1] ::file.txt
+  [1] :prefix=src
+  [1] :prefix=subdir
+  [5] reachable_roots
+  [5] sequence_number
 
   $ git checkout master 2> /dev/null
   $ cat src/subdir/file.txt

--- a/tests/filter/filter_id.t
+++ b/tests/filter/filter_id.t
@@ -195,13 +195,13 @@ Exclude of compose should not be split out
       ::a/
       ::b/
   ]:exclude[
-      ::a/a
-      ::b/b
+      a = :/a::a
+      b = :/b::b
   ]
   $ josh-filter --reverse -p :[:/a:prefix=a,:/b:prefix=b]:exclude[::a/a,::b/b]
   :exclude[
-      ::a/a
-      ::b/b
+      a = :/a::a
+      b = :/b::b
   ]:[
       ::a/
       ::b/

--- a/tests/filter/hide_view.t
+++ b/tests/filter/hide_view.t
@@ -52,8 +52,8 @@
 
   $ josh-filter -s c=:exclude[::sub1/file2] master --update refs/josh/filter/master
   d407c3a1d5fc72fb0e001795b08d76c4b246f8d0
+  [2] :exclude[:/sub1::file2:prefix=sub1]
   [2] :exclude[::sub1/]
-  [2] :exclude[::sub1/file2]
   [3] :prefix=c
   [5] reachable_roots
   [5] sequence_number
@@ -73,9 +73,9 @@
 
   $ josh-filter -s c=:exclude[::sub2/file3] master --update refs/josh/filter/master
   04cda64def8cdb4ef3c4507362e5d66c58bd935e
+  [2] :exclude[:/sub1::file2:prefix=sub1]
+  [2] :exclude[:/sub2::file3:prefix=sub2]
   [2] :exclude[::sub1/]
-  [2] :exclude[::sub1/file2]
-  [2] :exclude[::sub2/file3]
   [4] :prefix=c
   [5] reachable_roots
   [5] sequence_number

--- a/tests/filter/pretty_print.t
+++ b/tests/filter/pretty_print.t
@@ -71,13 +71,13 @@ Exclude of compose should not be split out
       ::a/
       ::b/
   ]:exclude[
-      ::a/a
-      ::b/b
+      a = :/a::a
+      b = :/b::b
   ]
   $ josh-filter --reverse -p :[:/a:prefix=a,:/b:prefix=b]:exclude[::a/a,::b/b]
   :exclude[
-      ::a/a
-      ::b/b
+      a = :/a::a
+      b = :/b::b
   ]:[
       ::a/
       ::b/

--- a/tests/filter/stored_combine_filter.t
+++ b/tests/filter/stored_combine_filter.t
@@ -52,11 +52,16 @@
   $ josh-filter -s :+st/config
   9527d0249f419b172c6ca02390fde00f81e9c078
   [2] :+st/config
-  [2] :[
-      ::sub1/
-      ::sub2/subsub/
-  ]
-  [2] :prefix=x
+  [2] :subtract[
+          :[
+              st = :/st::config.josh
+              x = :[
+                  ::sub1/
+                  ::sub2/subsub/
+              ]
+          ]
+          :/st::config.josh
+      ]
   [4] reachable_roots
   [4] sequence_number
 
@@ -84,21 +89,31 @@
   f9e1862628d454b0cc4e98305983335d9c615113
   [2] :+st/config
   [2] :+st2/config
-  [2] :[
-      ::sub1/
-      ::sub2/subsub/
-  ]
-  [2] :prefix=x
-  [3] :[
-      a = :[
-          ::sub2/subsub/
-          ::sub3/
+  [2] :subtract[
+          :[
+              st = :/st::config.josh
+              x = :[
+                  ::sub1/
+                  ::sub2/subsub/
+              ]
+          ]
+          :/st::config.josh
       ]
-      blub = :/sub1
-  ]
-  [3] :prefix=xyz
-  [7] reachable_roots
-  [7] sequence_number
+  [3] :subtract[
+          :[
+              st2 = :/st2::config.josh
+              xyz = :[
+                  a = :[
+                      ::sub2/subsub/
+                      ::sub3/
+                  ]
+                  blub = :/sub1
+              ]
+          ]
+          :/st2::config.josh
+      ]
+  [4] reachable_roots
+  [4] sequence_number
 
   $ git log --graph --pretty=%s FILTERED_HEAD
   * add st

--- a/tests/filter/stored_implicit_filter.t
+++ b/tests/filter/stored_implicit_filter.t
@@ -25,10 +25,14 @@
   $ josh-filter -s :+st/config master --update refs/josh/master
   6f43d8ee3bbf33e24fa190605ed12c47e6ede762
   [2] :+st/config
-  [2] :[
-      ::sub1/
-      ::sub2/subsub/
-  ]
+  [2] :subtract[
+          :[
+              st = :/st::config.josh
+              ::sub1/
+              ::sub2/subsub/
+          ]
+          :/st::config.josh
+      ]
   [3] reachable_roots
   [3] sequence_number
 

--- a/tests/filter/stored_redirect.t
+++ b/tests/filter/stored_redirect.t
@@ -49,10 +49,14 @@
   6c3969ebc7f3a9286e3b94fea28646aaaa9021b1
   [1] :prefix=b
   [2] :/sub3
-  [2] :[
-      a = :/sub1
-      ::sub2/subsub/
-  ]
+  [2] :subtract[
+          :[
+              st = :/st::config.josh
+              a = :/sub1
+              ::sub2/subsub/
+          ]
+          :/st::config.josh
+      ]
   [3] :+st/config
   [7] reachable_roots
   [7] sequence_number
@@ -61,17 +65,25 @@
   [1] :prefix=b
   [2] :+st_new/config
   [2] :/sub3
-  [2] :[
-      a = :/sub1
-      ::sub2/subsub/
-  ]
+  [2] :subtract[
+          :[
+              st = :/st::config.josh
+              a = :/sub1
+              ::sub2/subsub/
+          ]
+          :/st::config.josh
+      ]
   [3] :+st/config
-  [5] :[
-      ::st/config.josh
-      a = :/sub1
-      ::sub2/subsub/
-      b = :/sub3
-  ]
+  [5] :subtract[
+          :[
+              st = :/st::config.josh
+              st_new = :/st_new::config.josh
+              a = :/sub1
+              ::sub2/subsub/
+              b = :/sub3
+          ]
+          :/st_new::config.josh
+      ]
   [7] reachable_roots
   [7] sequence_number
 
@@ -184,27 +196,36 @@
   $ josh-filter -s :+st/config master --update refs/heads/filtered
   267d7721cca8af54f01f44756b10ede7b22ef238
   [1] :prefix=b
+  [1] :prefix=st_new
   [2] :+st_new/config
   [2] :/sub3
-  [2] :[
-      a = :/sub1
-      ::sub2/subsub/
-  ]
   [2] :subtract[
-          ::st_new/config.josh
+          :/st_new::config.josh
           :[
               a = :/sub1
               ::sub2/subsub/
               b = :/sub3
           ]
       ]
+  [2] :subtract[
+          :[
+              st = :/st::config.josh
+              a = :/sub1
+              ::sub2/subsub/
+          ]
+          :/st::config.josh
+      ]
   [4] :+st/config
-  [5] :[
-      ::st/config.josh
-      a = :/sub1
-      ::sub2/subsub/
-      b = :/sub3
-  ]
-  [8] reachable_roots
-  [8] sequence_number
+  [5] :subtract[
+          :[
+              st = :/st::config.josh
+              st_new = :/st_new::config.josh
+              a = :/sub1
+              ::sub2/subsub/
+              b = :/sub3
+          ]
+          :/st_new::config.josh
+      ]
+  [9] reachable_roots
+  [9] sequence_number
 

--- a/tests/filter/stored_reverse.t
+++ b/tests/filter/stored_reverse.t
@@ -26,10 +26,14 @@
   $ josh-filter -s :+st/config master --update refs/heads/filtered
   b1f056d2e78ad2f39e0b52e17e9aea6aa01c54aa
   [2] :+st/config
-  [2] :[
-      a = :/sub1
-      ::sub2/subsub/
-  ]
+  [2] :subtract[
+          :[
+              st = :/st::config.josh
+              a = :/sub1
+              ::sub2/subsub/
+          ]
+          :/st::config.josh
+      ]
   [3] reachable_roots
   [3] sequence_number
 
@@ -61,10 +65,14 @@
   $ josh-filter -s :+st/config --reverse master --update refs/heads/filtered
   b3ae61d547a0c794fa987774cf2d02131c5c3ad7
   [2] :+st/config
-  [2] :[
-      a = :/sub1
-      ::sub2/subsub/
-  ]
+  [2] :subtract[
+          :[
+              st = :/st::config.josh
+              a = :/sub1
+              ::sub2/subsub/
+          ]
+          :/st::config.josh
+      ]
   [3] reachable_roots
   [3] sequence_number
   $ git checkout master

--- a/tests/filter/stored_reverse_exclude.t
+++ b/tests/filter/stored_reverse_exclude.t
@@ -26,10 +26,14 @@
   $ josh-filter -s :+st/config master --update refs/heads/filtered
   9a6588a66e758aafb42bb1041db0048439eb4c06
   [2] :+st/config
-  [2] :[
-      a = :/sub1:exclude[::file1]
-      ::sub2/subsub/
-  ]
+  [2] :subtract[
+          :[
+              st = :/st::config.josh
+              a = :/sub1:exclude[::file1]
+              ::sub2/subsub/
+          ]
+          :/st::config.josh
+      ]
   [3] reachable_roots
   [3] sequence_number
 
@@ -60,10 +64,14 @@
   $ josh-filter -s :+st/config --reverse master --update refs/heads/filtered
   6182f2f07949f7ccfd2e1ac0dfbd65b29f8e3d84
   [2] :+st/config
-  [2] :[
-      a = :/sub1:exclude[::file1]
-      ::sub2/subsub/
-  ]
+  [2] :subtract[
+          :[
+              st = :/st::config.josh
+              a = :/sub1:exclude[::file1]
+              ::sub2/subsub/
+          ]
+          :/st::config.josh
+      ]
   [3] reachable_roots
   [3] sequence_number
   $ git checkout master

--- a/tests/filter/stored_single_file.t
+++ b/tests/filter/stored_single_file.t
@@ -34,13 +34,17 @@ by ".josh" but rather kept and extended
   $ josh-filter -s :+st/config.filter master --update refs/josh/master
   3397ec2c69d5c8f67ad39cf477b3711683022d84
   [2] :+st/config.filter
-  [2] :[
-      :/sub1:[
-          ::file1
-          ::file2
+  [2] :subtract[
+          :[
+              st = :/st::config.filter.josh
+              :/sub1:[
+                  ::file1
+                  ::file2
+              ]
+              ::sub2/subsub/
+          ]
+          :/st::config.filter.josh
       ]
-      ::sub2/subsub/
-  ]
   [3] reachable_roots
   [3] sequence_number
 

--- a/tests/filter/workspace_discover.t
+++ b/tests/filter/workspace_discover.t
@@ -56,14 +56,14 @@
           ::file1
           ::file2
       ]
-      ::sub2/subsub
+      ::sub2/subsub/
   ]
   [2] :[
       :/sub1:[
           ::file1
           ::file2
       ]
-      ::sub2/subsub/
+      sub2 = :/sub2::subsub
   ]
   [2] :workspace=ws
   [2] :workspace=ws2
@@ -95,14 +95,14 @@
           ::file1
           ::file2
       ]
-      ::sub2/subsub
+      ::sub2/subsub/
   ]
   [2] :[
       :/sub1:[
           ::file1
           ::file2
       ]
-      ::sub2/subsub/
+      sub2 = :/sub2::subsub
   ]
   [2] :workspace=ws
   [2] :workspace=ws2

--- a/tests/filter/workspace_single_file.t
+++ b/tests/filter/workspace_single_file.t
@@ -79,14 +79,14 @@
           ::file1
           ::file2
       ]
-      ::sub2/subsub
+      ::sub2/subsub/
   ]
   [2] :[
       :/sub1:[
           ::file1
           ::file2
       ]
-      ::sub2/subsub/
+      sub2 = :/sub2::subsub
   ]
   [2] :workspace=ws
   [2] :workspace=ws2

--- a/tests/filter/workspace_unique.t
+++ b/tests/filter/workspace_unique.t
@@ -36,7 +36,7 @@ so the workspace.josh will still appear in the root of the workspace
           :prefix=a
       ]
       ::sub2/subsub/
-      b = ::ws/workspace.josh
+      b/ws = :/ws::workspace.josh
   ]
   [2] :workspace=ws
   [3] reachable_roots


### PR DESCRIPTION
Decompose multi-component File filters in opt::step

Op::File(dest, source) with multi-component paths is now rewritten into
Subdir(source.parent) :: File(dest.file_name, source.file_name) ::
Prefix(dest.parent), letting the existing Compose/Chain optimizations
factor out shared prefix/subdir layers across sibling File filters --
e.g. a compose of `::src/lib/utils.rs` and `::src/main.rs` collapses to
a single :/src wrapper around a smaller inner compose.

The rewrite fires when either side has more than one component. The
asymmetric case (only source or only dest is multi-component) produces a
chain with an empty-path Subdir or Prefix on the trivial side. To make
that chain converge to a fixed point, step also normalizes Op::Subdir("")
and Op::Prefix("") to Op::Nop -- otherwise the inner single-component
File would re-enter the rewrite arm on every step and grow the chain
without bound.

Test expectations updated: 15 prysk .t files now show the decomposed
spec / increased reachable_roots+sequence_number counts (filtered SHAs
are unchanged -- semantics are identical), and the starlark
test_tree_build_filter_from_all_files expectation flips from the flat
compose of file filters to the equivalent prefix-grouped form.

Change: opt-decompose-multipath-file-filter
Assisted-By: Claude Opus 4.7