### PR TITLE
Skip futile trailing-Compose distribution in flatten

### DIFF
--- a/josh-filter/src/opt.rs
+++ b/josh-filter/src/opt.rs
@@ -242,6 +242,16 @@ pub fn flatten(filter: Filter) -> Filter {
                     if !others_invertible {
                         break;
                     }
+                    // Distributing a trailing Compose that has a non-empty prefix is
+                    // futile: it produces Compose([Chain[prefix, z_j]]) which step()'s
+                    // common_pre re-merges back to Chain[prefix, Compose(Z)]. For the
+                    // Chain[file_chain, compose(pinned)] shape this is an O(N*|pinned|)
+                    // build+collapse round-trip that converges to the input, so skip it.
+                    // Leading/middle Composes yield branches that are not re-merged and
+                    // are still distributed.
+                    if flattened.len() > 1 && i == flattened.len() - 1 {
+                        continue;
+                    }
                     // Distribute: create a Compose where each element is the chain with one compose element
                     let mut result = vec![];
                     for compose_filter in compose_filters {


### PR DESCRIPTION
Skip futile trailing-Compose distribution in flatten

flatten distributes Chain[.., Compose(Z)] into Compose([Chain[..,
z_j]]). When the Compose is the trailing element with a non-empty
prefix, step's common_pre re-merges the result straight back to
Chain[prefix, Compose(Z)], so the distribution is a round-trip that
converges to the input.

In ultrawide_pin this shape is reached via the pin-legalization
Subtract in per_rev_filter: legalize_pin exposes compose(pinned) as a
bare trailing element of each of the N wide-chains, and flatten
distributing it builds an O(N*|pinned|) tree that step then collapses
again. Skipping that case turns that path from O(N*|pinned|) into O(N).

Leading/middle Compose elements still distribute; their branches are
not re-merged.

Change-Id: skip-trailing-compose-distribution
Assisted-By: glm-5.2 <noreply@example.com>