### PR TITLE
Split multi-component Op::Blob paths into a Prefix chain

### DIFF
--- a/josh-filter/src/opt.rs
+++ b/josh-filter/src/opt.rs
@@ -598,6 +598,17 @@ fn step(filter: Filter) -> Filter {
                 Op::Prefix(path)
             }
         }
+        Op::Blob(dest_path, content) if dest_path.components().count() > 1 => {
+            if let (Some(dst_parent), Some(dst_name)) = (dest_path.parent(), dest_path.file_name())
+            {
+                Op::Chain(vec![
+                    to_filter(Op::Blob(std::path::PathBuf::from(dst_name), content)),
+                    to_filter(Op::Prefix(dst_parent.to_path_buf())),
+                ])
+            } else {
+                Op::Blob(dest_path, content)
+            }
+        }
         Op::File(dest_path, source_path)
             if source_path.components().count() > 1 || dest_path.components().count() > 1 =>
         {

--- a/tests/experimental/blob.t
+++ b/tests/experimental/blob.t
@@ -21,6 +21,14 @@ Roundtrip: blob specified by sha renders as bare hex
   $ josh-filter -p ':$added.txt=e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
   :$added.txt=e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 
+A multi-component path is split into a leaf blob followed by a prefix
+  $ josh-filter -p ':$a/b/c.txt="hello"'
+  a/b = :$c.txt="hello"
+
+The split form is stable under another round-trip
+  $ josh-filter -p 'a/b = :$c.txt="hello"'
+  a/b = :$c.txt="hello"
+
 Inverse renders as :exclude[::path]
   $ josh-filter --reverse -p ':$added.txt="hello world"'
   :exclude[::added.txt]
@@ -29,6 +37,11 @@ Apply: blob is inserted at correct path with correct content
   $ josh-filter -s ':$added.txt="hello world"' master --update refs/josh/filter/master 1> /dev/null
   $ git show josh/filter/master:added.txt
   hello world (no-eol)
+
+Apply: blob at a multi-component path lands at the nested destination
+  $ josh-filter -s ':$a/b/c.txt="hello"' master --update refs/josh/filter/nested 1> /dev/null
+  $ git show josh/filter/nested:a/b/c.txt
+  hello (no-eol)
 
 Apply: compose with blob inserts blob alongside other files
   $ josh-filter -s ':[:/sub1,:$added.txt="hello world"]' master --update refs/josh/filter/master2 1> /dev/null
@@ -60,22 +73,28 @@ Apply: referencing a non-blob sha (a commit) fails
   $ josh-filter -s ":\$bad.txt=$COMMIT" master --update refs/josh/filter/bad 2> /dev/null
   [1] :$added.txt="hello world"
   [1] :$added.txt=422057123b178e433e852ef1dfee39368fb5a8ce
+  [1] :$c.txt="hello"
   [1] :[
       :/sub1
       :$added.txt="hello world"
   ]
-  [1] reachable_roots
-  [1] sequence_number
+  [1] :prefix=a
+  [1] :prefix=b
+  [3] reachable_roots
+  [3] sequence_number
   [1]
 
 Apply: referencing a nonexistent sha fails
   $ josh-filter -s ':$bad.txt=0000000000000000000000000000000000000001' master --update refs/josh/filter/bad2 2> /dev/null
   [1] :$added.txt="hello world"
   [1] :$added.txt=422057123b178e433e852ef1dfee39368fb5a8ce
+  [1] :$c.txt="hello"
   [1] :[
       :/sub1
       :$added.txt="hello world"
   ]
-  [1] reachable_roots
-  [1] sequence_number
+  [1] :prefix=a
+  [1] :prefix=b
+  [3] reachable_roots
+  [3] sequence_number
   [1]


### PR DESCRIPTION
Split multi-component Op::Blob paths into a Prefix chain

The optimizer's step() already rewrites a multi-component Op::File into a
Subdir/File/Prefix chain so the directory components become ordinary path ops
the optimizer can reason about (src_path2/dst_path2 ordering, prefix_sort,
cache reuse). Op::Blob had no such rule, so a blob written to a nested path
(e.g. :$a/b/c.txt=...) stayed opaque: dst_path2 returned an empty path for it.

Add the analogous rule. Op::Blob is generative -- apply() ignores the input
tree and inserts the content at dest_path -- so only the destination side of
the File pattern applies: Blob(a/b/c.txt, content) becomes a chain of
Blob(c.txt, content) followed by Prefix(a/b). A Subdir would be wrong here
since it reads the input tree the blob discards. The guard on >1 components
prevents re-triggering, and the multi-component Prefix is further decomposed
by the existing Op::Prefix arm.

Change: blob-split-prefix
Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>