### PR TITLE
Wrap pushed commit in a merge on top of --base via --merge

### DIFF
--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -41,6 +41,16 @@ pub struct PushArgs {
     /// branch that does not yet exist on the remote.
     #[arg(long = "base")]
     pub base: Option<String>,
+
+    /// Wrap the reverse-filtered commit in a merge commit on top of the
+    /// base (mirrors `josh-proxy`'s `git push -o merge`).
+    ///
+    /// The resulting commit has two parents — the base and the
+    /// reverse-filtered new commit — and its tree is the 3-way merge of
+    /// both. Requires --base, or a destination branch that already
+    /// exists on the remote, to anchor the merge.
+    #[arg(long = "merge", action = clap::ArgAction::SetTrue)]
+    pub merge: bool,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -73,6 +83,13 @@ pub struct PublishArgs {
     /// See `josh push --base` for details.
     #[arg(long = "base")]
     pub base: Option<String>,
+
+    /// Wrap the reverse-filtered commit in a merge commit on top of the
+    /// base.
+    ///
+    /// See `josh push --merge` for details.
+    #[arg(long = "merge", action = clap::ArgAction::SetTrue)]
+    pub merge: bool,
 }
 
 struct PreparedPush {
@@ -84,6 +101,7 @@ fn prepare_push(
     refspec: &str,
     remote_name: &str,
     base: Option<&str>,
+    merge: bool,
     transaction: &josh_core::cache::Transaction,
     filter: josh_core::filter::Filter,
     push_mode: &PushMode,
@@ -161,6 +179,30 @@ fn prepare_push(
         base.map(|_| original_target),
     )
     .context("Failed to unapply filter")?;
+
+    let unfiltered_oid = if merge {
+        if original_target == git2::Oid::zero() {
+            return Err(anyhow!(
+                "--merge requires --base=<ref> or an existing destination ref"
+            ));
+        }
+        let base_commit = repo.find_commit(original_target)?;
+        let backward_commit = repo.find_commit(unfiltered_oid)?;
+        let merged_tree = repo
+            .merge_commits(&base_commit, &backward_commit, None)?
+            .write_tree_to(repo)?;
+        let signature = josh_core::git::josh_commit_signature()?;
+        repo.commit(
+            None,
+            &signature,
+            &signature,
+            &format!("Merge from {}", josh_core::filter::pretty(filter, 0)),
+            &repo.find_tree(merged_tree)?,
+            &[&base_commit, &backward_commit],
+        )?
+    } else {
+        unfiltered_oid
+    };
 
     log::debug!("unfiltered_oid: {:?}", unfiltered_oid);
 
@@ -272,6 +314,7 @@ fn orchestrate_push(
     remote: Option<&str>,
     refspecs_arg: &[String],
     base: Option<&str>,
+    merge: bool,
     force: bool,
     atomic: bool,
     dry_run: bool,
@@ -311,6 +354,7 @@ fn orchestrate_push(
                 refspec,
                 remote_name,
                 base,
+                merge,
                 transaction,
                 filter,
                 &push_mode,
@@ -363,6 +407,7 @@ pub fn handle_push(
         args.remote.as_deref(),
         &args.refspecs,
         args.base.as_deref(),
+        args.merge,
         args.force,
         args.atomic,
         args.dry_run,
@@ -383,6 +428,7 @@ pub fn handle_publish(
         args.remote.as_deref(),
         &args.refspecs,
         args.base.as_deref(),
+        args.merge,
         args.force,
         args.atomic,
         args.dry_run,

--- a/tests/cli/push_merge.t
+++ b/tests/cli/push_merge.t
@@ -1,0 +1,111 @@
+Wrap a vendored push in an explicit merge commit via `josh push --merge`,
+mirroring `josh-proxy`'s `git push -o merge`. The pushed branch's tip is
+a merge commit with two parents: the central base, and the
+reverse-filtered tip of the local commits.
+
+Setup
+
+  $ export TESTTMP=${PWD}
+
+Central repo (bare) with pre-existing history under app/
+
+  $ git init -q --bare central
+  $ git init -q central-seed
+  $ cd central-seed
+  $ mkdir -p app
+  $ echo "central app v1" > app/main.txt
+  $ git add app
+  $ git commit -q -m "central: add app/main.txt"
+  $ echo "central app v2" >> app/main.txt
+  $ git add app
+  $ git commit -q -m "central: extend app/main.txt"
+  $ git remote add origin ${TESTTMP}/central
+  $ git push -q origin master
+  $ cd ${TESTTMP}
+
+Standalone vendor repo
+
+  $ git init -q --bare vendor-origin
+  $ git init -q vendor-seed
+  $ cd vendor-seed
+  $ echo "lib v1" > lib.txt
+  $ git add lib.txt
+  $ git commit -q -m "vendor: initial lib"
+  $ echo "lib v2" >> lib.txt
+  $ git add lib.txt
+  $ git commit -q -m "vendor: extend lib"
+  $ git remote add origin ${TESTTMP}/vendor-origin
+  $ git push -q origin master
+  $ cd ${TESTTMP}
+
+Clone the vendor with vanilla `git clone`, wire up central, fetch the base.
+
+  $ git clone -q ${TESTTMP}/vendor-origin vendored
+  $ cd vendored
+  $ josh remote add central ${TESTTMP}/central :/libs/vendored
+  Added remote 'central' with filter ':/libs/vendored'
+  $ josh fetch --remote central
+  From file://${TESTTMP}/central
+   * [new branch]      master     -> refs/josh/remotes/central/master
+  
+  Fetched from remote: central
+
+Push with --merge --base=master. The reverse-filtered vendor commits are
+wrapped in a merge commit on top of central master.
+
+  $ josh push central HEAD:refs/heads/vendor-bring-in --base=master --merge
+  Pushing * to central/refs/heads/vendor-bring-in (glob)
+  To file://${TESTTMP}/central
+   * [new branch]      * -> vendor-bring-in (glob)
+  
+  Pushed 1 ref(s) to central
+
+The pushed tip is a merge commit: rev-list with --parents prints three
+OIDs (the tip and its two parents).
+
+  $ git --git-dir=${TESTTMP}/central rev-list --parents -n 1 vendor-bring-in | wc -w | tr -d ' '
+  3
+
+Merge commit subject identifies the source filter.
+
+  $ git --git-dir=${TESTTMP}/central log -1 --format='%s' vendor-bring-in
+  Merge from :/libs/vendored
+
+Full graph: a merge node with two parent lines feeding back into master.
+
+  $ git --git-dir=${TESTTMP}/central log --oneline --graph vendor-bring-in
+  *   9e7fd16 Merge from :/libs/vendored
+  |\  
+  | * e37e256 vendor: extend lib
+  | * 641e856 vendor: initial lib
+  |/  
+  * 12640c6 central: extend app/main.txt
+  * 1f1a5d1 central: add app/main.txt
+
+Master is an ancestor of vendor-bring-in.
+
+  $ git --git-dir=${TESTTMP}/central merge-base --is-ancestor master vendor-bring-in && echo ok
+  ok
+
+The merge tip tree contains BOTH central's pre-existing `app/main.txt`
+AND the vendored `libs/vendored/lib.txt`, with original content.
+
+  $ git --git-dir=${TESTTMP}/central ls-tree -r --name-only vendor-bring-in
+  app/main.txt
+  libs/vendored/lib.txt
+
+  $ git --git-dir=${TESTTMP}/central show vendor-bring-in:app/main.txt
+  central app v1
+  central app v2
+
+  $ git --git-dir=${TESTTMP}/central show vendor-bring-in:libs/vendored/lib.txt
+  lib v1
+  lib v2
+
+Reject path: `--merge` against a non-existent destination ref with no
+`--base` has no commit to merge against and must fail with a clear error.
+
+  $ josh push central HEAD:refs/heads/other --merge
+  Error: --merge requires --base=<ref> or an existing destination ref
+  --merge requires --base=<ref> or an existing destination ref
+  [1]


### PR DESCRIPTION
Wrap pushed commit in a merge on top of --base via --merge

CLI equivalent of `git push -o merge` against josh-proxy. When set, after
`unapply_filter` produces the unfiltered commit, wrap it in a 2-parent merge
commit whose parents are the base and the reverse-filtered new commit, and
whose tree is the 3-way merge of both. Push the merge commit's OID instead
of the unfiltered tip. Mirrors josh-proxy/src/upstream.rs:462-488 — same
helper (josh_core::git::josh_commit_signature) and same message format
("Merge from <filter spec>", using josh_core::filter::pretty).

`--merge` is orthogonal to `--base`: both flags can be set independently, as
in the proxy. With `--merge --base=master`, the reparent path from the
previous change still produces a linear vendor chain on top of master, and
the new merge wrapper records an explicit 2-parent integration commit on
top — which is the same shape the proxy produces. With `--merge` alone, the
existing destination ref's tip is used as `original_target`; if neither
`--base` nor an existing destination ref is available, the push is rejected
up front with "--merge requires --base=<ref> or an existing destination ref"
rather than silently merging against the zero OID.

tests/cli/push_merge.t covers the full vendoring scenario with `--merge
--base=master`. Asserts: 3 OIDs from rev-list --parents -n 1 (i.e. two
parents), the merge subject is `Merge from :/libs/vendored`, the full
`--graph --oneline` shape matches a diamond with both parent lines feeding
back into master, master is an ancestor of the new branch, and both
`app/main.txt` and `libs/vendored/lib.txt` are present at the tip with their
original contents. Also covers the reject path: `--merge` without `--base`
against a fresh destination ref errors out cleanly.

Change: push-merge-flag
Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>