### PR TITLE
Keep generative leaves out of common_pre hoisting

### DIFF
--- a/josh-filter/src/opt/structure.rs
+++ b/josh-filter/src/opt/structure.rs
@@ -89,7 +89,22 @@ pub(super) fn common_pre(filters: &Vec<Filter>) -> Option<(Filter, Vec<Filter>)>
             return None;
         }
     }
-    c.map(|c| (c, rest))
+    let c = c?;
+    // Do not hoist a generative leaf (Insert/TreeId). Such a filter fabricates its
+    // output independently in each branch; hoisting it would turn the branches into a
+    // single shared source fed through a prefix-compose, which the compose uniqueness
+    // handling then collapses down to one branch (dropping the siblings).
+    if is_generative(c) {
+        return None;
+    }
+    Some((c, rest))
+}
+
+/// A generative filter produces tree entries out of nothing (it ignores its input), so its
+/// output is meant to appear independently in every branch of a compose rather than being
+/// treated as a single shared source that the uniqueness handling may deduplicate.
+fn is_generative(filter: Filter) -> bool {
+    matches!(to_op_ref(filter), Op::Insert(..) | Op::TreeId(..))
 }
 
 pub(super) fn common_post(filters: &Vec<Filter>) -> Option<(Filter, Vec<Filter>)> {

--- a/tests/experimental/insert.t
+++ b/tests/experimental/insert.t
@@ -76,6 +76,15 @@ otherwise the compose uniqueness handling subtracts later groups away)
   $ git show josh/filter/many:y/b
   4 (no-eol)
 
+Apply: inserts with the same basename and content in different directories all survive
+(regression: the shared leaf blob :$f="X" must not be hoisted out of the compose, or
+the resulting :prefix compose collapses every branch but the first)
+  $ josh-filter -s ':[:$a/f="X",:$b/f="X",:$c/f="X"]' master --update refs/josh/filter/samebase 1> /dev/null
+  $ git ls-tree -r --name-only josh/filter/samebase
+  a/f
+  b/f
+  c/f
+
 Apply: blob referenced by sha is inserted at the destination path
   $ OID=$(printf 'big content' | git hash-object -w --stdin)
   $ josh-filter -s ":\$added.txt=$OID" master --update refs/josh/filter/master3 1> /dev/null
@@ -91,6 +100,11 @@ Apply: referencing a non-blob sha (a commit) fails
   [1] :[
       :/sub1
       :$added.txt="hello world"
+  ]
+  [1] :[
+      a = :$f="X"
+      b = :$f="X"
+      c = :$f="X"
   ]
   [1] :[
       x = :[
@@ -116,6 +130,11 @@ Apply: referencing a nonexistent sha fails
   [1] :[
       :/sub1
       :$added.txt="hello world"
+  ]
+  [1] :[
+      a = :$f="X"
+      b = :$f="X"
+      c = :$f="X"
   ]
   [1] :[
       x = :[

--- a/tests/experimental/treeblob.t
+++ b/tests/experimental/treeblob.t
@@ -56,6 +56,14 @@ uniqueness handling subtracts later groups away)
   x/va
   y/vb
 
+Apply: identical treeids with the same basename in different directories all survive
+(regression: the shared leaf treeid must not be hoisted out of the compose, or the
+resulting :prefix compose collapses every branch but the first)
+  $ josh-filter -s ':[:#x/v[:/sub1],:#y/v[:/sub1]]' master --update refs/josh/sametree 1> /dev/null
+  $ git ls-tree -r --name-only refs/josh/sametree
+  x/v
+  y/v
+
 Deref: path not found is treated as nop (reference is updated, path absent from output)
   $ josh-filter ':#version.txt' master --update refs/josh/noptest 1> /dev/null
   $ git rev-parse --verify refs/josh/noptest > /dev/null && echo "updated"


### PR DESCRIPTION
Keep generative leaves out of common_pre hoisting

Composing inserts that share an identical leaf filter, e.g.
:[:$a/f="X",:$b/f="X"], collapsed all branches but the first: only a/f survived.
The discriminator was filter identity (same basename and content), so distinct
content sidestepped it, which is why it hid behind the earlier group-collapse
bug.

The cause is a separate optimizer step. A multi-component insert splits into a
leaf blob plus a prefix, so both branches begin with the identical leaf
:$f="X". common_pre then hoists that shared leaf, rewriting the compose to

    Chain([ Insert(f,"X"), Compose([Prefix(a), Prefix(b)]) ])

The leaf now generates {f:"X"} once and the prefix-compose places it under a/
and b/. But the compose uniqueness handling tracks consumed input: once
Prefix(a) claims {f:"X"}, subtract removes it from Prefix(b)'s output even
though the two land at disjoint paths, so b/f is dropped. The same collapse
occurs for a selective shared prefix (:[:/a:prefix=x,:/a:prefix=y]), but for a
generative leaf the content is fabricated and is meant to appear in every
branch, so the hoist is simply wrong.

Guard common_pre so it does not hoist a common Insert/TreeId leaf. Left
unfactored the branches compose correctly (each generative leaf inverts to
:empty and contributes nothing to the consumed-input set), so every sibling
survives.

Change: common-pre-generative-leaf
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>