### PR TITLE
Rename Op::Blob to Op::Insert and support tree oids

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -15,7 +15,7 @@ pub use josh_filter::opt;
 pub use josh_filter::opt::invert;
 pub use josh_filter::persist::{as_tree, from_tree};
 pub use josh_filter::persist::{peel_op, to_filter, to_op, to_ops};
-pub use josh_filter::{BlobContent, Filter, LazyRef, Op, RevMatch};
+pub use josh_filter::{Filter, InsertContent, LazyRef, Op, RevMatch};
 pub use josh_filter::{as_file, pretty, spec};
 
 pub mod text;
@@ -1382,17 +1382,26 @@ pub fn apply<'a>(
                 to_filter(op.clone()).id(),
             )?))
         }
-        Op::Blob(dest_path, content) => {
-            let blob_oid = match content {
-                BlobContent::Inline(s) => repo.blob(s.as_bytes())?,
-                BlobContent::Oid(oid) => repo.find_blob(*oid)?.id(),
+        Op::Insert(dest_path, content) => {
+            let (oid, mode) = match content {
+                InsertContent::Inline(s) => (repo.blob(s.as_bytes())?, git2::FileMode::Blob.into()),
+                InsertContent::Oid(oid) => match repo.find_object(*oid, None)?.kind() {
+                    Some(git2::ObjectType::Blob) => (*oid, git2::FileMode::Blob.into()),
+                    Some(git2::ObjectType::Tree) => (*oid, git2::FileMode::Tree.into()),
+                    _ => {
+                        return Err(anyhow::anyhow!(
+                            "insert: {} is neither a blob nor a tree",
+                            oid
+                        ));
+                    }
+                },
             };
             Ok(x.clone().with_tree(tree::insert(
                 repo,
                 &tree::empty(repo),
                 &dest_path,
-                blob_oid,
-                git2::FileMode::Blob.into(),
+                oid,
+                mode,
             )?))
         }
         Op::File(dest_path, source_path) => {
@@ -1464,7 +1473,7 @@ pub fn apply<'a>(
             let oid_str = applied.tree().id().to_string();
             apply(
                 transaction,
-                to_filter(Op::Blob(path.clone(), BlobContent::Inline(oid_str))),
+                to_filter(Op::Insert(path.clone(), InsertContent::Inline(oid_str))),
                 x,
             )
         }

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -1,5 +1,5 @@
 use crate::check_experimental_features_enabled;
-use crate::op::{BlobContent, LazyRef, Op, Regex};
+use crate::op::{InsertContent, LazyRef, Op, Regex};
 use crate::opt;
 use crate::persist::{self, Node, to_filter, to_op};
 use std::sync::LazyLock;
@@ -161,27 +161,29 @@ impl Filter {
 
     /// Chain a filter that inserts a blob with the given content at the specified path.
     /// Syntax: `:$path="content"` (e.g. `:$label="my label"` inserts a blob at `label` with content "my label").
-    pub fn blob(
+    pub fn insert(
         self,
         path: impl Into<std::path::PathBuf>,
         content: impl Into<String>,
     ) -> anyhow::Result<Filter> {
-        check_experimental_features_enabled("Blob filter")?;
-        Ok(self.chain(to_filter(Op::Blob(
+        check_experimental_features_enabled("Insert filter")?;
+        Ok(self.chain(to_filter(Op::Insert(
             path.into(),
-            BlobContent::Inline(content.into()),
+            InsertContent::Inline(content.into()),
         ))))
     }
 
-    /// Chain a filter that inserts an existing blob (referenced by its OID) at the specified path.
-    /// Syntax: `:$path=<sha>`. Useful for large blobs that should not be inlined as a string.
-    pub fn blob_oid(
+    /// Chain a filter that inserts an existing object (referenced by its OID) at the specified
+    /// path. Syntax: `:$path=<sha>`. The object may be a blob or a tree; the kind is resolved
+    /// from the repository at apply time. Useful for large blobs or whole subtrees that should
+    /// not be inlined as a string.
+    pub fn insert_oid(
         self,
         path: impl Into<std::path::PathBuf>,
         oid: git2::Oid,
     ) -> anyhow::Result<Filter> {
-        check_experimental_features_enabled("Blob filter")?;
-        Ok(self.chain(to_filter(Op::Blob(path.into(), BlobContent::Oid(oid)))))
+        check_experimental_features_enabled("Insert filter")?;
+        Ok(self.chain(to_filter(Op::Insert(path.into(), InsertContent::Oid(oid)))))
     }
 
     /// Chain a filter that removes the `.link.josh` marker to produce a standalone history

--- a/josh-filter/src/flang/grammar.pest
+++ b/josh-filter/src/flang/grammar.pest
@@ -20,8 +20,8 @@ char = {
     | "\\" ~ ("\"" | "\'" | "\\" | "/" | "b" | "f" | "n" | "r" | "t" | "u")
 }
 
-blob_oid = @{ ASCII_HEX_DIGIT+ }
-filter_blob = { CMD_START ~ "$" ~ argument ~ "=" ~ (string | blob_oid) }
+object_oid = @{ ASCII_HEX_DIGIT+ }
+filter_insert = { CMD_START ~ "$" ~ argument ~ "=" ~ (string | object_oid) }
 
 filter_spec = { (
     filter_group
@@ -30,7 +30,7 @@ filter_spec = { (
   | filter_unapply
   | filter_replace
   | filter_squash
-  | filter_blob
+  | filter_insert
   | filter_presub
   | filter_subdir
   | filter_stored

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -4,7 +4,7 @@ use crate::filter::MESSAGE_MATCH_ALL_REGEX;
 use crate::filter::{reachable_roots, sequence_number};
 use crate::opt;
 use crate::persist::{to_filter, to_op, to_ops};
-use crate::{BlobContent, Filter, Op, RevMatch};
+use crate::{Filter, InsertContent, Op, RevMatch};
 
 /// Pretty print the filter on multiple lines with initial indentation level.
 /// Nested filters will be indented with additional 4 spaces per nesting level.
@@ -261,11 +261,11 @@ pub(crate) fn spec2(op: &Op) -> String {
         Op::Export => ":export".to_string(),
         Op::Unlink => ":unlink".to_string(),
         Op::Subdir(path) => format!(":/{}", parse::quote_if(&path.to_string_lossy())),
-        Op::Blob(path, content) => {
+        Op::Insert(path, content) => {
             let p = parse::quote_if(&path.to_string_lossy());
             match content {
-                BlobContent::Inline(s) => format!(":${}={}", p, parse::quote(s)),
-                BlobContent::Oid(oid) => format!(":${}={}", p, oid),
+                InsertContent::Inline(s) => format!(":${}={}", p, parse::quote(s)),
+                InsertContent::Oid(oid) => format!(":${}={}", p, oid),
             }
         }
         Op::File(dest_path, source_path) => {

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -4,7 +4,7 @@ use crate::filter::Filter;
 use crate::opt;
 use crate::opt::invert;
 use crate::persist::to_filter;
-use crate::{BlobContent, LazyRef, Op, Regex, RevMatch};
+use crate::{InsertContent, LazyRef, Op, Regex, RevMatch};
 
 use anyhow::{Context, anyhow};
 use indoc::{formatdoc, indoc};
@@ -174,17 +174,17 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
             let path = unquote(pair.into_inner().next().unwrap().as_str());
             Ok(parse_treederef(&path))
         }
-        Rule::filter_blob => {
-            check_experimental_features_enabled("Blob filter")?;
+        Rule::filter_insert => {
+            check_experimental_features_enabled("Insert filter")?;
             let mut inner = pair.into_inner();
             let path = Path::new(&unquote(inner.next().unwrap().as_str())).to_owned();
             let content_pair = inner.next().unwrap();
             let content = match content_pair.as_rule() {
-                Rule::string => BlobContent::Inline(unquote(content_pair.as_str())),
-                Rule::blob_oid => BlobContent::Oid(git2::Oid::from_str(content_pair.as_str())?),
+                Rule::string => InsertContent::Inline(unquote(content_pair.as_str())),
+                Rule::object_oid => InsertContent::Oid(git2::Oid::from_str(content_pair.as_str())?),
                 _ => unreachable!(),
             };
-            Ok(to_filter(Op::Blob(path, content)))
+            Ok(to_filter(Op::Insert(path, content)))
         }
         Rule::filter_presub => {
             let mut inner = pair.into_inner();

--- a/josh-filter/src/lib.rs
+++ b/josh-filter/src/lib.rs
@@ -8,7 +8,7 @@ pub use filter::{Filter, compose};
 pub use flang::parse;
 pub use flang::{as_file, pretty, spec};
 pub use op::LinkMode;
-pub use op::{BlobContent, LazyRef, Op, Regex, RevMatch};
+pub use op::{InsertContent, LazyRef, Op, Regex, RevMatch};
 
 static EXPERIMENTAL_FEATURES: std::sync::LazyLock<bool> =
     std::sync::LazyLock::new(|| std::env::var("JOSH_EXPERIMENTAL_FEATURES").as_deref() == Ok("1"));

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -62,7 +62,7 @@ pub enum LazyRef {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum BlobContent {
+pub enum InsertContent {
     Inline(String),
     Oid(git2::Oid),
 }
@@ -133,7 +133,7 @@ pub enum Op {
     Index,
     Invert,
 
-    Blob(std::path::PathBuf, BlobContent), // Blob(dest_path, content)
+    Insert(std::path::PathBuf, InsertContent), // Insert(dest_path, content)
     File(std::path::PathBuf, std::path::PathBuf), // File(dest_path, source_path)
     Prefix(std::path::PathBuf),
     Subdir(std::path::PathBuf),

--- a/josh-filter/src/opt/invert.rs
+++ b/josh-filter/src/opt/invert.rs
@@ -26,7 +26,9 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
             Op::Rev(_) => Some(Op::Nop),
             Op::RegexReplace(_) => Some(Op::Nop),
             Op::Pin(_) => Some(Op::Nop),
-            Op::Blob(path, _) => Some(Op::Exclude(to_filter(Op::File(path.clone(), path.clone())))),
+            Op::Insert(path, _) => {
+                Some(Op::Exclude(to_filter(Op::File(path.clone(), path.clone()))))
+            }
             Op::TreeId(path, _) => {
                 Some(Op::Exclude(to_filter(Op::File(path.clone(), path.clone()))))
             }

--- a/josh-filter/src/opt/step.rs
+++ b/josh-filter/src/opt/step.rs
@@ -53,18 +53,18 @@ pub(super) fn step(filter: Filter) -> Filter {
                 Op::Prefix(path.clone())
             }
         }
-        Op::Blob(dest_path, content) if dest_path.components().count() > 1 => {
+        Op::Insert(dest_path, content) if dest_path.components().count() > 1 => {
             if let (Some(dst_parent), Some(dst_name)) = (dest_path.parent(), dest_path.file_name())
             {
                 Op::Chain(vec![
-                    to_filter(Op::Blob(
+                    to_filter(Op::Insert(
                         std::path::PathBuf::from(dst_name),
                         content.clone(),
                     )),
                     to_filter(Op::Prefix(dst_parent.to_path_buf())),
                 ])
             } else {
-                Op::Blob(dest_path.clone(), content.clone())
+                Op::Insert(dest_path.clone(), content.clone())
             }
         }
         Op::File(dest_path, source_path)

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::{LazyLock, OnceLock};
 
 use crate::filter::Filter;
-use crate::op::{BlobContent, LazyRef, Op, Regex, RevMatch};
+use crate::op::{InsertContent, LazyRef, Op, Regex, RevMatch};
 
 /// An interned, immutable `Op` together with its lazily-computed content OID.
 /// Nodes are leaked (`&'static`) and live for the process lifetime. A `Filter` is just a
@@ -378,15 +378,17 @@ impl InMemoryBuilder {
                 let params_tree = self.build_str_params(&[path.to_string_lossy().as_ref()]);
                 push_tree_entries(&mut entries, [("prefix", params_tree)]);
             }
-            Op::Blob(path, content) => {
+            Op::Insert(path, content) => {
                 let path = path.to_string_lossy();
                 let params_tree = match content {
-                    BlobContent::Inline(s) => self.build_str_params(&[path.as_ref(), "inline", s]),
-                    BlobContent::Oid(oid) => {
+                    InsertContent::Inline(s) => {
+                        self.build_str_params(&[path.as_ref(), "inline", s])
+                    }
+                    InsertContent::Oid(oid) => {
                         self.build_str_params(&[path.as_ref(), "oid", &oid.to_string()])
                     }
                 };
-                push_tree_entries(&mut entries, [("blob", params_tree)]);
+                push_tree_entries(&mut entries, [("insert", params_tree)]);
             }
             Op::File(dest_path, source_path) => {
                 // Store as (dest_path, source_path) to match enum order
@@ -747,23 +749,23 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             let path = std::str::from_utf8(path_blob.content())?;
             Ok(Op::Prefix(std::path::PathBuf::from(path)))
         }
-        "blob" => {
+        "insert" => {
             let inner = repo.find_tree(entry.id())?;
             let path_blob =
-                repo.find_blob(inner.get_name("0").context("blob: missing path")?.id())?;
+                repo.find_blob(inner.get_name("0").context("insert: missing path")?.id())?;
             let kind_blob =
-                repo.find_blob(inner.get_name("1").context("blob: missing kind")?.id())?;
+                repo.find_blob(inner.get_name("1").context("insert: missing kind")?.id())?;
             let value_blob =
-                repo.find_blob(inner.get_name("2").context("blob: missing value")?.id())?;
+                repo.find_blob(inner.get_name("2").context("insert: missing value")?.id())?;
             let path = std::str::from_utf8(path_blob.content())?;
             let kind = std::str::from_utf8(kind_blob.content())?;
             let value = std::str::from_utf8(value_blob.content())?;
             let content = match kind {
-                "inline" => BlobContent::Inline(value.to_string()),
-                "oid" => BlobContent::Oid(git2::Oid::from_str(value)?),
-                other => return Err(anyhow::anyhow!("blob: unknown content kind {:?}", other)),
+                "inline" => InsertContent::Inline(value.to_string()),
+                "oid" => InsertContent::Oid(git2::Oid::from_str(value)?),
+                other => return Err(anyhow::anyhow!("insert: unknown content kind {:?}", other)),
             };
-            Ok(Op::Blob(std::path::PathBuf::from(path), content))
+            Ok(Op::Insert(std::path::PathBuf::from(path), content))
         }
         "file" => {
             let inner = repo.find_tree(entry.id())?;

--- a/josh-starlark/src/filter.rs
+++ b/josh-starlark/src/filter.rs
@@ -132,12 +132,12 @@ fn filter_methods(builder: &mut MethodsBuilder) {
     fn peel(this: &StarlarkFilter) -> anyhow::Result<StarlarkFilter> {
         Ok(this.peel())
     }
-    fn blob(
+    fn insert(
         this: &StarlarkFilter,
         path: StringValue,
         content: StringValue,
     ) -> anyhow::Result<StarlarkFilter> {
-        this.blob(path, content)
+        this.insert(path, content)
     }
     fn treeid(
         this: &StarlarkFilter,
@@ -303,12 +303,16 @@ impl StarlarkFilter {
         }
     }
 
-    /// Create a blob at path with the given content
-    pub fn blob(&self, path: StringValue, content: StringValue) -> anyhow::Result<StarlarkFilter> {
+    /// Insert a blob at path with the given content
+    pub fn insert(
+        &self,
+        path: StringValue,
+        content: StringValue,
+    ) -> anyhow::Result<StarlarkFilter> {
         Ok(StarlarkFilter {
             filter: self
                 .filter
-                .blob(PathBuf::from(path.as_str()), content.as_str())?,
+                .insert(PathBuf::from(path.as_str()), content.as_str())?,
         })
     }
 

--- a/tests/experimental/insert.t
+++ b/tests/experimental/insert.t
@@ -98,3 +98,9 @@ Apply: referencing a nonexistent sha fails
   [3] reachable_roots
   [3] sequence_number
   [1]
+
+Apply: a tree referenced by sha is inserted as a subtree at the destination path
+  $ TREE=$(git rev-parse 'HEAD^{tree}')
+  $ josh-filter -s ":\$sub=$TREE" master --update refs/josh/filter/tree 1> /dev/null
+  $ git show josh/filter/tree:sub/sub1/file1
+  contents1

--- a/tests/experimental/starlark_mempack.t
+++ b/tests/experimental/starlark_mempack.t
@@ -15,17 +15,17 @@
   > # mempack backend when running with --pack. This test verifies that the
   > # starlark evaluation can access that mempack tree.
   > content = tree.file("lib/file1")
-  > filter = filter.blob("foobar", content)
+  > filter = filter.insert("foobar", content)
   > # else:
   > #     filter = filter.empty()
   > EOF
 
 Apply with --pack: starlark must see the mempack tree to return the correct filter
   $ josh-filter --pack ':!config[:/sub1::file1:prefix=lib]' . --update refs/josh/master
-  e915167514a08e5e19839b871c13ec581f7d9618
+  81d483195a6fdd7068897fc5110968952f9b9977
 
   $ git ls-tree -r refs/josh/master
-  100644 blob 2b30477c6e975a7b6e8edec18bd617a629594681\tconfig.star (esc)
+  100644 blob ab1ac8155167304e9a0463cd1d04538cb6754418\tconfig.star (esc)
   100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfoobar (esc)
   100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tlib/file1 (esc)
 

--- a/tests/proxy/workspace_errors.t
+++ b/tests/proxy/workspace_errors.t
@@ -106,7 +106,7 @@ Error in filter
   remote: 1 | a/b = :b/sub2        
   remote:   |         ^---        
   remote:   |        
-  remote:   = expected EOI, filter_blob, filter_group, filter_subdir, filter_stored, filter_starlark, filter_treeid, filter_treeref, filter_treederef, filter_nop, filter_presub, filter, filter_noarg, filter_message, filter_rev, filter_unapply, filter_replace, filter_squash, filter_scope, or filter_meta        
+  remote:   = expected EOI, filter_insert, filter_group, filter_subdir, filter_stored, filter_starlark, filter_treeid, filter_treeref, filter_treederef, filter_nop, filter_presub, filter, filter_noarg, filter_message, filter_rev, filter_unapply, filter_replace, filter_squash, filter_scope, or filter_meta        
   remote: 
   remote: a/b = :b/sub2        
   remote: c = :/sub1        


### PR DESCRIPTION
Rename Op::Blob to Op::Insert and support tree oids

The blob filter (`:$path=...`) inserted either inline string content or a
blob referenced by oid, with the oid form hard-wired to blobs. Extend the
oid form to also accept a tree oid, inserting a whole subtree at the
destination path. The object kind is resolved from the repository at apply
time (blob -> file mode, tree -> tree mode, anything else -> error), so the
concrete syntax is unchanged.

Since the op is no longer blob-specific, rename `Op::Blob` to `Op::Insert`
and `BlobContent` to `InsertContent`, along with the grammar rules, the
`Filter::blob`/`blob_oid` constructors (now `insert`/`insert_oid`), the
Starlark method, and the serialized tag. The serialized-tag rename does not
require a CACHE_VERSION bump: the cache is content-addressed and stale
entries simply miss, and this remains an experimental feature.

Change: insert-tree-oid
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>