### PR TITLE
Use HashSet for Subtract compose set-difference

### DIFF
--- a/josh-filter/src/opt.rs
+++ b/josh-filter/src/opt.rs
@@ -9,11 +9,12 @@ use crate::op::Op;
 use crate::persist::{peel_op, to_filter, to_op};
 use anyhow::anyhow;
 use std::cmp::Ordering;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
 use std::sync::LazyLock;
 
 type FilterHashMap = HashMap<Filter, Filter, BuildHasherDefault<PassthroughHasher>>;
+type FilterSet = HashSet<Filter, BuildHasherDefault<PassthroughHasher>>;
 
 static OPTIMIZED: LazyLock<std::sync::Mutex<FilterHashMap>> =
     LazyLock::new(|| std::sync::Mutex::new(HashMap::default()));
@@ -766,9 +767,14 @@ fn step(filter: Filter) -> Filter {
             }
             (_, Op::Compose(bv)) if bv.contains(&af) => to_op(step(to_filter(Op::Empty))),
             (Op::Compose(mut av), Op::Compose(mut bv)) => {
-                let v = av.clone();
-                av.retain(|x| !bv.contains(x));
-                bv.retain(|x| !v.contains(x));
+                // Set difference via hash lookup instead of linear `contains`,
+                // turning the O(N*M) retains into O(N+M). `Filter` is just a
+                // 20-byte git OID, so `PassthroughHasher` (identity) avoids
+                // rehashing bytes that are already a hash.
+                let bv_set: FilterSet = bv.iter().copied().collect();
+                let av_set: FilterSet = av.iter().copied().collect();
+                av.retain(|x| !bv_set.contains(x));
+                bv.retain(|x| !av_set.contains(x));
 
                 Op::Subtract(
                     step(to_filter(Op::Compose(av))),


### PR DESCRIPTION
Use HashSet for Subtract compose set-difference

The Op::Subtract arm handling Subtract(Compose(av), Compose(bv))
computed the symmetric difference with retain() over linear
slice::contains(), making it O(N*M). ultrawide_pin reaches this path
via Pin legalization in per_rev_filter, which builds
Subtract(Compose(N), Compose(N)) over the full workspace compose.

Build Filter HashSets with PassthroughHasher (Filter is a 20-byte git
OID, so rehashing it is wasted work) and look up membership in O(1),
turning the two retains into O(N+M). Semantics are unchanged: retain
preserves order and set membership matches slice contains. Drops
ultrawide_pin iteration time 83s -> 75s.

Change-Id: subtract-compose-hashset
Assisted-By: glm-5.2 <noreply@example.com>