### PR TITLE
Pack filtered objects via an in-memory ODB backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,6 +3027,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "josh-filter",
+ "josh-git-data",
  "josh-starlark",
  "josh-test-support",
  "log",
@@ -3093,11 +3094,21 @@ dependencies = [
  "gix-object",
  "indoc",
  "itertools 0.14.0",
+ "josh-git-data",
  "pest",
  "pest_derive",
  "regex",
  "serde_json",
  "smallvec",
+]
+
+[[package]]
+name = "josh-git-data"
+version = "26.6.11"
+dependencies = [
+ "git2",
+ "libgit2-sys",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "axum-cgi",
     "axum-cgi-server",
     "josh-core",
+    "josh-git-data",
     "josh-cli",
     "josh-filter",
     "josh-graphql",
@@ -86,6 +87,7 @@ axum-cgi = { path = "axum-cgi", version = "26.6.11" }
 josh-filter = { path = "josh-filter", version = "26.6.11" }
 josh-changes = { path = "josh-changes", version = "26.6.11" }
 josh-core = { path = "josh-core", version = "26.6.11" }
+josh-git-data = { path = "josh-git-data", version = "26.6.11" }
 josh-compose = { path = "josh-compose", version = "26.6.11" }
 josh-graphql = { path = "josh-graphql", version = "26.6.11" }
 josh-link = { path = "josh-link", version = "26.6.11" }
@@ -179,6 +181,7 @@ axum-cgi = { path = "axum-cgi" }
 josh-filter = { path = "josh-filter" }
 josh-changes = { path = "josh-changes" }
 josh-core = { path = "josh-core" }
+josh-git-data = { path = "josh-git-data" }
 josh-compose = { path = "josh-compose" }
 josh-graphql = { path = "josh-graphql" }
 josh-link = { path = "josh-link" }

--- a/cq/josh-cq/src/bin/josh-cq.rs
+++ b/cq/josh-cq/src/bin/josh-cq.rs
@@ -81,7 +81,7 @@ fn open_repo(
     );
 
     let transaction = josh_core::cache::TransactionContext::new(&repo_path, cache.clone())
-        .open(None)
+        .open()
         .context("Failed TransactionContext::open")?;
 
     Ok((repo_path, cache, transaction))

--- a/cq/josh-cq/src/cq.rs
+++ b/cq/josh-cq/src/cq.rs
@@ -12,7 +12,6 @@ use tokio::sync::mpsc;
 
 use josh_core::cache::{CacheStack, TransactionContext};
 use josh_core::filter::tree;
-use josh_core::git::spawn_git_command;
 use josh_github_webhooks::webhook_server::WebhookPayload;
 use josh_link::make_signature;
 
@@ -43,7 +42,7 @@ pub fn handle_track(
 
     let refs = crate::remote::list_refs(url)?;
 
-    spawn_git_command(repo.path(), &["fetch", url, "HEAD"], &[])?;
+    transaction.spawn_git(&["fetch", url, "HEAD"], &[])?;
 
     let fetch_head_ref = repo
         .find_reference("FETCH_HEAD")
@@ -167,7 +166,7 @@ pub fn spawn_serve_task(repo_path: PathBuf, cache: Arc<CacheStack>) -> mpsc::Sen
             match event {
                 CqEvent::Track(req) => {
                     let transaction =
-                        match TransactionContext::new(&repo_path, cache.clone()).open(None) {
+                        match TransactionContext::new(&repo_path, cache.clone()).open() {
                             Ok(t) => t,
                             Err(e) => {
                                 eprintln!("Failed to open transaction: {e:#}");

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -224,8 +224,9 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         }
     });
 
-    let mut transaction =
-        josh_core::cache::TransactionContext::from_env(cache.clone())?.open(None)?;
+    let mut transaction = josh_core::cache::TransactionContext::from_env(cache.clone())?
+        .with_mem_odb_limit(josh_cli::MAX_MEM_PACK_SIZE)
+        .open()?;
 
     let repo_for_hook = git2::Repository::open_ext(
         transaction.repo().path(),
@@ -477,6 +478,10 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
 
     println!("{}", updated_refs[0].1);
 
+    // The queries below run in separate transactions whose stores only see on-disk objects, so
+    // flush the filtered objects out of this transaction first.
+    transaction.flush_mem_odb()?;
+
     if let Some(gql_query) = args.get_one::<String>("graphql") {
         let context = josh_graphql::context(transaction.try_clone()?, transaction.try_clone()?);
         *context.allow_refs.lock().unwrap() = true;
@@ -495,8 +500,9 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     std::mem::drop(finish);
 
     if let Some(query) = args.get_one::<String>("query") {
-        let transaction =
-            josh_core::cache::TransactionContext::from_env(cache.clone())?.open(None)?;
+        let transaction = josh_core::cache::TransactionContext::from_env(cache.clone())?
+            .with_mem_odb_limit(josh_cli::MAX_MEM_PACK_SIZE)
+            .open()?;
         let commit_id = transaction.repo().refname_to_id(update_target)?;
 
         print!(

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -250,10 +250,17 @@ fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
             ),
     );
 
-    // Create transaction using the known repo path
-    let transaction = josh_core::cache::TransactionContext::new(&repo_path, cache.clone())
-        .open(None)
-        .context("Failed TransactionContext::open")?;
+    let mut ctx = josh_core::cache::TransactionContext::new(&repo_path, cache.clone());
+
+    // For compose, we don't need to flush the objects to disk;
+    // everything else gets mem odb setup with an upper flush limit
+    if matches!(cmd, RepoCommand::Compose(_)) {
+        ctx = ctx.ephemeral();
+    } else {
+        ctx = ctx.with_mem_odb_limit(josh_cli::MAX_MEM_PACK_SIZE)
+    }
+
+    let transaction = ctx.open().context("Failed TransactionContext::open")?;
 
     match cmd {
         RepoCommand::Clone(args) => handle_clone(args, &transaction),
@@ -370,30 +377,30 @@ fn handle_clone(
         args.branch.clone()
     };
 
-    spawn_git_command(
-        repo.path(),
-        &[
-            "checkout",
-            "-b",
-            &default_branch,
-            &format!("origin/{}", default_branch),
-        ],
-        &[],
-    )
-    .with_context(|| format!("Failed to checkout branch {}", default_branch))?;
+    transaction
+        .spawn_git(
+            &[
+                "checkout",
+                "-b",
+                &default_branch,
+                &format!("origin/{}", default_branch),
+            ],
+            &[],
+        )
+        .with_context(|| format!("Failed to checkout branch {}", default_branch))?;
 
     // Set up upstream tracking for the branch
-    spawn_git_command(
-        repo.path(),
-        &[
-            "branch",
-            "--set-upstream-to",
-            &format!("origin/{}", default_branch),
-            &default_branch,
-        ],
-        &[],
-    )
-    .with_context(|| format!("Failed to set upstream for branch {}", default_branch))?;
+    transaction
+        .spawn_git(
+            &[
+                "branch",
+                "--set-upstream-to",
+                &format!("origin/{}", default_branch),
+                &default_branch,
+            ],
+            &[],
+        )
+        .with_context(|| format!("Failed to set upstream for branch {}", default_branch))?;
 
     let output_dir = normalize_repo_path(repo.path());
     let output_dir = output_dir.display().to_string();
@@ -409,8 +416,6 @@ fn handle_clone(
 }
 
 fn handle_pull(args: &PullArgs, transaction: &josh_core::cache::Transaction) -> anyhow::Result<()> {
-    let repo = transaction.repo();
-
     // Create FetchArgs from PullArgs
     let fetch_args = FetchArgs {
         remote: args.remote.clone(),
@@ -433,7 +438,9 @@ fn handle_pull(args: &PullArgs, transaction: &josh_core::cache::Transaction) -> 
 
     git_args.push(&args.remote);
 
-    spawn_git_command(repo.path(), &git_args, &[]).context("git pull failed")?;
+    transaction
+        .spawn_git(&git_args, &[])
+        .context("git pull failed")?;
 
     eprintln!("Pulled from remote: {}", args.remote);
 
@@ -461,12 +468,13 @@ fn handle_fetch(
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
 
     // First, fetch unfiltered refs to refs/josh/remotes/*
-    spawn_git_command(repo.path(), &["fetch", &url, &ref_spec], &[])
+    transaction
+        .spawn_git(&["fetch", &url, &ref_spec], &[])
         .context("git fetch to josh/remotes failed")?;
 
     // Warm the local cache from the remote before filtering
     let filter = filter_with_meta.peel();
-    if let Err(e) = josh_cli::commands::cache::fetch_remote_cache(repo, &url, filter) {
+    if let Err(e) = josh_cli::commands::cache::fetch_remote_cache(transaction, &url, filter) {
         eprintln!("Warning: could not fetch remote cache: {e}");
     }
 
@@ -507,13 +515,7 @@ fn handle_fetch(
         "josh remote HEAD",
     )?;
 
-    josh_cli::remote_ops::apply_josh_filtering(
-        transaction,
-        &repo_path,
-        filter,
-        &args.remote,
-        &default_branch,
-    )?;
+    josh_cli::remote_ops::apply_josh_filtering(transaction, filter, &args.remote, &default_branch)?;
 
     // Note: fetch doesn't checkout, it just updates the refs
     eprintln!("Fetched from remote: {}", args.remote);
@@ -622,13 +624,7 @@ fn handle_filter(
 
     let default_branch = josh_cli::remote_ops::resolve_default_branch(repo, &args.remote)?;
 
-    josh_cli::remote_ops::apply_josh_filtering(
-        transaction,
-        &repo_path,
-        filter,
-        &args.remote,
-        &default_branch,
-    )?;
+    josh_cli::remote_ops::apply_josh_filtering(transaction, filter, &args.remote, &default_branch)?;
 
     println!(
         "Applied filter '{}' to remote '{}'",

--- a/josh-cli/src/commands/cache.rs
+++ b/josh-cli/src/commands/cache.rs
@@ -6,7 +6,7 @@ use josh_core::cache::{
     CACHE_VERSION, CacheStack, DistributedCacheBackend, Transaction, TransactionContext,
 };
 use josh_core::filter::{self, Filter, flatten_chain, from_tree};
-use josh_core::git::{normalize_repo_path, spawn_git_command};
+use josh_core::git::normalize_repo_path;
 
 use crate::config::{RemoteConfig, read_remote_config};
 use crate::remote_ops;
@@ -150,7 +150,8 @@ fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyho
         DistributedCacheBackend::new(&repo_path).context("Failed to open distributed cache")?,
     ));
     let build_transaction = TransactionContext::new(&repo_path, cache)
-        .open(None)
+        .with_mem_odb_limit(crate::MAX_MEM_PACK_SIZE)
+        .open()
         .context("Failed to open build transaction")?;
 
     // Resolve the default branch commit from backing refs.
@@ -196,7 +197,11 @@ fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyho
                 }
                 let filtered_ref =
                     format!("refs/josh/filtered/{}/heads/{}", prefix_path, branch_name);
-                repo.reference(&filtered_ref, filtered_oid, true, "josh cache build")
+                // `filtered_oid`'s objects are in `build_transaction`'s in-memory store, so resolve
+                // the ref through its repo, not the outer one.
+                build_transaction
+                    .repo()
+                    .reference(&filtered_ref, filtered_oid, true, "josh cache build")
                     .with_context(|| format!("failed to write filtered ref '{}'", filtered_ref))?;
                 next_commits.push((branch_name, filtered_oid));
             }
@@ -235,7 +240,8 @@ fn handle_cache_push(args: &CachePushArgs, transaction: &Transaction) -> anyhow:
         "+refs/josh/cache/{}/*:refs/josh/cache/{}/*",
         CACHE_VERSION, CACHE_VERSION
     );
-    spawn_git_command(repo.path(), &["push", &url, &cache_refspec], &[])
+    transaction
+        .spawn_git(&["push", &url, &cache_refspec], &[])
         .context("Failed to push cache refs")?;
 
     // Push filtered refs for the default branch only so that recipients have
@@ -256,7 +262,8 @@ fn handle_cache_push(args: &CachePushArgs, transaction: &Transaction) -> anyhow:
         }
 
         let filtered_refspec = format!("+{r}:{r}", r = local_ref);
-        spawn_git_command(repo.path(), &["push", &url, &filtered_refspec], &[])
+        transaction
+            .spawn_git(&["push", &url, &filtered_refspec], &[])
             .with_context(|| format!("Failed to push filtered ref for step {}", step_idx))?;
     }
 
@@ -273,7 +280,7 @@ fn handle_cache_push(args: &CachePushArgs, transaction: &Transaction) -> anyhow:
 /// - `refs/josh/cache/{VERSION}/*` is fetched; errors are surfaced to the caller.
 /// - `refs/josh/filtered/…` per-step refs are fetched best-effort (errors ignored).
 pub fn fetch_remote_cache(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     url: &str,
     filter: Filter,
 ) -> anyhow::Result<()> {
@@ -281,7 +288,8 @@ pub fn fetch_remote_cache(
         "+refs/josh/cache/{v}/*:refs/josh/cache/{v}/*",
         v = CACHE_VERSION
     );
-    spawn_git_command(repo.path(), &["fetch", url, &cache_refspec], &[])
+    transaction
+        .spawn_git(&["fetch", url, &cache_refspec], &[])
         .context("Failed to fetch cache refs")?;
 
     let steps = flatten_chain(filter);
@@ -292,7 +300,7 @@ pub fn fetch_remote_cache(
             p = prefix_path
         );
         // Ignore errors: the remote may not have filtered refs for this step yet
-        let _ = spawn_git_command(repo.path(), &["fetch", url, &filtered_refspec], &[]);
+        let _ = transaction.spawn_git(&["fetch", url, &filtered_refspec], &[]);
     }
 
     Ok(())
@@ -311,7 +319,7 @@ fn handle_cache_fetch(args: &CacheFetchArgs, transaction: &Transaction) -> anyho
 
     let filter = filter_with_meta.peel();
 
-    fetch_remote_cache(repo, &url, filter)?;
+    fetch_remote_cache(transaction, &url, filter)?;
 
     eprintln!(
         "Fetched cache for remote '{}' (filter: {})",

--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -134,7 +134,8 @@ fn handle_link_add(
             normalized_path
         );
 
-        josh_core::git::spawn_git_command(repo.path(), &["fetch", &args.url, target], &[])
+        transaction
+            .spawn_git(&["fetch", &args.url, target], &[])
             .context("Failed to execute git fetch")?;
 
         let fetched_oid = repo
@@ -240,7 +241,8 @@ fn handle_link_fetch(
 
         eprintln!("Fetching {} from {}", link_ref.commit, link_ref.remote);
 
-        josh_core::git::spawn_git_command(repo.path(), &["fetch", &link_ref.remote, &refspec], &[])
+        transaction
+            .spawn_git(&["fetch", &link_ref.remote, &refspec], &[])
             .with_context(|| {
                 format!(
                     "git fetch of {} from {} failed",
@@ -315,7 +317,8 @@ fn handle_link_update(
 
         eprintln!("Fetching {} from {}", branch, remote);
 
-        josh_core::git::spawn_git_command(repo.path(), &["fetch", &remote, &branch], &[])
+        transaction
+            .spawn_git(&["fetch", &remote, &branch], &[])
             .with_context(|| format!("git fetch failed for '{}'", path.display()))?;
 
         let new_oid = repo
@@ -419,7 +422,8 @@ fn handle_link_push(
         push_ref
     );
 
-    josh_core::git::spawn_git_command(repo.path(), &["push", &remote, &refspec], &[])
+    transaction
+        .spawn_git(&["push", &remote, &refspec], &[])
         .with_context(|| format!("Failed to push to '{}'", remote))?;
 
     Ok(())

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, anyhow};
 
 use josh_changes::{PushMode, PushRef, build_to_push};
-use josh_core::git::{normalize_repo_path, spawn_git_command};
+use josh_core::git::normalize_repo_path;
 
 use crate::config::{RemoteConfig, read_remote_config};
 use crate::forge::Forge;
@@ -235,9 +235,9 @@ fn prepare_push(
 /// rather than one process per ref. This also makes `--atomic` meaningful across the whole
 /// set instead of applying to a single ref at a time.
 fn push_refs(
+    transaction: &josh_core::cache::Transaction,
     remote_name: &str,
     to_push: &[PushRef],
-    repo_path: &std::path::Path,
     url: &str,
     force: bool,
     atomic: bool,
@@ -276,7 +276,8 @@ fn push_refs(
         .collect();
     git_push_args.extend(refspecs.iter().map(String::as_str));
 
-    spawn_git_command(repo_path, &git_push_args, &[])
+    transaction
+        .spawn_git(&git_push_args, &[])
         .with_context(|| format!("Failed to push to {}", remote_name))?;
 
     eprintln!("Pushed {} ref(s) to {}", to_push.len(), remote_name);
@@ -385,9 +386,9 @@ fn orchestrate_push(
 
     // Phase 3: Execute the side effects.
     push_refs(
+        transaction,
         remote_name,
         &to_push,
-        repo.path(),
         &url,
         force,
         atomic,

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -122,7 +122,8 @@ pub fn handle_sync(
                 for oid in &oid_strs {
                     fetch_args.push(oid);
                 }
-                josh_core::git::spawn_git_command(repo.path(), &fetch_args, &[])
+                transaction
+                    .spawn_git(&fetch_args, &[])
                     .with_context(|| "Failed to fetch objects from GitHub")?;
             }
 
@@ -141,10 +142,9 @@ pub fn handle_sync(
                             let refspec = format!("refs/heads/{}", target);
                             let fetch_args: Vec<&str> =
                                 vec!["fetch", &github_url, "--no-tags", &refspec];
-                            josh_core::git::spawn_git_command(repo.path(), &fetch_args, &[])
-                                .with_context(|| {
-                                    format!("Failed to fetch target branch {}", target)
-                                })?;
+                            transaction.spawn_git(&fetch_args, &[]).with_context(|| {
+                                format!("Failed to fetch target branch {}", target)
+                            })?;
                             let output = std::process::Command::new("git")
                                 .args(["rev-parse", "FETCH_HEAD"])
                                 .current_dir(repo.path())

--- a/josh-cli/src/lib.rs
+++ b/josh-cli/src/lib.rs
@@ -2,3 +2,7 @@ pub mod commands;
 pub mod config;
 pub mod forge;
 pub mod remote_ops;
+
+/// Default cap (128 MiB) on a transaction's in-memory object buffer; exceeding it flushes a
+/// packfile.
+pub const MAX_MEM_PACK_SIZE: usize = 128 * 1024 * 1024;

--- a/josh-cli/src/remote_ops.rs
+++ b/josh-cli/src/remote_ops.rs
@@ -1,7 +1,6 @@
 use anyhow::Context;
 
 use josh_core::filter::{self, Filter, flatten_chain};
-use josh_core::git::{normalize_repo_path, spawn_git_command};
 
 /// Parse the symref output from `git ls-remote --symref` to extract the default branch.
 /// Returns `(branch_name, full_ref)` e.g. `("master", "refs/remotes/origin/master")`.
@@ -116,7 +115,6 @@ pub fn step_ref_prefix(step_idx: usize, steps: &[Filter]) -> String {
 /// Then runs `git fetch {remote_name}` to expose them through the configured remote.
 pub fn apply_josh_filtering(
     transaction: &josh_core::cache::Transaction,
-    repo_path: &std::path::Path,
     filter: josh_core::filter::Filter,
     remote_name: &str,
     default_branch: &str,
@@ -182,12 +180,9 @@ pub fn apply_josh_filtering(
             .context("failed to create filtered reference")?;
     }
 
-    spawn_git_command(
-        normalize_repo_path(repo_path).as_path(),
-        &["fetch", remote_name],
-        &[],
-    )
-    .context("failed to fetch filtered refs")?;
+    transaction
+        .spawn_git(&["fetch", remote_name], &[])
+        .context("failed to fetch filtered refs")?;
 
     Ok(())
 }

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -43,8 +43,6 @@ pub fn run(transaction: &josh_core::cache::Transaction, opts: RunOptions) -> any
 
     let filter_spec = opts.filter_spec.trim().to_string();
     let repo = transaction.repo();
-    // Keep temporary filter objects in memory; never write loose objects to disk.
-    let _mempack = repo.odb()?.add_new_mempack_backend(1000)?;
 
     let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
 
@@ -73,7 +71,6 @@ pub fn plan_images(
 
     let filter_spec = opts.filter_spec.trim().to_string();
     let repo = transaction.repo();
-    let _mempack = repo.odb()?.add_new_mempack_backend(1000)?;
 
     let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
 
@@ -98,7 +95,6 @@ pub fn plan_jobs(
 
     let filter_spec = opts.filter_spec.trim().to_string();
     let repo = transaction.repo();
-    let _mempack = repo.odb()?.add_new_mempack_backend(1000)?;
 
     let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
 

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -52,6 +52,7 @@ tracing.workspace = true
 toml.workspace = true
 
 josh-filter.workspace = true
+josh-git-data.workspace = true
 josh-starlark.workspace = true
 
 [dev-dependencies]

--- a/josh-core/benches/ultrawide_pin.rs
+++ b/josh-core/benches/ultrawide_pin.rs
@@ -248,7 +248,7 @@ fn ultrawide_pin(c: &mut Criterion) {
             // transaction so every run does the full filtering work instead of
             // hitting memoized results.
             josh_core::reset_caches().expect("reset caches");
-            let transaction = bench.context.open(None).expect("open transaction");
+            let transaction = bench.context.open().expect("open transaction");
 
             // Optional: route object writes through an in-memory mempack backend instead
             // of the loose-file backend, to measure the ODB write-path overhead. Reads of

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -33,6 +33,9 @@ pub fn clear_global_caches() {
 pub struct TransactionContext {
     path: std::path::PathBuf,
     cache: std::sync::Arc<CacheStack>,
+    ref_prefix: Option<String>,
+    mem_odb_limit: Option<usize>,
+    ephemeral: bool,
 }
 
 impl TransactionContext {
@@ -40,17 +43,42 @@ impl TransactionContext {
         let repo = git2::Repository::open_from_env()?;
         let path = repo.path().to_owned();
 
-        Ok(Self { path, cache })
+        Ok(Self {
+            path,
+            cache,
+            ref_prefix: None,
+            mem_odb_limit: None,
+            ephemeral: false,
+        })
     }
 
     pub fn new(path: impl AsRef<std::path::Path>, cache: std::sync::Arc<CacheStack>) -> Self {
         Self {
             path: path.as_ref().to_path_buf(),
             cache,
+            ref_prefix: None,
+            mem_odb_limit: None,
+            ephemeral: false,
         }
     }
 
-    pub fn open(&self, ref_prefix: Option<&str>) -> anyhow::Result<Transaction> {
+    pub fn with_ref_prefix(mut self, prefix: impl AsRef<str>) -> Self {
+        self.ref_prefix = Some(prefix.as_ref().to_string());
+        self
+    }
+
+    pub fn with_mem_odb_limit(mut self, limit: usize) -> Self {
+        self.mem_odb_limit = Some(limit);
+        self
+    }
+
+    pub fn ephemeral(mut self) -> Self {
+        self.mem_odb_limit = None;
+        self.ephemeral = true;
+        self
+    }
+
+    pub fn open(&self) -> anyhow::Result<Transaction> {
         if !self.path.exists() {
             return Err(anyhow!("path does not exist"));
         }
@@ -62,7 +90,9 @@ impl TransactionContext {
                 &[] as &[&std::ffi::OsStr],
             )?,
             self.cache.clone(),
-            ref_prefix,
+            self.ref_prefix.as_deref(),
+            self.mem_odb_limit,
+            self.ephemeral,
         ))
     }
 }
@@ -90,8 +120,27 @@ struct Transaction2 {
 pub struct Transaction {
     t2: std::cell::RefCell<Transaction2>,
     repo: git2::Repository,
-    ref_prefix: String,
+    /// Per-transaction in-memory object store, flushed to a packfile when the transaction drops, at
+    /// an explicit boundary, or mid-transaction when it exceeds its size limit. Never shared with
+    /// another transaction.
+    mem_odb: std::sync::Arc<josh_git_data::MemOdb>,
+    mem_odb_limit: Option<usize>,
+    ephemeral: bool,
+    ref_prefix: Option<String>,
     filter_hook: Option<std::sync::Arc<dyn FilterHook + Send + Sync>>,
+}
+
+impl Drop for Transaction {
+    fn drop(&mut self) {
+        // Skip flushing to disk, the mem odb will be lost, as requested.
+        if self.ephemeral {
+            return;
+        }
+
+        if let Err(e) = self.mem_odb.flush(&self.repo) {
+            log::error!("failed to flush in-memory object store: {e}");
+        }
+    }
 }
 
 impl Transaction {
@@ -99,12 +148,17 @@ impl Transaction {
         repo: git2::Repository,
         cache: std::sync::Arc<CacheStack>,
         ref_prefix: Option<&str>,
+        mem_odb_limit: Option<usize>,
+        ephemeral: bool,
     ) -> Transaction {
         // Disable libgit2's strict object creation globally: josh only ever writes objects
         // whose referenced objects it has just produced or read, so the per-write existence
         // checks are pure overhead. This is a process-wide C global, set exactly once.
         static STRICT_OBJECT_CREATION_OFF: std::sync::Once = std::sync::Once::new();
         STRICT_OBJECT_CREATION_OFF.call_once(|| git2::opts::strict_object_creation(false));
+
+        let mem_odb = josh_git_data::MemOdb::new(mem_odb_limit, repo.path().to_owned());
+        mem_odb.register(&repo);
 
         log::debug!("new transaction");
 
@@ -130,7 +184,10 @@ impl Transaction {
                 nesting_level: 0,
             }),
             repo,
-            ref_prefix: ref_prefix.unwrap_or("").to_string(),
+            mem_odb,
+            mem_odb_limit,
+            ephemeral,
+            ref_prefix: ref_prefix.map(|prefix| prefix.to_owned()),
             filter_hook: None,
         }
     }
@@ -139,17 +196,36 @@ impl Transaction {
         let context = TransactionContext {
             cache: self.t2.borrow().cache.clone(),
             path: self.repo.path().to_owned(),
+            ref_prefix: self.ref_prefix.clone(),
+            mem_odb_limit: self.mem_odb_limit,
+            ephemeral: self.ephemeral,
         };
 
-        context.open(Some(&self.ref_prefix))
+        context.open()
     }
 
     pub fn repo(&self) -> &git2::Repository {
         &self.repo
     }
 
+    // TODO: remove and rework proxy git launch path to use spawn_git
+    pub fn flush_mem_odb(&self) -> anyhow::Result<()> {
+        self.mem_odb.flush(&self.repo)?;
+        Ok(())
+    }
+
+    /// Flush this transaction's in-memory objects, then run a `git` subprocess against its repo. Use
+    /// this in place of [`crate::git::spawn_git_command`] whenever a transaction is in scope: the
+    /// spawned `git` reads objects from disk and cannot see the in-memory backend, so the store must
+    /// be flushed first.
+    pub fn spawn_git(&self, args: &[&str], env: &[(&str, &str)]) -> anyhow::Result<()> {
+        self.flush_mem_odb()?;
+        crate::git::spawn_git_command(self.repo.path(), args, env)
+    }
+
     pub fn refname(&self, r: &str) -> String {
-        format!("{}{}", self.ref_prefix, r)
+        let ref_prefix = self.ref_prefix.as_deref().unwrap_or_default();
+        format!("{}{}", ref_prefix, r)
     }
 
     pub fn misses(&self) -> usize {

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -784,7 +784,7 @@ pub fn trigram_search<'a>(
     let mut r = trees
         .par_iter()
         .map_init(
-            || tran_context.open(None).unwrap(),
+            || tran_context.open().unwrap(),
             |transaction, (id, name)| {
                 let s = transaction.repo().find_tree(*id).unwrap();
 

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -147,6 +147,8 @@ pub fn spawn_git_command(
 ) -> anyhow::Result<()> {
     log::debug!("spawn_git_command: {:?}", args);
 
+    // Does not flush any in-memory ODB; callers with a transaction in scope must use
+    // `Transaction::spawn_git` instead so the spawned `git` can see in-flight objects.
     let cwd = normalize_repo_path(repo_path);
 
     let mut command = std::process::Command::new("git");

--- a/josh-filter/Cargo.toml
+++ b/josh-filter/Cargo.toml
@@ -18,6 +18,7 @@ itertools = "0.14.0"
 
 anyhow.workspace = true
 git2.workspace = true
+josh-git-data.workspace = true
 gix-object.workspace = true
 gix-hash.workspace = true
 regex.workspace = true

--- a/josh-filter/src/lib.rs
+++ b/josh-filter/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod filter;
 pub mod flang;
-pub mod hash;
 pub mod op;
 pub mod opt;
 pub mod persist;

--- a/josh-filter/src/opt.rs
+++ b/josh-filter/src/opt.rs
@@ -4,10 +4,10 @@
  */
 
 use crate::filter::Filter;
-use crate::hash::PassthroughHasher;
 use crate::op::Op;
 use crate::persist::{peel_op_ref, to_filter, to_op, to_op_ref};
 use anyhow::anyhow;
+use josh_git_data::PassthroughHasher;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;

--- a/josh-git-data/Cargo.toml
+++ b/josh-git-data/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "josh-git-data"
+version = "26.6.11"
+repository = "https://ithub.com/josh-project/josh"
+authors = ["Josh Project authors <contact@josh-project.dev>"]
+license-file = "../LICENSE"
+description = "Custom libgit2 object-database backends for josh"
+keywords = ["git", "libgit2", "odb"]
+readme = "../README.md"
+edition = "2024"
+
+[dependencies]
+libgit2-sys = "0.18"
+git2.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/josh-git-data/src/hash.rs
+++ b/josh-git-data/src/hash.rs
@@ -1,10 +1,12 @@
 use std::hash::Hasher;
 use std::mem::size_of;
 
-/// A hasher that uses an already-uniform key directly as the hash value, avoiding
-/// double-hashing. Two key shapes are supported: the first 8 bytes of a 20-byte SHA1
-/// (e.g. an `Oid` key) via `write`, or a single pointer-sized integer (e.g. an interned
-/// `Filter` node pointer) via `write_usize`.
+/// A hasher that uses an already-uniform key directly as the hash value, avoiding double-hashing.
+///
+/// Two key shapes are supported: the first 8 bytes of a 20-byte SHA1 (e.g. a git `Oid` key) via
+/// [`write`](Hasher::write), or a single pointer-sized integer (e.g. an interned handle) via
+/// [`write_usize`](Hasher::write_usize). Anything else panics: the hasher assumes its input is
+/// already a cryptographic digest or a unique integer, so mixing it further would be wasted work.
 #[derive(Default)]
 pub struct PassthroughHasher {
     buffer: [u8; 8],
@@ -20,7 +22,7 @@ impl Hasher for PassthroughHasher {
         u64::from_le_bytes(self.buffer)
     }
 
-    // Used for interned `Filter` keys, whose hash is just the node pointer.
+    // Used for keys whose hash is the value itself, e.g. an interned pointer.
     fn write_usize(&mut self, i: usize) {
         if self.done {
             panic!("hasher data already written");

--- a/josh-git-data/src/lib.rs
+++ b/josh-git-data/src/lib.rs
@@ -1,0 +1,16 @@
+//! Custom libgit2 object-database backends for josh.
+//!
+//! [`OdbBackend`] is a safe Rust trait that [`odb_backend::register`] lifts into a
+//! `git_odb_backend` registered on a repository, so the usual `repo.blob()` / treebuilder /
+//! commit calls route through it with no call-site changes. [`MemOdb`] is the concrete backend
+//! josh uses: a per-operation in-memory store that buffers filtered objects and flushes them to a
+//! packfile at transaction and external-git boundaries.
+
+pub mod hash;
+pub mod mem_odb;
+mod odb_backend;
+pub mod pack;
+
+pub use hash::PassthroughHasher;
+pub use mem_odb::MemOdb;
+pub use odb_backend::{OdbBackend, register};

--- a/josh-git-data/src/mem_odb.rs
+++ b/josh-git-data/src/mem_odb.rs
@@ -1,0 +1,286 @@
+//! A per-operation in-memory ODB store buffering the objects josh produces while filtering, instead
+//! of writing each as a loose object. Flushed to a packfile at transaction and external-git
+//! boundaries, and additionally flushed mid-transaction once the buffered object data exceeds the
+//! configured size limit (so a single transaction may write several packfiles). One [`MemOdb`] per
+//! operation (not process-global), so flushes are isolated and deterministic. Access to a store is
+//! single-threaded, but it is `Send + Sync` to cross async boundaries.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use git2::{ErrorClass, ErrorCode, ObjectType, Oid};
+use libgit2_sys as raw;
+
+use crate::odb_backend::{self, OdbBackend};
+
+type ObjectMap = BTreeMap<Oid, (raw::git_object_t, Box<[u8]>)>;
+
+/// The buffered objects plus a running total of their data size, guarded by one lock so that an
+/// insert and the overflow check following it are observed atomically.
+struct Inner {
+    map: ObjectMap,
+    size: usize,
+}
+
+/// A per-operation in-memory object store. Create one with [`MemOdb::new`], attach it to a
+/// repository's object database with [`MemOdb::register`], and drain it to disk with
+/// [`MemOdb::flush`]. When `limit` is set, the store also drains itself from the write path as soon
+/// as the buffered data exceeds it (see [`MemOdb::flush_on_overflow`]).
+pub struct MemOdb {
+    inner: Mutex<Inner>,
+    limit: Option<usize>,
+    /// Repository the store is registered on, re-opened for overflow flushes
+    /// (see [`MemOdb::flush_on_overflow`]).
+    repo_path: PathBuf,
+}
+
+impl MemOdb {
+    /// Create an empty store. Returned as an [`Arc`] because the store is shared between the owning
+    /// transaction and the libgit2 backend registered on its repository. `limit` bounds the total
+    /// buffered object data: once exceeded the store flushes itself to a packfile (`None` = unbounded).
+    pub fn new(limit: Option<usize>, repo_path: PathBuf) -> Arc<MemOdb> {
+        Arc::new(MemOdb {
+            inner: Mutex::new(Inner {
+                map: Default::default(),
+                size: 0,
+            }),
+            limit,
+            repo_path,
+        })
+    }
+
+    /// Register a backend on `repo`'s object database that reads from / writes to this store, at a
+    /// priority above the on-disk loose (2) and pack (1) backends, so writes land in memory and reads
+    /// check memory first.
+    pub fn register(self: &Arc<Self>, repo: &git2::Repository) {
+        let _ = odb_backend::register(
+            repo,
+            1000,
+            MemBackend {
+                store: self.clone(),
+            },
+        );
+    }
+
+    /// Buffer `oid` (a no-op for a content-addressed duplicate) and return whether the store has now
+    /// exceeded its size limit, so the caller can flush.
+    fn insert(&self, oid: Oid, kind: raw::git_object_t, data: Box<[u8]>) -> bool {
+        let len = data.len();
+        let mut inner = self.inner.lock().unwrap();
+        if inner.map.insert(oid, (kind, data)).is_none() {
+            inner.size += len;
+        }
+        self.limit.is_some_and(|limit| inner.size > limit)
+    }
+
+    /// Drain every in-memory object into a packfile on disk and evict it from the store. Called when
+    /// the owning transaction completes (or at an explicit external-git boundary) so the on-disk
+    /// repository is left whole for any subsequent process that expects the objects on disk.
+    pub fn flush(&self, repo: &git2::Repository) -> Result<(), git2::Error> {
+        self.flush_into(repo)
+    }
+
+    /// Flush triggered from the ODB `write` path when the store overflows its limit. The write
+    /// callback has no repository handle, and the packbuilder reads each object back through a
+    /// registered backend, so re-open the repository, register a backend sharing this store on it,
+    /// and flush through that.
+    fn flush_on_overflow(self: &Arc<Self>) -> Result<(), git2::Error> {
+        let repo = git2::Repository::open(&self.repo_path)?;
+        odb_backend::register(
+            &repo,
+            1000,
+            MemBackend {
+                store: self.clone(),
+            },
+        )?;
+        self.flush_into(&repo)
+    }
+
+    fn flush_into(&self, repo: &git2::Repository) -> Result<(), git2::Error> {
+        // Snapshot the oids under the lock, then release it. The objects must stay in the store
+        // across the packbuilder below: `pb.write` reads each one back through the odb -> this
+        // backend -> `self.inner.lock()`, so we can neither hold the lock here (self-deadlock) nor
+        // drain the map before the pack is on disk. A BTreeMap iterates in sorted oid order, so the
+        // packbuilder produces a deterministic packfile (hence a deterministic pack name).
+        let oids: Vec<Oid> = {
+            let inner = self.inner.lock().unwrap();
+            if inner.map.is_empty() {
+                return Ok(());
+            }
+            inner.map.keys().copied().collect()
+        };
+
+        let mut pb = repo.packbuilder()?;
+        for oid in &oids {
+            pb.insert_object(*oid, None)?;
+        }
+        // `packfile_path` resolves the common object directory, so this is correct for linked
+        // worktrees (whose gitdir has no `objects/` of its own) as well as normal repos.
+        pb.write(&crate::pack::packfile_path(repo), 0)?;
+
+        // Dropping the whole map (rather than only the flushed oids) is safe because a store is
+        // never flushed with writes in flight.
+        let mut inner = self.inner.lock().unwrap();
+        inner.map.clear();
+        inner.size = 0;
+        Ok(())
+    }
+}
+
+/// The libgit2 backend handle for a [`MemOdb`]: a cheap [`Arc`] onto the store, registered on one
+/// repository by [`MemOdb::register`].
+struct MemBackend {
+    store: Arc<MemOdb>,
+}
+
+fn not_found() -> git2::Error {
+    // ErrorCode::NotFound maps to GIT_ENOTFOUND, so a miss makes libgit2 fall through to the next
+    // backend (the on-disk pack/loose backends) instead of treating it as a hard failure.
+    git2::Error::new(
+        ErrorCode::NotFound,
+        ErrorClass::Odb,
+        "not in in-memory store",
+    )
+}
+
+impl OdbBackend for MemBackend {
+    fn read_header(&self, oid: Oid) -> Result<(usize, ObjectType), git2::Error> {
+        self.store
+            .inner
+            .lock()
+            .unwrap()
+            .map
+            .get(&oid)
+            .map(|(kind, data)| (data.len(), raw_to_kind(*kind)))
+            .ok_or_else(not_found)
+    }
+
+    fn read(&self, oid: Oid) -> Result<(Vec<u8>, ObjectType), git2::Error> {
+        self.store
+            .inner
+            .lock()
+            .unwrap()
+            .map
+            .get(&oid)
+            .map(|(kind, data)| (data.to_vec(), raw_to_kind(*kind)))
+            .ok_or_else(not_found)
+    }
+
+    fn write(&mut self, oid: Oid, data: Vec<u8>, kind: ObjectType) -> Result<(), git2::Error> {
+        let overflow = self.store.insert(oid, kind.raw(), data.into_boxed_slice());
+        if overflow {
+            self.store.flush_on_overflow()?;
+        }
+        Ok(())
+    }
+
+    fn exists(&self, oid: Oid) -> bool {
+        self.store.inner.lock().unwrap().map.contains_key(&oid)
+    }
+
+    fn exists_prefix(&self, _oid: Oid, _oid_len: usize) -> Option<Oid> {
+        // Abbreviated-OID lookup against the in-memory store is not implemented; full-OID lookups
+        // (the hot path) are unaffected, and prefix lookups fall through to the on-disk backends.
+        None
+    }
+}
+
+fn raw_to_kind(kind: raw::git_object_t) -> ObjectType {
+    ObjectType::from_raw(kind).expect("stored objects always have a valid git type")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Objects written through a registered [`MemOdb`] are visible only in memory until flushed;
+    /// after a flush a fresh repository (no backend) must find them on disk.
+    #[test]
+    fn flush_writes_objects_to_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        let store = MemOdb::new(None, repo.path().to_owned());
+        store.register(&repo);
+
+        let ids: Vec<Oid> = (0..4)
+            .map(|i| repo.blob(format!("in-memory blob {i}").as_bytes()).unwrap())
+            .collect();
+
+        // Readable in-process before the flush, but only from memory.
+        for id in &ids {
+            assert!(repo.odb().unwrap().exists(*id));
+        }
+
+        store.flush(&repo).unwrap();
+
+        // A fresh repo with no backend can only see objects that made it to disk.
+        let on_disk = git2::Repository::open(dir.path()).unwrap();
+        for (i, id) in ids.iter().enumerate() {
+            let blob = on_disk.find_blob(*id).unwrap();
+            assert_eq!(blob.content(), format!("in-memory blob {i}").as_bytes());
+        }
+
+        // The store is drained: a second flush is a no-op.
+        store.flush(&repo).unwrap();
+    }
+
+    /// A linked worktree's gitdir has no `objects/` of its own, so the flush must write into the
+    /// common object directory rather than `repo.path()/objects/pack` (which does not exist and
+    /// previously failed with "No such file or directory").
+    #[test]
+    fn flush_writes_to_common_dir_for_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let main_path = tmp.path().join("main");
+        let repo = git2::Repository::init(&main_path).unwrap();
+
+        // A worktree can only be added once HEAD points at a commit.
+        let sig = git2::Signature::now("t", "t@t").unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+        drop(tree);
+
+        let wt_path = tmp.path().join("wt");
+        repo.worktree("wt", &wt_path, None).unwrap();
+        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+
+        // The worktree's gitdir differs from its common dir (the main gitdir).
+        assert_ne!(wt_repo.path(), wt_repo.commondir());
+
+        let store = MemOdb::new(None, wt_repo.path().to_owned());
+        store.register(&wt_repo);
+        let id = wt_repo.blob(b"worktree blob").unwrap();
+
+        // Must not fail on the (nonexistent) per-worktree objects/pack directory.
+        store.flush(&wt_repo).unwrap();
+
+        // The pack landed in the common object dir, so the main repo can read the blob from disk.
+        let main = git2::Repository::open(&main_path).unwrap();
+        assert_eq!(main.find_blob(id).unwrap().content(), b"worktree blob");
+    }
+
+    /// When `limit` is set, writing enough data to exceed it flushes the store to a packfile
+    /// mid-transaction (from inside the write path), leaving the objects on disk and the store
+    /// empty. Each further overflow writes another packfile.
+    #[test]
+    fn flushes_on_overflow_during_writes() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        // A 16-byte limit: each 100-byte blob overflows it, so every write flushes.
+        let store = MemOdb::new(Some(16), repo.path().to_owned());
+        store.register(&repo);
+
+        let id1 = repo.blob(&b"x".repeat(100)).unwrap();
+        // The write overflowed and flushed: id1 is already on disk, and a fresh repo can read it.
+        let on_disk = git2::Repository::open(dir.path()).unwrap();
+        assert_eq!(on_disk.find_blob(id1).unwrap().content(), &b"x".repeat(100));
+
+        // A second object overflows again, producing a second packfile.
+        let id2 = repo.blob(&b"y".repeat(100)).unwrap();
+        assert_eq!(on_disk.find_blob(id2).unwrap().content(), &b"y".repeat(100));
+    }
+}

--- a/josh-git-data/src/odb_backend.rs
+++ b/josh-git-data/src/odb_backend.rs
@@ -1,0 +1,275 @@
+//! Generic scaffolding for a custom libgit2 ODB backend.
+//!
+//! [`OdbBackend`] is a safe Rust trait; [`register`] lifts any implementation into a
+//! `git_odb_backend` registered on a repository's object database. The trait shape mirrors the
+//! `git2-rs` fork (branch `metahead/odb-backends`), where a safe trait object is wrapped by a
+//! `#[repr(C)]` [`RawOdbBackend`] and called through `extern "C"` trampolines.
+//!
+//! git2 does not expose the raw `git_odb`/`git_repository` pointers (its `Binding` trait is
+//! private), so [`register`] reads the pointer out of the single-field `Repository` newtype. That
+//! cast is sound only while josh pins `git2` exactly and must be re-verified on every upgrade.
+
+use std::ffi::{c_int, c_void};
+use std::ptr;
+
+use git2::{ObjectType, Oid};
+use libgit2_sys as raw;
+
+/// A safe Rust interface to a libgit2 object-database backend.
+///
+/// Any implementation is turned into a `git_odb_backend` by [`register`]. Methods receive
+/// [`git2::Oid`] / [`git2::ObjectType`] and return [`git2::Error`] so any libgit2 failure code can
+/// be signalled: signal "not present here" with [`git2::ErrorCode::NotFound`], which the trampoline
+/// forwards as `GIT_ENOTFOUND` so libgit2 falls through to the next backend (e.g. the on-disk
+/// pack/loose backends). Any other error code propagates and aborts the lookup.
+pub trait OdbBackend {
+    fn read_header(&self, oid: Oid) -> Result<(usize, ObjectType), git2::Error>;
+    fn read(&self, oid: Oid) -> Result<(Vec<u8>, ObjectType), git2::Error>;
+    /// A duplicate (content-addressed) `oid` may be treated as a no-op.
+    fn write(&mut self, oid: Oid, data: Vec<u8>, kind: ObjectType) -> Result<(), git2::Error>;
+    fn exists(&self, oid: Oid) -> bool;
+    /// Resolve an abbreviated object id to its full [`Oid`], if this backend holds a unique match.
+    fn exists_prefix(&self, oid: Oid, oid_len: usize) -> Option<Oid>;
+}
+
+/// `#[repr(C)]` wrapper placing a [`raw::git_odb_backend`] first (so a `*mut git_odb_backend`
+/// handed to a trampoline casts back to this) followed by the owning trait object. libgit2 owns the
+/// allocation and releases it through the `free` trampoline.
+#[repr(C)]
+struct RawOdbBackend {
+    raw: raw::git_odb_backend,
+    obj: Box<dyn OdbBackend>,
+}
+
+impl RawOdbBackend {
+    /// Cast a libgit2 backend pointer back to its wrapper. Safe only because the pointer always
+    /// originates from [`new`], which allocates a `RawOdbBackend` and hands libgit2 its address.
+    unsafe fn from_raw(backend: *mut raw::git_odb_backend) -> &'static mut RawOdbBackend {
+        unsafe { &mut *(backend as *mut RawOdbBackend) }
+    }
+
+    extern "C" fn backend_read(
+        data_p: *mut *mut c_void,
+        len_p: *mut usize,
+        kind_p: *mut raw::git_object_t,
+        backend: *mut raw::git_odb_backend,
+        oid: *const raw::git_oid,
+    ) -> c_int {
+        let (wrapper, oid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
+        match wrapper.obj.read(oid) {
+            Ok((data, kind)) => unsafe {
+                let len = data.len();
+                let buf = raw::git_odb_backend_data_alloc(backend, len);
+                if buf.is_null() {
+                    return raw::GIT_ERROR;
+                }
+                ptr::copy_nonoverlapping(data.as_ptr(), buf as *mut u8, len);
+                *data_p = buf;
+                *len_p = len;
+                *kind_p = kind.raw();
+                raw::GIT_OK
+            },
+            Err(err) => err.raw_code(),
+        }
+    }
+
+    extern "C" fn backend_read_header(
+        len_p: *mut usize,
+        kind_p: *mut raw::git_object_t,
+        backend: *mut raw::git_odb_backend,
+        oid: *const raw::git_oid,
+    ) -> c_int {
+        let (wrapper, oid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
+        match wrapper.obj.read_header(oid) {
+            Ok((len, kind)) => unsafe {
+                *len_p = len;
+                *kind_p = kind.raw();
+                raw::GIT_OK
+            },
+            Err(err) => err.raw_code(),
+        }
+    }
+
+    extern "C" fn backend_write(
+        backend: *mut raw::git_odb_backend,
+        oid: *const raw::git_oid,
+        data: *const c_void,
+        len: usize,
+        kind: raw::git_object_t,
+    ) -> c_int {
+        let (wrapper, oid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
+        let kind = match ObjectType::from_raw(kind) {
+            Some(kind) => kind,
+            None => return raw::GIT_ERROR,
+        };
+        let data = unsafe { std::slice::from_raw_parts(data as *const u8, len) }.to_vec();
+        match wrapper.obj.write(oid, data, kind) {
+            Ok(()) => raw::GIT_OK,
+            Err(err) => err.raw_code(),
+        }
+    }
+
+    extern "C" fn backend_exists(
+        backend: *mut raw::git_odb_backend,
+        oid: *const raw::git_oid,
+    ) -> c_int {
+        let (wrapper, oid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
+        c_int::from(wrapper.obj.exists(oid))
+    }
+
+    extern "C" fn backend_exists_prefix(
+        out_oid: *mut raw::git_oid,
+        backend: *mut raw::git_odb_backend,
+        oid_prefix: *const raw::git_oid,
+        len: usize,
+    ) -> c_int {
+        let (wrapper, oid_prefix) =
+            unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid_prefix)) };
+        match wrapper.obj.exists_prefix(oid_prefix, len) {
+            Some(oid) => unsafe {
+                (*out_oid).id.copy_from_slice(oid.as_bytes());
+                raw::GIT_OK
+            },
+            None => raw::GIT_ENOTFOUND,
+        }
+    }
+
+    extern "C" fn backend_free(backend: *mut raw::git_odb_backend) {
+        // libgit2 is done with the backend; reclaim the wrapper allocation.
+        unsafe {
+            drop(Box::from_raw(backend as *mut RawOdbBackend));
+        }
+    }
+}
+
+unsafe fn oid_from_raw(oid: *const raw::git_oid) -> Oid {
+    Oid::from_bytes(unsafe { &(*oid).id }).expect("git_oid is 20 raw bytes")
+}
+
+/// Build a `git_odb_backend` wrapping `callee`, owned by `odb`. The returned pointer is handed to
+/// libgit2 (which frees it via the `free` trampoline); the caller must not free it on success.
+fn new(odb: *mut raw::git_odb, callee: impl OdbBackend + 'static) -> *mut raw::git_odb_backend {
+    let backend = raw::git_odb_backend {
+        version: raw::GIT_ODB_BACKEND_VERSION,
+        odb,
+        read: Some(RawOdbBackend::backend_read),
+        read_prefix: None,
+        read_header: Some(RawOdbBackend::backend_read_header),
+        write: Some(RawOdbBackend::backend_write),
+        writestream: None,
+        readstream: None,
+        exists: Some(RawOdbBackend::backend_exists),
+        exists_prefix: Some(RawOdbBackend::backend_exists_prefix),
+        refresh: None,
+        foreach: None,
+        writepack: None,
+        writemidx: None,
+        freshen: None,
+        free: Some(RawOdbBackend::backend_free),
+    };
+    let wrapper = RawOdbBackend {
+        raw: backend,
+        obj: Box::new(callee),
+    };
+    Box::into_raw(Box::new(wrapper)) as *mut raw::git_odb_backend
+}
+
+/// Register `backend` on `repo`'s object database at `priority`. Higher values take precedence
+/// over the on-disk loose (2) and pack (1) backends.
+///
+/// git2 does not expose the raw `git_repository` pointer, so it is read out of the single-field
+/// `Repository` newtype. This is sound only while josh pins `git2` exactly; re-verify the layout on
+/// every upgrade.
+pub fn register<B>(repo: &git2::Repository, priority: i32, backend: B) -> Result<(), git2::Error>
+where
+    B: OdbBackend + 'static,
+{
+    unsafe {
+        let repo_raw = *(repo as *const git2::Repository as *const *mut raw::git_repository);
+        let mut odb: *mut raw::git_odb = ptr::null_mut();
+        if raw::git_repository_odb(&mut odb, repo_raw) != raw::GIT_OK {
+            return Err(git2::Error::last_error(raw::GIT_ERROR));
+        }
+        let backend = new(odb, backend);
+        if raw::git_odb_add_backend(odb, backend, priority) != raw::GIT_OK {
+            // add_backend failed: reclaim the allocation to avoid leaking it.
+            drop(Box::from_raw(backend as *mut RawOdbBackend));
+            return Err(git2::Error::last_error(raw::GIT_ERROR));
+        }
+        // git_repository_odb returned an owned (refcounted) handle; the odb itself is still held by
+        // the repo, which now also owns the backend (freed via `free` when the repo drops).
+        raw::git_odb_free(odb);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal in-memory backend used to exercise the trampolines end-to-end through libgit2.
+    struct MapBackend {
+        data: std::collections::HashMap<Oid, (Vec<u8>, ObjectType)>,
+    }
+
+    impl OdbBackend for MapBackend {
+        fn read_header(&self, oid: Oid) -> Result<(usize, ObjectType), git2::Error> {
+            self.read(oid).map(|(data, kind)| (data.len(), kind))
+        }
+
+        fn read(&self, oid: Oid) -> Result<(Vec<u8>, ObjectType), git2::Error> {
+            self.data.get(&oid).cloned().ok_or_else(not_found)
+        }
+
+        fn write(&mut self, oid: Oid, data: Vec<u8>, kind: ObjectType) -> Result<(), git2::Error> {
+            self.data.insert(oid, (data, kind));
+            Ok(())
+        }
+
+        fn exists(&self, oid: Oid) -> bool {
+            self.data.contains_key(&oid)
+        }
+
+        fn exists_prefix(&self, oid: Oid, oid_len: usize) -> Option<Oid> {
+            self.data
+                .keys()
+                .find(|key| key.as_bytes()[..oid_len] == oid.as_bytes()[..oid_len])
+                .copied()
+        }
+    }
+
+    fn not_found() -> git2::Error {
+        git2::Error::new(
+            git2::ErrorCode::NotFound,
+            git2::ErrorClass::Odb,
+            "not in test backend",
+        )
+    }
+
+    /// Write a blob through a repo whose odb has a `MapBackend` registered at high priority, then
+    /// read it back. libgit2 must route both the write and the read through our trampolines, and the
+    /// fall-through path must keep working for objects the backend does not hold.
+    #[test]
+    fn round_trip_through_registered_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        let backend = MapBackend {
+            data: std::collections::HashMap::new(),
+        };
+        register(&repo, 1000, backend).unwrap();
+
+        let payload = b"hello, in-memory odb";
+        let id = repo.blob(payload).unwrap();
+
+        // The blob is only in the backend, not on disk; a read must come back through `read`.
+        let blob = repo.find_blob(id).unwrap();
+        assert_eq!(blob.content(), payload);
+
+        assert!(repo.odb().unwrap().exists(id));
+
+        // An unknown oid must yield NotFound so lookups fall through rather than hard-failing.
+        let unknown = Oid::from_str("0000000000000000000000000000000000000001").unwrap();
+        assert!(!repo.odb().unwrap().exists(unknown));
+    }
+}

--- a/josh-git-data/src/pack.rs
+++ b/josh-git-data/src/pack.rs
@@ -1,0 +1,12 @@
+//! Helpers for locating on-disk packfile storage within a repository.
+
+use std::path::PathBuf;
+
+/// The directory where `repo`'s packfiles live (`objects/pack`).
+///
+/// Resolved from the repository's *common* directory rather than its gitdir: a linked worktree has
+/// no `objects/` of its own, so its packs live under the common dir. For a non-worktree repo the two
+/// are the same.
+pub fn packfile_path(repo: &git2::Repository) -> PathBuf {
+    repo.commondir().join("objects").join("pack")
+}

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -3193,6 +3193,7 @@ dependencies = [
  "itertools 0.14.0",
  "josh-filter",
  "josh-starlark",
+ "libgit2-sys",
  "log",
  "percent-encoding",
  "pest",
@@ -3201,6 +3202,7 @@ dependencies = [
  "regex",
  "rs_tracing",
  "rustc-hash 2.1.2",
+ "scc",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5123,12 +5125,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "saa"
+version = "5.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scc"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97f00241b418496a76c47eb60af2477a6086521d314f35322bec8a2ebd334751"
+dependencies = [
+ "saa",
+ "sdd",
 ]
 
 [[package]]

--- a/josh-proxy/src/housekeeping.rs
+++ b/josh-proxy/src/housekeeping.rs
@@ -140,10 +140,12 @@ pub fn run(
 
     const CRUFT_PACK_SIZE: usize = 1024 * 1024 * 64;
 
-    let transaction_mirror =
-        TransactionContext::new(repo_path.join("mirror"), cache.clone()).open(None)?;
-    let transaction_overlay =
-        TransactionContext::new(repo_path.join("overlay"), cache).open(None)?;
+    let transaction_mirror = TransactionContext::new(repo_path.join("mirror"), cache.clone())
+        .with_mem_odb_limit(crate::MAX_MEM_PACK_SIZE)
+        .open()?;
+    let transaction_overlay = TransactionContext::new(repo_path.join("overlay"), cache)
+        .with_mem_odb_limit(crate::MAX_MEM_PACK_SIZE)
+        .open()?;
 
     transaction_overlay
         .repo()

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -10,6 +10,10 @@ mod shell;
 pub mod trace;
 pub mod upstream;
 
+/// Default cap (128 MiB) on a transaction's in-memory object buffer; exceeding it flushes a
+/// packfile.
+pub(crate) const MAX_MEM_PACK_SIZE: usize = 128 * 1024 * 1024;
+
 use crate::http::{IntoRetryable, RetryableError};
 use crate::upstream::RemoteAuth;
 use josh_core;

--- a/josh-proxy/src/service.rs
+++ b/josh-proxy/src/service.rs
@@ -255,14 +255,24 @@ impl JoshProxyService {
         &self,
         ref_prefix: Option<&str>,
     ) -> anyhow::Result<josh_core::cache::Transaction> {
-        TransactionContext::new(self.repo_path.join("overlay"), self.cache.clone()).open(ref_prefix)
+        let mut ctx = TransactionContext::new(self.repo_path.join("overlay"), self.cache.clone())
+            .with_mem_odb_limit(crate::MAX_MEM_PACK_SIZE);
+        if let Some(ref_prefix) = ref_prefix {
+            ctx = ctx.with_ref_prefix(ref_prefix);
+        }
+        ctx.open()
     }
 
     pub fn open_mirror(
         &self,
         ref_prefix: Option<&str>,
     ) -> anyhow::Result<josh_core::cache::Transaction> {
-        TransactionContext::new(self.repo_path.join("mirror"), self.cache.clone()).open(ref_prefix)
+        let mut ctx = TransactionContext::new(self.repo_path.join("mirror"), self.cache.clone())
+            .with_mem_odb_limit(crate::MAX_MEM_PACK_SIZE);
+        if let Some(ref_prefix) = ref_prefix {
+            ctx = ctx.with_ref_prefix(ref_prefix);
+        }
+        ctx.open()
     }
 }
 
@@ -535,6 +545,9 @@ impl NamespacedRefs {
         self.transaction
             .repo()
             .reference_symbolic(&source, &target, true, "write_to_repo")?;
+
+        // Flush before the `git http-backend` subprocess serves these objects from disk.
+        self.transaction.flush_mem_odb()?;
 
         Ok(())
     }
@@ -1529,7 +1542,7 @@ async fn handle_graphql(
             };
 
             crate::upstream::push_head_url(
-                transaction.repo(),
+                &transaction,
                 serv.repo_path
                     .join("mirror")
                     .join("objects")

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -328,20 +328,19 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
     );
 
     let cache = std::sync::Arc::new(CacheStack::default());
-    let transaction_ctx = TransactionContext::new(&repo_update.git_dir, cache.clone());
-    let transaction_mirror_ctx =
-        TransactionContext::new(&repo_update.mirror_git_dir, cache.clone());
 
     if let Some((refname, (old, new))) = repo_update.refs.iter().next() {
-        let transaction = transaction_ctx.open(Some(&format!(
-            "refs/josh/upstream/{}/",
-            repo_update.base_ns
-        )))?;
+        let transaction_ctx = TransactionContext::new(&repo_update.git_dir, cache.clone())
+            .with_ref_prefix(format!("refs/josh/upstream/{}/", repo_update.base_ns))
+            .with_mem_odb_limit(crate::MAX_MEM_PACK_SIZE);
 
-        let transaction_mirror = transaction_mirror_ctx.open(Some(&format!(
-            "refs/josh/upstream/{}/",
-            repo_update.base_ns
-        )))?;
+        let transaction_mirror_ctx =
+            TransactionContext::new(&repo_update.mirror_git_dir, cache.clone())
+                .with_ref_prefix(format!("refs/josh/upstream/{}/", repo_update.base_ns))
+                .with_mem_odb_limit(crate::MAX_MEM_PACK_SIZE);
+
+        let transaction = transaction_ctx.open()?;
+        let transaction_mirror = transaction_mirror_ctx.open()?;
 
         transaction.repo().odb()?.add_disk_alternate(
             transaction_mirror
@@ -509,7 +508,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
             let force_push = !matches!(push_mode, PushMode::Normal) || push_options.force;
 
             let (text, status) = push_head_url(
-                transaction.repo(),
+                &transaction,
                 &format!("{}/objects", repo_update.mirror_git_dir),
                 push_ref.oid,
                 &push_ref.ref_name,
@@ -576,7 +575,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
 
 #[allow(clippy::too_many_arguments)]
 pub fn push_head_url(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     alternate: &str,
     oid: git2::Oid,
     refname: &str,
@@ -586,6 +585,7 @@ pub fn push_head_url(
     display_name: &str,
     force: bool,
 ) -> anyhow::Result<(String, i32)> {
+    let repo = transaction.repo();
     let push_temp_ref = format!("refs/{}", &namespace);
     let push_refspec = format!("{}:{}", &push_temp_ref, &refname);
 
@@ -597,6 +597,8 @@ pub fn push_head_url(
     cmd.push(&push_refspec);
 
     let mut fake_head = repo.reference(&push_temp_ref, oid, true, "push_head_url")?;
+    // Flush before the external `git push` below reads these objects from disk.
+    transaction.flush_mem_odb()?;
     let (stdout, stderr, status) =
         run_git_with_auth(repo.path(), &cmd, remote_auth, Some(alternate.to_owned()))?;
     fake_head.delete()?;

--- a/josh-templates/src/templates.rs
+++ b/josh-templates/src/templates.rs
@@ -12,7 +12,7 @@ struct GraphQLHelper {
 
 impl GraphQLHelper {
     fn transaction_context(&self, path: impl AsRef<std::path::Path>) -> TransactionContext {
-        TransactionContext::new(path, self.cache.clone())
+        TransactionContext::new(path, self.cache.clone()).with_ref_prefix(&self.ref_prefix)
     }
 }
 
@@ -36,10 +36,7 @@ impl GraphQLHelper {
             .join(path);
 
         let path = josh_core::normalize_path(&path);
-        let transaction = if let Ok(to) = self
-            .transaction_context(&mirror_path)
-            .open(Some(&self.ref_prefix))
-        {
+        let transaction = if let Ok(to) = self.transaction_context(&mirror_path).open() {
             to.repo().odb()?.add_disk_alternate(
                 self.repo_path
                     .join("overlay")
@@ -49,8 +46,7 @@ impl GraphQLHelper {
             )?;
             to
         } else {
-            self.transaction_context(&self.repo_path)
-                .open(Some(&self.ref_prefix))?
+            self.transaction_context(&self.repo_path).open()?
         };
 
         let tree = transaction.repo().find_commit(self.commit_id)?.tree()?;
@@ -70,7 +66,7 @@ impl GraphQLHelper {
         }
 
         let (transaction, transaction_mirror) =
-            if let Ok(to) = self.transaction_context(&overlay_path).open(None) {
+            if let Ok(to) = self.transaction_context(&overlay_path).open() {
                 to.repo().odb()?.add_disk_alternate(
                     self.repo_path
                         .join("mirror")
@@ -78,11 +74,11 @@ impl GraphQLHelper {
                         .to_str()
                         .unwrap(),
                 )?;
-                (to, self.transaction_context(&mirror_path).open(None)?)
+                (to, self.transaction_context(&mirror_path).open()?)
             } else {
                 (
-                    self.transaction_context(&self.repo_path).open(None)?,
-                    self.transaction_context(&self.repo_path).open(None)?,
+                    self.transaction_context(&self.repo_path).open()?,
+                    self.transaction_context(&self.repo_path).open()?,
                 )
             };
 
@@ -182,7 +178,7 @@ pub fn render(
             }
 
             let (transaction, transaction_mirror) =
-                if let Ok(to) = TransactionContext::new(&overlay_path, cache.clone()).open(None) {
+                if let Ok(to) = TransactionContext::new(&overlay_path, cache.clone()).open() {
                     to.repo().odb()?.add_disk_alternate(
                         transaction
                             .repo()
@@ -196,12 +192,12 @@ pub fn render(
                     )?;
                     (
                         to,
-                        TransactionContext::new(repo_path, cache.clone()).open(None)?,
+                        TransactionContext::new(repo_path, cache.clone()).open()?,
                     )
                 } else {
                     (
-                        TransactionContext::new(repo_path, cache.clone()).open(None)?,
-                        TransactionContext::new(repo_path, cache.clone()).open(None)?,
+                        TransactionContext::new(repo_path, cache.clone()).open()?,
+                        TransactionContext::new(repo_path, cache.clone()).open()?,
                     )
                 };
             let (res, _errors) = juniper::execute_sync(

--- a/tests/filter/cmdline.t
+++ b/tests/filter/cmdline.t
@@ -72,10 +72,7 @@
   |   |-- cache
   |   |   `-- 27
   |   |       `-- 0
-  |   |           |-- 4f443af7cd6a50ec0be1276ce9d164248f8a88a8
   |   |           |-- 5e165aaee1e65cc624bbb41dc6d1199316dfc1e5
-  |   |           |-- 6432ec67785fcabf15b86a2611df4df9da1ed724
-  |   |           |-- 66680954e9e76fac3ab86f3a75c77b8ce7ffb46e
   |   |           `-- bf567e0faf634a663d6cef48145a035e1974ab1d
   |   `-- filter
   |       `-- libs
@@ -88,7 +85,7 @@
   |       `-- master
   `-- tags
   
-  11 directories, 11 files
+  11 directories, 8 files
 
   $ git read-tree HEAD josh/filter/libs/master josh/filter/libs/foo
   $ git commit -m "sync"

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -192,31 +192,23 @@
       |   |   `-- 5984b1d05c7ba7842828bdc8669c69eed48540
       |   |-- 22
       |   |   `-- a3c9e53508f9532b5109352448c0051ff0a018
-      |   |-- 35
-      |   |   `-- 13da41fec4409551ee7aead656b211996b8f1d
-      |   |-- 47
-      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
       |   |-- 50
       |   |   `-- e9d1a4ad68f5edd03432b540ae6d56995810f5
-      |   |-- 76
-      |   |   `-- b2b18cc389f8dc88727cb143f362f3b4a07788
-      |   |-- 7c
-      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
       |   |-- 8e
       |   |   `-- 9eedb14562d157b873eb24a08d6c0cd225624b
-      |   |-- b0
-      |   |   `-- c372112e15e6946f82bebf73b70f5b3e0d5066
       |   |-- c3
       |   |   `-- 4ad756a74e200f89b43b0d6f21b41eb284b454
-      |   |-- d5
-      |   |   `-- 89c2fd7b5d736b868c4e196898cd9f578eb77f
-      |   |-- d9
-      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
       |   |-- info
       |   `-- pack
+      |       |-- pack-9f1d5b705f285451a89d8e75d2e3ed95ba8cc998.idx
+      |       |-- pack-9f1d5b705f285451a89d8e75d2e3ed95ba8cc998.pack
+      |       |-- pack-a0d4d7da863ed9bcde8d55093ccc35b5c0e7fd27.idx
+      |       |-- pack-a0d4d7da863ed9bcde8d55093ccc35b5c0e7fd27.pack
+      |       |-- pack-b1bafc32ba8e81e4a1a2f5a5d465d9bc1eab7ee1.idx
+      |       `-- pack-b1bafc32ba8e81e4a1a2f5a5d465d9bc1eab7ee1.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  56 directories, 40 files
+  49 directories, 39 files

--- a/tests/proxy/caching.t
+++ b/tests/proxy/caching.t
@@ -92,28 +92,24 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 06
-      |   |   `-- 8bef6976001fadcf131ff077eac37662ed3b7c
-      |   |-- 2e
-      |   |   `-- 310c493edb401f297aba1fc499506e4c85ca87
       |   |-- 63
       |   |   `-- 7f0347d31dad180d6fc7f6720c187b05a8754c
       |   |-- 77
       |   |   `-- d7000ec2f13c49605cd675075e1852881e4fea
       |   |-- bd
       |   |   `-- c926c483c4dfa77e84105c6967e74d8ff9bf5f
-      |   |-- be
-      |   |   `-- 911fd840d34b691403cf4e7d2a8e8bacec8d89
-      |   |-- eb
-      |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
       |   |-- info
       |   `-- pack
+      |       |-- pack-a44287650558d5610fb771360d8e3ee97671557c.idx
+      |       |-- pack-a44287650558d5610fb771360d8e3ee97671557c.pack
+      |       |-- pack-e6ea08342a6fbc40312444de4552434e4dbf41a9.idx
+      |       `-- pack-e6ea08342a6fbc40312444de4552434e4dbf41a9.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  39 directories, 24 files
+  35 directories, 24 files
 
 # setup without caching
   $ EXTRA_OPTS= . ${TESTDIR}/setup_test_env.sh
@@ -214,27 +210,23 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 06
-      |   |   `-- 8bef6976001fadcf131ff077eac37662ed3b7c
-      |   |-- 2e
-      |   |   `-- 310c493edb401f297aba1fc499506e4c85ca87
       |   |-- 63
       |   |   `-- 7f0347d31dad180d6fc7f6720c187b05a8754c
       |   |-- 77
       |   |   `-- d7000ec2f13c49605cd675075e1852881e4fea
       |   |-- bd
       |   |   `-- c926c483c4dfa77e84105c6967e74d8ff9bf5f
-      |   |-- be
-      |   |   `-- 911fd840d34b691403cf4e7d2a8e8bacec8d89
-      |   |-- d9
-      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
-      |   |-- eb
-      |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
       |   |-- info
       |   `-- pack
+      |       |-- pack-320458e5ec491f521fae67b51436d535dc9ecb49.idx
+      |       |-- pack-320458e5ec491f521fae67b51436d535dc9ecb49.pack
+      |       |-- pack-a44287650558d5610fb771360d8e3ee97671557c.idx
+      |       |-- pack-a44287650558d5610fb771360d8e3ee97671557c.pack
+      |       |-- pack-e6ea08342a6fbc40312444de4552434e4dbf41a9.idx
+      |       `-- pack-e6ea08342a6fbc40312444de4552434e4dbf41a9.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  44 directories, 29 files
+  39 directories, 30 files

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -121,21 +121,13 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 00
-      |   |   `-- f1db8b2e4bd1bf8337e0fe3a2ad9aeea478280
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
-      |   |-- 1f
-      |   |   `-- 0b9d8a7b40a35bb4ff64ffc0f08369df23bc61
-      |   |-- b5
-      |   |   `-- af4d1258141efaadc32e369f4dc4b1f6c524e4
-      |   |-- e9
-      |   |   `-- 67e7a8371f8e269cb1d9bb6b2fff5be29e8578
       |   |-- info
       |   `-- pack
+      |       |-- pack-99ecd3f961c673728c44c77b13523f71980ac569.idx
+      |       `-- pack-99ecd3f961c673728c44c77b13523f71980ac569.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  40 directories, 25 files
+  35 directories, 22 files

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -136,19 +136,15 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 55
-      |   |   `-- 279561e012bf3a8946e23cf16c909e8eb7a5f9
-      |   |-- b0
-      |   |   `-- 4a61a938114efbb60395f72e5904fc42eb123a
-      |   |-- ea
-      |   |   `-- 7beb7786b5dbadf54412f90d4e729f41f26c00
       |   |-- info
       |   `-- pack
+      |       |-- pack-442b8fb8b28a9e4db96c2918ac2b58a1f786beb1.idx
+      |       |-- pack-442b8fb8b28a9e4db96c2918ac2b58a1f786beb1.pack
+      |       |-- pack-dc6413149cc84a39b1f6795b6f032a4d391a2e9e.idx
+      |       `-- pack-dc6413149cc84a39b1f6795b6f032a4d391a2e9e.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  40 directories, 25 files
+  36 directories, 25 files

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -132,15 +132,13 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- info
       |   `-- pack
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
+      |       `-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  37 directories, 22 files
+  35 directories, 22 files

--- a/tests/proxy/clone_subtree_no_master.t
+++ b/tests/proxy/clone_subtree_no_master.t
@@ -124,14 +124,12 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- info
       |   `-- pack
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
+      |       `-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
       `-- refs
           |-- heads
           `-- tags
   
-  36 directories, 21 files
+  34 directories, 21 files

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -173,18 +173,14 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
-      |   |-- 6e
-      |   |   `-- 99e1e5ba1de7225f0d09a0b91d2e29ae15569c
       |   |-- info
       |   `-- pack
+      |       |-- pack-520761ba67cf670cd00b18237d9f65bab639d94b.idx
+      |       `-- pack-520761ba67cf670cd00b18237d9f65bab639d94b.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  41 directories, 29 files
+  38 directories, 28 files
 $ cat ${TESTTMP}/josh-proxy.out | grep TAGS

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -395,45 +395,25 @@ Flushed credential cache
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 31
-      |   |   `-- c287b0dca7d1ae668b175ba5fee1e010e5cb68
-      |   |-- 50
-      |   |   `-- f9324abab8bcfcf9ef3b86c4c9b81a258e4c8f
-      |   |-- 5d
-      |   |   `-- 98d297b3b16d5946dada2496accc9f99dc7056
-      |   |-- 6e
-      |   |   `-- 9a62b40f85b0952ea06023a8ee1fb99685e6f7
-      |   |-- 6f
-      |   |   `-- e45a9254eb9dd78951a804fa94a035a937ef0b
-      |   |-- 70
-      |   |   `-- 574c42095b00b4a0757af989a9211bd2c95c91
-      |   |-- 71
-      |   |   `-- 28ce7713fc45163e65c7ac4a9057ed1913a569
-      |   |-- 80
-      |   |   `-- 472110df082d0a921ecdcd6f0dd0021f48e019
-      |   |-- 85
-      |   |   `-- c3ce1926696ef4bdf2eff358bd83b079dcc8d4
-      |   |-- 92
-      |   |   `-- b32c39e590a35edb6c1b12dc8919da56869fe5
-      |   |-- 9c
-      |   |   `-- b7c3c14c5c084f6a6897b6e6bab231fae98ae5
-      |   |-- b1
-      |   |   `-- 5fcd0ea97c1755068288984cd9b4ec57ae02b4
-      |   |-- c4
-      |   |   `-- df336cf6578b6dac651a33fd265d92308c0e39
-      |   |-- e5
-      |   |   `-- 2c4e8d6c1f4960b92676424944ff3951f472aa
-      |   |-- ef
-      |   |   `-- 7e2202b63572aa95b06cda4f844fe8f83c2673
-      |   |-- f2
-      |   |   `-- 099eb4510f85688a21ce5fc3992ca4274a837b
-      |   |-- f9
-      |   |   `-- 97320406328b16277aca038db747cf60232267
       |   |-- info
       |   `-- pack
+      |       |-- pack-57aa405783926aecf0c4757c6c3a5705b9dcd606.idx
+      |       |-- pack-57aa405783926aecf0c4757c6c3a5705b9dcd606.pack
+      |       |-- pack-b3d0761cbb7d1687ce01bf427a8ee074404d8ad4.idx
+      |       |-- pack-b3d0761cbb7d1687ce01bf427a8ee074404d8ad4.pack
+      |       |-- pack-bd386714b9845c1d6f993b21c968c3189cb6c55f.idx
+      |       |-- pack-bd386714b9845c1d6f993b21c968c3189cb6c55f.pack
+      |       |-- pack-c3e5e7fe561eafbfd5bf726f4fe20f4e2b9966f1.idx
+      |       |-- pack-c3e5e7fe561eafbfd5bf726f4fe20f4e2b9966f1.pack
+      |       |-- pack-e32a11fa9491d13e1eef03a02a01717ffb893017.idx
+      |       |-- pack-e32a11fa9491d13e1eef03a02a01717ffb893017.pack
+      |       |-- pack-e8f089f082f050a67498a1702a9ef72c15b32be7.idx
+      |       |-- pack-e8f089f082f050a67498a1702a9ef72c15b32be7.pack
+      |       |-- pack-ed8851c038e9b9a76ee1cb84a7c6b1a23d6b4f26.idx
+      |       `-- pack-ed8851c038e9b9a76ee1cb84a7c6b1a23d6b4f26.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  75 directories, 61 files
+  58 directories, 58 files

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -110,29 +110,13 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 22
-      |   |   `-- b22885799153b100fdb3445c59c4c3f4482ed3
-      |   |-- 24
-      |   |   `-- 6b71ecf742c084ec41ba6f2c4e355ca4806ef0
-      |   |-- 5a
-      |   |   `-- 29d3ef74b34ca534513c6499e9c9011371fab4
-      |   |-- 68
-      |   |   `-- 9a59b2fad33839a7e8d6c1c02ce94095d8fe1e
-      |   |-- 85
-      |   |   `-- 352a4584261ab3b54e32aa4ddfe04e80c6800e
-      |   |-- 8e
-      |   |   `-- 9aa8ffc35bbc452f9654b834047168ce02dc48
-      |   |-- c3
-      |   |   `-- 0a8aef421831a8492d21efde601e90a742544f
-      |   |-- d9
-      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
-      |   |-- db
-      |   |   `-- dfb5702a23dd0a3502f4d6ce7287a3a4d85abe
       |   |-- info
       |   `-- pack
+      |       |-- pack-dfd9843a38e8a4c7ec7231382409474c2cbd5981.idx
+      |       `-- pack-dfd9843a38e8a4c7ec7231382409474c2cbd5981.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  46 directories, 31 files
+  37 directories, 24 files

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -456,103 +456,19 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 00
-      |   |   |-- 0fdb96141588097517f5361a52fd15f516236c
-      |   |   `-- 398737066733a879fdeac01f830d2b7c2212c7
-      |   |-- 10
-      |   |   `-- e44181805d5aa02e9ae9d42f8e6f16a177712e
-      |   |-- 11
-      |   |   `-- 474f8beca288b120a723a57c7d201ddc07672f
-      |   |-- 12
-      |   |   `-- 1288d478f72ac23fd2f6fa9ef40dcafc0dac9f
-      |   |-- 13
-      |   |   `-- 1043174b309a606a52c4f810cf509d4c120a69
-      |   |-- 18
-      |   |   `-- c7ee0bdd23edd6563b453e8773f3815f45022d
-      |   |-- 23
-      |   |   |-- 87c59576f220507ff0e0de060ceacd71ff41a3
-      |   |   `-- d5514a250d2387066895bc2575d329be7c9c38
-      |   |-- 24
-      |   |   |-- 9fd13d8f23051a218b48657ff1f2433de40b49
-      |   |   `-- d379f3645131d769fe0e5de2d075a69417ea94
-      |   |-- 30
-      |   |   `-- bad8e97384f1ac8cbccd35304d85c9e12b5665
-      |   |-- 3d
-      |   |   `-- d7fdbfe787ed80cb58a5905851a1840102e5f2
-      |   |-- 43
-      |   |   `-- ba4ca11186832c55431d069bcc673a697ac081
-      |   |-- 49
-      |   |   `-- 0782f700bcfb460af23fd4804534b219f845a6
-      |   |-- 5b
-      |   |   `-- c77f5c5a22619575241e72415aac832204e714
-      |   |-- 61
-      |   |   `-- 3cf076586b0dec8f8547b5bfd27f4327e2e489
-      |   |-- 62
-      |   |   `-- 4b4ae13c87b02e347717cedff72da5e175c689
-      |   |-- 6c
-      |   |   `-- adbbeea146ce3172c8229e9d573e3eab7bdff1
-      |   |-- 6f
-      |   |   `-- a39dde3631ce9a1934bcbb94b838237769a44e
-      |   |-- 77
-      |   |   `-- cc643f01813fec7eaac6388bbe44886e2659bd
-      |   |-- 8e
-      |   |   `-- 1b4e9d32c8a6c0138a4316eb94c36c1e7de384
-      |   |-- 91
-      |   |   `-- 509498b7b323626ac259fae13f6c50eea5c947
-      |   |-- 95
-      |   |   |-- 2e0ed4fdd6cc6daf3d1c4fcb138fddc8ffdabb
-      |   |   `-- c8826895fb97c2656fdc348d0dab5f943d9f7e
-      |   |-- 98
-      |   |   `-- 51c22e33a18b65ecc2dfcb07ac21ee53ecae8d
-      |   |-- 9e
-      |   |   `-- 6ec84b9177b428ce4a7343fca238e864cdf3d7
-      |   |-- a2
-      |   |   `-- b32d1c6c2e22ae44b3b3169ae14230d713c284
-      |   |-- a9
-      |   |   `-- 4835bf48c2916fbd6984c20564315e9c58660d
-      |   |-- b0
-      |   |   |-- d4426b7d7d8157600c990d18b62e8a237bffa6
-      |   |   `-- f8e35251e96a874f6c597a2eb2f597b4d4aed2
-      |   |-- b1
-      |   |   `-- d540fbdaef90043e873b454fca330ec20d57f3
-      |   |-- b2
-      |   |   `-- 8b2106a36e97a096e33a95825aff9f7d4860b5
-      |   |-- b5
-      |   |   `-- 2a6b1f3afba295c5463036ce7dd3f2a675b915
-      |   |-- b7
-      |   |   `-- 39c5e88e64a494ccf6a0980788c2b2ef429f28
-      |   |-- bf
-      |   |   `-- 3ce158537f47e137717eb738930e95facdd300
-      |   |-- ca
-      |   |   `-- 8c6bc19dc6ec1ea4f60d4982b003edb4e26c26
-      |   |-- cd
-      |   |   `-- 7388ce64302b3a643177b76d6f0beac6779478
-      |   |-- d1
-      |   |   `-- 86c79c2a8e295d663e9fbd8dc65a33fc8bd160
-      |   |-- d4
-      |   |   `-- 407037b9a530bea6873143bbe61c7ad6d26feb
-      |   |-- d6
-      |   |   `-- 49338b5bec68500d266921a289a518b956452c
-      |   |-- d7
-      |   |   |-- 15747fe0dcdc8e0a2e57d2c8bfcbc5ddfe1544
-      |   |   `-- ff5d05ada0212e6e904857429c406791b10c46
-      |   |-- db
-      |   |   `-- 7ce571bb0c987e4e4aadbbd727867158c4a309
-      |   |-- df
-      |   |   `-- 0fb9ea1e23fb68a3c589d9b356b6a52bbd3c6f
-      |   |-- e0
-      |   |   `-- 77d6ab1d2b2335e25b879c22c32fb3d9d64188
-      |   |-- e7
-      |   |   `-- e7b082cc60acffc7991c438f6a03833bad2641
-      |   |-- ed
-      |   |   `-- fdf0b26b57e156cb1f118a633af077d9ba128a
-      |   |-- f8
-      |   |   `-- 1b303f7a6f22739b9513836d934f622243c15a
       |   |-- info
       |   `-- pack
+      |       |-- pack-1a631b5bbd2b05937baaaa4ddeaa4c1b500cb2a7.idx
+      |       |-- pack-1a631b5bbd2b05937baaaa4ddeaa4c1b500cb2a7.pack
+      |       |-- pack-4ee9e150f10f6cd4ae11c19ac760d7e412da64e6.idx
+      |       |-- pack-4ee9e150f10f6cd4ae11c19ac760d7e412da64e6.pack
+      |       |-- pack-66f14bc6d6708cd5fbe113e5b5a7355273ea8ec2.idx
+      |       |-- pack-66f14bc6d6708cd5fbe113e5b5a7355273ea8ec2.pack
+      |       |-- pack-e429893378822d8bd667854bb44a9481094ddf8e.idx
+      |       `-- pack-e429893378822d8bd667854bb44a9481094ddf8e.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  110 directories, 106 files
+  67 directories, 65 files

--- a/tests/proxy/push_graphql.t
+++ b/tests/proxy/push_graphql.t
@@ -111,17 +111,13 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
-      |   |-- 7e
-      |   |   `-- 14e7e562164fb65d8f294303e07e915b95c5fe
-      |   |-- c9
-      |   |   `-- 0121689a90787dea0aa3be06701af6c66c3e20
       |   |-- info
       |   `-- pack
+      |       |-- pack-f365fdaf48fb6dfec6ed88c79867abe37a55162b.idx
+      |       `-- pack-f365fdaf48fb6dfec6ed88c79867abe37a55162b.pack
       `-- refs
           |-- heads
           `-- tags
   
-  34 directories, 21 files
+  31 directories, 20 files
 

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -170,40 +170,29 @@ Check the branch again
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 28
-      |   |   |-- 1431e1f2eaff44142f2c0512c06716b6ebd6d6
-      |   |   `-- d20855c7b65b5a9948283516ae62739360544d
-      |   |-- 49
-      |   |   `-- b12216dab2cefdb1cc0fcda7ab6bc9f8b882ab
-      |   |-- 56
-      |   |   `-- dc1f749ea31f735f981a42bc6c23e92baf2085
       |   |-- 75
       |   |   `-- 1ef4576e133fc6279ccf882cb812a9b4dcf5dd
       |   |-- 84
       |   |   `-- f7637c03dc38d6d22461003f6b9c65f6fdb4d3
       |   |-- 9d
       |   |   `-- aeafb9864cf43055ae93beb0afd6c7d144bfa4
-      |   |-- a5
-      |   |   `-- 5a119d24890de3a3e470f941217479629e50c6
-      |   |-- ab
-      |   |   `-- 26032e5a4ef35d64849e0af272ceb4b27948bf
       |   |-- b5
       |   |   `-- afbb444fd22857e78ee11ddd92b7dd2f5c7d11
-      |   |-- cf
-      |   |   `-- 704ed443e7351ab990ab68c916c2428dcf9100
-      |   |-- de
-      |   |   `-- 7cba2eb70af5ce3555c3670e7641f2f547db74
       |   |-- e5
       |   |   `-- 28cb6fde9d30fd62f42484c291bd1799245888
-      |   |-- ef
-      |   |   `-- 5ab66c07ba7c211e2a3d30bc9b6e4d5b6909fe
       |   |-- f4
       |   |   `-- 35f3fecaba02ae9cc9d462b1bd0d396fdf352f
       |   |-- info
       |   `-- pack
+      |       |-- pack-506f77be639c56f3124b09bc6c74ca46083eb416.idx
+      |       |-- pack-506f77be639c56f3124b09bc6c74ca46083eb416.pack
+      |       |-- pack-6f373fdfd68f130303e51d70f84843bbb3b9933d.idx
+      |       |-- pack-6f373fdfd68f130303e51d70f84843bbb3b9933d.pack
+      |       |-- pack-9284b8b46944ee6adfb791d61fa9faf125784a91.idx
+      |       `-- pack-9284b8b46944ee6adfb791d61fa9faf125784a91.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  53 directories, 40 files
+  45 directories, 37 files

--- a/tests/proxy/push_new_orphan_branch.t
+++ b/tests/proxy/push_new_orphan_branch.t
@@ -185,46 +185,33 @@ Make sure all temporary namespace got removed
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- 81
-      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
       |   |-- a4
       |   |   `-- ae8248b2e96725156258b90ced9e841dfd20d1
-      |   |-- b1
-      |   |   `-- d5238086b7f07024d8ed47360e3ce161d9b288
       |   |-- b9
       |   |   `-- 60d4fb2014cdabe5caa60b6e3bf8e3f1ee5a05
-      |   |-- ba
-      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
       |   |-- c2
       |   |   `-- 1c9352f7526e9576892a6631e0e8cf1fccd34d
-      |   |-- c4
-      |   |   `-- 8e30c7eeafdc8b5e6a103f26367c973b2c4df9
       |   |-- c6
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
-      |   |-- cb
-      |   |   `-- b66c35294ac2d5ba60420854a3a50ca4c88887
       |   |-- d8
-      |   |   |-- 388f5880393d255b371f1ed9b801d35620017e
-      |   |   `-- 43530e8283da7185faac160347db5c70ef4e18
+      |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- df
       |   |   `-- b06d7748772bdd407c5911c0ba02b0f5fb31a4
-      |   |-- e6
-      |   |   `-- 1d37de15923090979cf667263aefa07f78cc33
       |   |-- info
       |   `-- pack
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
+      |       |-- pack-c304c61c7328041fd1afafa4b6328b746cad31b1.idx
+      |       |-- pack-c304c61c7328041fd1afafa4b6328b746cad31b1.pack
+      |       |-- pack-ed1b2e1285c87d628ed4fedf2e84338a0fa698e1.idx
+      |       `-- pack-ed1b2e1285c87d628ed4fedf2e84338a0fa698e1.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  57 directories, 44 files
+  48 directories, 40 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -99,26 +99,22 @@
       |-- objects
       |   |-- 0f
       |   |   `-- 17ab2c89a1278ecb6a7438e915e491884d3efb
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
-      |   |-- 1f
-      |   |   `-- 0b9d8a7b40a35bb4ff64ffc0f08369df23bc61
       |   |-- 55
       |   |   `-- 4b59f0a39f6968f0101b8a0471f8a65bc25020
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- b5
-      |   |   `-- af4d1258141efaadc32e369f4dc4b1f6c524e4
-      |   |-- b7
-      |   |   `-- cf821182baff3432190af3ae2f1029d8e7ceb0
       |   |-- f9
       |   |   `-- 9a2dde698e6d3fc31cbeedea6d0204399f90ce
       |   |-- info
       |   `-- pack
+      |       |-- pack-a279587d75bc5b34c2c0e6a68a19e7f155e1eb54.idx
+      |       |-- pack-a279587d75bc5b34c2c0e6a68a19e7f155e1eb54.pack
+      |       |-- pack-e9cffc2f019d87d49415e5fc30cb50630fe29846.idx
+      |       `-- pack-e9cffc2f019d87d49415e5fc30cb50630fe29846.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  40 directories, 25 files
+  36 directories, 25 files
 

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -128,28 +128,24 @@ Make sure all temporary namespace got removed
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- 81
-      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
-      |   |-- ba
-      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
       |   |-- c6
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
       |   |-- d8
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
+      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.idx
+      |       `-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  39 directories, 24 files
+  35 directories, 24 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -134,30 +134,26 @@ Flushed credential cache
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 17
-      |   |   `-- d81bc99ff2b4a426c236dc1a36f7a2d1027c7b
       |   |-- 1c
       |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
-      |   |-- 89
-      |   |   `-- 52f96884e0ee453406177bebbf4f74a8a8d1be
       |   |-- ad
       |   |   `-- f650cd06e5434fe6deff7639b04c802d63fa5a
       |   |-- b2
       |   |   `-- 6a812a71a431e71d30949f25013ca63f8493c3
-      |   |-- d8
-      |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
+      |       |-- pack-43b004c57a05484b0057ece370e309a1528a2995.idx
+      |       |-- pack-43b004c57a05484b0057ece370e309a1528a2995.pack
+      |       |-- pack-a724713a58e1918b9032aed364764a0a4cece84b.idx
+      |       `-- pack-a724713a58e1918b9032aed364764a0a4cece84b.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  44 directories, 29 files
+  39 directories, 30 files
 
   $ cat ${TESTTMP}/josh-proxy.out | grep graph_descendant_of
   [1]

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -83,28 +83,24 @@ Make sure all temporary namespace got removed
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- 81
-      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
-      |   |-- ba
-      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
       |   |-- c6
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
       |   |-- d8
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
+      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.idx
+      |       `-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  39 directories, 24 files
+  35 directories, 24 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -242,50 +242,36 @@ Make sure all temporary namespace got removed
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 08
-      |   |   `-- c82a20e92d548ff32f86d634b82da6756e1f5f
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 0f
-      |   |   `-- 8d6bce4783eb0366cc72cb5f6fb7952c360d89
-      |   |-- 23
-      |   |   `-- b2396b6521abcd906f16d8492c5aeacaee06ed
-      |   |-- 38
-      |   |   `-- 25d17d9f46345e352ea6d1d0a89f2be16a1b2c
       |   |-- 3a
       |   |   `-- d32b3bd3bb778441e7eae43930d8dc6293eddc
       |   |-- 3b
       |   |   `-- 0e3dbefd779ec54d92286047f32d3129161c0d
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- 72
-      |   |   `-- 7902c81346e29c4f75e0913bd62d7b85d7033f
-      |   |-- 96
-      |   |   `-- 539577d449c8e5446b5339c20436a13ec51f41
       |   |-- 9a
       |   |   `-- 91b9f3056d29fafb535b6e801f26449b291daf
-      |   |-- a0
-      |   |   `-- 18dae3609294bc68eff023fabb96386ec483db
-      |   |-- ae
-      |   |   `-- a557394ce29f000108607abd97f19fed4d1b7c
       |   |-- b2
       |   |   `-- dd517c55420a48cb543e0195b4751bf514b941
       |   |-- ec
       |   |   `-- 41aad70b4b898baf48efeb795a7753d9674152
       |   |-- ed
       |   |   `-- b2a5b9c65fae1d20c1b1fb777d1ea025456faa
-      |   |-- fd
-      |   |   `-- b894f9431a237930c7a034f3ecc16dd686b19e
       |   |-- info
       |   `-- pack
+      |       |-- pack-78ffbd7e7c8abf2dbcfc09867596c326c91d05c3.idx
+      |       |-- pack-78ffbd7e7c8abf2dbcfc09867596c326c91d05c3.pack
+      |       |-- pack-8b21babdbe4d8b1392439429880860d8cf698332.idx
+      |       |-- pack-8b21babdbe4d8b1392439429880860d8cf698332.pack
+      |       |-- pack-9afe2a05aace90b45bcd9486b9fc09e71480633c.idx
+      |       |-- pack-9afe2a05aace90b45bcd9486b9fc09e71480633c.pack
+      |       |-- pack-f084b3cbab8aecd03fa3cd68e6aa79382657e69b.idx
+      |       `-- pack-f084b3cbab8aecd03fa3cd68e6aa79382657e69b.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  68 directories, 51 files
+  57 directories, 48 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_split.t
+++ b/tests/proxy/push_stacked_split.t
@@ -175,32 +175,24 @@ Make sure all temporary namespace got removed
       |   |   `-- 0e3dbefd779ec54d92286047f32d3129161c0d
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- 72
-      |   |   `-- 7902c81346e29c4f75e0913bd62d7b85d7033f
       |   |-- 7e
       |   |   `-- 693682dba1d7af1cb1eca7c3dcc5128e3ec9c6
-      |   |-- 8a
-      |   |   `-- 778416d88308bf017cf54f0247e4780765361f
-      |   |-- a0
-      |   |   `-- 18dae3609294bc68eff023fabb96386ec483db
       |   |-- b2
       |   |   `-- dd517c55420a48cb543e0195b4751bf514b941
-      |   |-- b7
-      |   |   `-- 8fc0fe9f3bd35c8dc8aeff5189ebda0750e974
       |   |-- ec
       |   |   `-- 41aad70b4b898baf48efeb795a7753d9674152
       |   |-- ed
       |   |   `-- b2a5b9c65fae1d20c1b1fb777d1ea025456faa
-      |   |-- fd
-      |   |   `-- b894f9431a237930c7a034f3ecc16dd686b19e
       |   |-- info
       |   `-- pack
+      |       |-- pack-d787933d12fa80e0118646c0aa4a83139c02e4cb.idx
+      |       `-- pack-d787933d12fa80e0118646c0aa4a83139c02e4cb.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  66 directories, 50 files
+  61 directories, 47 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -239,51 +239,36 @@ Make sure all temporary namespace got removed
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
       |   |-- 11
       |   |   `-- 06a6f09b169109f5ebd17428219142c67e84b9
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
-      |   |-- 24
-      |   |   `-- 4c0b793d0e21897e97d9898256f14734726faa
-      |   |-- 2b
-      |   |   `-- b94719cad2e76eb5dbcae874a2b0e44521e802
       |   |-- 40
       |   |   `-- 3e13a101fd75090369ffc317afafcfb646c576
       |   |-- 4b
       |   |   `-- 5ffb79a1f3852443bd747a6b213bf1e4abe168
-      |   |-- 53
-      |   |   `-- c45e312d8ea6082a7b3b8e738d367bf9349c53
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- 88
-      |   |   `-- 2b84c5d3241087bc41982a744b72b7a174c49e
-      |   |-- a2
-      |   |   `-- 8c68e091a9e9d04c154061018f168f7096caa9
-      |   |-- a3
-      |   |   `-- 065162ecee0fecc977ec04a275e10b5e15a39c
-      |   |-- a7
-      |   |   `-- 3c840b29576d95d87cfe9c39afc3853c2af820
-      |   |-- b2
-      |   |   `-- ea883bc5df63565960a38cad7a57f73ac66eaa
       |   |-- ba
-      |   |   |-- 7e17233d9f79c96cb694959eb065302acd96a6
       |   |   `-- c8af20b53d712874a32944874c66a21afa91f9
       |   |-- be
       |   |   `-- 33ab805ad4ef7ddda5b51e4a78ec0fac6b699a
       |   |-- c6
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
-      |   |-- e3
-      |   |   `-- a269743538338b0d059eda2f72976ec29220a8
       |   |-- info
       |   `-- pack
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
+      |       |-- pack-718676b296aa09fce4d6d811a3d7543ec8803d1e.idx
+      |       |-- pack-718676b296aa09fce4d6d811a3d7543ec8803d1e.pack
+      |       |-- pack-8ba16953737b1eddb48842059c6fea9cae77170f.idx
+      |       |-- pack-8ba16953737b1eddb48842059c6fea9cae77170f.pack
+      |       |-- pack-e64aa37e31e3b3b41104754707ae8b326ce1b30b.idx
+      |       `-- pack-e64aa37e31e3b3b41104754707ae8b326ce1b30b.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  75 directories, 59 files
+  64 directories, 55 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -89,37 +89,27 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
-      |   |-- 32
-      |   |   `-- bc15e3ec04d5d9d2a216055ea51bafb2249877
-      |   |-- 50
-      |   |   `-- bcd696c2041bb31c0a9a1111dfa2686fc6fea6
       |   |-- 52
       |   |   `-- 2525c3e5980592ddb5eb385ac1262dc6764af3
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- 81
-      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
-      |   |-- ba
-      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
       |   |-- c6
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
-      |   |-- cf
-      |   |   `-- 704ed443e7351ab990ab68c916c2428dcf9100
-      |   |-- d8
-      |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- e6
       |   |   `-- 2cc0b3d612792395dd9ac2ca649da0e6e54620
       |   |-- info
       |   `-- pack
+      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.idx
+      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.pack
+      |       |-- pack-9fb50b1e4c13a30e0da1720d8b22f58af0535d63.idx
+      |       |-- pack-9fb50b1e4c13a30e0da1720d8b22f58af0535d63.pack
+      |       |-- pack-a724713a58e1918b9032aed364764a0a4cece84b.idx
+      |       `-- pack-a724713a58e1918b9032aed364764a0a4cece84b.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  44 directories, 29 files
+  36 directories, 27 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -140,27 +140,23 @@ Make sure all temporary namespace got removed
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- 81
-      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
-      |   |-- ba
-      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
       |   |-- c6
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
       |   |-- d8
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
+      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.idx
+      |       `-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  43 directories, 29 files
+  39 directories, 29 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -172,40 +172,32 @@ Put a double slash in the URL to see that it also works
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 03
-      |   |   `-- e4d4431d56b09a58ee53e177a966b75b5adc2a
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-      |   |-- 1d
-      |   |   `-- 9470cf784c751ec8cc3556d50737a7de1f5262
-      |   |-- 3c
-      |   |   `-- cd09de42d21f7e5318bc5eaf258bf82e4103e6
       |   |-- 5c
       |   |   `-- 1144a1e71fe21014b2afec1ed3a3298bd46200
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- 81
-      |   |   `-- b10fb4984d20142cd275b89c91c346e536876a
       |   |-- 8d
       |   |   `-- 08b32a321a9d226e3b22d01793f62a6c9b22e2
       |   |-- b1
       |   |   `-- 0b7acda365c0c0ed8f7482ccaf201ebbc6dd12
-      |   |-- ba
-      |   |   `-- 7e17233d9f79c96cb694959eb065302acd96a6
       |   |-- c6
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
       |   |-- d8
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
-      |   |-- dc
-      |   |   `-- d1fcde90e4a52777feaf5d7e608f33e5eda53f
-      |   |-- e3
-      |   |   `-- 1c69658259e37ed5ad682c49a53ec5dc066aec
       |   |-- info
       |   `-- pack
+      |       |-- pack-0d4b38b140b6e8e4cae7dbc5e5ae6e12b11d2d52.idx
+      |       |-- pack-0d4b38b140b6e8e4cae7dbc5e5ae6e12b11d2d52.pack
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
+      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
+      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.idx
+      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.pack
+      |       |-- pack-f445d148fd9a82f820ea90fe67d7f3a794e393a4.idx
+      |       `-- pack-f445d148fd9a82f820ea90fe67d7f3a794e393a4.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  53 directories, 37 files
+  45 directories, 37 files
 

--- a/tests/proxy/unrelated_leak.t
+++ b/tests/proxy/unrelated_leak.t
@@ -202,51 +202,29 @@ Flushed credential cache
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 4cf6c9efbbda1eada39fa9c1d21d2525b027bb
       |   |-- 1c
       |   |   `-- b5d64cdb55e3db2a8d6f00d596572b4cfa9d5c
-      |   |-- 24
-      |   |   `-- ce298ca12ec52cff187ef6638a2ba3d1c9503d
       |   |-- 26
       |   |   `-- 1fdca7dd1cc67009c11551191e84aa1ba21c20
-      |   |-- 35
-      |   |   `-- 95f38d11ec8c849f1c1a11fe676ed8dfac8145
-      |   |-- 36
-      |   |   `-- 8bfdc83325632d67cb93d96f095f0b04e4e26d
       |   |-- 37
       |   |   `-- fad4aaffb0ee24ab0ad6767701409bfbc52330
-      |   |-- 3f
-      |   |   `-- 7ab67d01db03914916161b51dbda1a4635f8d2
-      |   |-- 42
-      |   |   `-- e0161c1ad82c05895e0f2caeae95925ac5ae6a
       |   |-- 6b
       |   |   `-- 46faacade805991bcaea19382c9d941828ce80
-      |   |-- 86
-      |   |   `-- 5c34e9a2c40198324cdc2fc796827653cb11df
-      |   |-- 8a
-      |   |   `-- f523d3883c24610cf99813ea15df65eb20ea84
-      |   |-- b7
-      |   |   `-- 97411c60180287c8da2d26c325038c44fd78b0
-      |   |-- c8
-      |   |   `-- 2fc150c43f13cc56c0e9caeba01b58ec612022
-      |   |-- cd
-      |   |   `-- e160edcb6f5ed11cc6d74e64bf06679420c10c
       |   |-- da
       |   |   `-- 0d1f304c4686b5ed11c682fa9c8d1544c49b96
       |   |-- db
       |   |   `-- 184bf11ece7fbeb99395ab7676b80e7d98631a
-      |   |-- dc
-      |   |   `-- 0dbab6030c0673ece5706b067e74ca8a573397
-      |   |-- e0
-      |   |   `-- 6f0e81ff3d5f8d60ba86bf4f99b47c8aa47654
-      |   |-- e1
-      |   |   `-- 70e962d0fb4b94a491a176a7f39a6207ada3e8
       |   |-- info
       |   `-- pack
+      |       |-- pack-365bafb594d0b05b03a3c90ea320df4fe4021f9e.idx
+      |       |-- pack-365bafb594d0b05b03a3c90ea320df4fe4021f9e.pack
+      |       |-- pack-749ce45681f8e4fe8c7b114878930d43b1828c50.idx
+      |       |-- pack-749ce45681f8e4fe8c7b114878930d43b1828c50.pack
+      |       |-- pack-e314ce900fa86c59aa7128e98b5cb3ec9520949a.idx
+      |       `-- pack-e314ce900fa86c59aa7128e98b5cb3ec9520949a.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  65 directories, 52 files
+  51 directories, 44 files

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -308,95 +308,35 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 0b
-      |   |   `-- 3b1286342fd8f9cd6c83347ba939815ce4ce9b
-      |   |-- 10
-      |   |   `-- 4395792f8b6494b9a0fad94ebaf2d1b57422b8
-      |   |-- 13
-      |   |   `-- 7228bdcd2ae40007860a69d05168279d95117a
-      |   |-- 2e
-      |   |   `-- aadc29a9215c79ff47c4b3a82a024816eb195a
-      |   |-- 39
-      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
-      |   |-- 3d
-      |   |   `-- 22f66f0814eac3e4b5c9dfe4cf1f6b679157ce
-      |   |-- 3e
-      |   |   `-- 838be41249b645bb9d17a5fdc8cc6bbca5f353
-      |   |-- 40
-      |   |   `-- 4703da297c8621c4806c8a145e08c7ddc54a3e
-      |   |-- 42
-      |   |   `-- 0b8bc82569d478e5af945068843a993a50de2d
-      |   |-- 43
-      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
       |   |-- 5a
       |   |   `-- f4045367114a7584eefa64b95bb69d7f840aef
-      |   |-- 64
-      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
-      |   |-- 77
-      |   |   `-- 788a139643ad181e2b1684dd7f8a31e3da6249
-      |   |-- 78
-      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 85
-      |   |   `-- 5c8765f063f6ab4a2563eb2de090a6c9b9deb4
-      |   |-- 98
-      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
-      |   |-- 9c
-      |   |   `-- afb9379b412184574e4f15a86c54609a07e6af
-      |   |-- 9f
-      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
       |   |-- a3
       |   |   `-- d19dcb2f51fa1efd55250f60df559c2b8270b8
       |   |-- a4
       |   |   `-- 36b5a3ef821ad5db735ff557d1cb2c8cbb3599
       |   |-- b1
       |   |   `-- 76252014d4a10d3ec078667ecf45dd9a140951
-      |   |-- b7
-      |   |   `-- 5b16149287cb154dc97714814f3be0f9f52d2c
-      |   |-- b8
-      |   |   `-- ddfe2d00f876ae2513a5b26a560485762f6bfa
-      |   |-- bb
-      |   |   `-- 76696a87dd29d841caa7f0d48e2f4e5359d369
       |   |-- bc
       |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
-      |   |-- be
-      |   |   |-- 06ec33a91b8a108bd135b5a42a84292b035d6b
-      |   |   `-- 1afe91719c4fb58e09207874905f09858cfb66
-      |   |-- c1
-      |   |   `-- 8d1454dda3f68d09d2736441353a44d5962b08
-      |   |-- c2
-      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
-      |   |-- c5
-      |   |   `-- dd0ee2c3106a581cdea7db0c4297ef82c0f874
-      |   |-- c6
-      |   |   `-- 735a7b0d9da9bf6ef5e445ad2f4ce3d825ceb0
-      |   |-- cc
-      |   |   `-- 1d9224522c5f62049f867b6e7ba50177ef3fb5
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
-      |   |-- e2
-      |   |   `-- 7e2eec980a81625f680243092205b23ea040ad
-      |   |-- ea
-      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |-- f0
-      |   |   `-- 91e02d893a86b20486acf5b0585899634fc755
       |   |-- f2
-      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
-      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |   `-- 257977b96d2272be155d6699046148e477e9fb
       |   |-- f6
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
-      |   |-- fa
-      |   |   `-- 3b9622c1bcc8363c27d4eb05d1ae8dae15e871
-      |   |-- fc
-      |   |   `-- 332f8a40afcb71e997704bb301c93802b193bc
       |   |-- info
       |   `-- pack
+      |       |-- pack-4378f3c9eee002d89f697838daffcaa2c8886b64.idx
+      |       |-- pack-4378f3c9eee002d89f697838daffcaa2c8886b64.pack
+      |       |-- pack-5d11ca698a761cfb0102d4d44599349077fbafb5.idx
+      |       |-- pack-5d11ca698a761cfb0102d4d44599349077fbafb5.pack
+      |       |-- pack-cf634696f53f4ca2e6072988b224113252440145.idx
+      |       `-- pack-cf634696f53f4ca2e6072988b224113252440145.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  93 directories, 80 files
+  61 directories, 52 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -560,193 +560,58 @@ Note that ws/d/ is now present in the ws
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 00
-      |   |   `-- 3a2970e4c23b64f915025e9adc2e6ed04bc63a
-      |   |-- 02
-      |   |   `-- 668d7af968c8eed910db7539a57b18dd62a50e
       |   |-- 04
       |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
-      |   |-- 07
-      |   |   `-- f825fbedafa02f2e5158e69bc25250113b0b64
-      |   |-- 09
-      |   |   `-- b613e901acc0b5e4279ec6732261134a06f667
-      |   |-- 0c
-      |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
-      |   |-- 10
-      |   |   `-- 8eb9a1d2082ac57860d2358d445156e35558a9
-      |   |-- 13
-      |   |   `-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
-      |   |-- 14
-      |   |   |-- 1a3bdf0a2739ded6e233ababff0cd490fd0c56
-      |   |   `-- da1560586adda328cca1fbf58c026d6730444f
-      |   |-- 17
-      |   |   `-- ac72002199728c133087acfa6b23009e00a52a
-      |   |-- 19
-      |   |   `-- b9637ac9437ea11d42632cd65ca2313952c32f
       |   |-- 1b
       |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
-      |   |-- 20
-      |   |   `-- 189c97a0ef53368b7ec335baa7a1b86bd76f8e
-      |   |-- 23
-      |   |   `-- d20398ffe09015ada5794763b97c750b61bdc4
-      |   |-- 27
-      |   |   `-- d0eee16bdbe4a1ade0ebf877f97467de3b218e
-      |   |-- 2a
-      |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
-      |   |   |-- 3e798288165d5b090a10460984776489bcc7cc
-      |   |   `-- 6aa2a100b34d0d56e4b5f19e9bfdc2cd6f7d54
-      |   |-- 2c
-      |   |   |-- 50404f5c69295bd3d4d0cb5475be9cc2aada23
-      |   |   `-- 913262d99f8cd15ea711a89e943cd902fb87a0
-      |   |-- 2d
-      |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
       |   |-- 2f
       |   |   `-- 10c52e8ac3117e818b2b8a527c03d9345104c3
-      |   |-- 30
-      |   |   `-- 48804b01e298df4a6e1bc60a1e3b2ca0b016bd
-      |   |-- 36
-      |   |   `-- 52f9baa44258d0f505314830ad37d16eafc981
-      |   |-- 39
-      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
-      |   |-- 3a
-      |   |   `-- 748f0be2a5670c0c282196d3a66620e8599ee5
       |   |-- 40
       |   |   `-- c389b6b248e13f3cb88dcd79467d7396a4489e
-      |   |-- 42
-      |   |   `-- 8f5d5c5a3ce27a5d9f513c1a051a18a4266528
-      |   |-- 43
-      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
-      |   |-- 46
-      |   |   `-- bc1eabe4b2029b9fcb661f0d447d8389d17337
-      |   |-- 47
-      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
-      |   |-- 4b
-      |   |   |-- 6c1f65548a50c9ee26e3aec66946b48e65d08f
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
-      |   |-- 4c
-      |   |   `-- a9fbf65ee12663ac24db4be4cab10e53d6d6e7
-      |   |-- 5b
-      |   |   `-- 560252b0c3c6abc5e0327596a49efb15e494cb
-      |   |-- 5e
-      |   |   |-- 34ec2fa3c3188874f0a6b12ddf76a167df4229
-      |   |   `-- 9213824faf1eb95d0c522329518489196374fd
-      |   |-- 60
-      |   |   `-- bd0e180735e169b5c853545d8b1272ed0fc319
-      |   |-- 64
-      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
-      |   |-- 6d
-      |   |   `-- 4b5c23a94a89c7f26266ccf635647fd4002b19
-      |   |-- 70
-      |   |   `-- eb05d32223342a549cfb00c20b1464bf1b9513
-      |   |-- 71
-      |   |   `-- fb4611471b5f67b815e54590ca24224d4f8786
       |   |-- 75
       |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
-      |   |-- 78
-      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 7c
-      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
-      |   |-- 7f
-      |   |   |-- 39c7601f2c1ca44fdc9237efa34f2887daa2b4
-      |   |   `-- c8ee5474068055f7740240dfce6fa6e38bbf4d
       |   |-- 82
-      |   |   |-- 4c0e846b41e1eb9f95d141b47bbb9ff9baef17
-      |   |   `-- 678b3bcd868634f36ad4ec719cca378028dfa4
-      |   |-- 87
-      |   |   `-- 7af85c0624835da58fe4b2fa9a259a44213acf
-      |   |-- 8c
-      |   |   |-- 4e94969f16bfec56af4b29c1a20e732401ed32
-      |   |   `-- c4bb045e98da7cf00714d91ac77c7ea7e08b63
-      |   |-- 93
-      |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
+      |   |   `-- 4c0e846b41e1eb9f95d141b47bbb9ff9baef17
       |   |-- 95
       |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
-      |   |-- 98
-      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
-      |   |-- 99
-      |   |   `-- acd82fe2a9b89022d1aee5a580c123a8161f4a
-      |   |-- 9d
-      |   |   `-- e3bbb26e2b40f02ca8de195933eb620bbf0b6a
-      |   |-- 9e
-      |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
-      |   |-- 9f
-      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
-      |   |-- a1
-      |   |   |-- 1e8a91058875f157ca1246bdc403b88e93cd94
-      |   |   |-- 269dc50ffcdc1b87664a061926bf9a072a3456
-      |   |   |-- a7760c60ac08ecdcac395823637989a4d681a6
-      |   |   `-- c31372c5de4fb705ffdcbf5a4ec5c5103231d9
-      |   |-- b1
-      |   |   `-- c3c9b731fea98c82ce8e9286e213fcb033f70d
-      |   |-- b2
-      |   |   `-- 7fe8d094037d5b5b911893496bb2ee0f40d820
-      |   |-- b7
-      |   |   `-- bb51e63095336302e4f6b0eead63cb716eb630
       |   |-- b8
       |   |   `-- 012aab20a6c6a0c2dc3b428d3578aadc9c527f
-      |   |-- b9
-      |   |   `-- 90567474f1f8af9784478614483684e88ccf4f
-      |   |-- ba
-      |   |   `-- f9dcf1394d5152de67b115f55f25e4dc0a2398
       |   |-- bc
       |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
-      |   |-- bf
-      |   |   `-- 7841c0db704465dda4b387d5da09694647d188
-      |   |-- c1
-      |   |   `-- 489fc8fd6ae9ac08c0168d7cabaf5645b922fa
-      |   |-- c2
-      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
-      |   |-- d3
-      |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
       |   |-- d6
       |   |   `-- 81a08f543313f2a8bd86fab920e2271d0403d1
       |   |-- d7
-      |   |   |-- 330ea337031af43ba1cf6982a873a40b9170ac
-      |   |   `-- e36a04a3c59c966815fae6db6fe5d518a3456a
-      |   |-- d9
-      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
-      |   |-- da
-      |   |   `-- af0560e4e779353311a9039b31ea4f0f1dec37
-      |   |-- e1
-      |   |   |-- 0bf0281a70e6b19939ad6e26e10252bbebe300
-      |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
-      |   |-- e4
-      |   |   `-- a5e5c828510a51aacfdb9e38cea9440d8882ec
-      |   |-- e7
-      |   |   `-- cee3592aaac624fd48c258daa5d62d17352043
-      |   |-- e9
-      |   |   `-- 9a2c69c0fb10af8dd1524e7f976df3d898f6ac
-      |   |-- ea
-      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |-- ec
-      |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
-      |   |-- ee
-      |   |   `-- b52a9c8fe143baf970160aa4716ff5c019d8cb
-      |   |-- f0
-      |   |   `-- e6089346823559463c115a65180fef59299ae4
-      |   |-- f1
-      |   |   `-- f2c1bd855237608d4293f1ee98fee640e78405
+      |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
       |   |-- f2
-      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
-      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
-      |   |-- f5
-      |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+      |   |   `-- 257977b96d2272be155d6699046148e477e9fb
       |   |-- f6
       |   |   |-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |   `-- 7e3cdbde0a4bc95d09a1344d2d1f163b5aa172
-      |   |-- f7
-      |   |   `-- 35d04266733d64d2f49ab23a183a5207e8961d
       |   |-- f8
       |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
-      |   |-- fd
-      |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
       |   |-- info
       |   `-- pack
+      |       |-- pack-035feff92861c255244681ddc84b90e321ec6b35.idx
+      |       |-- pack-035feff92861c255244681ddc84b90e321ec6b35.pack
+      |       |-- pack-0a5087aa14c50693a3d73b25e94466c4b21c7d30.idx
+      |       |-- pack-0a5087aa14c50693a3d73b25e94466c4b21c7d30.pack
+      |       |-- pack-132b596594e7cf7bc3af1b2c7a24fdf62d759469.idx
+      |       |-- pack-132b596594e7cf7bc3af1b2c7a24fdf62d759469.pack
+      |       |-- pack-369060c82a79aba08c50857e8818b02e9fb2578f.idx
+      |       |-- pack-369060c82a79aba08c50857e8818b02e9fb2578f.pack
+      |       |-- pack-56434dd1073324f0c25f881a1c87eff63af5c27e.idx
+      |       |-- pack-56434dd1073324f0c25f881a1c87eff63af5c27e.pack
+      |       |-- pack-7014dc333fab5e96e9d4838c01b668dbd434774b.idx
+      |       |-- pack-7014dc333fab5e96e9d4838c01b668dbd434774b.pack
+      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
+      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
+      |       |-- pack-ac69f084a822e26e92fcd950197630c5d06a5ddf.idx
+      |       `-- pack-ac69f084a822e26e92fcd950197630c5d06a5ddf.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  152 directories, 154 files
+  84 directories, 87 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -185,47 +185,15 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 18
-      |   |   `-- fc53a050ffb86358d5e58e4280ce3c5fc218a4
-      |   |-- 1b
-      |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
-      |   |-- 22
-      |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
-      |   |-- 27
-      |   |   `-- 5b45aec0a1c944c3a4c71cc71ee08d0c9ea347
-      |   |-- 39
-      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
-      |   |-- 43
-      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
-      |   |-- 6b
-      |   |   `-- e0d68b8e87001c8b91281636e21d6387010332
-      |   |-- 78
-      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 7f
-      |   |   `-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
-      |   |-- 83
-      |   |   `-- 3812f1557e561166754add564fe32228dd1703
-      |   |-- 98
-      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
-      |   |-- 9c
-      |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
-      |   |-- 9f
-      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
-      |   |-- b6
-      |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
-      |   |-- c2
-      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
-      |   |-- f2
-      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
       |   |-- info
       |   `-- pack
+      |       |-- pack-bc2bd46c4c017717f7584aad0c1f3b80cdb1fee6.idx
+      |       `-- pack-bc2bd46c4c017717f7584aad0c1f3b80cdb1fee6.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  70 directories, 55 files
+  53 directories, 40 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -297,153 +297,35 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 00
-      |   |   `-- 0c330fa2c083613dfd2b0dce1dde1201b6357c
       |   |-- 02
       |   |   `-- 667f8e29e4b012540e81065f01c16031c2df27
-      |   |-- 03
-      |   |   `-- abc9b48b4da3daca498937b225ff8d54ba8c56
-      |   |-- 0c
-      |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
-      |   |-- 10
-      |   |   `-- 105c45d21be850089b3f326502436adfa5ab0e
-      |   |-- 16
-      |   |   `-- f299bec8b6eece08fd28777d7cff5edf6132ed
-      |   |-- 19
-      |   |   `-- cff5ef0fce401a1a33c2ac2713d6356cbc1b15
-      |   |-- 1b
-      |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
-      |   |-- 1f
-      |   |   `-- 8abd6f6494fc2f715b3c1a39ac2e01ba806938
-      |   |-- 20
-      |   |   `-- 31777de79cd7c74834915674377e96d6864cc9
-      |   |-- 22
-      |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
-      |   |-- 26
-      |   |   `-- 2c83b56549e1690e3f878c4df4be1af11c19f0
-      |   |-- 28
-      |   |   `-- 619ba172ac02f6f6ee83091721f9b345648ec9
-      |   |-- 2e
-      |   |   `-- 994f29aa1828fece591a9d63a61e93b4c2c629
-      |   |-- 30
-      |   |   `-- 48804b01e298df4a6e1bc60a1e3b2ca0b016bd
-      |   |-- 39
-      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
-      |   |-- 3e
-      |   |   `-- c3e854c68442bfaa047033e1ade729892017a0
-      |   |-- 43
-      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
-      |   |-- 47
-      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
-      |   |-- 4d
-      |   |   `-- aab0f68d3893d3b39725ce9f81d68cc8d5503d
-      |   |-- 50
-      |   |   |-- 207be2e0fadfbe2ca8d5e0616a71e7ec01f3e2
-      |   |   `-- 724c0a6bac8e87c89b64f6c409a2e0382ff65e
-      |   |-- 55
-      |   |   `-- 652697c232470cde4141b0e1bbbe2c6ac91260
       |   |-- 56
       |   |   `-- 45805dcc75cfe4922b9cb301c40a4a4b35a59d
-      |   |-- 57
-      |   |   `-- a36663dff20a0906952548a999b9d3ff770dc4
       |   |-- 58
       |   |   `-- b0c1e483109b33f416e0ae08487b4d1b6bfd5b
-      |   |-- 5e
-      |   |   `-- 7ff045529989036cbd11bc32b2eaf5a8311aea
-      |   |-- 60
-      |   |   `-- 5066c26f66fca5a424aa32bd042ae71c7c8705
       |   |-- 6a
       |   |   `-- 80a5b3af9023d11cb7f37bc1f80d1d1805bfdb
-      |   |-- 74
-      |   |   `-- 3fcd7100630aea3ab423c23ec9c012549467ad
-      |   |-- 75
-      |   |   `-- e89ed8367a6ac09038ca4517967569e1c60858
-      |   |-- 76
-      |   |   `-- 9e718288ea6c1390adb2b1b6cd8c2c73f2785b
-      |   |-- 78
-      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 7c
-      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
-      |   |-- 7f
-      |   |   `-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
-      |   |-- 89
-      |   |   `-- ae198bc1b2f11718bd1e76fbe6473054801274
-      |   |-- 8c
-      |   |   `-- 4e94969f16bfec56af4b29c1a20e732401ed32
-      |   |-- 8f
-      |   |   `-- 1b78740f35dafecc063980e2afb231b9ee74a3
-      |   |-- 91
-      |   |   `-- c0b3ea5e7c1dbeae440c93116450f6c4de65c1
-      |   |-- 93
-      |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
-      |   |-- 97
-      |   |   `-- 738bf1d1a305512158d536564d3fccbcb0dbec
-      |   |-- 98
-      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
-      |   |-- 9a
-      |   |   `-- 28fa82a736714d831348bbf62b951be65331b7
-      |   |-- 9b
-      |   |   `-- d58f891b4f17736c1b51903837de717fce13a5
-      |   |-- 9c
-      |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
-      |   |-- 9f
-      |   |   |-- 24b55d4263082d93987e2c0ff6b24df3323f5b
-      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
-      |   |-- a7
-      |   |   |-- 7106b607ba6489028e85eeec937463cc29c39a
-      |   |   `-- cf4e83688bf0ec633d4e4abae4b74dce4852ba
-      |   |-- a9
-      |   |   `-- 954d28dd1313fb2d8f20fc11a1106376c2ffae
-      |   |-- af
-      |   |   `-- 7c13846465562922d156aef649f6844d51798b
-      |   |-- b5
-      |   |   `-- c12ea9494f5e3824d5f7e979dcc56d898036b6
-      |   |-- b6
-      |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
-      |   |-- bd
-      |   |   `-- 56f16bf42ff74e68cfb7a59869c81920b02b87
-      |   |-- be
-      |   |   `-- c9383652a22b8a07acb86d5357a75f988286dc
-      |   |-- bf
-      |   |   `-- a4b41bb449aa6f5f0be272340b83b3f3317ff8
-      |   |-- c2
-      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
-      |   |-- c5
-      |   |   `-- ab31f80e2b8c97a7d354d252272a9eaebd4581
-      |   |-- c7
-      |   |   `-- c20449d3cd7e2084419fa525c7b36eb7d5ef8c
-      |   |-- d3
-      |   |   `-- d28f0a10d8f6be1a5f85c80e3c40bb2b5671cb
-      |   |-- d4
-      |   |   `-- c6c9ce1c5286d73c55da95d50fbf65ed90bcea
-      |   |-- d8
-      |   |   `-- 631b65275580884aa3cfbac4b2aafc570fb616
       |   |-- dc
       |   |   `-- 268932c3e0a21d51ec34fb88c6947f51faa430
-      |   |-- dd
-      |   |   |-- 29249d0f31950d5337ec484230651c3c4cf8ad
-      |   |   `-- 9ebd9f693084e229dbcc0998906e42eab1acd5
-      |   |-- e1
-      |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
-      |   |-- e5
-      |   |   `-- a8caaa59058b8beb8a603a3b4447c07218a617
       |   |-- e6
       |   |   `-- 3efb2615e1c17f0d0b6e610da85da09438cd29
-      |   |-- e9
-      |   |   `-- 9a2c69c0fb10af8dd1524e7f976df3d898f6ac
-      |   |-- ec
-      |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
-      |   |-- f2
-      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
-      |   |-- fd
-      |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
       |   |-- info
       |   `-- pack
+      |       |-- pack-020a9c25afd039b7908829ed180c3c5b5c2aeb43.idx
+      |       |-- pack-020a9c25afd039b7908829ed180c3c5b5c2aeb43.pack
+      |       |-- pack-206ba4dfaf5b6561e1fa899650b6e690c0f674f7.idx
+      |       |-- pack-206ba4dfaf5b6561e1fa899650b6e690c0f674f7.pack
+      |       |-- pack-5e1711c1c8fd3c58e9ecf87c44dda797a57b4d09.idx
+      |       |-- pack-5e1711c1c8fd3c58e9ecf87c44dda797a57b4d09.pack
+      |       |-- pack-810042fcc342c573b7d491be291eac8697326115.idx
+      |       |-- pack-810042fcc342c573b7d491be291eac8697326115.pack
+      |       |-- pack-b531b8e915c7145f1ef6b21dba15bd66a73cdc32.idx
+      |       |-- pack-b531b8e915c7145f1ef6b21dba15bd66a73cdc32.pack
+      |       |-- pack-f3754114f5e623d4b9710175aed17f8bd2ce1f30.idx
+      |       `-- pack-f3754114f5e623d4b9710175aed17f8bd2ce1f30.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  130 directories, 121 files
+  67 directories, 66 files

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -350,122 +350,50 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 00
-      |   |   `-- e02597bb7117c22dc0b551a4062607895fc3d3
-      |   |-- 10
-      |   |   `-- 105c45d21be850089b3f326502436adfa5ab0e
-      |   |-- 11
-      |   |   `-- e2559617afa238a8332c15d15fff48d5b57c83
-      |   |-- 13
-      |   |   `-- 7228bdcd2ae40007860a69d05168279d95117a
-      |   |-- 1b
-      |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
-      |   |-- 1d
-      |   |   `-- 2a35c53f4e5901c9cc083a94b417c15837cad8
-      |   |-- 22
-      |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
-      |   |-- 2c
-      |   |   `-- bcd105ead63a4fecf486b949db7f44710300e5
-      |   |-- 2d
-      |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
-      |   |-- 2e
-      |   |   `-- aadc29a9215c79ff47c4b3a82a024816eb195a
       |   |-- 2f
       |   |   `-- a28dd621122cd858cf13f53f88dfe37eef5424
-      |   |-- 34
-      |   |   `-- e6cdfeada6ead6f8df3602f54f5a05bfd4c670
-      |   |-- 39
-      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
-      |   |-- 43
-      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
-      |   |-- 45
-      |   |   `-- c7960fc4d4b38a6a28dcc27f0ae158afa59747
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
-      |   |-- 51
-      |   |   `-- 7813c12644d29529502e7445a026b549129817
       |   |-- 58
       |   |   `-- 6af2034d76913e16ad09d5a7b683938badb049
       |   |-- 5a
       |   |   `-- f4045367114a7584eefa64b95bb69d7f840aef
       |   |-- 5f
       |   |   `-- a942ed9d35f280b35df2c4ef7acd23319271a5
-      |   |-- 60
-      |   |   `-- 5066c26f66fca5a424aa32bd042ae71c7c8705
-      |   |-- 64
-      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
       |   |-- 68
       |   |   `-- b1430cedd477c8117976bdb8aba3cee8b9aa9e
-      |   |-- 6b
-      |   |   `-- e0d68b8e87001c8b91281636e21d6387010332
-      |   |-- 6f
-      |   |   `-- 707bfe4b7a16450de3f2cf3d8b23eccad0f74c
-      |   |-- 78
-      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 7f
-      |   |   `-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
-      |   |-- 83
-      |   |   `-- 3812f1557e561166754add564fe32228dd1703
-      |   |-- 98
-      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
       |   |-- 9b
       |   |   `-- 518075958ed3bda719b38249cd91fcef1da965
-      |   |-- 9c
-      |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
-      |   |-- 9f
-      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
       |   |-- a3
       |   |   `-- d19dcb2f51fa1efd55250f60df559c2b8270b8
-      |   |-- a4
-      |   |   `-- 1772e0c7cdad1a13b7a7bc38c0d382a5a827ce
-      |   |-- ad
-      |   |   `-- 24149d789e59d4b5f9ce41cda90110ca0f98b7
-      |   |-- b0
-      |   |   `-- fdeb65d9b9069015ef9c0f735a4f6f2f28fe77
-      |   |-- b3
-      |   |   `-- be5ad252e0f493a404a8785653065d7e677f21
-      |   |-- b6
-      |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
-      |   |-- b8
-      |   |   `-- ddfe2d00f876ae2513a5b26a560485762f6bfa
-      |   |-- b9
-      |   |   `-- 1faa49e725f148de89346f193a4a4295e071cd
       |   |-- bb
       |   |   `-- bd62ec41c785d12270e69b9d49f9babe62fcd6
       |   |-- bc
       |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
-      |   |-- c2
-      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
-      |   |-- c5
-      |   |   `-- dd0ee2c3106a581cdea7db0c4297ef82c0f874
-      |   |-- c6
-      |   |   `-- 735a7b0d9da9bf6ef5e445ad2f4ce3d825ceb0
       |   |-- d3
-      |   |   |-- 1a8dce16b9b197a1411e750602e62d8d2f97ae
-      |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
+      |   |   `-- 1a8dce16b9b197a1411e750602e62d8d2f97ae
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
       |   |-- e2
       |   |   `-- 532f1207290ed9a961f9fc377a6b7afe415312
-      |   |-- e7
-      |   |   `-- cc5fdb96f774bb7a1cf2300a88a43a04f1ea4b
-      |   |-- ea
-      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |-- eb
-      |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
       |   |-- f2
-      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
-      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
-      |   |-- f5
-      |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+      |   |   `-- 257977b96d2272be155d6699046148e477e9fb
       |   |-- f6
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
+      |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.idx
+      |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.pack
+      |       |-- pack-7aa46131845bcb33ada5dd9264a54f6bda553621.idx
+      |       |-- pack-7aa46131845bcb33ada5dd9264a54f6bda553621.pack
+      |       |-- pack-969240cacd518199eb056a306b470700114f2177.idx
+      |       |-- pack-969240cacd518199eb056a306b470700114f2177.pack
+      |       |-- pack-b0339b769beb47ea5c28c0a4f4379ab2d18a4b29.idx
+      |       |-- pack-b0339b769beb47ea5c28c0a4f4379ab2d18a4b29.pack
+      |       |-- pack-d61f3c8dbb59af6cc0c1604d99c262527ccad92e.idx
+      |       `-- pack-d61f3c8dbb59af6cc0c1604d99c262527ccad92e.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  116 directories, 107 files
+  76 directories, 75 files
 

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -252,75 +252,29 @@ Flushed credential cache
       |-- objects
       |   |-- 0a
       |   |   `-- 3e20b963d30a7071105313fada241306df8695
-      |   |-- 0b
-      |   |   `-- 5d2fad8a9bd1ebecf89f086ffedcb2741d7a1b
-      |   |-- 0f
-      |   |   `-- 70f195d1852ceed0a13b3839eee7aeb07571f7
-      |   |-- 24
-      |   |   `-- cce5c76886d1a63b5eeb02e78f64f9bc399ee3
-      |   |-- 2b
-      |   |   `-- 20b4f8abb6d70648e2573e2f798a18e0079f9e
       |   |-- 31
       |   |   `-- f15ce76ce6a453ecc90f5852e70babf3554707
-      |   |-- 37
-      |   |   `-- c79e64948d36bd1bb804e274ef5419bb44e602
-      |   |-- 3d
-      |   |   `-- 96ae1a24134d32cf3eca0629fb4fd1d095693a
       |   |-- 41
       |   |   `-- 3c883bf377b8a2b9ec80ba847a926f5d50e751
-      |   |-- 46
-      |   |   `-- ac801dc88e2ce2a836fbc7f6e3e35a7c7892ab
-      |   |-- 4a
-      |   |   `-- 9ee6ea51565adf5c005dd1bc93f4b42f335be3
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
-      |   |-- 51
-      |   |   `-- 45dedc66248700cf33e354ef555877bc24f533
-      |   |-- 63
-      |   |   `-- eda6a178059b4e910cf10492006a162316c988
-      |   |-- 66
-      |   |   `-- 1bafe5fb60524a9efafd413c42e4c2d706bae8
-      |   |-- 6c
-      |   |   `-- 8233465e92d353e2ef47c02dc568ea44a32339
-      |   |-- 70
-      |   |   `-- 5dcb4e33bd0dd3f95d5831fc8dc8a41ca3e566
-      |   |-- 7b
-      |   |   `-- 418ed7c356797b1a8eef3ff949632495d273c6
-      |   |-- 7d
-      |   |   `-- 5816334652b9738e33e4ceaf925573c3414e0c
       |   |-- 85
       |   |   `-- ee20960c56619305e098b301d8253888b6ce5b
-      |   |-- 88
-      |   |   `-- e9ef64b0c92e2881fb759e1cf774e75d398d4f
-      |   |-- 8e
-      |   |   `-- 4d581b934717eb1f52fcdf21e731e7d7899717
-      |   |-- 8f
-      |   |   `-- 2bb1e9e57ae77c662a82586d21fb7ee54e7c65
-      |   |-- 91
-      |   |   `-- 6a12fa6687633241c43db9a96277d6fd056870
       |   |-- 97
       |   |   `-- 398140f110f4009f1fce46e15f9fc140d6908b
-      |   |-- 9d
-      |   |   `-- 613be55337cdfab189935d8dbd1d4f427ef75e
       |   |-- b7
       |   |   `-- 8eb888451be077531b50794384c2faec025765
-      |   |-- cd
-      |   |   `-- 9ae8cb61e7d1aaa7b90766ff9aa9b3dc78c856
-      |   |-- d8
-      |   |   `-- b5906ab0322bc119e3142d76447591c41c29a4
-      |   |-- d9
-      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
-      |   |-- db
-      |   |   `-- 9120ba624b0afe79d37a5a262d8deb14e13707
-      |   |-- f0
-      |   |   `-- 2803a3f6b703de58a33b330f70b5034e0ebcf8
-      |   |-- f7
-      |   |   `-- 99a2ffcfae170f01efea806ff109e5e702191a
       |   |-- info
       |   `-- pack
+      |       |-- pack-6094f48eea5b3933a6584a6925dac03cf644f01e.idx
+      |       |-- pack-6094f48eea5b3933a6584a6925dac03cf644f01e.pack
+      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
+      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
+      |       |-- pack-90b662d3c4386bdd60eaa36cc1699fa799a7dd30.idx
+      |       |-- pack-90b662d3c4386bdd60eaa36cc1699fa799a7dd30.pack
+      |       |-- pack-9f918747f4ae3e54ccf603a1e77dd40c584aa821.idx
+      |       `-- pack-9f918747f4ae3e54ccf603a1e77dd40c584aa821.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  77 directories, 63 files
+  50 directories, 44 files

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -563,200 +563,59 @@ Note that ws/d/ is now present in the ws
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 02
-      |   |   `-- 668d7af968c8eed910db7539a57b18dd62a50e
       |   |-- 04
       |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
-      |   |-- 07
-      |   |   `-- f825fbedafa02f2e5158e69bc25250113b0b64
-      |   |-- 09
-      |   |   `-- b613e901acc0b5e4279ec6732261134a06f667
-      |   |-- 0c
-      |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
-      |   |-- 0e
-      |   |   `-- bcca72a14d4aa4b50037956fdad1d440deeee1
-      |   |-- 13
-      |   |   `-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
-      |   |-- 14
-      |   |   |-- c05920b084cdb89feaa847f9c99d764148ff9b
-      |   |   `-- da1560586adda328cca1fbf58c026d6730444f
-      |   |-- 17
-      |   |   `-- ac72002199728c133087acfa6b23009e00a52a
-      |   |-- 19
-      |   |   `-- b9637ac9437ea11d42632cd65ca2313952c32f
       |   |-- 1b
       |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
-      |   |-- 20
-      |   |   `-- 189c97a0ef53368b7ec335baa7a1b86bd76f8e
-      |   |-- 23
-      |   |   `-- d20398ffe09015ada5794763b97c750b61bdc4
-      |   |-- 2a
-      |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
-      |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
-      |   |-- 2c
-      |   |   |-- 50404f5c69295bd3d4d0cb5475be9cc2aada23
-      |   |   `-- 913262d99f8cd15ea711a89e943cd902fb87a0
-      |   |-- 2d
-      |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
       |   |-- 2f
       |   |   `-- 10c52e8ac3117e818b2b8a527c03d9345104c3
-      |   |-- 30
-      |   |   `-- 48804b01e298df4a6e1bc60a1e3b2ca0b016bd
-      |   |-- 31
-      |   |   `-- af3d0a5be6cc36a10a6b984673087c2d068432
-      |   |-- 32
-      |   |   `-- 3e79ffc7608345e286a313b55d97a3652de33b
-      |   |-- 34
-      |   |   `-- c24765275d6f3ec5d6baeaaa4299471d6f7df0
-      |   |-- 36
-      |   |   `-- 52f9baa44258d0f505314830ad37d16eafc981
-      |   |-- 38
-      |   |   `-- 1a4abe20b33f38f4b6f559d08a38c59355ff7e
-      |   |-- 39
-      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
-      |   |-- 3a
-      |   |   `-- 748f0be2a5670c0c282196d3a66620e8599ee5
-      |   |-- 3f
-      |   |   `-- c46d98fe664e12a931c5c1365a1cd845a78a64
       |   |-- 40
       |   |   `-- c389b6b248e13f3cb88dcd79467d7396a4489e
-      |   |-- 42
-      |   |   `-- 8f5d5c5a3ce27a5d9f513c1a051a18a4266528
-      |   |-- 43
-      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
-      |   |-- 44
-      |   |   `-- 625a9b34b1c6747c29903c3e641a4b2e580673
-      |   |-- 46
-      |   |   `-- bc1eabe4b2029b9fcb661f0d447d8389d17337
-      |   |-- 47
-      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
-      |   |-- 4c
-      |   |   `-- a9fbf65ee12663ac24db4be4cab10e53d6d6e7
-      |   |-- 59
-      |   |   `-- 632d8d838ce9390679767c02c6bfe6c0d244a9
-      |   |-- 5a
-      |   |   `-- 8a4b8c1452d54f1ca88454067369112809a4d2
-      |   |-- 5b
-      |   |   `-- 560252b0c3c6abc5e0327596a49efb15e494cb
-      |   |-- 5d
-      |   |   `-- 189f7f6e9e6ca744c8a397c1b63f653e7158b5
-      |   |-- 5e
-      |   |   `-- 9213824faf1eb95d0c522329518489196374fd
-      |   |-- 64
-      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
-      |   |-- 6d
-      |   |   `-- 4b5c23a94a89c7f26266ccf635647fd4002b19
-      |   |-- 70
-      |   |   `-- eb05d32223342a549cfb00c20b1464bf1b9513
       |   |-- 75
       |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
-      |   |-- 78
-      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 7a
-      |   |   `-- c71a2d1648e7de21f4fbe4935cf54b44bfef9a
-      |   |-- 7c
-      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
       |   |-- 7d
-      |   |   |-- 46532a74cbb9e9f9f17d760a4eb7fea62e888e
       |   |   `-- a1ae7f2b93967ad7ea421fa7db95b73b8aa07e
-      |   |-- 7f
-      |   |   |-- 39c7601f2c1ca44fdc9237efa34f2887daa2b4
-      |   |   `-- c8ee5474068055f7740240dfce6fa6e38bbf4d
       |   |-- 82
       |   |   `-- 4c0e846b41e1eb9f95d141b47bbb9ff9baef17
-      |   |-- 8c
-      |   |   |-- 4e94969f16bfec56af4b29c1a20e732401ed32
-      |   |   `-- c4bb045e98da7cf00714d91ac77c7ea7e08b63
-      |   |-- 93
-      |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
-      |   |-- 94
-      |   |   `-- 41c1b9a5eb6356cd9f7a1640d2683283ac6053
       |   |-- 95
-      |   |   |-- 19a72b0b8d581a4e859d412cfe9c2689acac53
-      |   |   `-- d99506044285b3088aef86540c478f09606763
-      |   |-- 98
-      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
-      |   |-- 99
-      |   |   `-- acd82fe2a9b89022d1aee5a580c123a8161f4a
-      |   |-- 9d
-      |   |   `-- e3bbb26e2b40f02ca8de195933eb620bbf0b6a
-      |   |-- 9e
-      |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
-      |   |-- 9f
-      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
-      |   |-- a1
-      |   |   |-- 1e8a91058875f157ca1246bdc403b88e93cd94
-      |   |   |-- 269dc50ffcdc1b87664a061926bf9a072a3456
-      |   |   `-- c31372c5de4fb705ffdcbf5a4ec5c5103231d9
-      |   |-- ab
-      |   |   `-- a295fbe181a47f04650542b7d5582fbd983b98
+      |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
       |   |-- b1
-      |   |   |-- 55ee8a0221a6d1f94982ab3624f47f7e4931e2
-      |   |   `-- c3c9b731fea98c82ce8e9286e213fcb033f70d
-      |   |-- b7
-      |   |   `-- bb51e63095336302e4f6b0eead63cb716eb630
-      |   |-- b9
-      |   |   `-- 90567474f1f8af9784478614483684e88ccf4f
-      |   |-- ba
-      |   |   `-- f9dcf1394d5152de67b115f55f25e4dc0a2398
+      |   |   `-- 55ee8a0221a6d1f94982ab3624f47f7e4931e2
       |   |-- bc
       |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
-      |   |-- c1
-      |   |   `-- 489fc8fd6ae9ac08c0168d7cabaf5645b922fa
-      |   |-- c2
-      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
-      |   |-- c8
-      |   |   `-- 8a8cea02112a17891dfdffe7ebd55efd3a3fa2
-      |   |-- d3
-      |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
-      |   |-- d9
-      |   |   |-- 1fa4981fe3546f44fa5a779ec6f69b20fdaa0f
-      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
-      |   |-- da
-      |   |   `-- af0560e4e779353311a9039b31ea4f0f1dec37
       |   |-- dc
       |   |   `-- e83c94807b93f44776c7a1e71cf4f4f8f222b5
-      |   |-- e1
-      |   |   |-- 0bf0281a70e6b19939ad6e26e10252bbebe300
-      |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
-      |   |-- e4
-      |   |   `-- a5e5c828510a51aacfdb9e38cea9440d8882ec
-      |   |-- e7
-      |   |   `-- cee3592aaac624fd48c258daa5d62d17352043
-      |   |-- e9
-      |   |   `-- 9a2c69c0fb10af8dd1524e7f976df3d898f6ac
-      |   |-- ea
-      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |-- ec
-      |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
-      |   |-- ee
-      |   |   `-- b52a9c8fe143baf970160aa4716ff5c019d8cb
       |   |-- f2
-      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
-      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
-      |   |-- f5
-      |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+      |   |   `-- 257977b96d2272be155d6699046148e477e9fb
       |   |-- f6
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
-      |   |-- f7
-      |   |   `-- 35d04266733d64d2f49ab23a183a5207e8961d
       |   |-- f8
       |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
-      |   |-- fc
-      |   |   `-- c182ce4e8039ae321c009746e9a5b42a224bf5
-      |   |-- fd
-      |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
       |   |-- info
       |   `-- pack
+      |       |-- pack-133a4127e8d4c9bdc124e21786a688c4e8f778c9.idx
+      |       |-- pack-133a4127e8d4c9bdc124e21786a688c4e8f778c9.pack
+      |       |-- pack-14805803f920d9666668bc656d8f0515ee1bd064.idx
+      |       |-- pack-14805803f920d9666668bc656d8f0515ee1bd064.pack
+      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
+      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
+      |       |-- pack-9344ad8c1e2b9aca23229bfb5dfbc1a19f64e2dc.idx
+      |       |-- pack-9344ad8c1e2b9aca23229bfb5dfbc1a19f64e2dc.pack
+      |       |-- pack-af3e3339c7bd303ace0b6210e7f1c13374606269.idx
+      |       |-- pack-af3e3339c7bd303ace0b6210e7f1c13374606269.pack
+      |       |-- pack-bbd5e1b2aa5ccd4e9879b7d452262fea964c8044.idx
+      |       |-- pack-bbd5e1b2aa5ccd4e9879b7d452262fea964c8044.pack
+      |       |-- pack-dc4dca83cf9851930e174c49e92f2de588f25e71.idx
+      |       |-- pack-dc4dca83cf9851930e174c49e92f2de588f25e71.pack
+      |       |-- pack-fb51f94a07756db0b90e50e60315402cd82f9ac3.idx
+      |       `-- pack-fb51f94a07756db0b90e50e60315402cd82f9ac3.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  159 directories, 158 files
+  87 directories, 89 files
 
 $ cat ${TESTTMP}/josh-proxy.out

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -339,169 +339,37 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 00
-      |   |   `-- 5d8d52eafd3d5f0b2272be08b36693b2b5b76b
-      |   |-- 02
-      |   |   `-- 668d7af968c8eed910db7539a57b18dd62a50e
       |   |-- 04
       |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
-      |   |-- 0c
-      |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
-      |   |-- 13
-      |   |   `-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
-      |   |-- 16
-      |   |   `-- 2e9b45be8bbc12e975d13c0089eccbbcba9b56
-      |   |-- 17
-      |   |   `-- b82a3b31749dc7d6dbc5a528eb19a103a5bdb9
-      |   |-- 1d
-      |   |   |-- 6d81877130bc5a54c8ea27e8497f838cfe9aa3
-      |   |   `-- ff8a2dce92f202d13c5995a0f898b6cfba26c9
-      |   |-- 20
-      |   |   `-- 5dccdc2e37df9aaccec46009520154219134e7
-      |   |-- 27
-      |   |   `-- d0eee16bdbe4a1ade0ebf877f97467de3b218e
-      |   |-- 2a
-      |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
-      |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
-      |   |-- 2b
-      |   |   `-- 158ac79b2dae332577be854a9fc8fb558f13f9
       |   |-- 2c
       |   |   `-- fb80c68126f24a61b2778ce3f55d65d93f5e90
-      |   |-- 2d
-      |   |   `-- b4c60cceb3afe11f40f945c01dd5cd513f5653
       |   |-- 2f
       |   |   `-- 10c52e8ac3117e818b2b8a527c03d9345104c3
-      |   |-- 30
-      |   |   `-- ab6d81f7ffe88ab3a82ff74ff09439b2d5afa7
-      |   |-- 34
-      |   |   `-- be7abf6de2d37711a568059e7aa150ed428a43
-      |   |-- 39
-      |   |   |-- 0caf88590ab9ce40b6092c82a5f5e68041e4a6
-      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
-      |   |-- 43
-      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
-      |   |-- 46
-      |   |   `-- 3b7672b3bcf00bbd95e650076c375528d5f5c3
-      |   |-- 47
-      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
-      |   |-- 4e
-      |   |   `-- 8ed8ed549306fc01dba32ee643084f1070ba9c
-      |   |-- 4f
-      |   |   `-- 314491719dffbb4340268e5f04136e74821e2c
-      |   |-- 53
-      |   |   `-- 0148978e42a91926dbe2f5fe0c71fe63aacf8e
-      |   |-- 5a
-      |   |   `-- 38ed8e4d96b624c6ef7e36f8b696d52be785db
-      |   |-- 5b
-      |   |   `-- 545e12c5b297509b8d99df5f0b952a2dd7862d
-      |   |-- 5d
-      |   |   `-- 0e549ae0392ba043767615c0225b9a9c7f40ab
       |   |-- 64
-      |   |   |-- 6fd2c5bfe156d57ba03f62f2fe735ddbb74e22
-      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
-      |   |-- 65
-      |   |   `-- 1de74dfe1abe2024ed2798bbfcf9ba683d3f86
-      |   |-- 67
-      |   |   `-- 48a16f7d9b29607fcd4df93681361a6105a14a
-      |   |-- 69
-      |   |   `-- a612aea46e9d365755e3b930d8aa4458e7bbf6
-      |   |-- 6f
-      |   |   `-- 4ee6b7661cc1905bb762d80a94c4337d43697d
-      |   |-- 70
-      |   |   `-- 1b7746c347750d035ddd29ad67ad2f2c4851a8
+      |   |   `-- 6fd2c5bfe156d57ba03f62f2fe735ddbb74e22
       |   |-- 75
       |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
-      |   |-- 78
-      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 7a
-      |   |   `-- 185c5a9aa33cf2e7749b1ad15a4aebfdd070a5
-      |   |-- 7c
-      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
-      |   |-- 7f
-      |   |   `-- c8ee5474068055f7740240dfce6fa6e38bbf4d
-      |   |-- 89
-      |   |   `-- 8b763a1483259f4667f399a019b96f52a28f8c
-      |   |-- 8a
-      |   |   `-- bb8094049472170b402ad3aaee6db3d5a97286
-      |   |-- 8c
-      |   |   `-- 4e94969f16bfec56af4b29c1a20e732401ed32
-      |   |-- 91
-      |   |   `-- 584adddb4f190d805ec45ce500a0661671fb25
-      |   |-- 93
-      |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
-      |   |-- 98
-      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
-      |   |-- 9d
-      |   |   `-- e3bbb26e2b40f02ca8de195933eb620bbf0b6a
-      |   |-- 9e
-      |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
-      |   |-- 9f
-      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
-      |   |-- a0
-      |   |   `-- aedc37ec419934689622688e75ae66f5aa0742
-      |   |-- a3
-      |   |   `-- d027b4cc082c08af95fcbe03eecd9a62a08c48
-      |   |-- a7
-      |   |   `-- 3af649c49fa4b0facff36fafdc1e2bef594d4e
-      |   |-- aa
-      |   |   `-- 0654329f0642e4505db87c24aea80ba52fd689
-      |   |-- ac
-      |   |   `-- 0969c65843463b2d0e86fd4c6efcae33012332
-      |   |-- b0
-      |   |   `-- 3b5fbc9a12109cd3f5308929e4812b3c998da6
-      |   |-- b8
-      |   |   `-- 54e8ec3db62174179b215404936a58f1bb6a79
-      |   |-- b9
-      |   |   `-- 90567474f1f8af9784478614483684e88ccf4f
       |   |-- bc
-      |   |   |-- 61a0ff30ea25db7bcfc9a67fdae747904ed55f
       |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
-      |   |-- c1
-      |   |   `-- 489fc8fd6ae9ac08c0168d7cabaf5645b922fa
-      |   |-- c2
-      |   |   |-- 054840bbf17ac9939d8165a0b88f1065ff57f7
-      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
-      |   |-- c5
-      |   |   `-- 30c1385a6297aa79fd3d1ced94b089ca760fd6
-      |   |-- cd
-      |   |   |-- 0544cd5f702a9b3418205ec0425c6ae77f9e3e
-      |   |   `-- 7c94c08f59302a2b1587a01d4fd1680d7378c9
-      |   |-- d0
-      |   |   `-- a80cebe6f692edee7c959da2ffa66cf7d6c755
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
-      |   |-- e1
-      |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
-      |   |-- e5
-      |   |   `-- f5b3645e5400bd404016c5111c18c3942f02e7
-      |   |-- e8
-      |   |   `-- d34a664c80ff36cdff2c41c1fd3964f6e30f00
-      |   |-- ea
-      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |-- ec
-      |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
-      |   |-- ef
-      |   |   `-- 4639405a27655c750c3ca6249b35fbf3ea25ca
-      |   |-- f0
-      |   |   `-- 932972a6075f9a82e1ca23d65f9983145abd9e
       |   |-- f2
-      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
-      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |   `-- 257977b96d2272be155d6699046148e477e9fb
       |   |-- f6
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
-      |   |-- f7
-      |   |   `-- 7930069cbf71e47b72fb4e5ede3dff15123884
-      |   |-- fa
-      |   |   `-- 1745f6c84f945b51a305aa9751c466e26fb78a
       |   |-- info
       |   `-- pack
+      |       |-- pack-89f5d1c01530839eab589ceec8565f11ff4679a5.idx
+      |       |-- pack-89f5d1c01530839eab589ceec8565f11ff4679a5.pack
+      |       |-- pack-a3e156efacbcda80b8277b4b01596dd8366d6c94.idx
+      |       |-- pack-a3e156efacbcda80b8277b4b01596dd8366d6c94.pack
+      |       |-- pack-c455f6d9504526b7c14867a795a5b2e27610956a.idx
+      |       `-- pack-c455f6d9504526b7c14867a795a5b2e27610956a.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  130 directories, 124 files
+  65 directories, 57 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -422,179 +422,47 @@ Note that ws/d/ is now present in the ws
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 02
-      |   |   `-- 668d7af968c8eed910db7539a57b18dd62a50e
       |   |-- 04
       |   |   `-- 28323b9901ac5959af01b8686b2524c671adc1
-      |   |-- 07
-      |   |   `-- f825fbedafa02f2e5158e69bc25250113b0b64
-      |   |-- 09
-      |   |   `-- b613e901acc0b5e4279ec6732261134a06f667
-      |   |-- 0c
-      |   |   |-- 66ddcaed3f256f7dacc400a684aa1b91ac638f
-      |   |   `-- d4309cc22b5903503a7196f49c24cf358a578a
-      |   |-- 13
-      |   |   `-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
-      |   |-- 14
-      |   |   `-- da1560586adda328cca1fbf58c026d6730444f
-      |   |-- 17
-      |   |   `-- ac72002199728c133087acfa6b23009e00a52a
-      |   |-- 19
-      |   |   `-- b9637ac9437ea11d42632cd65ca2313952c32f
-      |   |-- 20
-      |   |   `-- 189c97a0ef53368b7ec335baa7a1b86bd76f8e
-      |   |-- 22
-      |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
-      |   |-- 23
-      |   |   `-- d20398ffe09015ada5794763b97c750b61bdc4
-      |   |-- 27
-      |   |   `-- 5b45aec0a1c944c3a4c71cc71ee08d0c9ea347
-      |   |-- 2a
-      |   |   |-- 03ad0fe1720ee0afc95ba8e1bc38a35b87983f
-      |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
-      |   |-- 2c
-      |   |   |-- 50404f5c69295bd3d4d0cb5475be9cc2aada23
-      |   |   `-- 913262d99f8cd15ea711a89e943cd902fb87a0
       |   |-- 2f
       |   |   `-- 10c52e8ac3117e818b2b8a527c03d9345104c3
-      |   |-- 30
-      |   |   `-- 48804b01e298df4a6e1bc60a1e3b2ca0b016bd
-      |   |-- 31
-      |   |   `-- af3d0a5be6cc36a10a6b984673087c2d068432
-      |   |-- 34
-      |   |   `-- c24765275d6f3ec5d6baeaaa4299471d6f7df0
-      |   |-- 36
-      |   |   `-- 52f9baa44258d0f505314830ad37d16eafc981
-      |   |-- 39
-      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
-      |   |-- 3a
-      |   |   `-- 748f0be2a5670c0c282196d3a66620e8599ee5
       |   |-- 40
       |   |   `-- c389b6b248e13f3cb88dcd79467d7396a4489e
-      |   |-- 42
-      |   |   `-- 8f5d5c5a3ce27a5d9f513c1a051a18a4266528
-      |   |-- 43
-      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
-      |   |-- 44
-      |   |   |-- 625a9b34b1c6747c29903c3e641a4b2e580673
-      |   |   `-- edc62d506b9805a3edfc74db15b1cc0bfc6871
-      |   |-- 46
-      |   |   `-- bc1eabe4b2029b9fcb661f0d447d8389d17337
-      |   |-- 47
-      |   |   `-- 8644b35118f1d733b14cafb04c51e5b6579243
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
-      |   |-- 4c
-      |   |   `-- a9fbf65ee12663ac24db4be4cab10e53d6d6e7
-      |   |-- 5a
-      |   |   `-- 8a4b8c1452d54f1ca88454067369112809a4d2
-      |   |-- 5b
-      |   |   `-- 560252b0c3c6abc5e0327596a49efb15e494cb
-      |   |-- 5e
-      |   |   `-- 9213824faf1eb95d0c522329518489196374fd
-      |   |-- 64
-      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
-      |   |-- 67
-      |   |   `-- 12cb1b8c89e3b2272182f140c81aef3b718671
-      |   |-- 6d
-      |   |   `-- 4b5c23a94a89c7f26266ccf635647fd4002b19
-      |   |-- 70
-      |   |   |-- 7a20731ff94c2dee063a8b274665b1cc730e26
-      |   |   `-- eb05d32223342a549cfb00c20b1464bf1b9513
       |   |-- 75
       |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
-      |   |-- 78
-      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 7a
-      |   |   `-- c71a2d1648e7de21f4fbe4935cf54b44bfef9a
-      |   |-- 7c
-      |   |   `-- 30b7adfa79351301a11882adf49f438ec294f8
       |   |-- 7d
       |   |   `-- e033196d3f74f40139647122f499286a97498b
-      |   |-- 7f
-      |   |   |-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
-      |   |   |-- 39c7601f2c1ca44fdc9237efa34f2887daa2b4
-      |   |   `-- c8ee5474068055f7740240dfce6fa6e38bbf4d
       |   |-- 82
       |   |   `-- 4c0e846b41e1eb9f95d141b47bbb9ff9baef17
-      |   |-- 8c
-      |   |   |-- 4e94969f16bfec56af4b29c1a20e732401ed32
-      |   |   `-- c4bb045e98da7cf00714d91ac77c7ea7e08b63
-      |   |-- 93
-      |   |   `-- f66d258b7b4c3757e63f985b08f7daa33db64e
-      |   |-- 95
-      |   |   `-- d99506044285b3088aef86540c478f09606763
-      |   |-- 98
-      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
-      |   |-- 99
-      |   |   `-- acd82fe2a9b89022d1aee5a580c123a8161f4a
-      |   |-- 9d
-      |   |   `-- e3bbb26e2b40f02ca8de195933eb620bbf0b6a
-      |   |-- 9e
-      |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
       |   |-- 9f
-      |   |   |-- 7fe44ebf4b96d3fc03aa7bffff6baa4a84eb63
-      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
-      |   |-- a1
-      |   |   |-- 269dc50ffcdc1b87664a061926bf9a072a3456
-      |   |   `-- c31372c5de4fb705ffdcbf5a4ec5c5103231d9
-      |   |-- a4
-      |   |   `-- b68220bdf7fb846eb9780f7846a2f4bf7cbcc3
-      |   |-- ab
-      |   |   `-- a295fbe181a47f04650542b7d5582fbd983b98
+      |   |   `-- 7fe44ebf4b96d3fc03aa7bffff6baa4a84eb63
       |   |-- b1
       |   |   `-- 55ee8a0221a6d1f94982ab3624f47f7e4931e2
-      |   |-- b7
-      |   |   `-- bb51e63095336302e4f6b0eead63cb716eb630
-      |   |-- b9
-      |   |   `-- 90567474f1f8af9784478614483684e88ccf4f
-      |   |-- ba
-      |   |   `-- f9dcf1394d5152de67b115f55f25e4dc0a2398
       |   |-- bc
       |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
-      |   |-- c1
-      |   |   `-- 489fc8fd6ae9ac08c0168d7cabaf5645b922fa
-      |   |-- c2
-      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
-      |   |-- d9
-      |   |   `-- a323ee316cda6f241fcc35cbd29d4a882aa45e
-      |   |-- e1
-      |   |   |-- 0bf0281a70e6b19939ad6e26e10252bbebe300
-      |   |   `-- 25e6d9f8f9acca5ffd25ee3c97d09748ad2a8b
-      |   |-- e4
-      |   |   `-- a5e5c828510a51aacfdb9e38cea9440d8882ec
-      |   |-- e7
-      |   |   `-- cee3592aaac624fd48c258daa5d62d17352043
-      |   |-- e9
-      |   |   `-- 9a2c69c0fb10af8dd1524e7f976df3d898f6ac
-      |   |-- ea
-      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |-- ec
-      |   |   `-- 4f59ca1a0ac5b2f375d4917dbba5e6aedff12a
-      |   |-- ed
-      |   |   `-- efd7dc70381a72b7af5bff2e49b8eb60cb9237
-      |   |-- ee
-      |   |   `-- b52a9c8fe143baf970160aa4716ff5c019d8cb
       |   |-- f2
-      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
-      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
+      |   |   `-- 257977b96d2272be155d6699046148e477e9fb
       |   |-- f6
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
-      |   |-- f7
-      |   |   `-- 35d04266733d64d2f49ab23a183a5207e8961d
-      |   |-- fc
-      |   |   `-- c182ce4e8039ae321c009746e9a5b42a224bf5
-      |   |-- fd
-      |   |   `-- 2bc852c86f084dd411054c9c297b05ccf76427
       |   |-- info
       |   `-- pack
+      |       |-- pack-003dec79becceac35fcf4dc6da69067da9076b43.idx
+      |       |-- pack-003dec79becceac35fcf4dc6da69067da9076b43.pack
+      |       |-- pack-5f43de7285cc69f6f7f779f1c22bbcc404fea509.idx
+      |       |-- pack-5f43de7285cc69f6f7f779f1c22bbcc404fea509.pack
+      |       |-- pack-78ce499d43b7df7a0b507140d5134ff90a058eeb.idx
+      |       |-- pack-78ce499d43b7df7a0b507140d5134ff90a058eeb.pack
+      |       |-- pack-84f244e975f0cef0625d4b0763f10884293e2c92.idx
+      |       |-- pack-84f244e975f0cef0625d4b0763f10884293e2c92.pack
+      |       |-- pack-e876a75ec76e589fce94f48879886deedaa62f4c.idx
+      |       `-- pack-e876a75ec76e589fce94f48879886deedaa62f4c.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  147 directories, 145 files
+  82 directories, 78 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -147,37 +147,15 @@ file was created
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 06
-      |   |   `-- f56dd7e7b5abf977267595ccfc3f1a5f1eea28
-      |   |-- 27
-      |   |   `-- 5b45aec0a1c944c3a4c71cc71ee08d0c9ea347
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
-      |   |-- 4f
-      |   |   `-- be5e3e9300ad2318545b9b8197029d55ac5395
-      |   |-- 78
-      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 98
-      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
-      |   |-- 9c
-      |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
-      |   |-- a8
-      |   |   `-- 6544ef29b946481d26cb4cfb55844342069c0e
-      |   |-- a9
-      |   |   `-- 252e3936cb6309dfebcafd688cd6a0d2225036
-      |   |-- b6
-      |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
-      |   |-- eb
-      |   |   `-- 6a31166c5bf0dbb65c82f89130976a12533ce6
-      |   |-- f8
-      |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
       |   |-- info
       |   `-- pack
+      |       |-- pack-8917b273641be5244854c2fbf57281b0086ccc85.idx
+      |       `-- pack-8917b273641be5244854c2fbf57281b0086ccc85.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  53 directories, 38 files
+  41 directories, 28 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -177,93 +177,37 @@
       |   |   `-- 14c74ac19f876065ca26a4e9b578c2bc61ef18
       |   |-- 0f
       |   |   `-- 61d50b4e5a814afb71b3da5a2986efd37bc605
-      |   |-- 13
-      |   |   `-- 10813ea4e1d46c4c5c59bfdaf97a6de3b24c31
       |   |-- 20
       |   |   `-- c53646e34e6079f7dc3090be5c2c3fdd81a4f3
-      |   |-- 2a
-      |   |   `-- 3e798288165d5b090a10460984776489bcc7cc
-      |   |-- 2d
-      |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
       |   |-- 2f
       |   |   `-- 10c52e8ac3117e818b2b8a527c03d9345104c3
-      |   |-- 36
-      |   |   `-- e70a0bbbb8847771f037d5682f33cd26223bc5
-      |   |-- 39
-      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
-      |   |-- 3e
-      |   |   `-- ade035db71b1ce109c190c3e587aff04b82c55
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
-      |   |-- 4c
-      |   |   `-- af7229f3533f1e776f493fe4f1bc4cb234e72f
-      |   |-- 4d
-      |   |   `-- dbf4f812dbd547947a2511b01985fb7a460eae
-      |   |-- 59
-      |   |   `-- ce9b0ca657f0fd704efc832cea8cf64da5bbf5
-      |   |-- 5e
-      |   |   `-- a433bcec0b828c04d26f0fb03b40535dc4f855
-      |   |-- 64
-      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
-      |   |-- 65
-      |   |   `-- b0ecf29d3808ba274af864643f5a3f9c8706f1
-      |   |-- 67
-      |   |   `-- c1c331298672b86d90c2c847942ee7714463a9
-      |   |-- 6e
-      |   |   `-- 8d20f7effed65135756c3d3428ccf7d7efb818
-      |   |-- 73
-      |   |   `-- 3cdae47736c40c40238fa2902185b30a5a1831
       |   |-- 75
       |   |   `-- 1ecd943cf17e1530017a1db8006771d6c5c4d4
       |   |-- 77
       |   |   `-- b5962d8bd7ad507a02af9767c4cf68c0781200
-      |   |-- 84
-      |   |   `-- 2d4785bdebe66a26cd2c094a2373cfc6b936ed
-      |   |-- 88
-      |   |   `-- 4f260811f923775b9f6433ee9ec063ebe19efd
       |   |-- 95
       |   |   `-- 19a72b0b8d581a4e859d412cfe9c2689acac53
-      |   |-- 9d
-      |   |   `-- b51080a4d148b32bd4c4e0b39eae8d0b3df763
-      |   |-- 9e
-      |   |   `-- 4d2bcaee240904058a6160e84311667b409b08
-      |   |-- a2
-      |   |   `-- ad9d7bed2fe8d70e88273ee480142893bf1a8b
-      |   |-- b5
-      |   |   `-- f6121773050641aa77d3f4f8f02f1e22d10b2e
-      |   |-- ba
-      |   |   `-- 300b195019b96ef5d20dfe135143b0e8df7636
       |   |-- bc
       |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
-      |   |-- bf
-      |   |   `-- 0dfac2aeb5becb6a4bf38061056375bc3ef32c
-      |   |-- c1
-      |   |   `-- 489fc8fd6ae9ac08c0168d7cabaf5645b922fa
-      |   |-- c2
-      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
-      |   |-- c4
-      |   |   `-- c85b2c5c47af364fa064bd2b6523fe98ed3852
-      |   |-- d3
-      |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
-      |   |-- ea
-      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
       |   |-- f2
-      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
-      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
-      |   |-- f5
-      |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+      |   |   `-- 257977b96d2272be155d6699046148e477e9fb
       |   |-- f6
-      |   |   |-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
-      |   |   `-- e8ded2e63ba78ef5e9c02679331383cc4b2203
+      |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
+      |       |-- pack-22feba8ae58a3472f764b3f5060292f7190e37fe.idx
+      |       |-- pack-22feba8ae58a3472f764b3f5060292f7190e37fe.pack
+      |       |-- pack-6b38b3f70def6c73711d6d00ddbf675f33f854b8.idx
+      |       |-- pack-6b38b3f70def6c73711d6d00ddbf675f33f854b8.pack
+      |       |-- pack-941b0ed2e56099a0daa91129b84275672d56b2be.idx
+      |       `-- pack-941b0ed2e56099a0daa91129b84275672d56b2be.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  76 directories, 64 files
+  46 directories, 38 files
 
 $ cat ${TESTTMP}/josh-proxy.out | grep VIEW

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -330,116 +330,37 @@
       |-- info
       |   `-- exclude
       |-- objects
-      |   |-- 00
-      |   |   `-- e02597bb7117c22dc0b551a4062607895fc3d3
-      |   |-- 10
-      |   |   `-- 105c45d21be850089b3f326502436adfa5ab0e
-      |   |-- 11
-      |   |   `-- e2559617afa238a8332c15d15fff48d5b57c83
-      |   |-- 13
-      |   |   `-- 7228bdcd2ae40007860a69d05168279d95117a
-      |   |-- 1b
-      |   |   `-- 46698f32d1d1db1eaeb34f8c9037778d65f3a9
-      |   |-- 1d
-      |   |   `-- 2a35c53f4e5901c9cc083a94b417c15837cad8
-      |   |-- 22
-      |   |   `-- b3eaf7b374287220ac787fd2bce5958b69115c
-      |   |-- 23
-      |   |   `-- f7e90462b3fc5db0a26335139e1fe83d04d2cd
-      |   |-- 2c
-      |   |   `-- bcd105ead63a4fecf486b949db7f44710300e5
-      |   |-- 2d
-      |   |   `-- 1906dd31141f2fbab6485ccd34bbd1ea440464
-      |   |-- 2e
-      |   |   `-- aadc29a9215c79ff47c4b3a82a024816eb195a
-      |   |-- 39
-      |   |   `-- abfc68c47fd430cd9775fc18c9f93bc391052e
-      |   |-- 43
-      |   |   `-- 52611a9e7c56dfdfeadec043ced6d6ef7a5c33
-      |   |-- 45
-      |   |   `-- c7960fc4d4b38a6a28dcc27f0ae158afa59747
-      |   |-- 4b
-      |   |   `-- 825dc642cb6eb9a060e54bf8d69288fbee4904
       |   |-- 5a
       |   |   `-- f4045367114a7584eefa64b95bb69d7f840aef
       |   |-- 5f
       |   |   `-- a942ed9d35f280b35df2c4ef7acd23319271a5
-      |   |-- 60
-      |   |   `-- 5066c26f66fca5a424aa32bd042ae71c7c8705
-      |   |-- 64
-      |   |   `-- d1f8d32b274d8c1eeb69891931f52b6ade9417
-      |   |-- 6b
-      |   |   `-- e0d68b8e87001c8b91281636e21d6387010332
-      |   |-- 6f
-      |   |   `-- 361fef653a193d6f2241b7226c3be8610d1262
-      |   |-- 78
-      |   |   `-- 2f6261fa32f8bfec7b89f77bb5cce40c4611cb
-      |   |-- 7f
-      |   |   `-- 0f21b330a3d45f363fcde6bfb57eed22948cb6
-      |   |-- 83
-      |   |   `-- 3812f1557e561166754add564fe32228dd1703
-      |   |-- 96
-      |   |   `-- f5351b972284f81d7246836f82f6be06c6631f
-      |   |-- 98
-      |   |   `-- 84cc2efe368ea0aa9d912fa596b26c5d75dbee
-      |   |-- 9c
-      |   |   `-- f258b407cd9cdba97e16a293582b29d302b796
-      |   |-- 9f
-      |   |   `-- 8daab1754f04fbe8aaac6fcbb44c8324df09eb
-      |   |-- a0
-      |   |   `-- 28e4ad33176e7db6f3d4a5fc7e92257cfe213e
       |   |-- a3
       |   |   `-- d19dcb2f51fa1efd55250f60df559c2b8270b8
-      |   |-- a4
-      |   |   |-- 1772e0c7cdad1a13b7a7bc38c0d382a5a827ce
-      |   |   `-- 8223bf4fc7801a0322b4ecaa5ed6a2c5dce7f1
-      |   |-- a6
-      |   |   `-- a87b60d0096fd465f5190507aaa1e06248bced
-      |   |-- b0
-      |   |   `-- fdeb65d9b9069015ef9c0f735a4f6f2f28fe77
-      |   |-- b1
-      |   |   |-- c1b15558aebbce0682f25933cb729e9acd209c
-      |   |   `-- cbc68940fd6afb1420b1be50c3acd06e8b3fc2
-      |   |-- b6
-      |   |   `-- c8440fe2cd36638ddb6b3505c1e8f2202f6191
-      |   |-- b8
-      |   |   `-- ddfe2d00f876ae2513a5b26a560485762f6bfa
       |   |-- bb
       |   |   `-- bd62ec41c785d12270e69b9d49f9babe62fcd6
       |   |-- bc
       |   |   `-- 665856e841c4ae4a956483dc57b2ea4cc20116
-      |   |-- c2
-      |   |   `-- d86319b61f31a7f4f1bc89b8ea4356b60c4658
-      |   |-- c5
-      |   |   `-- dd0ee2c3106a581cdea7db0c4297ef82c0f874
-      |   |-- c6
-      |   |   `-- 735a7b0d9da9bf6ef5e445ad2f4ce3d825ceb0
-      |   |-- d3
-      |   |   `-- d2a4d6db7addc2b087dcdb3e63785d3315c00e
       |   |-- d7
       |   |   `-- 330ea337031af43ba1cf6982a873a40b9170ac
-      |   |-- e2
-      |   |   `-- 5d071c2db414f24473e3768c063dbcf8c55d04
-      |   |-- ea
-      |   |   `-- 1ae75547e348b07cb28a721a06ef6580ff67f0
-      |   |-- ed
-      |   |   `-- 8ae0c02d30bd34d7a8584cb0930d0d7a58df26
-      |   |-- f1
-      |   |   `-- 84b6c58c9b6470ea291406c20ed54ae50d0ce3
       |   |-- f2
-      |   |   |-- 257977b96d2272be155d6699046148e477e9fb
-      |   |   `-- 7e0d18d976fd84da0a9e260989ecb6edaa593f
-      |   |-- f5
-      |   |   `-- d0c4d5fe3173ba8ca39fc198658487eaab8014
+      |   |   `-- 257977b96d2272be155d6699046148e477e9fb
       |   |-- f6
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
+      |       |-- pack-4ee5410a0d07448774a9d777901482c58c903f84.idx
+      |       |-- pack-4ee5410a0d07448774a9d777901482c58c903f84.pack
+      |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.idx
+      |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.pack
+      |       |-- pack-969240cacd518199eb056a306b470700114f2177.idx
+      |       |-- pack-969240cacd518199eb056a306b470700114f2177.pack
+      |       |-- pack-d61f3c8dbb59af6cc0c1604d99c262527ccad92e.idx
+      |       `-- pack-d61f3c8dbb59af6cc0c1604d99c262527ccad92e.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  109 directories, 101 files
+  67 directories, 64 files
 
 $ cat ${TESTTMP}/josh-proxy.out


### PR DESCRIPTION
josh wrote every object it produced while filtering as a loose object -- a file,
a zlib stream, and a directory insert apiece -- which dominates the cost of large
rewrites. Route those writes through a per-transaction in-memory libgit2 ODB
backend instead, and flush them to a packfile.

The backend lives in a new josh-git-data crate: an OdbBackend trait that a safe
Rust impl satisfies and that register() lifts into a git_odb_backend, with no
hand-written extern "C" callbacks. git2 does not expose the raw
git_odb/git_repository pointers, so register() reads the pointer out of the
single-field Repository newtype -- sound only while josh pins git2 exactly,
re-verify on every upgrade. The backend is registered at high priority on every
repository opened through a Transaction, so existing repo.blob()/treebuilder/
commit calls land in memory with no filter call-site changes; reads check memory
first and fall through to the on-disk backends on a miss (GIT_ENOTFOUND).

The store is bounded: once the buffered object data exceeds the limit it flushes
itself mid-transaction, so a transaction may write several packfiles. The proxy
and CLI default to 128 MiB; josh-core's trigram search, josh-templates, and
josh-cq run unbounded. Otherwise objects are flushed to a packfile (OIDs sorted,
so the pack name is deterministic) and evicted at the boundaries where an external
git process reads them from disk -- Transaction::spawn_git (CLI), and the proxy's
write_to_repo and push_head_url -- with a drop-time flush as the backstop. The
in-memory backend is invisible to those subprocesses until the flush runs,
keeping proxy serve/push and CLI clone/push/fetch correct.

The .t snapshots that list .git/objects change from loose objects to packfiles
accordingly; no command output changed.

Caveats: abbreviated-OID lookup against the store is not implemented (full OIDs,
the hot path, work); and DistributedCacheBackend and josh-filter's notes-hook
repo open their own repositories without the backend, so they cannot see in-flight
filtered objects.

Change: in-memory-odb-backend
Assisted-By: Claude Opus 4.8 <noreply@anthropic.com>
Assisted-By: glm-5.2[1m]
Change-Id: I464aeccb376708f3097c3900c966ba0a67a7a1c5
