### PR TITLE
Match change dependencies by Change-Id

### DIFF
--- a/josh-changes/src/change.rs
+++ b/josh-changes/src/change.rs
@@ -88,6 +88,33 @@ impl Change {
         }
         Ok(oids)
     }
+
+    /// Return known downstack Change-Ids in dependency order, excluding this change.
+    /// Trailer matching survives commit splitting, unlike tip-OID matching.
+    pub fn dependency_ids(
+        &self,
+        transaction: &josh_core::cache::Transaction,
+        known: &std::collections::HashSet<String>,
+    ) -> anyhow::Result<Vec<String>> {
+        let odb = transaction.odb();
+        let mut deps = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for oid in self.contributing(transaction)? {
+            let commit = objects::CommitData::read(odb, oid)?;
+            let (id, _) = commit_change_meta(&commit);
+            let id = match id {
+                Some(id) => id,
+                None => continue,
+            };
+            if Some(id.as_str()) == self.id() || !known.contains(&id) {
+                continue;
+            }
+            if seen.insert(id.clone()) {
+                deps.push(id);
+            }
+        }
+        Ok(deps)
+    }
 }
 
 pub fn encode_change_id_path(id: &str) -> String {

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -173,6 +173,37 @@ impl Change {
         }
         Ok(oids)
     }
