### PR TITLE
Pack filtered objects on a background thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3107,6 +3107,7 @@ version = "26.6.11"
 dependencies = [
  "git2",
  "libgit2-sys",
+ "log",
  "tempfile",
 ]
 

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -137,7 +137,7 @@ impl Drop for Transaction {
             return;
         }
 
-        if let Err(e) = self.mem_odb.flush(&self.repo) {
+        if let Err(e) = self.mem_odb.flush() {
             log::error!("failed to flush in-memory object store: {e}");
         }
     }
@@ -210,7 +210,7 @@ impl Transaction {
 
     // TODO: remove and rework proxy git launch path to use spawn_git
     pub fn flush_mem_odb(&self) -> anyhow::Result<()> {
-        self.mem_odb.flush(&self.repo)?;
+        self.mem_odb.flush()?;
         Ok(())
     }
 

--- a/josh-git-data/Cargo.toml
+++ b/josh-git-data/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2024"
 [dependencies]
 libgit2-sys = "0.18"
 git2.workspace = true
+log.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/josh-git-data/src/flusher.rs
+++ b/josh-git-data/src/flusher.rs
@@ -1,0 +1,98 @@
+//! Background packfile writer for [`MemOdb`](crate::mem_odb::MemOdb).
+//!
+//! Writing a packfile (zlib-compressing every buffered object and fsyncing the result) is the
+//! expensive tail of a flush. Running it inline would block the filter hot path — the mid-run
+//! overflow flush most of all, which fires repeatedly during a large rewrite. So all packing is
+//! funnelled to one process-global worker thread:
+//!
+//! * [`enqueue_chunk`] hands the worker a store to pack and returns immediately. It is best-effort
+//!   (fire-and-forget), used from the write path when a store overflows its size limit.
+//! * [`drain`] hands the worker a store and blocks until it is packed and evicted, used at
+//!   transaction and external-git boundaries where the objects must be durable on disk before the
+//!   caller proceeds.
+//!
+//! A single worker processes jobs FIFO, so a store's queued overflow chunks always complete before
+//! its drain — and no two packbuilders ever run against the same store concurrently. Stores are
+//! per-operation, so a job carries the store's `Arc` and its repo path (a `git2::Repository` is not
+//! `Send`); the worker opens its own repository handle to run the packbuilder.
+
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::mpsc::{Sender, SyncSender, channel, sync_channel};
+
+use crate::mem_odb::MemOdb;
+
+/// A unit of packing work for the background worker. Each carries the store's `Arc` (the packbuilder
+/// reads objects back out of it) rather than a repository handle, which is not `Send`.
+enum Job {
+    /// Pack the store's currently-buffered objects and evict them. Best-effort; no acknowledgement.
+    Chunk { store: Arc<MemOdb> },
+    /// Pack and evict, then acknowledge, so a boundary caller can block until the objects are on
+    /// disk.
+    Drain {
+        store: Arc<MemOdb>,
+        ack: SyncSender<Result<(), String>>,
+    },
+}
+
+struct Flusher {
+    sender: Sender<Job>,
+}
+
+/// The process-global worker, spawned on first use.
+static FLUSHER: LazyLock<Flusher> = LazyLock::new(Flusher::spawn);
+
+impl Flusher {
+    fn spawn() -> Flusher {
+        let (sender, receiver) = channel::<Job>();
+        std::thread::Builder::new()
+            .name("josh-mem-odb-flusher".to_string())
+            .spawn(move || {
+                while let Ok(job) = receiver.recv() {
+                    match job {
+                        Job::Chunk { store } => {
+                            if let Err(e) = store.pack_to_disk() {
+                                log::error!("background chunk flush failed: {e}");
+                            }
+                            // Cleared only now (after packing + eviction), so the write path does
+                            // not enqueue a fresh chunk until this store's size reflects the drain.
+                            store.clear_chunk_in_flight();
+                        }
+                        Job::Drain { store, ack } => {
+                            let _ = ack.send(store.pack_to_disk().map_err(|e| e.to_string()));
+                        }
+                    }
+                }
+            })
+            .expect("failed to spawn josh-mem-odb-flusher thread");
+        Flusher { sender }
+    }
+}
+
+/// Enqueue a best-effort background pack of `store`. Returns immediately; if the worker is gone the
+/// request is dropped (the next overflow, or the drain at drop, retries).
+pub(crate) fn enqueue_chunk(store: Arc<MemOdb>) {
+    let _ = FLUSHER.sender.send(Job::Chunk { store });
+}
+
+/// Pack `store` to disk and block until it is done, so the objects are durable before the caller
+/// proceeds. Any queued chunks for the same store complete first (FIFO on the single worker).
+pub(crate) fn drain(store: Arc<MemOdb>) -> Result<(), git2::Error> {
+    let (ack_tx, ack_rx) = sync_channel::<Result<(), String>>(1);
+    if FLUSHER
+        .sender
+        .send(Job::Drain { store, ack: ack_tx })
+        .is_err()
+    {
+        return Err(git2::Error::from_str(
+            "mem-odb flusher channel disconnected",
+        ));
+    }
+    match ack_rx.recv() {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(msg)) => Err(git2::Error::from_str(&msg)),
+        Err(_) => Err(git2::Error::from_str(
+            "mem-odb flusher ack channel disconnected",
+        )),
+    }
+}

