### PR TITLE
Invert generative filters to empty to fix compose collapse

### DIFF
--- a/josh-filter/src/opt/invert.rs
+++ b/josh-filter/src/opt/invert.rs
@@ -26,12 +26,12 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
             Op::Rev(_) => Some(Op::Nop),
             Op::RegexReplace(_) => Some(Op::Nop),
             Op::Pin(_) => Some(Op::Nop),
-            Op::Insert(path, _) => {
-                Some(Op::Exclude(to_filter(Op::File(path.clone(), path.clone()))))
-            }
-            Op::TreeId(path, _) => {
-                Some(Op::Exclude(to_filter(Op::File(path.clone(), path.clone()))))
-            }
+            // Insert and TreeId are generative: they fabricate tree entries and consume no
+            // input, so their inverse is empty. Using Exclude here would break composition
+            // uniqueness handling, since composing complements (Exclude) unions back to a
+            // no-op and lets sibling groups subtract each other away.
+            Op::Insert(_, _) => Some(Op::Empty),
+            Op::TreeId(_, _) => Some(Op::Empty),
             Op::ObjectDeref(path) => Some(Op::ObjectRef(path.clone())),
             Op::ObjectRef(path) => Some(Op::ObjectDeref(path.clone())),
             _ => None,

--- a/tests/experimental/blob_replace.t
+++ b/tests/experimental/blob_replace.t
@@ -33,13 +33,13 @@ Forward: a blob referenced by sha overwrites the pre-existing file
   $ git show josh/sha:a/b/c.txt
   from-sha (no-eol)
 
-Reverse: the multi-component blob inverts to an exclude of the destination path
+Reverse: a multi-component blob inverts to :empty (it consumes no input)
   $ josh-filter --reverse -p ':$a/b/c.txt="new"'
-  :/a/b:exclude[::c.txt]
+  :empty
 
 Reverse: the inverse does not depend on the blob content (sha form is identical)
   $ josh-filter --reverse -p ":\$a/b/c.txt=$OID"
-  :/a/b:exclude[::c.txt]
+  :empty
 
 Composing the blob with the exclude of the same blob keeps the siblings
   $ josh-filter ':[:exclude[:$a/b/c.txt="new"],:$a/b/c.txt="new"]' master --update refs/josh/keep 1> /dev/null
@@ -51,6 +51,21 @@ Composing the blob with the exclude of the same blob keeps the siblings
   new (no-eol)
   $ git show josh/keep:a/b/d.txt
   keep (no-eol)
+
+Composing the blob over a passthrough replaces the file while keeping siblings
+  $ josh-filter ':[:/,:$a/b/c.txt="new"]' master --update refs/josh/overlay 1> /dev/null
+  $ git ls-tree -r --name-only josh/overlay
+  a/b/c.txt
+  a/b/d.txt
+  top.txt
+  $ git show josh/overlay:a/b/c.txt
+  new (no-eol)
+  $ git show josh/overlay:a/b/d.txt
+  keep (no-eol)
+
+Reverse: the passthrough overlay inverts to identity (the blob contributes no input)
+  $ josh-filter --reverse -p ':[:/,:$a/b/c.txt="new"]'
+  :/
 
 Reverse: edits to the filtered tree flow back upstream, including the blob path
   $ josh-filter ':[:exclude[:$a/b/c.txt="new"],:$a/b/c.txt="new"]' master --update refs/josh/rt 1> /dev/null

--- a/tests/experimental/insert.t
+++ b/tests/experimental/insert.t
@@ -29,9 +29,9 @@ The split form is stable under another round-trip
   $ josh-filter -p 'a/b = :$c.txt="hello"'
   a/b = :$c.txt="hello"
 
-Inverse renders as :exclude[::path]
+Inverse renders as :empty (insert is generative: it fabricates content and consumes no input)
   $ josh-filter --reverse -p ':$added.txt="hello world"'
-  :exclude[::added.txt]
+  :empty
 
 Apply: blob is inserted at correct path with correct content
   $ josh-filter -s ':$added.txt="hello world"' master --update refs/josh/filter/master 1> /dev/null
@@ -62,6 +62,20 @@ Apply: compose with blob inserts blob alongside other files
   @@ -0,0 +1 @@
   +contents1
 
