### PR TITLE
Skip futile trailing-Compose distribution; flatten fully off hot paths

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1976,7 +1976,14 @@ fn compute_splice_parents(
     let splice_parents = parent_filters
         .into_iter()
         .map(|(parent, pcw)| {
-            let f = opt::optimize(to_filter(Op::Subtract(
+            // Collapsing this Subtract as far as possible really matters here: it folds to
+            // `Empty` whenever the new filter selects no paths beyond the parent's -- not only
+            // for equivalent filters but for any change that does not expand the set, such as a
+            // rename or a removal -- and an empty result lets `apply_to_commit2` skip a whole
+            // history walk. `optimize` skips the trailing-Compose distribution, which can leave
+            // the subtract less collapsed, so use `optimize_full` here to flatten fully and give
+            // `step`'s set-difference the flat form it needs to cancel.
+            let f = opt::optimize_full(to_filter(Op::Subtract(
                 strip_pins(commit_filter.peel()),
                 strip_pins(pcw.peel()),
             )));
@@ -2419,5 +2426,105 @@ mod tests {
 
         // Clean up
         let _ = fs::remove_dir_all(&test_dir);
+    }
+
+    // Apply-based correctness oracle for the optimizer's Subtract handling: applying the
+    // optimized filter to a tree must produce the same tree as applying the unoptimized filter
+    // (`apply` is the ground-truth interpreter), and optimizing an invertible filter must keep it
+    // invertible (the workspace machinery inverts optimized filters).
+    #[test]
+    fn subtract_optimizer_apply_oracle() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(td.path()).unwrap();
+
+        let mut b = git2::build::TreeUpdateBuilder::new();
+        for p in [
+            "d1/s1/f0",
+            "d1/s1/f1",
+            "d2/s2/f0",
+            "d2/s2/f1",
+            "d3/s3/f0",
+            "sub1/file1",
+            "sub1/file2",
+            "sub2/subsub/file2",
+        ] {
+            let oid = repo.blob(p.as_bytes()).unwrap();
+            b.upsert(p, oid, git2::FileMode::Blob);
+        }
+        let ws_content = ":/sub1::file1\n:/sub1::file2\n::sub2/subsub/\n";
+        for p in ["ws/workspace.josh", "ws2/workspace.josh"] {
+            let oid = repo.blob(ws_content.as_bytes()).unwrap();
+            b.upsert(p, oid, git2::FileMode::Blob);
+        }
+        let empty = repo.treebuilder(None).unwrap().write().unwrap();
+        let tree = b
+            .create_updated(&repo, &repo.find_tree(empty).unwrap())
+            .unwrap();
+        let tree = repo.find_tree(tree).unwrap();
+
+        cache::sled_load(td.path()).unwrap();
+        let cachestack = std::sync::Arc::new(
+            cache::CacheStack::new().with_backend(cache::SledCacheBackend::default()),
+        );
+        let ctx = cache::TransactionContext::new(td.path(), cachestack);
+        let t = ctx.open().unwrap();
+
+        let apply_tree = |f: Filter| -> anyhow::Result<git2::Oid> {
+            Ok(apply(&t, f, Rewrite::from_tree(tree.clone()))?.tree().id())
+        };
+
+        // The pin-legalisation subtract, built exactly like per_rev_filter.
+        let files: Vec<Filter> = ["d1/s1/f0", "d1/s1/f1", "d2/s2/f0", "d2/s2/f1", "d3/s3/f0"]
+            .iter()
+            .map(|p| Filter::new().file(p))
+            .collect();
+        let wide = josh_filter::compose(&files);
+        let pins = josh_filter::compose(&[Filter::new().file("d1/s1/f0")]);
+        let cf = wide.pin(pins);
+        let pin_sub = to_filter(Op::Subtract(
+            legalize_pin(cf.peel(), &|f| f),
+            legalize_pin(cf.peel(), &|f| to_filter(Op::Exclude(f))),
+        ));
+
+        let mut cases = vec![pin_sub];
+        for s in [
+            ":workspace=ws",
+            ":workspace=ws2",
+            ":subtract[:/sub1,::ws/]",
+            ":subtract[:[::sub1/,::sub2/],::sub1/]",
+            ":subtract[:/d1,:/d1/s1]",
+            ":subtract[:[a=:/sub1,b=:/sub2],:[a=:/sub1]]",
+        ] {
+            cases.push(parse(s).unwrap());
+        }
+        // The nested subtract the workspace history machinery builds and then inverts.
+        let contents = parse(":[:/sub1::file1,:/sub1::file2,::sub2/subsub/]").unwrap();
+        let wsj = parse(":/ws::workspace.josh").unwrap();
+        cases.push(to_filter(Op::Subtract(
+            to_filter(Op::Subtract(contents, wsj)),
+            to_filter(Op::Subdir(std::path::PathBuf::from("ws"))),
+        )));
+
+        for sub in cases {
+            let optimized = opt::optimize(sub);
+            match (apply_tree(sub), apply_tree(optimized)) {
+                (Ok(g), Ok(o)) => {
+                    assert_eq!(
+                        g, o,
+                        "optimizer changed result for {sub:?} -> {optimized:?}"
+                    )
+                }
+                (Err(ge), _) => panic!("ground-truth apply failed for {sub:?}: {ge}"),
+                (_, Err(oe)) => {
+                    panic!("optimized apply failed for {sub:?} -> {optimized:?}: {oe}")
+                }
+            }
+            if invert(sub).is_ok() {
+                assert!(
+                    invert(optimized).is_ok(),
+                    "optimize broke invertibility of {sub:?} -> {optimized:?}"
+                );
+            }
+        }
     }
 }

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -9,7 +9,9 @@ use crate::{BlobContent, Filter, Op, RevMatch};
 /// Pretty print the filter on multiple lines with initial indentation level.
 /// Nested filters will be indented with additional 4 spaces per nesting level.
 pub fn pretty(filter: Filter, indent: usize) -> String {
-    let filter = opt::simplify(filter);
+    // Pretty printing is display-only and off any hot path, so collapse the filter as far as
+    // possible with `optimize_full` (which flattens fully, unlike the general `optimize`).
+    let filter = opt::simplify(opt::optimize_full(filter));
 
     if let Op::Compose(filters) = to_op(filter)
         && indent == 0

--- a/josh-filter/src/opt/flatten.rs
+++ b/josh-filter/src/opt/flatten.rs
@@ -1,5 +1,5 @@
-use super::FLATTENED;
 use super::invert::invert;
+use super::{FLATTENED, FLATTENED_FULL};
 use crate::filter::Filter;
 use crate::op::Op;
 use crate::persist::{to_filter, to_op, to_op_ref};
@@ -10,7 +10,22 @@ use crate::persist::{to_filter, to_op, to_op_ref};
  * the difference between two complex filters.
  */
 pub fn flatten(filter: Filter) -> Filter {
-    if let Some(f) = FLATTENED.lock().unwrap().get(&filter) {
+    flatten_impl(filter, false)
+}
+
+/*
+ * Like `flatten`, but distributes *every* Compose, including the trailing-Compose case that
+ * `flatten` skips as futile (see below). Distributing a trailing Compose is normally an
+ * O(N*|Z|) build+collapse round-trip that converges back to the input, so `flatten` avoids it.
+ * Backs `optimize_full`, which is the maximally-collapsing counterpart of `optimize`.
+ */
+pub(super) fn flatten_full(filter: Filter) -> Filter {
+    flatten_impl(filter, true)
+}
+
+fn flatten_impl(filter: Filter, full: bool) -> Filter {
+    let cache = if full { &FLATTENED_FULL } else { &FLATTENED };
+    if let Some(f) = cache.lock().unwrap().get(&filter) {
         return *f;
     }
     let original = filter;
@@ -24,7 +39,7 @@ pub fn flatten(filter: Filter) -> Filter {
                     out.push(*f);
                 }
             }
-            Op::Compose(out.drain(..).map(flatten).collect())
+            Op::Compose(out.drain(..).map(|f| flatten_impl(f, full)).collect())
         }
         Op::Chain(filters) => {
             // Flatten nested chains first
@@ -53,6 +68,16 @@ pub fn flatten(filter: Filter) -> Filter {
                     if !others_invertible {
                         break;
                     }
+                    // Distributing a trailing Compose with a non-empty prefix is often futile: it
+                    // produces Compose([Chain[prefix, z_j]]) which step()'s common_pre re-merges
+                    // back to Chain[prefix, Compose(Z)]. For the Chain[file_chain, compose(pinned)]
+                    // shape (reached via pin-legalization in ultrawide_pin) this is an
+                    // O(N*|pinned|) build+collapse round-trip that converges to the input, so skip
+                    // it to keep that path O(N). `flatten_full` distributes it anyway, for callers
+                    // that need the maximally-collapsed form and whose operands cannot blow up.
+                    if !full && flattened.len() > 1 && i == flattened.len() - 1 {
+                        continue;
+                    }
                     // Distribute: create a Compose where each element is the chain with one compose element
                     let mut result = vec![];
                     for compose_filter in compose_filters {
@@ -61,17 +86,17 @@ pub fn flatten(filter: Filter) -> Filter {
                         result.push(to_filter(Op::Chain(new_chain)));
                     }
                     let distributed = to_filter(Op::Compose(result));
-                    FLATTENED.lock().unwrap().insert(original, distributed);
+                    cache.lock().unwrap().insert(original, distributed);
                     return distributed;
                 }
             }
-            Op::Chain(flattened.iter().map(|f| flatten(*f)).collect())
+            Op::Chain(flattened.iter().map(|f| flatten_impl(*f, full)).collect())
         }
-        Op::Subtract(a, b) => Op::Subtract(flatten(*a), flatten(*b)),
-        Op::Exclude(b) => Op::Exclude(flatten(*b)),
-        Op::Pin(b) => Op::Pin(flatten(*b)),
-        Op::Starlark(path, sub) => Op::Starlark(path.clone(), flatten(*sub)),
-        Op::TreeId(path, sub) => Op::TreeId(path.clone(), flatten(*sub)),
+        Op::Subtract(a, b) => Op::Subtract(flatten_impl(*a, full), flatten_impl(*b, full)),
+        Op::Exclude(b) => Op::Exclude(flatten_impl(*b, full)),
+        Op::Pin(b) => Op::Pin(flatten_impl(*b, full)),
+        Op::Starlark(path, sub) => Op::Starlark(path.clone(), flatten_impl(*sub, full)),
+        Op::TreeId(path, sub) => Op::TreeId(path.clone(), flatten_impl(*sub, full)),
         Op::ObjectDeref(_) => to_op(filter),
         Op::ObjectRef(_) => to_op(filter),
         _ => to_op(filter),
@@ -80,9 +105,9 @@ pub fn flatten(filter: Filter) -> Filter {
     let r = if result == original {
         result
     } else {
-        flatten(result)
+        flatten_impl(result, full)
     };
 
-    FLATTENED.lock().unwrap().insert(original, r);
+    cache.lock().unwrap().insert(original, r);
     r
 }

--- a/josh-filter/src/opt/mod.rs
+++ b/josh-filter/src/opt/mod.rs
@@ -21,6 +21,7 @@ pub use flatten::flatten;
 pub use invert::invert;
 pub use simplify::simplify;
 
+use self::flatten::flatten_full;
 use self::step::step;
 
 type FilterHashMap = HashMap<Filter, Filter, BuildHasherDefault<PassthroughHasher>>;
@@ -29,11 +30,17 @@ type InvertHashMap = HashMap<Filter, Option<Filter>, BuildHasherDefault<Passthro
 
 static OPTIMIZED: LazyLock<std::sync::Mutex<FilterHashMap>> =
     LazyLock::new(|| std::sync::Mutex::new(HashMap::default()));
+static OPTIMIZED_FULL: LazyLock<std::sync::Mutex<FilterHashMap>> =
+    LazyLock::new(|| std::sync::Mutex::new(HashMap::default()));
 static INVERTED: LazyLock<std::sync::Mutex<InvertHashMap>> =
     LazyLock::new(|| std::sync::Mutex::new(HashMap::default()));
 static SIMPLIFIED: LazyLock<std::sync::Mutex<FilterHashMap>> =
     LazyLock::new(|| std::sync::Mutex::new(HashMap::default()));
 static FLATTENED: LazyLock<std::sync::Mutex<FilterHashMap>> =
+    LazyLock::new(|| std::sync::Mutex::new(HashMap::default()));
+// Separate cache for the `full` (skip-disabled) flatten: the two produce different results for
+// the same filter, so they must not share a memo.
+static FLATTENED_FULL: LazyLock<std::sync::Mutex<FilterHashMap>> =
     LazyLock::new(|| std::sync::Mutex::new(HashMap::default()));
 
 /*
@@ -41,12 +48,30 @@ static FLATTENED: LazyLock<std::sync::Mutex<FilterHashMap>> =
  * suitable for fast evaluation and cache reuse.
  */
 pub fn optimize(filter: Filter) -> Filter {
-    if let Some(f) = OPTIMIZED.lock().unwrap().get(&filter) {
+    optimize_impl(filter, false)
+}
+
+/*
+ * Like `optimize`, but flattens fully (`flatten_full`): distributes even the trailing Compose
+ * that `optimize` leaves alone as futile, letting `step` cancel more. For callers that want the
+ * maximally-collapsed representation and are not on a hot path (e.g. pretty printing).
+ */
+pub fn optimize_full(filter: Filter) -> Filter {
+    optimize_impl(filter, true)
+}
+
+fn optimize_impl(filter: Filter, full: bool) -> Filter {
+    let cache = if full { &OPTIMIZED_FULL } else { &OPTIMIZED };
+    if let Some(f) = cache.lock().unwrap().get(&filter) {
         return *f;
     }
     let original = filter;
 
-    let mut filter = flatten(filter);
+    let mut filter = if full {
+        flatten_full(filter)
+    } else {
+        flatten(filter)
+    };
     let result = loop {
         let pretty = simplify(filter);
         let optimized = iterate(filter);
@@ -57,7 +82,7 @@ pub fn optimize(filter: Filter) -> Filter {
         }
     };
 
-    OPTIMIZED.lock().unwrap().insert(original, result);
+    cache.lock().unwrap().insert(original, result);
     result
 }
 

--- a/tests/proxy/workspace_errors.t
+++ b/tests/proxy/workspace_errors.t
@@ -145,10 +145,12 @@ No match for filters
   remote: warnings:        
   remote: No match for "::abc"        
   remote: No match for "a/b = :/b/c/*"        
-  remote: No match for "c/sub = :/sub"        
-  remote: No match for "test/sub = :/sub"        
+  remote: No match for ":/sub:prefix=sub:[        
+  remote:     :prefix=c        
+  remote:     :prefix=test        
+  remote: ]"        
   remote: No match for "test = ::test"        
-  remote: No match for "test/test = :/test:/"        
+  remote: No match for "test/test = :/test"        
   remote: No match for "::test/test/"        
   remote: REWRITE(064643c5fdf5295695d383a511e4335ea3262fce -> e972e5448a9595045a092fb5f7d82dc6797b4d23)        
   To http://localhost:8002/real_repo.git:workspace=ws.git
@@ -180,16 +182,13 @@ Flushed credential cache
             "message": "No match for \"a/b = :/b/c/*\""
           },
           {
-            "message": "No match for \"c/sub = :/sub\""
-          },
-          {
-            "message": "No match for \"test/sub = :/sub\""
+            "message": "No match for \":/sub:prefix=sub:[\n    :prefix=c\n    :prefix=test\n]\""
           },
           {
             "message": "No match for \"test = ::test\""
           },
           {
-            "message": "No match for \"test/test = :/test:/\""
+            "message": "No match for \"test/test = :/test\""
           },
           {
             "message": "No match for \"::test/test/\""


### PR DESCRIPTION
Skip futile trailing-Compose distribution; flatten fully off hot paths

Distributing a trailing Compose out of a chain is a futile O(N*|Z|) round-trip that step's
common_pre re-merges straight back; for the Chain[wide, compose(pins)] pin-legalization shape it
is the ultrawide_pin O(files*pins) blow-up. flatten skips it.

Some callers want the maximally-collapsed form and are off any hot path, so flatten takes a skip
toggle, exposed as optimize_full. compute_splice_parents uses it so its subtract can fold to
Empty and skip a history walk; pretty printing (and thus as_file) uses it so the
displayed/serialized filter is fully collapsed.

Adds an apply-based oracle test for the optimizer's Subtract handling.

Change: skip-futile-flatten-full
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>