--- a/josh-git-data/src/lib.rs
+++ b/josh-git-data/src/lib.rs
@@ -6,6 +6,7 @@
 //! josh uses: a per-operation in-memory store that buffers filtered objects and flushes them to a
 //! packfile at transaction and external-git boundaries.
 
+mod flusher;
 pub mod hash;
 pub mod mem_odb;
 mod odb_backend;

--- a/josh-git-data/src/mem_odb.rs
+++ b/josh-git-data/src/mem_odb.rs
@@ -1,12 +1,18 @@
 //! A per-operation in-memory ODB store buffering the objects josh produces while filtering, instead
-//! of writing each as a loose object. Flushed to a packfile at transaction and external-git
-//! boundaries, and additionally flushed mid-transaction once the buffered object data exceeds the
+//! of writing each as a loose object. Packed to a packfile at transaction and external-git
+//! boundaries, and additionally packed mid-transaction once the buffered object data exceeds the
 //! configured size limit (so a single transaction may write several packfiles). One [`MemOdb`] per
-//! operation (not process-global), so flushes are isolated and deterministic. Access to a store is
-//! single-threaded, but it is `Send + Sync` to cross async boundaries.
+//! operation (not process-global), so flushes are isolated and deterministic.
+//!
+//! Packing itself runs on a background thread (see [`crate::flusher`]): the write path enqueues the
+//! work and keeps filtering, and a boundary flush blocks only until the pack is durable. The store's
+//! `Mutex` therefore guards concurrent access from the filter thread (writes/reads through the
+//! backend) and the flusher thread (which reads objects to pack them, then evicts them); it is
+//! `Send + Sync` so its `Arc` can cross to the flusher.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use git2::{ErrorClass, ErrorCode, ObjectType, Oid};
@@ -25,14 +31,18 @@ struct Inner {
 
 /// A per-operation in-memory object store. Create one with [`MemOdb::new`], attach it to a
 /// repository's object database with [`MemOdb::register`], and drain it to disk with
-/// [`MemOdb::flush`]. When `limit` is set, the store also drains itself from the write path as soon
-/// as the buffered data exceeds it (see [`MemOdb::flush_on_overflow`]).
+/// [`MemOdb::flush`]. When `limit` is set, the store also enqueues a background pack from the write
+/// path as soon as the buffered data exceeds it (see [`MemOdb::enqueue_chunk`]).
 pub struct MemOdb {
     inner: Mutex<Inner>,
     limit: Option<usize>,
-    /// Repository the store is registered on, re-opened for overflow flushes
-    /// (see [`MemOdb::flush_on_overflow`]).
+    /// Repository the store is registered on, re-opened by the background flusher to run the
+    /// packbuilder (a `git2::Repository` is not `Send`).
     repo_path: PathBuf,
+    /// Set while an overflow chunk is queued on or running in the background flusher, so the write
+    /// path does not pile up redundant chunk requests every time the store crosses its limit.
+    /// Cleared by the flusher once the chunk has packed and evicted.
+    chunk_in_flight: AtomicBool,
 }
 
 impl MemOdb {
@@ -47,6 +57,7 @@ impl MemOdb {
             }),
             limit,
             repo_path,
+            chunk_in_flight: AtomicBool::new(false),
         })
     }
 
