### PR TITLE
Rename optimize_full to minimize

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1970,9 +1970,9 @@ fn compute_splice_parents(
             // for equivalent filters but for any change that does not expand the set, such as a
             // rename or a removal -- and an empty result lets `apply_to_commit2` skip a whole
             // history walk. `optimize` skips the trailing-Compose distribution, which can leave
-            // the subtract less collapsed, so use `optimize_full` here to flatten fully and give
+            // the subtract less collapsed, so use `minimize` here to flatten fully and give
             // `step`'s set-difference the flat form it needs to cancel.
-            let f = opt::optimize_full(to_filter(Op::Subtract(commit_filter.peel(), pcw.peel())));
+            let f = opt::minimize(to_filter(Op::Subtract(commit_filter.peel(), pcw.peel())));
             let f = propagate_meta(f, meta);
             apply_to_commit2(f, &parent, transaction)
         })

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -10,8 +10,8 @@ use crate::{BlobContent, Filter, Op, RevMatch};
 /// Nested filters will be indented with additional 4 spaces per nesting level.
 pub fn pretty(filter: Filter, indent: usize) -> String {
     // Pretty printing is display-only and off any hot path, so collapse the filter as far as
-    // possible with `optimize_full` (which flattens fully, unlike the general `optimize`).
-    let filter = opt::simplify(opt::optimize_full(filter));
+    // possible with `minimize` (which flattens fully, unlike the general `optimize`).
+    let filter = opt::simplify(opt::minimize(filter));
 
     if let Op::Compose(filters) = to_op(filter)
         && indent == 0

--- a/josh-filter/src/opt/flatten.rs
+++ b/josh-filter/src/opt/flatten.rs
@@ -17,7 +17,7 @@ pub fn flatten(filter: Filter) -> Filter {
  * Like `flatten`, but distributes *every* Compose, including the trailing-Compose case that
  * `flatten` skips as futile (see below). Distributing a trailing Compose is normally an
  * O(N*|Z|) build+collapse round-trip that converges back to the input, so `flatten` avoids it.
- * Backs `optimize_full`, which is the maximally-collapsing counterpart of `optimize`.
+ * Backs `minimize`, which is the maximally-collapsing counterpart of `optimize`.
  */
 pub(super) fn flatten_full(filter: Filter) -> Filter {
     flatten_impl(filter, true)

--- a/josh-filter/src/opt/mod.rs
+++ b/josh-filter/src/opt/mod.rs
@@ -30,7 +30,7 @@ type InvertHashMap = HashMap<Filter, Option<Filter>, BuildHasherDefault<Passthro
 
 static OPTIMIZED: LazyLock<std::sync::Mutex<FilterHashMap>> =
     LazyLock::new(|| std::sync::Mutex::new(HashMap::default()));
-static OPTIMIZED_FULL: LazyLock<std::sync::Mutex<FilterHashMap>> =
+static MINIMIZED: LazyLock<std::sync::Mutex<FilterHashMap>> =
     LazyLock::new(|| std::sync::Mutex::new(HashMap::default()));
 static INVERTED: LazyLock<std::sync::Mutex<InvertHashMap>> =
     LazyLock::new(|| std::sync::Mutex::new(HashMap::default()));
@@ -56,18 +56,18 @@ pub fn optimize(filter: Filter) -> Filter {
  * that `optimize` leaves alone as futile, letting `step` cancel more. For callers that want the
  * maximally-collapsed representation and are not on a hot path (e.g. pretty printing).
  */
-pub fn optimize_full(filter: Filter) -> Filter {
+pub fn minimize(filter: Filter) -> Filter {
     optimize_impl(filter, true)
 }
 
-fn optimize_impl(filter: Filter, full: bool) -> Filter {
-    let cache = if full { &OPTIMIZED_FULL } else { &OPTIMIZED };
+fn optimize_impl(filter: Filter, minimize: bool) -> Filter {
+    let cache = if minimize { &MINIMIZED } else { &OPTIMIZED };
     if let Some(f) = cache.lock().unwrap().get(&filter) {
         return *f;
     }
     let original = filter;
 
-    let mut filter = if full {
+    let mut filter = if minimize {
         flatten_full(filter)
     } else {
         flatten(filter)


### PR DESCRIPTION
Rename optimize_full to minimize

Rename the maximally-collapsing optimize entry point from `optimize_full`
to `minimize`, along with its internals: the `OPTIMIZED_FULL` cache static
becomes `MINIMIZED` and the `full` flag on `optimize_impl` becomes
`minimize`.

Change: rename-optimize-full-minimize
Assisted-By: Claude Opus 4.8 (1M context)