### PR TITLE
Skip futile trailing-Compose distribution in flatten (experimental)

### DIFF
--- a/josh-filter/src/opt/flatten.rs
+++ b/josh-filter/src/opt/flatten.rs
@@ -53,6 +53,22 @@ pub fn flatten(filter: Filter) -> Filter {
                     if !others_invertible {
                         break;
                     }
+                    // EXPERIMENTAL: distributing a trailing Compose that has a non-empty prefix is
+                    // often futile: it produces Compose([Chain[prefix, z_j]]) which step()'s
+                    // common_pre re-merges back to Chain[prefix, Compose(Z)]. For the
+                    // Chain[file_chain, compose(pinned)] shape (reached via pin-legalization in
+                    // ultrawide_pin) this is an O(N*|pinned|) build+collapse round-trip that
+                    // converges to the input, so skip it to keep that path O(N). Leading/middle
+                    // Composes yield branches that are not re-merged and are still distributed.
+                    //
+                    // Known trade-off: for some subtract/exclude-of-compose filters this leaves a
+                    // valid but less-collapsed representation (see the updated pretty_print /
+                    // filter_id / workspace_errors snapshots); the distribution there had enabled a
+                    // downstream collapse. Refining the guard to skip only the truly-futile case is
+                    // future work.
+                    if flattened.len() > 1 && i == flattened.len() - 1 {
+                        continue;
+                    }
                     // Distribute: create a Compose where each element is the chain with one compose element
                     let mut result = vec![];
                     for compose_filter in compose_filters {

--- a/tests/filter/filter_id.t
+++ b/tests/filter/filter_id.t
@@ -374,9 +374,35 @@ Exclude of compose should not be split out
   > EOF
 
   $ josh-filter -p --file f
-  x/g = :subtract[
-      :/a/x/g
-      :/m/bs/m2/i/tc/i1
+  :subtract[
+      :/a:[
+          a = :[
+              ::b/
+              ::j/
+          ]
+          x = :/x:[
+              ::c++666/
+              ::d/
+              ::g/
+              ::gg/
+              ::u/
+          ]
+      ]
+      :[
+          :/a:[
+              a = :[
+                  ::b/
+                  ::j/
+              ]
+              x = :/x:[
+                  ::c++666/
+                  ::d/
+                  ::gg/
+                  ::u/
+              ]
+          ]
+          p/au/bs/i1 = :/m/bs/m2/i/tc/i1
+      ]
   ]
 
   $ cat > f <<EOF

--- a/tests/filter/pretty_print.t
+++ b/tests/filter/pretty_print.t
@@ -250,9 +250,35 @@ Exclude of compose should not be split out
   > EOF
 
   $ josh-filter -p --file f
-  x/g = :subtract[
-      :/a/x/g
-      :/m/bs/m2/i/tc/i1
+  :subtract[
+      :/a:[
+          a = :[
+              ::b/
+              ::j/
+          ]
+          x = :/x:[
+              ::c++666/
+              ::d/
+              ::g/
+              ::gg/
+              ::u/
+          ]
+      ]
+      :[
+          :/a:[
+              a = :[
+                  ::b/
+                  ::j/
+              ]
+              x = :/x:[
+                  ::c++666/
+                  ::d/
+                  ::gg/
+                  ::u/
+              ]
+          ]
+          p/au/bs/i1 = :/m/bs/m2/i/tc/i1
+      ]
   ]
 
   $ cat > f <<EOF

--- a/tests/proxy/workspace_errors.t
+++ b/tests/proxy/workspace_errors.t
@@ -145,8 +145,10 @@ No match for filters
   remote: warnings:        
   remote: No match for "::abc"        
   remote: No match for "a/b = :/b/c/*"        
-  remote: No match for "c/sub = :/sub"        
-  remote: No match for "test/sub = :/sub"        
+  remote: No match for ":/sub:prefix=sub:[        
+  remote:     :prefix=c        
+  remote:     :prefix=test        
+  remote: ]"        
   remote: No match for "test = ::test"        
   remote: No match for "test/test = :/test:/"        
   remote: No match for "::test/test/"        
@@ -180,10 +182,7 @@ Flushed credential cache
             "message": "No match for \"a/b = :/b/c/*\""
           },
           {
-            "message": "No match for \"c/sub = :/sub\""
-          },
-          {
-            "message": "No match for \"test/sub = :/sub\""
+            "message": "No match for \":/sub:prefix=sub:[\n    :prefix=c\n    :prefix=test\n]\""
           },
           {
             "message": "No match for \"test = ::test\""


### PR DESCRIPTION
Skip futile trailing-Compose distribution in flatten (experimental)

flatten distributes Chain[.., Compose(Z)] into Compose([Chain[.., z_j]]). When
the Compose is the trailing element with a non-empty prefix, step's common_pre
re-merges the result straight back to Chain[prefix, Compose(Z)], so the
distribution is a round-trip that converges to the input.

In ultrawide_pin this shape is reached via the pin-legalization Subtract in
per_rev_filter: legalize_pin exposes compose(pinned) as a bare trailing element
of each of the N wide-chains, and flatten distributing it builds an
O(N*|pinned|) tree that step then collapses again. Skipping that case turns that
path from O(N*|pinned|) into O(N). Leading/middle Compose elements still
distribute; their branches are not re-merged.

Experimental, and deliberately not behaviour-neutral: for some
subtract/exclude-of-compose filters the distribution had enabled a downstream
collapse, so skipping it leaves a valid but less-collapsed representation. The
pretty_print, filter_id and workspace_errors snapshots are updated to that form.
Refining the guard to skip only the truly-futile Chain[prefix, compose(pinned)]
round-trip -- without giving up the subtract/exclude collapse -- is future work.

Change: skip-trailing-compose-distribution
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>