@@ -73,29 +84,36 @@ impl MemOdb {
         self.limit.is_some_and(|limit| inner.size > limit)
     }
 
-    /// Drain every in-memory object into a packfile on disk and evict it from the store. Called when
-    /// the owning transaction completes (or at an explicit external-git boundary) so the on-disk
-    /// repository is left whole for any subsequent process that expects the objects on disk.
-    pub fn flush(&self, repo: &git2::Repository) -> Result<(), git2::Error> {
-        self.flush_into(repo)
+    /// Drain every in-memory object into a packfile on disk and evict it from the store, blocking
+    /// until done. Called when the owning transaction completes (or at an explicit external-git
+    /// boundary) so the on-disk repository is left whole for any subsequent process that expects the
+    /// objects on disk. Packing runs on the background flusher, behind any overflow chunks already
+    /// queued for this store, so it returns only once every buffered object is durable.
+    pub fn flush(self: &Arc<Self>) -> Result<(), git2::Error> {
+        crate::flusher::drain(self.clone())
     }
 
-    /// Flush triggered from the ODB `write` path when the store overflows its limit. The write
-    /// callback has no repository handle, and the packbuilder reads each object back through a
-    /// registered backend, so re-open the repository, register a backend sharing this store on it,
-    /// and flush through that.
-    fn flush_on_overflow(self: &Arc<Self>) -> Result<(), git2::Error> {
-        let repo = git2::Repository::open(&self.repo_path)?;
-        odb_backend::register(
-            &repo,
-            MemBackend {
-                store: self.clone(),
-            },
-        )?;
-        self.flush_into(&repo)
+    /// Enqueue a best-effort background pack of this store, called from the ODB `write` path when the
+    /// store overflows its size limit. `chunk_in_flight` collapses the burst of overflowing writes
+    /// that follow into a single queued chunk; the flusher clears it once the chunk has packed and
+    /// evicted (so `size` reflects the drain before another chunk can be enqueued).
+    fn enqueue_chunk(self: &Arc<Self>) {
+        if self.chunk_in_flight.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        crate::flusher::enqueue_chunk(self.clone());
     }
 
-    fn flush_into(&self, repo: &git2::Repository) -> Result<(), git2::Error> {
+    /// Clear the [`Self::chunk_in_flight`] guard. Called by the background flusher after a chunk.
+    pub(crate) fn clear_chunk_in_flight(&self) {
+        self.chunk_in_flight.store(false, Ordering::Release);
+    }
+
+    /// Pack this store's currently-buffered objects into a packfile and evict them. Runs only on the
+    /// background flusher, which owns no repository handle (`git2::Repository` is not `Send`), so it
+    /// re-opens the repository and registers a backend sharing this store — the packbuilder reads
+    /// each object back through that backend.
+    pub(crate) fn pack_to_disk(self: &Arc<Self>) -> Result<(), git2::Error> {
         // Snapshot the oids under the lock, then release it. The objects must stay in the store
         // across the packbuilder below: `pb.write` reads each one back through the odb -> this
         // backend -> `self.inner.lock()`, so we can neither hold the lock here (self-deadlock) nor
@@ -109,11 +127,14 @@ impl MemOdb {
             inner.map.keys().copied().collect()
         };
 
+        let repo = git2::Repository::open(&self.repo_path)?;
+        self.register(&repo);
+
         // The memory-only freshen (see `odb_backend`) no longer deduplicates writes against disk,
         // so objects already present on disk may have been re-buffered into the store. Pack only the
         // genuinely-new ones — `filter_absent_on_disk` preserves the sorted oid order, so the
         // packfile (and its name) stays deterministic.
-        let to_pack = odb_backend::filter_absent_on_disk(repo, &oids);
+        let to_pack = odb_backend::filter_absent_on_disk(&repo, &oids);
         if !to_pack.is_empty() {
             let mut pb = repo.packbuilder()?;
             for oid in &to_pack {
@@ -121,14 +142,18 @@ impl MemOdb {
             }
             // `packfile_path` resolves the common object directory, so this is correct for linked
             // worktrees (whose gitdir has no `objects/` of its own) as well as normal repos.
-            pb.write(&crate::pack::packfile_path(repo), 0)?;
+            pb.write(&crate::pack::packfile_path(&repo), 0)?;
         }
 
-        // Dropping the whole map (rather than only the flushed oids) is safe because a store is
-        // never flushed with writes in flight.
+        // Evict exactly the snapshotted oids (now durable: packed just above, or already on disk).
+        // Writes that landed after the snapshot stay buffered for the next chunk or the drain, so a
+        // background chunk running concurrently with the write path never drops a live object.
         let mut inner = self.inner.lock().unwrap();
-        inner.map.clear();
-        inner.size = 0;
+        for oid in &oids {
+            if let Some((_, data)) = inner.map.remove(oid) {
+                inner.size = inner.size.saturating_sub(data.len());
+            }
+        }
         Ok(())
     }
 }
@@ -175,7 +200,7 @@ impl OdbBackend for MemBackend {
     fn write(&mut self, oid: Oid, data: Vec<u8>, kind: ObjectType) -> Result<(), git2::Error> {
         let overflow = self.store.insert(oid, kind.raw(), data.into_boxed_slice());
         if overflow {
-            self.store.flush_on_overflow()?;
+            self.store.enqueue_chunk();
         }
         Ok(())
     }
@@ -218,7 +243,7 @@ mod tests {
             assert!(repo.odb().unwrap().exists(*id));
         }
 
-        store.flush(&repo).unwrap();
+        store.flush().unwrap();
 
         // A fresh repo with no backend can only see objects that made it to disk.
         let on_disk = git2::Repository::open(dir.path()).unwrap();
@@ -228,7 +253,7 @@ mod tests {
         }
 
         // The store is drained: a second flush is a no-op.
-        store.flush(&repo).unwrap();
+        store.flush().unwrap();
     }
 
     /// A linked worktree's gitdir has no `objects/` of its own, so the flush must write into the
@@ -260,32 +285,52 @@ mod tests {
         let id = wt_repo.blob(b"worktree blob").unwrap();
 
         // Must not fail on the (nonexistent) per-worktree objects/pack directory.
-        store.flush(&wt_repo).unwrap();
+        store.flush().unwrap();
 
         // The pack landed in the common object dir, so the main repo can read the blob from disk.
         let main = git2::Repository::open(&main_path).unwrap();
         assert_eq!(main.find_blob(id).unwrap().content(), b"worktree blob");
     }
 
-    /// When `limit` is set, writing enough data to exceed it flushes the store to a packfile
-    /// mid-transaction (from inside the write path), leaving the objects on disk and the store
-    /// empty. Each further overflow writes another packfile.
+    /// When `limit` is set, writing enough data to exceed it enqueues a background pack from inside
+    /// the write path, which lands the objects on disk asynchronously (leaving the store to drain
+    /// the rest at the transaction boundary). Each further overflow enqueues another pack.
     #[test]
     fn flushes_on_overflow_during_writes() {
         let dir = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init(dir.path()).unwrap();
 
-        // A 16-byte limit: each 100-byte blob overflows it, so every write flushes.
+        // A 16-byte limit: each 100-byte blob overflows it, so every write enqueues a pack.
         let store = MemOdb::new(Some(16), repo.path().to_owned());
         store.register(&repo);
 
+        // The write overflowed and enqueued a background pack; it lands on the flusher thread, so
+        // poll a fresh on-disk view until the object appears.
         let id1 = repo.blob(&b"x".repeat(100)).unwrap();
-        // The write overflowed and flushed: id1 is already on disk, and a fresh repo can read it.
-        let on_disk = git2::Repository::open(dir.path()).unwrap();
-        assert_eq!(on_disk.find_blob(id1).unwrap().content(), &b"x".repeat(100));
+        assert!(
+            wait_on_disk(dir.path(), id1),
+            "overflow pack never reached disk"
+        );
 
-        // A second object overflows again, producing a second packfile.
+        // A second object overflows again, enqueueing another pack.
         let id2 = repo.blob(&b"y".repeat(100)).unwrap();
-        assert_eq!(on_disk.find_blob(id2).unwrap().content(), &b"y".repeat(100));
+        assert!(
+            wait_on_disk(dir.path(), id2),
+            "second overflow pack never reached disk"
+        );
+    }
+
+    /// Poll a freshly-opened (backend-less) view of the repository until `id` is readable from disk,
+    /// up to ~2s. Used to observe asynchronous background packs without racing the flusher thread.
+    fn wait_on_disk(repo_path: &std::path::Path, id: Oid) -> bool {
+        for _ in 0..200 {
+            if let Ok(repo) = git2::Repository::open(repo_path) {
+                if repo.find_blob(id).is_ok() {
+                    return true;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        false
     }
 }

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -487,6 +487,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
@@ -3167,6 +3168,7 @@ name = "josh-changes"
 version = "26.6.11"
 dependencies = [
  "anyhow",
+ "chrono",
  "git2",
  "josh-core",
  "serde",
@@ -3180,6 +3182,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "bitvec",
+ "chrono",
  "git-version",
  "git2",
  "gix-actor",
@@ -3192,17 +3195,15 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "josh-filter",
+ "josh-git-data",
  "josh-starlark",
- "libgit2-sys",
  "log",
  "percent-encoding",
  "pest",
  "pest_derive",
- "rayon",
  "regex",
  "rs_tracing",
  "rustc-hash 2.1.2",
- "scc",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3223,11 +3224,21 @@ dependencies = [
  "gix-object",
  "indoc",
  "itertools 0.14.0",
+ "josh-git-data",
  "pest",
  "pest_derive",
  "regex",
  "serde_json",
  "smallvec",
+]
+
+[[package]]
+name = "josh-git-data"
+version = "26.6.11"
+dependencies = [
+ "git2",
+ "libgit2-sys",
+ "log",
 ]
 
 [[package]]
@@ -5125,28 +5136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "saa"
-version = "5.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5acb362a0e75c2a963532fa7fabf13dff81626dc494df16488d30befcbea0"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "scc"
-version = "3.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f00241b418496a76c47eb60af2477a6086521d314f35322bec8a2ebd334751"
-dependencies = [
- "saa",
- "sdd",
 ]
 
 [[package]]


### PR DESCRIPTION
Pack filtered objects on a background thread

Writing a packfile -- zlib-compressing every buffered object and fsyncing the
result -- is the expensive tail of a MemOdb flush. Running it inline blocked the
filter hot path, most of all the mid-transaction overflow flush that fires
repeatedly during a large rewrite.

Funnel all packing to one process-global background worker (josh-git-data's new
flusher module). A store's overflow now enqueues a best-effort chunk and returns
immediately, so the write path keeps filtering while the pack is built; a
chunk_in_flight guard collapses the burst of overflowing writes that follow into
a single queued chunk. The transaction- and external-git-boundary flush enqueues
a drain and blocks until the objects are durable. A single worker processes jobs
FIFO, so a store's queued chunks always complete before its drain and no two
packbuilders ever run against the same store concurrently.

Stores stay per-operation, so a job carries the store's Arc and its repo path (a
git2::Repository is not Send); the worker opens its own handle to run the
packbuilder. Because the write path and the flusher now touch a store from
different threads, pack_to_disk evicts only the oids it snapshotted -- writes
that land during a background chunk stay buffered for the next chunk or the
drain -- rather than clearing the whole map.

Boundary drains remain synchronous, so on-disk output is unchanged: overflow
does not trigger at test-suite object volumes, and no snapshot moves.

Change: mem-odb-background-flusher
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>