+
+    /// The change-ids this change depends on (the changes in its downstack),
+    /// restricted to `known` and excluding itself, in downstack order, deduped.
+    ///
+    /// Dependencies are matched by each contributing commit's `Change-Id`
+    /// trailer, not by commit oid: a stored change's tip is a downstack-split
+    /// commit whose oid does not appear in another change's contributing
+    /// history, so oid matching only ever links the un-split (identity) changes.
+    pub fn dependency_ids(
+        &self,
+        repo: &git2::Repository,
+        known: &std::collections::HashSet<String>,
+    ) -> anyhow::Result<Vec<String>> {
+        let mut deps = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+        for oid in self.contributing(repo)? {
+            let commit = repo.find_commit(oid)?;
+            let (id, _) = commit_change_meta(&commit);
+            let id = match id {
+                Some(id) => id,
+                None => continue,
+            };
+            if Some(id.as_str()) == self.id() || !known.contains(&id) {
+                continue;
+            }
+            if seen.insert(id.clone()) {
+                deps.push(id);
+            }
+        }
+        Ok(deps)
+    }
 }
 
 pub fn encode_change_id_path(id: &str) -> String {

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 use anyhow::anyhow;
 
@@ -49,7 +49,7 @@ pub fn handle_list(
         return Ok(());
     }
 
-    let oid_to_change_id = build_oid_to_change_id(&changes);
+    let known = known_change_ids(&changes);
 
     struct Row {
         id: String,
@@ -72,12 +72,9 @@ pub fn handle_list(
             .to_string();
 
         let deps_count = change
-            .contributing(repo)
+            .dependency_ids(repo, &known)
             .unwrap_or_default()
-            .into_iter()
-            .filter_map(|oid| oid_to_change_id.get(&oid.to_string()).cloned())
-            .filter(|dep_id| dep_id != &id)
-            .count();
+            .len();
 
         let comments_count = change
             .id()
@@ -221,7 +218,7 @@ pub fn handle_deps(
     let repo = transaction.repo();
     let scope = args.scope.resolve(repo)?;
     let changes = josh_changes::list_changes(repo, &scope)?;
-    let oid_to_change_id = build_oid_to_change_id(&changes);
+    let known = known_change_ids(&changes);
 
     let change = changes
         .iter()
@@ -235,15 +232,11 @@ pub fn handle_deps(
         })?;
 
     let mut deps: Vec<(String, String)> = Vec::new();
-    for oid in change.contributing(repo)? {
-        let oid_str = oid.to_string();
-        let dep_id = match oid_to_change_id.get(&oid_str) {
-            Some(d) if d != &args.change_id => d.clone(),
-            _ => continue,
-        };
-        let subject = repo
-            .find_commit(oid)
-            .ok()
+    for dep_id in change.dependency_ids(repo, &known)? {
+        let subject = changes
+            .iter()
+            .find(|c| c.id() == Some(dep_id.as_str()))
+            .and_then(|c| repo.find_commit(c.commit()).ok())
             .and_then(|c| {
                 c.message()
                     .ok()
@@ -275,12 +268,11 @@ fn scope_label(scope: &josh_changes::ChangesRef) -> String {
     }
 }
 
-fn build_oid_to_change_id(changes: &[josh_changes::Change]) -> HashMap<String, String> {
-    let mut map = HashMap::with_capacity(changes.len());
-    for c in changes {
-        map.insert(c.commit().to_string(), c.id().unwrap_or("").to_string());
-    }
-    map
+fn known_change_ids(changes: &[josh_changes::Change]) -> HashSet<String> {
+    changes
+        .iter()
+        .filter_map(|c| c.id().map(|s| s.to_string()))
+        .collect()
 }
 
 fn resolve_change_by_id(

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 use anyhow::anyhow;
 
@@ -49,7 +49,7 @@ pub fn handle_list(
         return Ok(());
     }
 
-    let oid_to_change_id = build_oid_to_change_id(&changes);
+    let known = known_change_ids(&changes);
 
     struct Row {
         id: String,
@@ -66,12 +66,9 @@ pub fn handle_list(
         let subject = commit.summary().unwrap_or_default();
 
         let deps_count = change
-            .contributing(transaction)
+            .dependency_ids(transaction, &known)
             .unwrap_or_default()
-            .into_iter()
-            .filter_map(|oid| oid_to_change_id.get(&oid.to_string()).cloned())
-            .filter(|dep_id| dep_id != &id)
-            .count();
+            .len();
 
         let comments_count = change
             .id()
@@ -211,7 +208,7 @@ pub fn handle_deps(
     let odb = transaction.odb();
     let scope = args.scope.resolve(transaction)?;
     let changes = josh_changes::list_changes(transaction, &scope)?;
-    let oid_to_change_id = build_oid_to_change_id(&changes);
+    let known = known_change_ids(&changes);
 
     let change = changes
         .iter()
@@ -225,14 +222,11 @@ pub fn handle_deps(
         })?;
 
     let mut deps: Vec<(String, String)> = Vec::new();
-    for oid in change.contributing(transaction)? {
-        let oid_str = oid.to_string();
-        let dep_id = match oid_to_change_id.get(&oid_str) {
-            Some(d) if d != &args.change_id => d.clone(),
-            _ => continue,
-        };
-        let subject = josh_core::objects::CommitData::read(odb, oid)
-            .ok()
+    for dep_id in change.dependency_ids(transaction, &known)? {
+        let subject = changes
+            .iter()
+            .find(|c| c.id() == Some(dep_id.as_str()))
+            .and_then(|c| josh_core::objects::CommitData::read(odb, c.commit()).ok())
             .and_then(|c| c.summary())
             .unwrap_or_default();
         deps.push((dep_id, subject));
@@ -260,12 +254,11 @@ fn scope_label(scope: &josh_changes::ChangesRef) -> String {
     }
 }
 
-fn build_oid_to_change_id(changes: &[josh_changes::Change]) -> HashMap<String, String> {
-    let mut map = HashMap::with_capacity(changes.len());
-    for c in changes {
-        map.insert(c.commit().to_string(), c.id().unwrap_or("").to_string());
-    }
-    map
+fn known_change_ids(changes: &[josh_changes::Change]) -> HashSet<String> {
+    changes
+        .iter()
+        .filter_map(|c| c.id().map(|s| s.to_string()))
+        .collect()
 }
 
 fn resolve_change_by_id(

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -315,13 +315,10 @@ pub fn load_rows(scope: &josh_changes::ChangesRef) -> anyhow::Result<ListData> {
 
     let changes = josh_changes::list_changes(&repo, scope)?;
 
-    let mut oid_to_change_id: HashMap<String, String> = HashMap::new();
-    for change in &changes {
-        oid_to_change_id.insert(
-            change.commit().to_string(),
-            change.id().unwrap_or("").to_string(),
-        );
-    }
+    let known: HashSet<String> = changes
+        .iter()
+        .filter_map(|c| c.id().map(|s| s.to_string()))
+        .collect();
 
     let mut rows = Vec::new();
     let mut dependencies: HashMap<String, Vec<String>> = HashMap::new();
@@ -338,15 +335,7 @@ pub fn load_rows(scope: &josh_changes::ChangesRef) -> anyhow::Result<ListData> {
 
         let change_id = change.id().unwrap_or("").to_string();
 
-        let mut deps: Vec<String> = Vec::new();
-        for oid in change.contributing(&repo)? {
-            let oid_str = oid.to_string();
-            if let Some(dep_id) = oid_to_change_id.get(&oid_str) {
-                if dep_id != &change_id {
-                    deps.push(dep_id.clone());
-                }
-            }
-        }
+        let deps: Vec<String> = change.dependency_ids(&repo, &known)?;
 
         rows.push(Row {
             change_id: change_id.clone(),

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -313,13 +313,10 @@ pub fn load_rows(scope: &josh_changes::ChangesRef) -> anyhow::Result<ListData> {
 
     let changes = josh_changes::list_changes(&transaction, scope)?;
 
-    let mut oid_to_change_id: HashMap<String, String> = HashMap::new();
-    for change in &changes {
-        oid_to_change_id.insert(
-            change.commit().to_string(),
-            change.id().unwrap_or("").to_string(),
-        );
-    }
+    let known: HashSet<String> = changes
+        .iter()
+        .filter_map(|c| c.id().map(|s| s.to_string()))
+        .collect();
 
     let mut rows = Vec::new();
     let mut dependencies: HashMap<String, Vec<String>> = HashMap::new();
@@ -331,15 +328,7 @@ pub fn load_rows(scope: &josh_changes::ChangesRef) -> anyhow::Result<ListData> {
 
         let change_id = change.id().unwrap_or("").to_string();
 
-        let mut deps: Vec<String> = Vec::new();
-        for oid in change.contributing(&transaction)? {
-            let oid_str = oid.to_string();
-            if let Some(dep_id) = oid_to_change_id.get(&oid_str) {
-                if dep_id != &change_id {
-                    deps.push(dep_id.clone());
-                }
-            }
-        }
+        let deps: Vec<String> = change.dependency_ids(&transaction, &known)?;
 
         rows.push(Row {
             change_id: change_id.clone(),


### PR DESCRIPTION
Match change dependencies by Change-Id

Split commits have different OIDs, so resolve dependencies from preserved
Change-Id trailers.

Change: deps-by-change-id-trailer
Assisted-By: anthropic/claude-opus-4-8
Assisted-By: openai-codex/gpt-5.6-sol