### PR TITLE
Reject :pin combined with history splicing

### DIFF
--- a/docs/src/reference/filters.md
+++ b/docs/src/reference/filters.md
@@ -406,6 +406,14 @@ Note that this filter is only practical when used with `:hook` or `workspace.jos
 as it should apply per-revision only. Applying `:pin` for the whole history
 will result in the subtree being excluded from all revisions.
 
+`:pin` cannot be combined with history splicing, since the two have no well-defined
+combined semantics. Splicing is on by default, so a filter that uses `:pin` must set the
+`no-splice` history flag; otherwise filtering fails with an error. For example:
+
+```
+:~(history="no-splice")[:workspace=workspaces/code]
+```
+
 Refer to `pin_filter_workspace.t` and `pin_filter_hook.t` for reference.
 
 Filter order matters

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1960,19 +1960,8 @@ fn compute_splice_parents(
     parent_filters: Vec<(git2::Commit, Filter)>,
     meta: &std::collections::BTreeMap<String, String>,
 ) -> anyhow::Result<Option<Vec<git2::Oid>>> {
-    // `Op::Pin` is somewhat of a special category: it doesn't operate on either
-    // commit trees or the history graph, and is more of a marker for per-rev
-    // filter application process. Therefore, in the tree-level `apply`, it's an identity.
-    //
-    // This is important because we rely on the filter optimizer to properly fold
-    // `Op::Subtract`. If there are pins inside, the optimizer will not be able to collapse
-    // it, and this will trigger extra history walks in `apply_to_commit2` below.
-    //
-    // Actual work of :pin still happens in `pin_details` in `per_rev_filter`, so :pin still works.
-    fn strip_pins(f: Filter) -> Filter {
-        legalize_pin(f, &|_| to_filter(Op::Empty))
-    }
-
+    // This is only reached when history splicing is enabled, and `per_rev_filter` rejects `:pin`
+    // in that case, so the filters here are pin-free -- no pin handling is needed.
     let splice_parents = parent_filters
         .into_iter()
         .map(|(parent, pcw)| {
@@ -1983,10 +1972,7 @@ fn compute_splice_parents(
             // history walk. `optimize` skips the trailing-Compose distribution, which can leave
             // the subtract less collapsed, so use `optimize_full` here to flatten fully and give
             // `step`'s set-difference the flat form it needs to cancel.
-            let f = opt::optimize_full(to_filter(Op::Subtract(
-                strip_pins(commit_filter.peel()),
-                strip_pins(pcw.peel()),
-            )));
+            let f = opt::optimize_full(to_filter(Op::Subtract(commit_filter.peel(), pcw.peel())));
             let f = propagate_meta(f, meta);
             apply_to_commit2(f, &parent, transaction)
         })
@@ -2014,15 +2000,28 @@ fn per_rev_filter(
     let meta = filter.into_meta();
     let commit_filter = propagate_meta(commit_filter, &meta);
 
-    let splice_parents =
-        if history::history_flag(meta.get("history").map(String::as_str), "no-splice") {
-            vec![]
-        } else {
-            some_or!(
-                compute_splice_parents(transaction, commit_filter, parent_filters, &meta)?,
-                { return Ok(None) }
-            )
-        };
+    // Legalize the pins two ways up front (kept, or excluded); they differ iff the filter uses
+    // `:pin`. Splicing is on unless the "no-splice" history flag is set, and combining it with
+    // `:pin` has no well-defined semantics, so reject that rather than guess.
+    let legalized_a = legalize_pin(commit_filter.peel(), &|f| f);
+    let legalized_b = legalize_pin(commit_filter.peel(), &|f| to_filter(Op::Exclude(f)));
+    let uses_pin = legalized_a != legalized_b;
+    let no_splice = history::history_flag(meta.get("history").map(String::as_str), "no-splice");
+    if uses_pin && !no_splice {
+        return Err(anyhow!(
+            "combining :pin with history splicing is not supported; \
+             set the \"no-splice\" history flag"
+        ));
+    }
+
+    let splice_parents = if no_splice {
+        vec![]
+    } else {
+        some_or!(
+            compute_splice_parents(transaction, commit_filter, parent_filters, &meta)?,
+            { return Ok(None) }
+        )
+    };
 
     let normal_parents = commit
         .parent_ids()
@@ -2032,10 +2031,7 @@ fn per_rev_filter(
 
     // Special case: `:pin` filter needs to be aware of filtered history
     let pin_details = if let Some(&parent) = normal_parents.first() {
-        let legalized_a = legalize_pin(commit_filter.peel(), &|f| f);
-        let legalized_b = legalize_pin(commit_filter.peel(), &|f| to_filter(Op::Exclude(f)));
-
-        if legalized_a != legalized_b {
+        if uses_pin {
             let pin_subtract = apply(
                 transaction,
                 opt::optimize(to_filter(Op::Subtract(legalized_a, legalized_b))),

--- a/tests/filter/pin_filter_hook.t
+++ b/tests/filter/pin_filter_hook.t
@@ -52,7 +52,7 @@ Add note with pin filter for this commit
 
 Filter using the hook
 
-  $ josh-filter ':hook=commits'
+  $ josh-filter ':~(history="no-splice")[:hook=commits]'
   e22b4d031f61b2d443a11700627fa73011bfd95f
 
 Check the filtered history
@@ -100,7 +100,7 @@ Add note to pin the new file and allow app.js changes
 
   $ git notes add -m ':/code:pin[::lib3.js]' -f
 
-  $ josh-filter ':hook=commits'
+  $ josh-filter ':~(history="no-splice")[:hook=commits]'
   6b712b21b99511e8b40334a96ef266d2a38f2e94
 
 Check the resulting history

--- a/tests/filter/pin_filter_workspace.t
+++ b/tests/filter/pin_filter_workspace.t
@@ -34,7 +34,7 @@ Don't pin anything yet.
   $ git add .
   $ git commit -q -m "first commit"
 
-  $ josh-filter ':workspace=workspaces/code'
+  $ josh-filter ':~(history="no-splice")[:workspace=workspaces/code]'
   6620984e0025382baa68fadd32674591710c3417
   $ git ls-tree --format="${GIT_TREE_FMT}" -r FILTERED_HEAD
   100644 blob 0747fcb9cd688a7876932dcc30006e6ffa9106d6 app.js
@@ -58,7 +58,7 @@ Update a file, but put it on pin in workspace
 
 Filter and check history
 
-  $ josh-filter ':workspace=workspaces/code'
+  $ josh-filter ':~(history="no-splice")[:workspace=workspaces/code]'
   4f83a362554fde79389596222637db9084e028bc
   $ git log --oneline FILTERED_HEAD
   4f83a36 secret update
@@ -83,7 +83,7 @@ We only see workspace.josh update
 
 We can also exclude workspace.josh itself
 
-  $ josh-filter ':workspace=workspaces/code:exclude[::workspace.josh]'
+  $ josh-filter ':~(history="no-splice")[:workspace=workspaces/code:exclude[::workspace.josh]]'
   71f53f9d53491b1b751e26a892a6c52462d61405
 
 This makes the commit disappear completely
@@ -113,7 +113,7 @@ Also, update app.js and remove pin from it
   $ git add .
   $ git commit -q -m "read env variable"
 
-  $ josh-filter ':workspace=workspaces/code'
+  $ josh-filter ':~(history="no-splice")[:workspace=workspaces/code]'
   824fe83d4a74a71fd7bec25756166863e063b932
 
 Check the resulting history
@@ -165,3 +165,10 @@ We can also verify that the "offending" version was skipped in filtered history
   +  const host = process.env.REMOTE_HOST;
   +  await fetch(host);
    }
+
+Combining :pin with history splicing (on by default) has no well-defined semantics
+and is rejected:
+
+  $ josh-filter ':workspace=workspaces/code'
+  ERROR: combining :pin with history splicing is not supported; set the "no-splice" history flag
+  [1]


### PR DESCRIPTION
Reject :pin combined with history splicing

The semantics of :pin together with history splicing are undefined, so error out rather than
produce an ill-defined result. Splicing is on unless the "no-splice" history flag is set, so a
pin filter must set it; the existing pin tests are updated to do so.

With that guard in place, compute_splice_parents (only reached when splicing is on) can no
longer see pins, so its strip_pins workaround is removed.

Change: reject-pin-with-splice
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>