### PR TITLE
Intern filter Ops into hash-consed nodes

### DIFF
--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -1,5 +1,5 @@
 use crate::check_experimental_features_enabled;
-use crate::op::{BlobContent, LazyRef, Op};
+use crate::op::{BlobContent, LazyRef, Op, Regex};
 use crate::opt;
 use crate::persist::{self, to_filter, to_op};
 use std::sync::LazyLock;
@@ -242,13 +242,13 @@ impl Filter {
     pub fn message(self, m: &str) -> Filter {
         self.chain(to_filter(Op::Message(
             m.to_string(),
-            MESSAGE_MATCH_ALL_REGEX.clone(),
+            Regex(MESSAGE_MATCH_ALL_REGEX.clone()),
         )))
     }
 
     /// Chain a message filter that transforms commit messages
     pub fn message_regex(self, m: impl Into<String>, regex: regex::Regex) -> Filter {
-        self.chain(to_filter(Op::Message(m.into(), regex)))
+        self.chain(to_filter(Op::Message(m.into(), Regex(regex))))
     }
 
     /// Chain a hook filter

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -4,7 +4,7 @@ use crate::filter::Filter;
 use crate::opt;
 use crate::opt::invert;
 use crate::persist::to_filter;
-use crate::{BlobContent, LazyRef, Op, RevMatch};
+use crate::{BlobContent, LazyRef, Op, Regex, RevMatch};
 
 use anyhow::{Context, anyhow};
 use indoc::{formatdoc, indoc};
@@ -339,7 +339,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
                 .tuples()
                 .map(|(regex, replacement)| {
                     regex::Regex::new(&regex)
-                        .map(|r| (r, replacement))
+                        .map(|r| (Regex(r), replacement))
                         .context("invalid regex")
                 })
                 .collect::<Result<Vec<_>, _>>()?;

--- a/josh-filter/src/lib.rs
+++ b/josh-filter/src/lib.rs
@@ -9,7 +9,7 @@ pub use filter::{Filter, compose};
 pub use flang::parse;
 pub use flang::{as_file, pretty, spec};
 pub use op::LinkMode;
-pub use op::{BlobContent, LazyRef, Op, RevMatch};
+pub use op::{BlobContent, LazyRef, Op, Regex, RevMatch};
 
 static EXPERIMENTAL_FEATURES: std::sync::LazyLock<bool> =
     std::sync::LazyLock::new(|| std::env::var("JOSH_EXPERIMENTAL_FEATURES").as_deref() == Ok("1"));

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -1,11 +1,37 @@
 use crate::filter::Filter;
 use anyhow::anyhow;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum LinkMode {
     Embedded,
     Snapshot,
     Pointer,
+}
+
+/// Newtype around `regex::Regex` adding structural `PartialEq`/`Eq`/`Hash` (by pattern
+/// string) so `Op` can derive them for use as an interning key. Derefs to the inner regex.
+#[derive(Clone, Debug)]
+pub struct Regex(pub regex::Regex);
+
+impl std::ops::Deref for Regex {
+    type Target = regex::Regex;
+    fn deref(&self) -> &regex::Regex {
+        &self.0
+    }
+}
+
+impl PartialEq for Regex {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_str() == other.0.as_str()
+    }
+}
+
+impl Eq for Regex {}
+
+impl std::hash::Hash for Regex {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.as_str().hash(state);
+    }
 }
 
 impl std::fmt::Display for LinkMode {
@@ -35,13 +61,13 @@ pub enum LazyRef {
     Lazy(String),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum BlobContent {
     Inline(String),
     Oid(git2::Oid),
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum RevMatch {
     /// `<` - matches if is_ancestor_of(commit, tip) && commit != tip (strict)
     AncestorStrict,
@@ -77,7 +103,7 @@ impl LazyRef {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Op {
     Meta(std::collections::BTreeMap<String, String>, Filter),
 
@@ -100,7 +126,7 @@ pub enum Op {
     // Vec instead of BTreeMap to preserve order - first match wins
     Rev(Vec<(RevMatch, LazyRef, Filter)>),
     Prune,
-    RegexReplace(Vec<(regex::Regex, String)>),
+    RegexReplace(Vec<(Regex, String)>),
 
     Hook(String),
 
@@ -119,7 +145,7 @@ pub enum Op {
     ObjectRef(std::path::PathBuf),
 
     Pattern(String),
-    Message(String, regex::Regex),
+    Message(String, Regex),
 
     Unapply(LazyRef, Filter),
 

--- a/josh-filter/src/opt.rs
+++ b/josh-filter/src/opt.rs
@@ -6,7 +6,7 @@
 use crate::filter::Filter;
 use crate::hash::PassthroughHasher;
 use crate::op::Op;
-use crate::persist::{peel_op, to_filter, to_op};
+use crate::persist::{peel_op_ref, to_filter, to_op, to_op_ref};
 use anyhow::anyhow;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
@@ -54,7 +54,7 @@ fn normalize_path(path: &std::path::Path) -> std::path::PathBuf {
 }
 
 fn src_path(filter: Filter) -> std::path::PathBuf {
-    src_path2(&peel_op(filter))
+    src_path2(peel_op_ref(filter))
 }
 
 fn src_path2(op: &Op) -> std::path::PathBuf {
@@ -69,7 +69,7 @@ fn src_path2(op: &Op) -> std::path::PathBuf {
 }
 
 fn dst_path(filter: Filter) -> std::path::PathBuf {
-    dst_path2(&peel_op(filter))
+    dst_path2(peel_op_ref(filter))
 }
 
 fn dst_path2(op: &Op) -> std::path::PathBuf {
@@ -119,14 +119,14 @@ pub fn simplify(filter: Filter) -> Filter {
         return *f;
     }
     let original = filter;
-    let result = to_filter(match to_op(filter) {
+    let result = to_filter(match to_op_ref(filter) {
         Op::Compose(filters) => {
             let mut out = vec![];
             for f in filters {
-                if let Op::Compose(mut v) = to_op(f) {
-                    out.append(&mut v);
+                if let Op::Compose(v) = to_op_ref(*f) {
+                    out.extend(v.iter().copied());
                 } else {
-                    out.push(f);
+                    out.push(*f);
                 }
             }
             Op::Compose(out.drain(..).map(simplify).collect())
@@ -135,10 +135,10 @@ pub fn simplify(filter: Filter) -> Filter {
             // Flatten nested chains
             let mut flattened = Vec::with_capacity(filters.len());
             for filter in filters {
-                if let Op::Chain(nested) = to_op(filter) {
-                    flattened.extend(nested);
+                if let Op::Chain(nested) = to_op_ref(*filter) {
+                    flattened.extend(nested.iter().copied());
                 } else {
-                    flattened.push(filter);
+                    flattened.push(*filter);
                 }
             }
             // Simplify each filter
@@ -148,7 +148,7 @@ pub fn simplify(filter: Filter) -> Filter {
             let mut i = 0;
             while i < simplified.len() {
                 if i + 1 < simplified.len() {
-                    match (to_op(simplified[i]), to_op(simplified[i + 1])) {
+                    match (to_op_ref(simplified[i]), to_op_ref(simplified[i + 1])) {
                         (Op::Prefix(x), Op::Prefix(y)) => {
                             result.push(to_filter(Op::Prefix(y.join(x))));
                             i += 2;
@@ -171,14 +171,11 @@ pub fn simplify(filter: Filter) -> Filter {
                 Op::Chain(result)
             }
         }
-        Op::Subtract(a, b) => {
-            let (a, b) = (to_op(a), to_op(b));
-            Op::Subtract(simplify(to_filter(a)), simplify(to_filter(b)))
-        }
-        Op::Exclude(b) => Op::Exclude(simplify(b)),
-        Op::Pin(b) => Op::Pin(simplify(b)),
-        Op::Starlark(path, sub) => Op::Starlark(path.clone(), simplify(sub)),
-        Op::TreeId(path, sub) => Op::TreeId(path.clone(), simplify(sub)),
+        Op::Subtract(a, b) => Op::Subtract(simplify(*a), simplify(*b)),
+        Op::Exclude(b) => Op::Exclude(simplify(*b)),
+        Op::Pin(b) => Op::Pin(simplify(*b)),
+        Op::Starlark(path, sub) => Op::Starlark(path.clone(), simplify(*sub)),
+        Op::TreeId(path, sub) => Op::TreeId(path.clone(), simplify(*sub)),
         Op::ObjectDeref(_) => to_op(filter),
         Op::ObjectRef(_) => to_op(filter),
         _ => to_op(filter),
@@ -204,14 +201,14 @@ pub fn flatten(filter: Filter) -> Filter {
         return *f;
     }
     let original = filter;
-    let result = to_filter(match to_op(filter) {
+    let result = to_filter(match to_op_ref(filter) {
         Op::Compose(filters) => {
             let mut out = vec![];
             for f in filters {
-                if let Op::Compose(mut v) = to_op(f) {
-                    out.append(&mut v);
+                if let Op::Compose(v) = to_op_ref(*f) {
+                    out.extend(v.iter().copied());
                 } else {
-                    out.push(f);
+                    out.push(*f);
                 }
             }
             Op::Compose(out.drain(..).map(flatten).collect())
@@ -220,15 +217,15 @@ pub fn flatten(filter: Filter) -> Filter {
             // Flatten nested chains first
             let mut flattened = vec![];
             for filter in filters {
-                if let Op::Chain(nested) = to_op(filter) {
-                    flattened.extend(nested);
+                if let Op::Chain(nested) = to_op_ref(*filter) {
+                    flattened.extend(nested.iter().copied());
                 } else {
-                    flattened.push(filter);
+                    flattened.push(*filter);
                 }
             }
             // Check if any filter is a Compose and distribute
             for (i, filter) in flattened.iter().enumerate() {
-                if let Op::Compose(compose_filters) = to_op(*filter) {
+                if let Op::Compose(compose_filters) = to_op_ref(*filter) {
                     // Distribution duplicates the other chain elements into
                     // each branch of a new Compose. Compose children must be
                     // invertible (downstream `step()`/`common_post` calls
@@ -247,7 +244,7 @@ pub fn flatten(filter: Filter) -> Filter {
                     let mut result = vec![];
                     for compose_filter in compose_filters {
                         let mut new_chain = flattened.clone();
-                        new_chain[i] = compose_filter;
+                        new_chain[i] = *compose_filter;
                         result.push(to_filter(Op::Chain(new_chain)));
                     }
                     let distributed = to_filter(Op::Compose(result));
@@ -257,14 +254,11 @@ pub fn flatten(filter: Filter) -> Filter {
             }
             Op::Chain(flattened.iter().map(|f| flatten(*f)).collect())
         }
-        Op::Subtract(a, b) => {
-            let (a, b) = (to_op(a), to_op(b));
-            Op::Subtract(flatten(to_filter(a)), flatten(to_filter(b)))
-        }
-        Op::Exclude(b) => Op::Exclude(flatten(b)),
-        Op::Pin(b) => Op::Pin(flatten(b)),
-        Op::Starlark(path, sub) => Op::Starlark(path.clone(), flatten(sub)),
-        Op::TreeId(path, sub) => Op::TreeId(path.clone(), flatten(sub)),
+        Op::Subtract(a, b) => Op::Subtract(flatten(*a), flatten(*b)),
+        Op::Exclude(b) => Op::Exclude(flatten(*b)),
+        Op::Pin(b) => Op::Pin(flatten(*b)),
+        Op::Starlark(path, sub) => Op::Starlark(path.clone(), flatten(*sub)),
+        Op::TreeId(path, sub) => Op::TreeId(path.clone(), flatten(*sub)),
         Op::ObjectDeref(_) => to_op(filter),
         Op::ObjectRef(_) => to_op(filter),
         _ => to_op(filter),
@@ -290,9 +284,9 @@ fn group(filters: &Vec<Filter>) -> Vec<Vec<Filter>> {
             continue;
         }
 
-        if let Op::Chain(filters) = to_op(*f)
+        if let Op::Chain(filters) = to_op_ref(*f)
             && !filters.is_empty()
-            && let Op::Chain(other_filters) = to_op(res[res.len() - 1][0])
+            && let Op::Chain(other_filters) = to_op_ref(res[res.len() - 1][0])
             && !other_filters.is_empty()
             && filters[0] == other_filters[0]
         {
@@ -327,7 +321,7 @@ fn group(filters: &Vec<Filter>) -> Vec<Vec<Filter>> {
 }
 
 fn last_chain(rest: Filter, filter: Filter) -> (Filter, Filter) {
-    match to_op(filter) {
+    match to_op_ref(filter) {
         Op::Chain(filters) => {
             if filters.is_empty() {
                 (rest, filter)
@@ -482,7 +476,7 @@ fn common_pre(filters: &Vec<Filter>) -> Option<(Filter, Vec<Filter>)> {
     let mut rest = vec![];
     let mut c: Option<Filter> = None;
     for f in filters {
-        if let Op::Chain(chain_filters) = to_op(*f) {
+        if let Op::Chain(chain_filters) = to_op_ref(*f) {
             if !chain_filters.is_empty() {
                 let first = chain_filters[0];
                 let rest_chain = if chain_filters.len() > 1 {
@@ -525,9 +519,9 @@ fn common_post(filters: &Vec<Filter>) -> Option<(Filter, Vec<Filter>)> {
     if let Some(c) = common_post {
         if invert(c).is_ok() && invert(c).unwrap() == c {
             common_post.map(|c| (c, rest))
-        } else if let Op::Prefix(_) = to_op(c) {
+        } else if let Op::Prefix(_) = to_op_ref(c) {
             common_post.map(|c| (c, rest))
-        } else if let Op::Message(..) = to_op(c) {
+        } else if let Op::Message(..) = to_op_ref(c) {
             common_post.map(|c| (c, rest))
         } else {
             None
@@ -574,7 +568,7 @@ fn step(filter: Filter) -> Filter {
         return *f;
     }
     let original = filter;
-    let result = to_filter(match to_op(filter) {
+    let result = to_filter(match to_op_ref(filter) {
         Op::Subdir(path) if path.as_os_str().is_empty() => Op::Nop,
         Op::Subdir(path) => {
             if path.components().count() > 1 {
@@ -584,7 +578,7 @@ fn step(filter: Filter) -> Filter {
                         .collect(),
                 )
             } else {
-                Op::Subdir(path)
+                Op::Subdir(path.clone())
             }
         }
         Op::Prefix(path) if path.as_os_str().is_empty() => Op::Nop,
@@ -597,18 +591,21 @@ fn step(filter: Filter) -> Filter {
                         .collect(),
                 )
             } else {
-                Op::Prefix(path)
+                Op::Prefix(path.clone())
             }
         }
         Op::Blob(dest_path, content) if dest_path.components().count() > 1 => {
             if let (Some(dst_parent), Some(dst_name)) = (dest_path.parent(), dest_path.file_name())
             {
                 Op::Chain(vec![
-                    to_filter(Op::Blob(std::path::PathBuf::from(dst_name), content)),
+                    to_filter(Op::Blob(
+                        std::path::PathBuf::from(dst_name),
+                        content.clone(),
+                    )),
                     to_filter(Op::Prefix(dst_parent.to_path_buf())),
                 ])
             } else {
-                Op::Blob(dest_path, content)
+                Op::Blob(dest_path.clone(), content.clone())
             }
         }
         Op::File(dest_path, source_path)
@@ -629,18 +626,19 @@ fn step(filter: Filter) -> Filter {
                     to_filter(Op::Prefix(dst_parent.to_path_buf())),
                 ])
             } else {
-                Op::File(dest_path, source_path)
+                Op::File(dest_path.clone(), source_path.clone())
             }
         }
         Op::Rev(filters) => Op::Rev(
             filters
-                .into_iter()
-                .map(|(m, i, f)| (m, i, step(f)))
+                .iter()
+                .map(|(m, i, f)| (*m, i.clone(), step(*f)))
                 .collect(),
         ),
         Op::Compose(filters) if filters.is_empty() => Op::Empty,
         Op::Compose(filters) if filters.len() == 1 => to_op(filters[0]),
-        Op::Compose(mut filters) => {
+        Op::Compose(filters) => {
+            let mut filters = filters.clone();
             filters.dedup();
             filters.retain(|x| *x != to_filter(Op::Empty));
             let mut grouped = group(&filters);
@@ -663,10 +661,10 @@ fn step(filter: Filter) -> Filter {
         Op::Chain(filters) => {
             // Flatten nested chains
             let mut flattened = vec![];
-            for filter in &filters {
+            for filter in filters {
                 let filter = step(*filter);
-                if let Op::Chain(nested) = to_op(filter) {
-                    flattened.extend(nested);
+                if let Op::Chain(nested) = to_op_ref(filter) {
+                    flattened.extend(nested.iter().copied());
                 } else {
                     flattened.push(filter);
                 }
@@ -689,7 +687,7 @@ fn step(filter: Filter) -> Filter {
             let mut i = 0;
             while i < flattened.len() {
                 if i + 1 < flattened.len() {
-                    match (to_op(flattened[i]), to_op(flattened[i + 1])) {
+                    match (to_op_ref(flattened[i]), to_op_ref(flattened[i + 1])) {
                         (Op::Prefix(a), Op::Subdir(b)) if a == b => {
                             // Skip both, they cancel out
                             i += 2;
@@ -716,74 +714,77 @@ fn step(filter: Filter) -> Filter {
                 Op::Chain(result)
             }
         }
-        Op::Exclude(b) if b == to_filter(Op::Nop) => Op::Empty,
-        Op::Exclude(b) | Op::Pin(b) if b == to_filter(Op::Empty) => Op::Nop,
-        Op::Exclude(b) => Op::Exclude(step(b)),
-        Op::Pin(b) => Op::Pin(step(b)),
-        Op::Starlark(path, sub) => Op::Starlark(path.clone(), step(sub)),
-        Op::TreeId(path, sub) => Op::TreeId(path.clone(), step(sub)),
+        Op::Exclude(b) if *b == to_filter(Op::Nop) => Op::Empty,
+        Op::Exclude(b) | Op::Pin(b) if *b == to_filter(Op::Empty) => Op::Nop,
+        Op::Exclude(b) => Op::Exclude(step(*b)),
+        Op::Pin(b) => Op::Pin(step(*b)),
+        Op::Starlark(path, sub) => Op::Starlark(path.clone(), step(*sub)),
+        Op::TreeId(path, sub) => Op::TreeId(path.clone(), step(*sub)),
         Op::ObjectDeref(_) => to_op(filter),
         Op::ObjectRef(_) => to_op(filter),
         Op::Subtract(a, b) if a == b => Op::Empty,
-        Op::Subtract(af, bf) => match (to_op(af), to_op(bf)) {
-            (Op::Empty, _) => Op::Empty,
-            (Op::Message(..), Op::Message(..)) => Op::Empty,
-            (_, Op::Nop) => Op::Empty,
-            (a, Op::Empty) => a,
-            (Op::Chain(a_filters), Op::Chain(b_filters))
-                if !a_filters.is_empty()
-                    && !b_filters.is_empty()
-                    && a_filters[0] == b_filters[0] =>
-            {
-                let mut new_a = a_filters.clone();
-                let mut new_b = b_filters.clone();
-                let common = new_a.remove(0);
-                new_b.remove(0);
-                Op::Chain(vec![
-                    common,
+        Op::Subtract(af, bf) => {
+            let (af, bf) = (*af, *bf);
+            match (to_op(af), to_op(bf)) {
+                (Op::Empty, _) => Op::Empty,
+                (Op::Message(..), Op::Message(..)) => Op::Empty,
+                (_, Op::Nop) => Op::Empty,
+                (a, Op::Empty) => a,
+                (Op::Chain(a_filters), Op::Chain(b_filters))
+                    if !a_filters.is_empty()
+                        && !b_filters.is_empty()
+                        && a_filters[0] == b_filters[0] =>
+                {
+                    let mut new_a = a_filters.clone();
+                    let mut new_b = b_filters.clone();
+                    let common = new_a.remove(0);
+                    new_b.remove(0);
+                    Op::Chain(vec![
+                        common,
+                        to_filter(Op::Subtract(
+                            to_filter(Op::Chain(new_a)),
+                            to_filter(Op::Chain(new_b)),
+                        )),
+                    ])
+                }
+                (_, b) if prefix_of(b.clone()) != to_filter(Op::Nop) => {
+                    Op::Subtract(af, last_chain(to_filter(Op::Nop), to_filter(b)).0)
+                }
+                (a, _) if prefix_of(a.clone()) != to_filter(Op::Nop) => Op::Chain(vec![
                     to_filter(Op::Subtract(
-                        to_filter(Op::Chain(new_a)),
-                        to_filter(Op::Chain(new_b)),
+                        last_chain(to_filter(Op::Nop), to_filter(a.clone())).0,
+                        bf,
                     )),
-                ])
-            }
-            (_, b) if prefix_of(b.clone()) != to_filter(Op::Nop) => {
-                Op::Subtract(af, last_chain(to_filter(Op::Nop), to_filter(b)).0)
-            }
-            (a, _) if prefix_of(a.clone()) != to_filter(Op::Nop) => Op::Chain(vec![
-                to_filter(Op::Subtract(
-                    last_chain(to_filter(Op::Nop), to_filter(a.clone())).0,
-                    bf,
-                )),
-                prefix_of(a),
-            ]),
-            (_, b) if is_prefix(b.clone()) => Op::Subtract(af, to_filter(Op::Nop)),
-            _ if common_post(&vec![af, bf]).is_some_and(|cp| cp.0 != to_filter(Op::Nop)) => {
-                let (cp, rest) = common_post(&vec![af, bf]).unwrap();
-                Op::Chain(vec![to_filter(Op::Subtract(rest[0], rest[1])), cp])
-            }
-            (Op::Compose(mut av), _) if av.contains(&bf) => {
-                av.retain(|x| *x != bf);
-                to_op(step(to_filter(Op::Compose(av))))
-            }
-            (_, Op::Compose(bv)) if bv.contains(&af) => to_op(step(to_filter(Op::Empty))),
-            (Op::Compose(mut av), Op::Compose(mut bv)) => {
-                // Set difference via hash lookup instead of linear `contains`,
-                // turning the O(N*M) retains into O(N+M). `Filter` is just a
-                // 20-byte git OID, so `PassthroughHasher` (identity) avoids
-                // rehashing bytes that are already a hash.
-                let bv_set: FilterSet = bv.iter().copied().collect();
-                let av_set: FilterSet = av.iter().copied().collect();
-                av.retain(|x| !bv_set.contains(x));
-                bv.retain(|x| !av_set.contains(x));
+                    prefix_of(a),
+                ]),
+                (_, b) if is_prefix(b.clone()) => Op::Subtract(af, to_filter(Op::Nop)),
+                _ if common_post(&vec![af, bf]).is_some_and(|cp| cp.0 != to_filter(Op::Nop)) => {
+                    let (cp, rest) = common_post(&vec![af, bf]).unwrap();
+                    Op::Chain(vec![to_filter(Op::Subtract(rest[0], rest[1])), cp])
+                }
+                (Op::Compose(mut av), _) if av.contains(&bf) => {
+                    av.retain(|x| *x != bf);
+                    to_op(step(to_filter(Op::Compose(av))))
+                }
+                (_, Op::Compose(bv)) if bv.contains(&af) => to_op(step(to_filter(Op::Empty))),
+                (Op::Compose(mut av), Op::Compose(mut bv)) => {
+                    // Set difference via hash lookup instead of linear `contains`,
+                    // turning the O(N*M) retains into O(N+M). `Filter` is just a
+                    // 20-byte git OID, so `PassthroughHasher` (identity) avoids
+                    // rehashing bytes that are already a hash.
+                    let bv_set: FilterSet = bv.iter().copied().collect();
+                    let av_set: FilterSet = av.iter().copied().collect();
+                    av.retain(|x| !bv_set.contains(x));
+                    bv.retain(|x| !av_set.contains(x));
 
-                Op::Subtract(
-                    step(to_filter(Op::Compose(av))),
-                    step(to_filter(Op::Compose(bv))),
-                )
+                    Op::Subtract(
+                        step(to_filter(Op::Compose(av))),
+                        step(to_filter(Op::Compose(bv))),
+                    )
+                }
+                (a, b) => Op::Subtract(step(to_filter(a)), step(to_filter(b))),
             }
-            (a, b) => Op::Subtract(step(to_filter(a)), step(to_filter(b))),
-        },
+        }
         _ => to_op(filter),
     });
 
@@ -797,22 +798,26 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
     }
 
     let computed = (|| -> anyhow::Result<Filter> {
-        let result = match to_op(filter) {
+        let result = match to_op_ref(filter) {
             Op::Nop => Some(Op::Nop),
             Op::Message(..) => Some(Op::Nop),
             Op::Prune => Some(Op::Prune),
             Op::Export => Some(Op::Export),
             Op::Empty => Some(Op::Empty),
             Op::Link(..) => Some(Op::Unlink),
-            Op::Subdir(path) => Some(Op::Prefix(path)),
-            Op::File(dest_path, source_path) => Some(Op::File(source_path, dest_path)),
-            Op::Prefix(path) => Some(Op::Subdir(path)),
-            Op::Pattern(pattern) => Some(Op::Pattern(pattern)),
+            Op::Subdir(path) => Some(Op::Prefix(path.clone())),
+            Op::File(dest_path, source_path) => {
+                Some(Op::File(source_path.clone(), dest_path.clone()))
+            }
+            Op::Prefix(path) => Some(Op::Subdir(path.clone())),
+            Op::Pattern(pattern) => Some(Op::Pattern(pattern.clone())),
             Op::Rev(_) => Some(Op::Nop),
             Op::RegexReplace(_) => Some(Op::Nop),
             Op::Pin(_) => Some(Op::Nop),
-            Op::Blob(path, _) => Some(Op::Exclude(to_filter(Op::File(path.clone(), path)))),
-            Op::TreeId(path, _) => Some(Op::Exclude(to_filter(Op::File(path.clone(), path)))),
+            Op::Blob(path, _) => Some(Op::Exclude(to_filter(Op::File(path.clone(), path.clone())))),
+            Op::TreeId(path, _) => {
+                Some(Op::Exclude(to_filter(Op::File(path.clone(), path.clone()))))
+            }
             Op::ObjectDeref(path) => Some(Op::ObjectRef(path.clone())),
             Op::ObjectRef(path) => Some(Op::ObjectDeref(path.clone())),
             _ => None,
@@ -822,8 +827,8 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
             return Ok(to_filter(result));
         }
 
-        let result = to_filter(match to_op(filter) {
-            Op::Meta(m, f) => Op::Meta(m, invert(f)?),
+        let result = to_filter(match to_op_ref(filter) {
+            Op::Meta(m, f) => Op::Meta(m.clone(), invert(*f)?),
             Op::Chain(filters) => {
                 let inverted: Vec<_> = filters
                     .iter()
@@ -834,11 +839,11 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
             }
             Op::Compose(filters) => Op::Compose(
                 filters
-                    .into_iter()
-                    .map(invert)
+                    .iter()
+                    .map(|f| invert(*f))
                     .collect::<Result<Vec<_>, _>>()?,
             ),
-            Op::Exclude(filter) => Op::Exclude(invert(filter)?),
+            Op::Exclude(filter) => Op::Exclude(invert(*filter)?),
             _ => return Err(anyhow!("no invert {:?}", filter)),
         });
 

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -3,44 +3,75 @@ use gix_object::WriteTo;
 use gix_object::bstr::BString;
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, OnceLock};
 
 use crate::filter::{Filter, reachable_roots, sequence_number};
 use crate::hash::PassthroughHasher;
-use crate::op::{BlobContent, LazyRef, Op, RevMatch};
+use crate::op::{BlobContent, LazyRef, Op, Regex, RevMatch};
 
+/// An interned, immutable `Op` together with its lazily-computed `Filter` OID.
+/// Nodes are leaked (`&'static`) and live for the process lifetime, exactly like the
+/// `Op`s previously stored in `FILTERS`. The OID is built at most once via `build_op`.
+pub(crate) struct Node {
+    op: Op,
+    oid: OnceLock<git2::Oid>,
+}
+
+/// `Filter` (OID) -> node, populated when a node's OID is first materialized in `to_filter`.
+/// Used by `to_op_ref` to resolve a `Filter` back to its `Op` without cloning.
 pub(crate) static FILTERS: LazyLock<
-    std::sync::Mutex<HashMap<Filter, Op, BuildHasherDefault<PassthroughHasher>>>,
+    std::sync::Mutex<HashMap<Filter, &'static Node, BuildHasherDefault<PassthroughHasher>>>,
 > = LazyLock::new(Default::default);
 
+/// Canonicalizes each `Op` to a single interned node by structural equality, so `to_filter`
+/// can skip `build_op` when an equal `Op` was interned before. `Op` derives `Hash`/`Eq`, so
+/// the `Op` itself is the key — no separate fingerprint.
+static INTERN: LazyLock<std::sync::Mutex<HashMap<Op, &'static Node>>> =
+    LazyLock::new(Default::default);
+
+static NOP_OP: Op = Op::Nop;
+
 pub fn peel_op(filter: Filter) -> Op {
-    let op = to_op(filter);
+    peel_op_ref(filter).clone()
+}
+
+pub fn peel_op_ref(filter: Filter) -> &'static Op {
+    let op = to_op_ref(filter);
     if let Op::Meta(_, f) = op {
-        peel_op(f)
+        peel_op_ref(*f)
     } else {
         op
     }
 }
 
 pub fn to_op(filter: Filter) -> Op {
+    to_op_ref(filter).clone()
+}
+
+pub fn to_op_ref(filter: Filter) -> &'static Op {
     if filter == sequence_number() || filter == reachable_roots() {
-        return Op::Nop;
+        return &NOP_OP;
     }
-    FILTERS
+    let node = *FILTERS
         .lock()
         .unwrap()
         .get(&filter)
-        .expect("unknown filter")
-        .clone()
+        .expect("unknown filter");
+    &node.op
 }
 
 pub fn to_ops(filters: &[Filter]) -> Vec<Op> {
     filters.iter().map(|x| to_op(*x)).collect()
 }
 
-/// Get a clone of the FILTERS map for use in as_tree/from_tree
+/// Get the known `Filter` -> `Op` mappings for use in as_tree/from_tree.
 pub fn get_filters() -> HashMap<Filter, Op, BuildHasherDefault<PassthroughHasher>> {
-    FILTERS.lock().unwrap().clone()
+    FILTERS
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|(f, node)| (*f, node.op.clone()))
+        .collect()
 }
 
 fn push_blob_entries(
@@ -284,7 +315,7 @@ impl InMemoryBuilder {
 
     fn build_regex_replace_params(
         &mut self,
-        replacements: &[(regex::Regex, String)],
+        replacements: &[(Regex, String)],
     ) -> gix_hash::ObjectId {
         let mut outer_entries = Vec::new();
         for (i, (regex, replacement)) in replacements.iter().enumerate() {
@@ -501,14 +532,32 @@ impl InMemoryBuilder {
     }
 }
 
-pub fn to_filter(op: Op) -> Filter {
-    let mut builder = InMemoryBuilder::new();
-    let tree_id = builder.build_op(&op).expect("failed to build op");
-    let oid = git2::Oid::from_bytes(tree_id.as_bytes()).unwrap();
+// Canonicalize an `Op` to its single interned node via structural equality. On a hit we
+// return the existing node and drop `op`; on a miss we leak a node (its `Op` lives for the
+// process, exactly like the old `FILTERS` map) and key it by a clone of the `Op`.
+fn intern(op: Op) -> &'static Node {
+    let mut intern = INTERN.lock().unwrap();
+    if let Some(node) = intern.get(&op) {
+        return node;
+    }
+    let node: &'static Node = Box::leak(Box::new(Node {
+        op: op.clone(),
+        oid: OnceLock::new(),
+    }));
+    intern.insert(op, node);
+    node
+}
 
-    let f = Filter(oid);
-    FILTERS.lock().unwrap().entry(f).or_insert(op);
-    f
+pub fn to_filter(op: Op) -> Filter {
+    let node = intern(op);
+    let oid = *node.oid.get_or_init(|| {
+        let mut builder = InMemoryBuilder::new();
+        let tree_id = builder.build_op(&node.op).expect("failed to build op");
+        let oid = git2::Oid::from_bytes(tree_id.as_bytes()).unwrap();
+        FILTERS.lock().unwrap().entry(Filter(oid)).or_insert(node);
+        oid
+    });
+    Filter(oid)
 }
 
 pub fn as_tree(repo: &git2::Repository, filter: Filter) -> anyhow::Result<git2::Oid> {
@@ -670,7 +719,7 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             let fmt = std::str::from_utf8(fmt_blob.content())?.to_string();
             let regex_str = std::str::from_utf8(regex_blob.content())?;
             let regex = regex::Regex::new(regex_str).context("invalid regex")?;
-            Ok(Op::Message(fmt, regex))
+            Ok(Op::Message(fmt, Regex(regex)))
         }
         "subdir" => {
             let inner = repo.find_tree(entry.id())?;
@@ -1003,7 +1052,7 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
                 let regex_str = std::str::from_utf8(regex_blob.content())?;
                 let replacement = std::str::from_utf8(replacement_blob.content())?.to_string();
                 let regex = regex::Regex::new(regex_str)?;
-                replacements.push((regex, replacement));
+                replacements.push((Regex(regex), replacement));
             }
             Ok(Op::RegexReplace(replacements))
         }


### PR DESCRIPTION
Intern filter Ops into hash-consed nodes

The filter optimizer paid two repeated costs per node. to_op() locked a
global map and deep-cloned the stored Op (the Vec<Filter> of a large
Compose/Chain, plus paths) on each of its ~37 hot call sites, and
to_filter() re-ran build_op() -- a gix tree serialize plus SHA-1 -- on
every call, even though the great majority rebuilt an Op whose value was
already known.

Intern each Op into a single leaked &'static Node that owns the Op and
caches its OID in a OnceLock, so build_op() runs at most once per unique
Op. to_op_ref() hands out a borrow into that node instead of cloning, and
the optimizer reads through &Op, cloning only the inner Vec at the few
sites that mutate it. Filter stays content-addressed by its OID, so
persistence, the distributed/sled/transaction caches, sentinels and
pretty-printed output are all unchanged.

The interner is keyed by the Op itself through a structural Hash/Eq
rather than a hand-built byte fingerprint; a small Regex newtype (compared
by pattern string) lets Op derive those traits. This also deduplicates the
regex/squash/rev variants that the old fingerprint skipped.

Change: intern-filter-ops
Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>