### PR TITLE
Add history="no-splice" flag to disable synthetic splice merges

### DIFF
--- a/docs/src/reference/filters.md
+++ b/docs/src/reference/filters.md
@@ -48,9 +48,12 @@ This applies the `:/sub1` filter with the specified options attached as metadata
 The `history` option controls how the commit history is processed during filtering.
 It affects both how commits are walked and how merge commits are handled in the output history.
 
-**Available values:**
+The value is a comma-separated list of flags, so multiple behaviours can be combined in a
+single option — for example `history="linear,no-splice"`.
 
-- **`history="linear"`** - Produces a linear history by converting merge commits into regular commits,
+**Available flags:**
+
+- **`linear`** - Produces a linear history by converting merge commits into regular commits,
   creating a linear chain of commits in the output history.
 
   **Example:**
@@ -58,21 +61,35 @@ It affects both how commits are walked and how merge commits are handled in the 
   :~(history="linear")[:/sub1]
   ```
 
-- **`history="keep-trivial-merges"`** - Prevents dropping trivial merge commits that would
+- **`keep-trivial-merges`** - Prevents dropping trivial merge commits that would
   normally be pruned from the output history.
-  
+
   Normally, Josh will drop merge commits from the filtered history if their filtered tree is
-  identical to the first parent's tree. Setting this option to `"keep-trivial-merges"` preserves
-  these commits in the output history.
-  
+  identical to the first parent's tree. Setting this flag preserves these commits in the
+  output history.
+
   **Example:**
   ```
   :~(history="keep-trivial-merges")[::file1]
   ```
-  
+
   **Note for users of older versions:** In older versions of Josh, `"keep-trivial-merges"` was the
   default behavior. If you're upgrading from an older version and need to recreate the same history
   structure, you should explicitly set `history="keep-trivial-merges"` in your filter options.
+
+- **`no-splice`** - Disables the synthetic merges that Josh normally inserts when a filter
+  change causes new paths to become visible.
+
+  When a commit's filtered tree picks up entries because the *filter* changed (not the source
+  tree), Josh by default adds synthetic merge parents that splice in the prior history of those
+  newly-visible paths, so the filtered DAG doesn't look like those paths sprang from nowhere.
+  Setting this flag suppresses those synthetic parents — the filtered commit keeps only its
+  ordinary parents.
+
+  **Example:**
+  ```
+  :~(history="no-splice")[:workspace=ws]
+  ```
 
 ### Gpgsig option
 

--- a/josh-core/benches/ultrawide_pin.rs
+++ b/josh-core/benches/ultrawide_pin.rs
@@ -45,7 +45,9 @@ impl PinBench {
 
         // The filter under benchmark: select the workspace defined by the
         // `workspace/workspace.josh` files generated throughout the history.
-        let filter = josh_core::filter::Filter::new().workspace("workspace");
+        let filter = josh_core::filter::Filter::new()
+            .stored("workspace/workspace")
+            .with_meta("history", "no-splice");
 
         Ok(Self {
             _tmp: tmp,

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1949,6 +1949,52 @@ fn legalize_stored(t: &cache::Transaction, f: Filter, tree: &git2::Tree) -> anyh
     Ok(r)
 }
 
+// Compute the difference between the current commit's filter and each parent's filter.
+// Figure out which new entries in this commit's tree appeared because of the filter changes,
+// as opposed of the changes of the trees itself. For those entries, we create synthetic
+// merges that splice in the history of the new entries coming in. Returns `Ok(None)` to
+// propagate the same short-circuit as `apply_to_commit2` (parent not yet filtered).
+fn compute_splice_parents(
+    transaction: &cache::Transaction,
+    commit_filter: Filter,
+    parent_filters: Vec<(git2::Commit, Filter)>,
+    meta: &std::collections::BTreeMap<String, String>,
+) -> anyhow::Result<Option<Vec<git2::Oid>>> {
+    // `Op::Pin` is somewhat of a special category: it doesn't operate on either
+    // commit trees or the history graph, and is more of a marker for per-rev
+    // filter application process. Therefore, in the tree-level `apply`, it's an identity.
+    //
+    // This is important because we rely on the filter optimizer to properly fold
+    // `Op::Subtract`. If there are pins inside, the optimizer will not be able to collapse
+    // it, and this will trigger extra history walks in `apply_to_commit2` below.
+    //
+    // Actual work of :pin still happens in `pin_details` in `per_rev_filter`, so :pin still works.
+    fn strip_pins(f: Filter) -> Filter {
+        legalize_pin(f, &|_| to_filter(Op::Empty))
+    }
+
+    let splice_parents = parent_filters
+        .into_iter()
+        .map(|(parent, pcw)| {
+            let f = opt::optimize(to_filter(Op::Subtract(
+                strip_pins(commit_filter.peel()),
+                strip_pins(pcw.peel()),
+            )));
+            let f = propagate_meta(f, meta);
+            apply_to_commit2(f, &parent, transaction)
+        })
+        .collect::<anyhow::Result<Option<Vec<_>>>>()?;
+
+    let splice_parents = some_or!(splice_parents, { return Ok(None) });
+
+    Ok(Some(
+        splice_parents
+            .into_iter()
+            .filter(|&oid| oid != git2::Oid::zero())
+            .collect(),
+    ))
+}
+
 fn per_rev_filter(
     transaction: &cache::Transaction,
     commit: &git2::Commit,
@@ -1960,41 +2006,16 @@ fn per_rev_filter(
     // into the per-commit filter so they are applied during commit rewriting.
     let meta = filter.into_meta();
     let commit_filter = propagate_meta(commit_filter, &meta);
-    // Compute the difference between the current commit's filter and each parent's filter.
-    // Figure out which new entries in this commit's tree appeared because of the filter changes,
-    // as opposed of the changes of the trees itself. For those entries, we want to create
-    // synthetic merges that preserve the history of the new entries coming in.
-    let extra_parents = parent_filters
-        .into_iter()
-        .map(|(parent, pcw)| {
-            // `Op::Pin` is somewhat of a special category: it doesn't operate on either
-            // commit trees or the history graph, and is more of a marker for per-rev
-            // filter application process. Therefore, in the tree-level `apply`, it's an identity.
-            //
-            // This is important because we rely on the filter optimizer to properly fold
-            // `Op::Subtract`. If there are pins inside, the optimizer will not be able to collapse
-            // it, and this will trigger extra history walks in `apply_to_commit2` below.
-            //
-            // Actual work of :pin still happens in `pin_details` below, so the :pin still works.
-            fn strip_pins(f: Filter) -> Filter {
-                legalize_pin(f, &|_| to_filter(Op::Nop))
-            }
 
-            let f = opt::optimize(to_filter(Op::Subtract(
-                strip_pins(commit_filter.peel()),
-                strip_pins(pcw.peel()),
-            )));
-            let f = propagate_meta(f, &meta);
-            apply_to_commit2(f, &parent, transaction)
-        })
-        .collect::<anyhow::Result<Option<Vec<_>>>>()?;
-
-    let extra_parents = some_or!(extra_parents, { return Ok(None) });
-
-    let extra_parents: Vec<_> = extra_parents
-        .into_iter()
-        .filter(|&oid| oid != git2::Oid::zero())
-        .collect();
+    let splice_parents =
+        if history::history_flag(meta.get("history").map(String::as_str), "no-splice") {
+            vec![]
+        } else {
+            some_or!(
+                compute_splice_parents(transaction, commit_filter, parent_filters, &meta)?,
+                { return Ok(None) }
+            )
+        };
 
     let normal_parents = commit
         .parent_ids()
@@ -2004,8 +2025,8 @@ fn per_rev_filter(
 
     // Special case: `:pin` filter needs to be aware of filtered history
     let pin_details = if let Some(&parent) = normal_parents.first() {
-        let legalized_a = legalize_pin(commit_filter, &|f| f);
-        let legalized_b = legalize_pin(commit_filter, &|f| to_filter(Op::Exclude(f)));
+        let legalized_a = legalize_pin(commit_filter.peel(), &|f| f);
+        let legalized_b = legalize_pin(commit_filter.peel(), &|f| to_filter(Op::Exclude(f)));
 
         if legalized_a != legalized_b {
             let pin_subtract = apply(
@@ -2030,7 +2051,7 @@ fn per_rev_filter(
         None
     };
 
-    let filtered_parent_ids: Vec<_> = normal_parents.into_iter().chain(extra_parents).collect();
+    let filtered_parent_ids: Vec<_> = normal_parents.into_iter().chain(splice_parents).collect();
 
     let mut tree_data = apply(transaction, commit_filter, Rewrite::from_commit(commit)?)?;
 

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -9,6 +9,12 @@ pub enum GpgsigMode {
     NormLf,
 }
 
+/// Returns true if a comma-separated meta value contains `flag` (trimmed).
+/// The `history` meta accepts multiple flags, e.g. `history="linear,no-splice"`.
+pub(crate) fn history_flag(value: Option<&str>, flag: &str) -> bool {
+    value.is_some_and(|v| v.split(',').any(|f| f.trim() == flag))
+}
+
 pub fn walk2(
     filter: filter::Filter,
     input: git2::Oid,
@@ -26,7 +32,7 @@ pub fn walk2(
 
     let walk = {
         let mut walk = transaction.repo().revwalk()?;
-        if filter.get_meta("history").is_some_and(|s| s == "linear") {
+        if history_flag(filter.get_meta("history").as_deref(), "linear") {
             walk.simplify_first_parent()?;
         }
         walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
@@ -870,14 +876,14 @@ fn create_filtered_commit2<'a>(
         }
     }
 
-    if options.get("history").is_some_and(|s| s == "linear") {
+    if history_flag(options.get("history").map(String::as_str), "linear") {
         filtered_parent_commits.truncate(1);
     }
 
-    if !options
-        .get("history")
-        .is_some_and(|s| s == "keep-trivial-merges")
-    {
+    if !history_flag(
+        options.get("history").map(String::as_str),
+        "keep-trivial-merges",
+    ) {
         if filtered_parent_commits.len() > 1 {
             let is_trivial_merge = filtered_parent_commits[0].tree_id() == rewrite_data.tree().id();
             let was_trivial_merge = original_commit

--- a/tests/filter/history_no_splice.t
+++ b/tests/filter/history_no_splice.t
@@ -1,0 +1,55 @@
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+Create initial state: two directories (a/ and b/) plus a workspace that only covers a/
+
+  $ mkdir a b ws
+  $ echo contents1 > a/file1
+  $ echo contents2 > b/file2
+  $ cat > ws/workspace.josh <<EOF
+  > :/a
+  > EOF
+  $ git add .
+  $ git commit -m "initial" 1> /dev/null
+
+Add a commit that only touches a/
+
+  $ echo more > a/file3
+  $ git add .
+  $ git commit -m "add a/file3" 1> /dev/null
+
+Extend the workspace to include b/ as well. By default, per_rev_filter notices
+that b/ became visible because the *filter* changed (not the source tree) and
+splices in b/'s prior history as a synthetic merge parent.
+
+  $ cat > ws/workspace.josh <<EOF
+  > :[
+  >   :/a
+  >   :/b
+  > ]
+  > EOF
+  $ git add .
+  $ git commit -m "extend workspace to b/" 1> /dev/null
+
+Default: the "extend workspace" commit gets a synthetic parent splicing in b/ history.
+
+  $ josh-filter ":workspace=ws"
+  c9b197c2fb88bf281d014f9abea6f61d299b4aa9
+  $ git log --graph --pretty=%s FILTERED_HEAD
+  *   extend workspace to b/
+  |\  
+  | * initial
+  * add a/file3
+  * initial
+
+With history="no-splice": no synthetic parent, so b/ history is not spliced in.
+
+  $ josh-filter ":~(history=\"no-splice\")[:workspace=ws]"
+  f4d5b37465c0a8d498fb9e28f7b9728aaa21a654
+  $ git log --graph --pretty=%s FILTERED_HEAD
+  * extend workspace to b/
+  * add a/file3
+  * initial


### PR DESCRIPTION
Add history="no-splice" flag to disable synthetic splice merges

When per_rev_filter sees a path become visible because the filter
changed (not the source tree), it adds synthetic merge parents that
splice in the prior history of those newly-visible paths. The
history meta value now accepts a comma-separated list of flags, and
the new "no-splice" flag suppresses those synthetic parents — the
filtered commit keeps only its ordinary parents.

The per-revision splice computation is also extracted into a
dedicated compute_splice_parents helper, and the existing history
meta readers in history.rs are routed through a small history_flag
helper so combinations like history="linear,no-splice" work.

Change: history-no-splice-flag
Assisted-By: claude-opus-4-7