### PR TITLE
Keep git_odb__freshen off the filter write path

### DIFF
--- a/josh-git-data/src/mem_odb.rs
+++ b/josh-git-data/src/mem_odb.rs
@@ -50,13 +50,12 @@ impl MemOdb {
         })
     }
 
-    /// Register a backend on `repo`'s object database that reads from / writes to this store, at a
-    /// priority above the on-disk loose (2) and pack (1) backends, so writes land in memory and reads
-    /// check memory first.
+    /// Replace `repo`'s object database with a backend that reads from / writes to this store,
+    /// delegating read-side misses to the original on-disk ODB (see [`odb_backend::register`]), so
+    /// writes land in memory and reads check memory first.
     pub fn register(self: &Arc<Self>, repo: &git2::Repository) {
         let _ = odb_backend::register(
             repo,
-            1000,
             MemBackend {
                 store: self.clone(),
             },
@@ -89,7 +88,6 @@ impl MemOdb {
         let repo = git2::Repository::open(&self.repo_path)?;
         odb_backend::register(
             &repo,
-            1000,
             MemBackend {
                 store: self.clone(),
             },
@@ -111,13 +109,20 @@ impl MemOdb {
             inner.map.keys().copied().collect()
         };
 
-        let mut pb = repo.packbuilder()?;
-        for oid in &oids {
-            pb.insert_object(*oid, None)?;
+        // The memory-only freshen (see `odb_backend`) no longer deduplicates writes against disk,
+        // so objects already present on disk may have been re-buffered into the store. Pack only the
+        // genuinely-new ones — `filter_absent_on_disk` preserves the sorted oid order, so the
+        // packfile (and its name) stays deterministic.
+        let to_pack = odb_backend::filter_absent_on_disk(repo, &oids);
+        if !to_pack.is_empty() {
+            let mut pb = repo.packbuilder()?;
+            for oid in &to_pack {
+                pb.insert_object(*oid, None)?;
+            }
+            // `packfile_path` resolves the common object directory, so this is correct for linked
+            // worktrees (whose gitdir has no `objects/` of its own) as well as normal repos.
+            pb.write(&crate::pack::packfile_path(repo), 0)?;
         }
-        // `packfile_path` resolves the common object directory, so this is correct for linked
-        // worktrees (whose gitdir has no `objects/` of its own) as well as normal repos.
-        pb.write(&crate::pack::packfile_path(repo), 0)?;
 
         // Dropping the whole map (rather than only the flushed oids) is safe because a store is
         // never flushed with writes in flight.
@@ -135,8 +140,8 @@ struct MemBackend {
 }
 
 fn not_found() -> git2::Error {
-    // ErrorCode::NotFound maps to GIT_ENOTFOUND, so a miss makes libgit2 fall through to the next
-    // backend (the on-disk pack/loose backends) instead of treating it as a hard failure.
+    // ErrorCode::NotFound signals a memory miss, which the backend trampolines resolve by reading
+    // through to the delegate on-disk ODB instead of treating it as a hard failure.
     git2::Error::new(
         ErrorCode::NotFound,
         ErrorClass::Odb,

--- a/josh-git-data/src/odb_backend.rs
+++ b/josh-git-data/src/odb_backend.rs
@@ -1,18 +1,28 @@
 //! Generic scaffolding for a custom libgit2 ODB backend.
 //!
 //! [`OdbBackend`] is a safe Rust trait; [`register`] lifts any implementation into a
-//! `git_odb_backend` registered on a repository's object database. The trait shape mirrors the
-//! `git2-rs` fork (branch `metahead/odb-backends`), where a safe trait object is wrapped by a
-//! `#[repr(C)]` [`RawOdbBackend`] and called through `extern "C"` trampolines.
+//! `git_odb_backend` and installs it on a repository. The trait shape mirrors the `git2-rs` fork
+//! (branch `metahead/odb-backends`), where a safe trait object is wrapped by a `#[repr(C)]`
+//! [`RawOdbBackend`] and called through `extern "C"` trampolines.
+//!
+//! Rather than registering the backend *alongside* the repository's on-disk loose/pack backends,
+//! [`register`] *replaces* the repository's entire ODB with a new one containing only this backend,
+//! which delegates read-side misses to the original on-disk ODB (kept as [`RawOdbBackend::delegate`]).
+//! The reason is `git_odb_write`: it unconditionally calls `git_odb__freshen` before every write,
+//! and freshen walks the ODB's backends doing a per-object filesystem stat/touch on the loose
+//! backend. With the loose/pack backends absent from the repo's ODB and a memory-only `freshen`
+//! callback on this backend, that wasted disk I/O disappears from the filter hot path while reads
+//! still resolve on-disk objects via delegation.
 //!
 //! git2 does not expose the raw `git_odb`/`git_repository` pointers (its `Binding` trait is
 //! private), so [`register`] reads the pointer out of the single-field `Repository` newtype. That
-//! cast is sound only while josh pins `git2` exactly and must be re-verified on every upgrade.
+//! cast is sound only while josh pins `git2` exactly and must be re-verified on every upgrade, along
+//! with the continued presence of `git_odb_new`/`git_repository_set_odb`/`git_odb_object_*`.
 
 use std::ffi::{c_int, c_void};
 use std::ptr;
 
-use git2::{ObjectType, Oid};
+use git2::{ErrorCode, ObjectType, Oid};
 use libgit2_sys as raw;
 
 /// A safe Rust interface to a libgit2 object-database backend.
@@ -20,8 +30,7 @@ use libgit2_sys as raw;
 /// Any implementation is turned into a `git_odb_backend` by [`register`]. Methods receive
 /// [`git2::Oid`] / [`git2::ObjectType`] and return [`git2::Error`] so any libgit2 failure code can
 /// be signalled: signal "not present here" with [`git2::ErrorCode::NotFound`], which the trampoline
-/// forwards as `GIT_ENOTFOUND` so libgit2 falls through to the next backend (e.g. the on-disk
-/// pack/loose backends). Any other error code propagates and aborts the lookup.
+/// forwards to the on-disk delegate. Any other error code propagates and aborts the lookup.
 pub trait OdbBackend {
     fn read_header(&self, oid: Oid) -> Result<(usize, ObjectType), git2::Error>;
     fn read(&self, oid: Oid) -> Result<(Vec<u8>, ObjectType), git2::Error>;
@@ -39,6 +48,9 @@ pub trait OdbBackend {
 struct RawOdbBackend {
     raw: raw::git_odb_backend,
     obj: Box<dyn OdbBackend>,
+    /// The repository's original on-disk ODB (loose + pack), kept as an owned reference so read-side
+    /// callbacks can delegate to it on a memory miss. Released in [`backend_free`].
+    delegate: *mut raw::git_odb,
 }
 
 impl RawOdbBackend {
@@ -55,8 +67,8 @@ impl RawOdbBackend {
         backend: *mut raw::git_odb_backend,
         oid: *const raw::git_oid,
     ) -> c_int {
-        let (wrapper, oid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
-        match wrapper.obj.read(oid) {
+        let (wrapper, roid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
+        match wrapper.obj.read(roid) {
             Ok((data, kind)) => unsafe {
                 let len = data.len();
                 let buf = raw::git_odb_backend_data_alloc(backend, len);
@@ -69,6 +81,29 @@ impl RawOdbBackend {
                 *kind_p = kind.raw();
                 raw::GIT_OK
             },
+            Err(err) if is_not_found(&err) && !wrapper.delegate.is_null() => unsafe {
+                // Memory miss: read through to the original on-disk ODB and copy its bytes into a
+                // backend-owned buffer (libgit2 frees `*data_p` via the backend's allocator).
+                let mut obj: *mut raw::git_odb_object = ptr::null_mut();
+                let rc = raw::git_odb_read(&mut obj, wrapper.delegate, oid);
+                if rc != 0 {
+                    return rc;
+                }
+                let src = raw::git_odb_object_data(obj) as *const u8;
+                let len = raw::git_odb_object_size(obj);
+                let kind = raw::git_odb_object_type(obj);
+                let buf = raw::git_odb_backend_data_alloc(backend, len);
+                if buf.is_null() {
+                    raw::git_odb_object_free(obj);
+                    return raw::GIT_ERROR;
+                }
+                ptr::copy_nonoverlapping(src, buf as *mut u8, len);
+                *data_p = buf;
+                *len_p = len;
+                *kind_p = kind;
+                raw::git_odb_object_free(obj);
+                raw::GIT_OK
+            },
             Err(err) => err.raw_code(),
         }
     }
@@ -79,12 +114,15 @@ impl RawOdbBackend {
         backend: *mut raw::git_odb_backend,
         oid: *const raw::git_oid,
     ) -> c_int {
-        let (wrapper, oid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
-        match wrapper.obj.read_header(oid) {
+        let (wrapper, roid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
+        match wrapper.obj.read_header(roid) {
             Ok((len, kind)) => unsafe {
                 *len_p = len;
                 *kind_p = kind.raw();
                 raw::GIT_OK
+            },
+            Err(err) if is_not_found(&err) && !wrapper.delegate.is_null() => unsafe {
+                raw::git_odb_read_header(len_p, kind_p, wrapper.delegate, oid)
             },
             Err(err) => err.raw_code(),
         }
@@ -113,8 +151,14 @@ impl RawOdbBackend {
         backend: *mut raw::git_odb_backend,
         oid: *const raw::git_oid,
     ) -> c_int {
-        let (wrapper, oid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
-        c_int::from(wrapper.obj.exists(oid))
+        let (wrapper, roid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
+        if wrapper.obj.exists(roid) {
+            return 1;
+        }
+        if wrapper.delegate.is_null() {
+            return 0;
+        }
+        unsafe { raw::git_odb_exists(wrapper.delegate, oid) }
     }
 
     extern "C" fn backend_exists_prefix(
@@ -123,32 +167,81 @@ impl RawOdbBackend {
         oid_prefix: *const raw::git_oid,
         len: usize,
     ) -> c_int {
-        let (wrapper, oid_prefix) =
+        let (wrapper, roid) =
             unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid_prefix)) };
-        match wrapper.obj.exists_prefix(oid_prefix, len) {
+        match wrapper.obj.exists_prefix(roid, len) {
             Some(oid) => unsafe {
                 (*out_oid).id.copy_from_slice(oid.as_bytes());
                 raw::GIT_OK
+            },
+            None if !wrapper.delegate.is_null() => unsafe {
+                raw::git_odb_exists_prefix(out_oid, wrapper.delegate, oid_prefix, len)
             },
             None => raw::GIT_ENOTFOUND,
         }
     }
 
-    extern "C" fn backend_free(backend: *mut raw::git_odb_backend) {
-        // libgit2 is done with the backend; reclaim the wrapper allocation.
-        unsafe {
-            drop(Box::from_raw(backend as *mut RawOdbBackend));
+    /// Object enumeration is delegated to the on-disk ODB only; in-memory objects are not enumerated
+    /// (the filter path inserts objects into the packbuilder by OID, not via `foreach`).
+    extern "C" fn backend_foreach(
+        backend: *mut raw::git_odb_backend,
+        cb: raw::git_odb_foreach_cb,
+        payload: *mut c_void,
+    ) -> c_int {
+        let wrapper = unsafe { RawOdbBackend::from_raw(backend) };
+        if wrapper.delegate.is_null() {
+            return raw::GIT_OK;
+        }
+        unsafe { raw::git_odb_foreach(wrapper.delegate, cb, payload) }
+    }
+
+    /// Memory-only freshen, used by `git_odb__freshen` on every `git_odb_write`. Returns `GIT_OK`
+    /// when the object is already in memory (so the write is skipped — in-run dedup) and
+    /// `GIT_ENOTFOUND` otherwise (so the write proceeds to `backend_write`). It deliberately never
+    /// consults the on-disk delegate: avoiding that per-object filesystem stat/touch is the whole
+    /// point of the ODB swap. Objects already on disk are deduplicated at the flush boundary instead
+    /// (see [`filter_absent_on_disk`]).
+    extern "C" fn backend_freshen(
+        backend: *mut raw::git_odb_backend,
+        oid: *const raw::git_oid,
+    ) -> c_int {
+        let (wrapper, roid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
+        if wrapper.obj.exists(roid) {
+            raw::GIT_OK
+        } else {
+            raw::GIT_ENOTFOUND
         }
     }
+
+    extern "C" fn backend_free(backend: *mut raw::git_odb_backend) {
+        // libgit2 is done with the backend; release the delegate ODB reference and reclaim the
+        // wrapper allocation.
+        unsafe {
+            let be = Box::from_raw(backend as *mut RawOdbBackend);
+            if !be.delegate.is_null() {
+                raw::git_odb_free(be.delegate);
+            }
+            drop(be);
+        }
+    }
+}
+
+fn is_not_found(err: &git2::Error) -> bool {
+    err.code() == ErrorCode::NotFound
 }
 
 unsafe fn oid_from_raw(oid: *const raw::git_oid) -> Oid {
     Oid::from_bytes(unsafe { &(*oid).id }).expect("git_oid is 20 raw bytes")
 }
 
-/// Build a `git_odb_backend` wrapping `callee`, owned by `odb`. The returned pointer is handed to
-/// libgit2 (which frees it via the `free` trampoline); the caller must not free it on success.
-fn new(odb: *mut raw::git_odb, callee: impl OdbBackend + 'static) -> *mut raw::git_odb_backend {
+/// Build a `git_odb_backend` wrapping `callee` and delegating read-side misses to `delegate`. The
+/// returned pointer is handed to libgit2 (which frees it via the `free` trampoline); the caller must
+/// not free it on success.
+fn new(
+    odb: *mut raw::git_odb,
+    delegate: *mut raw::git_odb,
+    callee: impl OdbBackend + 'static,
+) -> *mut raw::git_odb_backend {
     let backend = raw::git_odb_backend {
         version: raw::GIT_ODB_BACKEND_VERSION,
         odb,
@@ -161,45 +254,115 @@ fn new(odb: *mut raw::git_odb, callee: impl OdbBackend + 'static) -> *mut raw::g
         exists: Some(RawOdbBackend::backend_exists),
         exists_prefix: Some(RawOdbBackend::backend_exists_prefix),
         refresh: None,
-        foreach: None,
+        foreach: Some(RawOdbBackend::backend_foreach),
         writepack: None,
         writemidx: None,
-        freshen: None,
+        freshen: Some(RawOdbBackend::backend_freshen),
         free: Some(RawOdbBackend::backend_free),
     };
     let wrapper = RawOdbBackend {
         raw: backend,
         obj: Box::new(callee),
+        delegate,
     };
     Box::into_raw(Box::new(wrapper)) as *mut raw::git_odb_backend
 }
 
-/// Register `backend` on `repo`'s object database at `priority`. Higher values take precedence
-/// over the on-disk loose (2) and pack (1) backends.
+/// Replace `repo`'s object database with one containing only `backend`, which delegates read-side
+/// misses to the original on-disk ODB. Writes then land in `backend` and `git_odb__freshen` never
+/// touches the filesystem (see the module docs).
+///
+/// Must be called at most once per `git2::Repository` handle (josh opens a fresh handle per
+/// transaction and per overflow flush); calling it twice would swap an already-swapped ODB.
 ///
 /// git2 does not expose the raw `git_repository` pointer, so it is read out of the single-field
 /// `Repository` newtype. This is sound only while josh pins `git2` exactly; re-verify the layout on
 /// every upgrade.
-pub fn register<B>(repo: &git2::Repository, priority: i32, backend: B) -> Result<(), git2::Error>
+pub fn register<B>(repo: &git2::Repository, backend: B) -> Result<(), git2::Error>
 where
     B: OdbBackend + 'static,
 {
     unsafe {
         let repo_raw = *(repo as *const git2::Repository as *const *mut raw::git_repository);
+
+        // Owned (refcount-incremented) reference to the current on-disk ODB; handed to the backend
+        // as its read delegate and released in `backend_free`.
+        let mut old: *mut raw::git_odb = ptr::null_mut();
+        if raw::git_repository_odb(&mut old, repo_raw) != raw::GIT_OK {
+            return Err(git2::Error::last_error(raw::GIT_ERROR));
+        }
+
+        let mut new: *mut raw::git_odb = ptr::null_mut();
+        if raw::git_odb_new(&mut new) != raw::GIT_OK {
+            raw::git_odb_free(old);
+            return Err(git2::Error::last_error(raw::GIT_ERROR));
+        }
+
+        let backend = self::new(new, old, backend);
+        if raw::git_odb_add_backend(new, backend, 1000) != raw::GIT_OK {
+            // The backend was not adopted by `new`; reclaim it. Its Drop does not touch the raw
+            // `delegate` pointer, so free `old` explicitly.
+            drop(Box::from_raw(backend as *mut RawOdbBackend));
+            raw::git_odb_free(old);
+            raw::git_odb_free(new);
+            return Err(git2::Error::last_error(raw::GIT_ERROR));
+        }
+
+        if raw::git_repository_set_odb(repo_raw, new) != raw::GIT_OK {
+            // The repo kept its original ODB. Dropping our only reference to `new` frees it, which
+            // runs `backend_free` and releases `old`.
+            raw::git_odb_free(new);
+            return Err(git2::Error::last_error(raw::GIT_ERROR));
+        }
+
+        // The repo took its own reference on `new`; drop our local one. `old` stays alive through
+        // the backend's `delegate` field until the repo (and thus `new`) is freed.
+        raw::git_odb_free(new);
+        Ok(())
+    }
+}
+
+/// The on-disk ODB that `repo`'s swapped in-memory backend delegates reads to, or null if the
+/// backend is not installed. Reaches the backend at index 0 of the (swapped) repo ODB, which is
+/// always the single backend added by [`register`].
+unsafe fn delegate_of(repo: &git2::Repository) -> *mut raw::git_odb {
+    unsafe {
+        let repo_raw = *(repo as *const git2::Repository as *const *mut raw::git_repository);
         let mut odb: *mut raw::git_odb = ptr::null_mut();
         if raw::git_repository_odb(&mut odb, repo_raw) != raw::GIT_OK {
-            return Err(git2::Error::last_error(raw::GIT_ERROR));
+            return ptr::null_mut();
         }
-        let backend = new(odb, backend);
-        if raw::git_odb_add_backend(odb, backend, priority) != raw::GIT_OK {
-            // add_backend failed: reclaim the allocation to avoid leaking it.
-            drop(Box::from_raw(backend as *mut RawOdbBackend));
-            return Err(git2::Error::last_error(raw::GIT_ERROR));
-        }
-        // git_repository_odb returned an owned (refcounted) handle; the odb itself is still held by
-        // the repo, which now also owns the backend (freed via `free` when the repo drops).
+        let mut backend: *mut raw::git_odb_backend = ptr::null_mut();
+        let rc = raw::git_odb_get_backend(&mut backend, odb, 0);
         raw::git_odb_free(odb);
-        Ok(())
+        if rc != raw::GIT_OK || backend.is_null() {
+            return ptr::null_mut();
+        }
+        (*(backend as *const RawOdbBackend)).delegate
+    }
+}
+
+/// Return the subset of `oids` that are NOT already present in the on-disk ODB that `repo`'s swapped
+/// backend delegates to, using `NO_REFRESH` (matching the non-refreshing semantics of the write-time
+/// freshen that the memory-only [`RawOdbBackend::backend_freshen`] replaced). The memory-only
+/// freshen no longer deduplicates writes against disk, so a flush uses this to pack only
+/// genuinely-new objects and keep the on-disk layout deterministic. If the backend is not installed
+/// (no delegate), every oid is returned.
+pub fn filter_absent_on_disk(repo: &git2::Repository, oids: &[Oid]) -> Vec<Oid> {
+    unsafe {
+        let disk = delegate_of(repo);
+        if disk.is_null() {
+            return oids.to_vec();
+        }
+        oids.iter()
+            .copied()
+            .filter(|oid| {
+                let mut goid: raw::git_oid = std::mem::zeroed();
+                goid.id.copy_from_slice(oid.as_bytes());
+                let flags = raw::GIT_ODB_LOOKUP_NO_REFRESH as std::os::raw::c_uint;
+                raw::git_odb_exists_ext(disk, &goid, flags) == 0
+            })
+            .collect()
     }
 }
 
@@ -246,8 +409,8 @@ mod tests {
         )
     }
 
-    /// Write a blob through a repo whose odb has a `MapBackend` registered at high priority, then
-    /// read it back. libgit2 must route both the write and the read through our trampolines, and the
+    /// Write a blob through a repo whose odb has been swapped for a `MapBackend`, then read it back.
+    /// libgit2 must route both the write and the read through our trampolines, and the delegate
     /// fall-through path must keep working for objects the backend does not hold.
     #[test]
     fn round_trip_through_registered_backend() {
@@ -257,7 +420,7 @@ mod tests {
         let backend = MapBackend {
             data: std::collections::HashMap::new(),
         };
-        register(&repo, 1000, backend).unwrap();
+        register(&repo, backend).unwrap();
 
         let payload = b"hello, in-memory odb";
         let id = repo.blob(payload).unwrap();


### PR DESCRIPTION
Keep git_odb__freshen off the filter write path

Every object josh writes while filtering goes through git_odb_write, which
unconditionally calls git_odb__freshen before dispatching to backends. Freshen
walks the repo's ODB backends doing a per-object filesystem stat/touch on the
loose backend to refresh mtimes against gc. josh never relies on that during
filtering -- it produces a fresh packfile at the transaction boundary -- so on a
cold rewrite the freshen of every new object is wasted disk I/O.

josh-git-data registered its in-memory backend alongside the on-disk loose/pack
backends, so freshen still fell through to disk for every object not yet in the
map. Instead, have odb_backend::register replace the repo's ODB with a new one
containing only the in-memory backend, delegating read-side misses
(read/read_header/exists/exists_prefix/foreach) to the original on-disk ODB,
which it keeps as an owned reference and frees in backend_free. With the
loose/pack backends absent from the repo's ODB and a memory-only freshen
callback, freshen consults only the in-memory map and never touches the
filesystem, while reads still resolve on-disk objects.

A memory-only freshen no longer deduplicates against objects already on disk, so
MemOdb::flush moves that work to the flush boundary: filter_absent_on_disk skips
packing any object git_odb_exists_ext (NO_REFRESH, matching the old freshen's
non-refreshing semantics) already finds on disk. The packed object set and the
on-disk layout are unchanged; no test snapshot moves.

git2 still does not expose the raw odb/repository pointers, so this deepens the
existing exact-pin coupling: register now also depends on git_odb_new,
git_repository_set_odb and git_odb_object_*, which must be re-verified on a git2
upgrade. read_prefix is left unset (the filter path resolves only full OIDs).

Change: odb-freshen-off-write-path
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>