### PR TITLE
Allow Op::Blob content to be given as a blob sha

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -15,7 +15,7 @@ pub use josh_filter::opt;
 pub use josh_filter::opt::invert;
 pub use josh_filter::persist::{as_tree, from_tree};
 pub use josh_filter::persist::{peel_op, to_filter, to_op, to_ops};
-pub use josh_filter::{Filter, LazyRef, Op, RevMatch};
+pub use josh_filter::{BlobContent, Filter, LazyRef, Op, RevMatch};
 pub use josh_filter::{as_file, pretty, spec};
 
 pub mod text;
@@ -1363,7 +1363,10 @@ pub fn apply<'a>(
             )?))
         }
         Op::Blob(dest_path, content) => {
-            let blob_oid = repo.blob(content.as_bytes())?;
+            let blob_oid = match content {
+                BlobContent::Inline(s) => repo.blob(s.as_bytes())?,
+                BlobContent::Oid(oid) => repo.find_blob(*oid)?.id(),
+            };
             Ok(x.clone().with_tree(tree::insert(
                 repo,
                 &tree::empty(repo),
@@ -1439,7 +1442,11 @@ pub fn apply<'a>(
         Op::TreeId(path, subfilter) => {
             let applied = apply(transaction, *subfilter, x.clone())?;
             let oid_str = applied.tree().id().to_string();
-            apply(transaction, to_filter(Op::Blob(path.clone(), oid_str)), x)
+            apply(
+                transaction,
+                to_filter(Op::Blob(path.clone(), BlobContent::Inline(oid_str))),
+                x,
+            )
         }
         Op::ObjectRef(path) => {
             let repo = transaction.repo();

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -1,5 +1,5 @@
 use crate::check_experimental_features_enabled;
-use crate::op::{LazyRef, Op};
+use crate::op::{BlobContent, LazyRef, Op};
 use crate::opt;
 use crate::persist::{self, to_filter, to_op};
 use std::sync::LazyLock;
@@ -138,7 +138,21 @@ impl Filter {
         content: impl Into<String>,
     ) -> anyhow::Result<Filter> {
         check_experimental_features_enabled("Blob filter")?;
-        Ok(self.chain(to_filter(Op::Blob(path.into(), content.into()))))
+        Ok(self.chain(to_filter(Op::Blob(
+            path.into(),
+            BlobContent::Inline(content.into()),
+        ))))
+    }
+
+    /// Chain a filter that inserts an existing blob (referenced by its OID) at the specified path.
+    /// Syntax: `:$path=<sha>`. Useful for large blobs that should not be inlined as a string.
+    pub fn blob_oid(
+        self,
+        path: impl Into<std::path::PathBuf>,
+        oid: git2::Oid,
+    ) -> anyhow::Result<Filter> {
+        check_experimental_features_enabled("Blob filter")?;
+        Ok(self.chain(to_filter(Op::Blob(path.into(), BlobContent::Oid(oid)))))
     }
 
     /// Chain a filter that removes the `.link.josh` marker to produce a standalone history

--- a/josh-filter/src/flang/grammar.pest
+++ b/josh-filter/src/flang/grammar.pest
@@ -20,7 +20,8 @@ char = {
     | "\\" ~ ("\"" | "\'" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | "u")
 }
 
-filter_blob = { CMD_START ~ "$" ~ argument ~ "=" ~ string }
+blob_oid = @{ ASCII_HEX_DIGIT+ }
+filter_blob = { CMD_START ~ "$" ~ argument ~ "=" ~ (string | blob_oid) }
 
 filter_spec = { (
     filter_group

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -4,7 +4,7 @@ use crate::filter::MESSAGE_MATCH_ALL_REGEX;
 use crate::filter::{reachable_roots, sequence_number};
 use crate::opt;
 use crate::persist::{to_filter, to_op, to_ops};
-use crate::{Filter, Op, RevMatch};
+use crate::{BlobContent, Filter, Op, RevMatch};
 
 /// Pretty print the filter on multiple lines with initial indentation level.
 /// Nested filters will be indented with additional 4 spaces per nesting level.
@@ -259,11 +259,13 @@ pub(crate) fn spec2(op: &Op) -> String {
         Op::Export => ":export".to_string(),
         Op::Unlink => ":unlink".to_string(),
         Op::Subdir(path) => format!(":/{}", parse::quote_if(&path.to_string_lossy())),
-        Op::Blob(path, content) => format!(
-            ":${}={}",
-            parse::quote_if(&path.to_string_lossy()),
-            parse::quote(content)
-        ),
+        Op::Blob(path, content) => {
+            let p = parse::quote_if(&path.to_string_lossy());
+            match content {
+                BlobContent::Inline(s) => format!(":${}={}", p, parse::quote(s)),
+                BlobContent::Oid(oid) => format!(":${}={}", p, oid),
+            }
+        }
         Op::File(dest_path, source_path) => {
             if source_path == dest_path {
                 format!("::{}", parse::quote_if(&dest_path.to_string_lossy()))

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -4,7 +4,7 @@ use crate::filter::Filter;
 use crate::opt;
 use crate::opt::invert;
 use crate::persist::to_filter;
-use crate::{LazyRef, Op, RevMatch};
+use crate::{BlobContent, LazyRef, Op, RevMatch};
 
 use anyhow::{Context, anyhow};
 use indoc::{formatdoc, indoc};
@@ -163,7 +163,12 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
             check_experimental_features_enabled("Blob filter")?;
             let mut inner = pair.into_inner();
             let path = Path::new(&unquote(inner.next().unwrap().as_str())).to_owned();
-            let content = unquote(inner.next().unwrap().as_str());
+            let content_pair = inner.next().unwrap();
+            let content = match content_pair.as_rule() {
+                Rule::string => BlobContent::Inline(unquote(content_pair.as_str())),
+                Rule::blob_oid => BlobContent::Oid(git2::Oid::from_str(content_pair.as_str())?),
+                _ => unreachable!(),
+            };
             Ok(to_filter(Op::Blob(path, content)))
         }
         Rule::filter_presub => {

--- a/josh-filter/src/lib.rs
+++ b/josh-filter/src/lib.rs
@@ -9,7 +9,7 @@ pub use filter::{Filter, compose};
 pub use flang::parse;
 pub use flang::{as_file, pretty, spec};
 pub use op::LinkMode;
-pub use op::{LazyRef, Op, RevMatch};
+pub use op::{BlobContent, LazyRef, Op, RevMatch};
 
 static EXPERIMENTAL_FEATURES: std::sync::LazyLock<bool> =
     std::sync::LazyLock::new(|| std::env::var("JOSH_EXPERIMENTAL_FEATURES").as_deref() == Ok("1"));

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -35,6 +35,12 @@ pub enum LazyRef {
     Lazy(String),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BlobContent {
+    Inline(String),
+    Oid(git2::Oid),
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RevMatch {
     /// `<` - matches if is_ancestor_of(commit, tip) && commit != tip (strict)
@@ -101,7 +107,7 @@ pub enum Op {
     Index,
     Invert,
 
-    Blob(std::path::PathBuf, String), // Blob(dest_path, content)
+    Blob(std::path::PathBuf, BlobContent), // Blob(dest_path, content)
     File(std::path::PathBuf, std::path::PathBuf), // File(dest_path, source_path)
     Prefix(std::path::PathBuf),
     Subdir(std::path::PathBuf),

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 
 use crate::filter::{Filter, reachable_roots, sequence_number};
 use crate::hash::PassthroughHasher;
-use crate::op::{LazyRef, Op, RevMatch};
+use crate::op::{BlobContent, LazyRef, Op, RevMatch};
 
 pub(crate) static FILTERS: LazyLock<
     std::sync::Mutex<HashMap<Filter, Op, BuildHasherDefault<PassthroughHasher>>>,
@@ -358,8 +358,13 @@ impl InMemoryBuilder {
                 push_tree_entries(&mut entries, [("prefix", params_tree)]);
             }
             Op::Blob(path, content) => {
-                let params_tree =
-                    self.build_str_params(&[path.to_string_lossy().as_ref(), content.as_str()]);
+                let path = path.to_string_lossy();
+                let params_tree = match content {
+                    BlobContent::Inline(s) => self.build_str_params(&[path.as_ref(), "inline", s]),
+                    BlobContent::Oid(oid) => {
+                        self.build_str_params(&[path.as_ref(), "oid", &oid.to_string()])
+                    }
+                };
                 push_tree_entries(&mut entries, [("blob", params_tree)]);
             }
             Op::File(dest_path, source_path) => {
@@ -680,10 +685,18 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             let inner = repo.find_tree(entry.id())?;
             let path_blob =
                 repo.find_blob(inner.get_name("0").context("blob: missing path")?.id())?;
-            let content_blob =
-                repo.find_blob(inner.get_name("1").context("blob: missing content")?.id())?;
+            let kind_blob =
+                repo.find_blob(inner.get_name("1").context("blob: missing kind")?.id())?;
+            let value_blob =
+                repo.find_blob(inner.get_name("2").context("blob: missing value")?.id())?;
             let path = std::str::from_utf8(path_blob.content())?;
-            let content = std::str::from_utf8(content_blob.content())?.to_string();
+            let kind = std::str::from_utf8(kind_blob.content())?;
+            let value = std::str::from_utf8(value_blob.content())?;
+            let content = match kind {
+                "inline" => BlobContent::Inline(value.to_string()),
+                "oid" => BlobContent::Oid(git2::Oid::from_str(value)?),
+                other => return Err(anyhow::anyhow!("blob: unknown content kind {:?}", other)),
+            };
             Ok(Op::Blob(std::path::PathBuf::from(path), content))
         }
         "file" => {

--- a/tests/experimental/blob.t
+++ b/tests/experimental/blob.t
@@ -17,6 +17,10 @@ Roundtrip: path with special chars is quoted
   $ josh-filter -p ':$"hello world.txt"="content"'
   :$"hello world.txt"="content"
 
+Roundtrip: blob specified by sha renders as bare hex
+  $ josh-filter -p ':$added.txt=e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
+  :$added.txt=e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+
 Inverse renders as :exclude[::path]
   $ josh-filter --reverse -p ':$added.txt="hello world"'
   :exclude[::added.txt]
@@ -44,3 +48,34 @@ Apply: compose with blob inserts blob alongside other files
   +++ b/file1
   @@ -0,0 +1 @@
   +contents1
+
+Apply: blob referenced by sha is inserted at the destination path
+  $ OID=$(printf 'big content' | git hash-object -w --stdin)
+  $ josh-filter -s ":\$added.txt=$OID" master --update refs/josh/filter/master3 1> /dev/null
+  $ git show josh/filter/master3:added.txt
+  big content (no-eol)
+
+Apply: referencing a non-blob sha (a commit) fails
+  $ COMMIT=$(git rev-parse HEAD)
+  $ josh-filter -s ":\$bad.txt=$COMMIT" master --update refs/josh/filter/bad 2> /dev/null
+  [1] :$added.txt="hello world"
+  [1] :$added.txt=422057123b178e433e852ef1dfee39368fb5a8ce
+  [1] :[
+      :/sub1
+      :$added.txt="hello world"
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+  [1]
+
+Apply: referencing a nonexistent sha fails
+  $ josh-filter -s ':$bad.txt=0000000000000000000000000000000000000001' master --update refs/josh/filter/bad2 2> /dev/null
+  [1] :$added.txt="hello world"
+  [1] :$added.txt=422057123b178e433e852ef1dfee39368fb5a8ce
+  [1] :[
+      :/sub1
+      :$added.txt="hello world"
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+  [1]


### PR DESCRIPTION
Allow Op::Blob content to be given as a blob sha

The blob filter previously only accepted inline string content
(`:$path="text"`), which is impractical for large blobs since the whole
content has to be embedded in the filter spec. Extend it so the content
can instead be an existing blob's OID.

The variant now holds `BlobContent::{Inline(String), Oid(git2::Oid)}`.
On the RHS of `:$path=...`, a quoted string stays inline content while a
bare hex token is parsed as an OID reference (mirroring how LazyRef
distinguishes bare hex from quoted strings). At apply time the OID is
resolved via `find_blob`, which errors if it is missing or not a blob.

Persistence tags each entry `inline` or `oid` so the two cases round
trip unambiguously, and a `blob_oid` builder is added alongside `blob`.

Change: blob-content-by-sha
Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>