+Apply: composing many inserts across sibling directories keeps every insert
+(regression: an insert group must invert to :empty, not a union of excludes,
+otherwise the compose uniqueness handling subtracts later groups away)
+  $ josh-filter -s ':[:$x/a="1",:$x/b="2",:$y/a="3",:$y/b="4"]' master --update refs/josh/filter/many 1> /dev/null
+  $ git ls-tree -r --name-only josh/filter/many
+  x/a
+  x/b
+  y/a
+  y/b
+  $ git show josh/filter/many:y/a
+  3 (no-eol)
+  $ git show josh/filter/many:y/b
+  4 (no-eol)
+
 Apply: blob referenced by sha is inserted at the destination path
   $ OID=$(printf 'big content' | git hash-object -w --stdin)
   $ josh-filter -s ":\$added.txt=$OID" master --update refs/josh/filter/master3 1> /dev/null
@@ -78,6 +92,16 @@ Apply: referencing a non-blob sha (a commit) fails
       :/sub1
       :$added.txt="hello world"
   ]
+  [1] :[
+      x = :[
+          :$a="1"
+          :$b="2"
+      ]
+      y = :[
+          :$a="3"
+          :$b="4"
+      ]
+  ]
   [1] :prefix=a
   [1] :prefix=b
   [3] reachable_roots
@@ -92,6 +116,16 @@ Apply: referencing a nonexistent sha fails
   [1] :[
       :/sub1
       :$added.txt="hello world"
+  ]
+  [1] :[
+      x = :[
+          :$a="1"
+          :$b="2"
+      ]
+      y = :[
+          :$a="3"
+          :$b="4"
+      ]
   ]
   [1] :prefix=a
   [1] :prefix=b

--- a/tests/experimental/treeblob.t
+++ b/tests/experimental/treeblob.t
@@ -44,6 +44,18 @@ Apply via stored filter: blob at path contains tree OID of subfilter result
   $ [ "$(git show refs/josh/master:version.txt)" = "$(git rev-parse master:sub1)" ] && echo "match"
   match
 
+Reverse: a treeid inverts to :empty (it fabricates a blob and consumes no input)
+  $ josh-filter --reverse -p ':#version.txt[:/sub1]'
+  :empty
+
+Apply: composing treeid groups across sibling directories keeps every entry
+(regression: an insert/treeid group must invert to :empty, otherwise the compose
+uniqueness handling subtracts later groups away)
+  $ josh-filter -s ':[:#x/va[:/sub1],:#y/vb[:/sub2]]' master --update refs/josh/manytree 1> /dev/null
+  $ git ls-tree -r --name-only refs/josh/manytree
+  x/va
+  y/vb
+
 Deref: path not found is treated as nop (reference is updated, path absent from output)
   $ josh-filter ':#version.txt' master --update refs/josh/noptest 1> /dev/null
   $ git rev-parse --verify refs/josh/noptest > /dev/null && echo "updated"


### PR DESCRIPTION
Invert generative filters to empty to fix compose collapse

Op::Insert and Op::TreeId fabricate tree entries and consume no input, but
their inverse was Exclude(File(path, path)). Exclude is a complement ("all but
path"), and complements do not survive Compose's union: Compose([Exclude(a),
Exclude(b)]) is a no-op because (all - a) union (all - b) is all. So the input
footprint that tree::compose computes for a group of inserts came out non-empty
(the full leaf set with its prefix stripped) instead of empty. That poisoned the
"taken" set, and applying the next group's prefix to it fabricated phantom
entries at the next group's paths; the content-blind subtract then deleted that
group's real inserts.

The visible symptom: composing several inserts that share directory prefixes,
e.g. :[:$x/a="1",:$x/b="2",:$y/a="3",:$y/b="4"], dropped every group but the
first.

The honest inverse of a generative filter (which reads nothing from the input)
is empty, so invert both Insert and TreeId to Op::Empty. Empty composes cleanly,
so the uniqueness math is correct without touching the general invert(Compose)
rule that the workspace and reverse tests depend on. For the common passthrough
+ insert overlay this leaves unapply unchanged (overlay reduces to identity);
only the reverse of a bare generative filter changes, from "exclude the path" to
"empty", which is the more correct semantics for fabricated content.

Add regression coverage for multi-group insert and treeid composition, the
passthrough overlay replacement idiom, and update the reverse-rendering
expectations.

Change: invert-generative-empty
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>