### PR TITLE
Introduce a caching system for bench setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,6 +3348,10 @@ dependencies = [
 name = "josh-test-support"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "dirs",
+ "git2",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ members = [
     "deployment/josh-test-webhook-client",
     "deployment/josh-test-webhook-service",
     "deployment/josh-command-middleware",
+
+    "devtools/josh-test-support",
 ]
 
 exclude = ["josh-gui", "devtools"]

--- a/devtools/josh-test-support/Cargo.toml
+++ b/devtools/josh-test-support/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+anyhow.workspace = true
+dirs.workspace = true
+git2.workspace = true
+tempfile.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/devtools/josh-test-support/src/lib.rs
+++ b/devtools/josh-test-support/src/lib.rs
@@ -1,5 +1,7 @@
 use std::time::Instant;
 
+pub mod provision_repo;
+
 use tracing::field::{Field, Visit};
 use tracing::span::{Attributes, Id};
 use tracing::{Event, Subscriber};
@@ -85,7 +87,9 @@ where
         };
 
         let extensions = span.extensions();
-        let fields = extensions.get::<Fields>().and_then(|fields| fields.0.as_deref());
+        let fields = extensions
+            .get::<Fields>()
+            .and_then(|fields| fields.0.as_deref());
 
         match fields {
             Some(fields) => eprintln!("[{}] {:.2?} {}", span.name(), elapsed, fields),

--- a/devtools/josh-test-support/src/provision_repo.rs
+++ b/devtools/josh-test-support/src/provision_repo.rs
@@ -1,0 +1,158 @@
+//! Cache expensive benchmark-repo builds on disk so they are rebuilt from scratch
+//! at most once per build configuration.
+//!
+//! See [`provision_repo`] for the entry point.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, bail, Context, Result};
+
+/// A benchmark repo provisioned into a throwaway tempdir.
+///
+/// The canonical form is cached under the user's cache directory; this handle
+/// owns a fresh copy in a tempdir together with the [`git2::Repository`] opened
+/// from it. Drop the value to delete the tempdir.
+pub struct ProvisionedRepo {
+    /// Keeps the on-disk tempdir alive for as long as the repo handle is used.
+    _tmp: tempfile::TempDir,
+    /// A bare repo opened from the tempdir copy.
+    pub repo: git2::Repository,
+    /// The head oid the callback produced (always equal to the `expected` that
+    /// was passed to [`provision_repo`]).
+    pub head: git2::Oid,
+}
+
+impl ProvisionedRepo {
+    /// Path of the bare repo, which for a bare repo is the tempdir itself.
+    pub fn path(&self) -> &Path {
+        self.repo.path()
+    }
+}
+
+/// Provision a benchmark repo for `testcase`, caching the canonical build under
+/// `<cache_dir>/josh/benches/<testcase>`.
+///
+/// If the cache already contains the `expected` object, the cached bare repo is
+/// copied into a fresh tempdir and returned. Otherwise a new bare repo is built
+/// by invoking `callback` (erasing any stale cache), repacked into a single
+/// packfile, verified to produce `expected`, cached, and copied into a tempdir.
+///
+/// `expected` is a content-addressed version stamp: changing the build (file
+/// counts, history length, etc.) changes the head oid the callback returns,
+/// which no longer matches `expected`, so the strict check fires and the cache
+/// is treated as invalid. On the first run after such a change, the error
+/// message reports the oid the callback produced so it can be pasted in as the
+/// new `expected`.
+pub fn provision_repo<C>(
+    testcase: &str,
+    expected: &git2::Oid,
+    callback: C,
+) -> Result<ProvisionedRepo>
+where
+    C: FnMut(&git2::Repository) -> Result<git2::Oid>,
+{
+    let expected = *expected;
+    let cache_root = cache_root_for(testcase)?;
+
+    if cache_hit(&cache_root, expected) {
+        return copy_to_tempdir(&cache_root, expected);
+    }
+
+    let mut callback = callback;
+    rebuild(&cache_root, expected, &mut callback)?;
+    copy_to_tempdir(&cache_root, expected)
+}
+
+fn cache_root_for(testcase: &str) -> Result<PathBuf> {
+    let cache_dir = dirs::cache_dir()
+        .ok_or_else(|| anyhow!("no cache directory available on this platform"))?;
+    Ok(cache_dir.join("josh").join("benches").join(testcase))
+}
+
+/// A cached repo is reusable if it opens as a bare repo and contains `expected`.
+fn cache_hit(cache_root: &Path, expected: git2::Oid) -> bool {
+    let Ok(repo) = git2::Repository::open_bare(cache_root) else {
+        return false;
+    };
+    repo.odb().map(|odb| odb.exists(expected)).unwrap_or(false)
+}
+
+/// Build `testcase` from scratch into `cache_root`, erasing any prior cache.
+fn rebuild<C>(cache_root: &Path, expected: git2::Oid, callback: &mut C) -> Result<()>
+where
+    C: FnMut(&git2::Repository) -> Result<git2::Oid>,
+{
+    if cache_root.exists() {
+        std::fs::remove_dir_all(cache_root)
+            .with_context(|| format!("removing stale cache at {}", cache_root.display()))?;
+    }
+    if let Some(parent) = cache_root.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating cache parent {}", parent.display()))?;
+    }
+
+    let repo = git2::Repository::init_bare(cache_root)
+        .with_context(|| format!("initializing bare repo at {}", cache_root.display()))?;
+
+    let produced = callback(&repo)?;
+
+    // Pack everything into a single packfile so the tempdir copy is cheap, then
+    // drop unreachable loose objects the pack did not absorb (e.g. the empty-tree
+    // baseline a treebuilder may leave behind).
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(cache_root)
+        .args(["repack", "-a", "-d"])
+        .status()
+        .context("spawning git repack")?;
+    if !status.success() {
+        bail!("git repack failed with status {status}");
+    }
+    let status = Command::new("git")
+        .arg("-C")
+        .arg(cache_root)
+        .args(["prune", "--expire=now"])
+        .status()
+        .context("spawning git prune")?;
+    if !status.success() {
+        bail!("git prune failed with status {status}");
+    }
+
+    if produced != expected {
+        bail!(
+            "provision_repo: callback produced head {produced}, \
+             but expected {expected}; set EXPECTED to {produced}"
+        );
+    }
+
+    Ok(())
+}
+
+/// Copy the canonical cached repo into a fresh tempdir and open it.
+fn copy_to_tempdir(cache_root: &Path, expected: git2::Oid) -> Result<ProvisionedRepo> {
+    let tmp = tempfile::tempdir().context("creating tempdir for repo copy")?;
+    copy_dir_recursive(cache_root, tmp.path())
+        .with_context(|| format!("copying {} to tempdir", cache_root.display()))?;
+    let repo = git2::Repository::open_bare(tmp.path()).context("opening copied bare repo")?;
+    Ok(ProvisionedRepo {
+        _tmp: tmp,
+        repo,
+        head: expected,
+    })
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}

--- a/josh-core/benches/ultrawide_pin.rs
+++ b/josh-core/benches/ultrawide_pin.rs
@@ -13,9 +13,22 @@ const N_PER_SUBFOLDER_MAX: usize = 100;
 
 const NESTING_LEVEL: usize = 3;
 
+/// Expected head oid of the cached bench repo. This is the cache validity key:
+/// changing any of the build parameters above changes the produced oid, which
+/// then fails the strict check in `provision_repo` and reports the new value to
+/// paste here. Filled in by running the bench once after a build change.
+const EXPECTED_HEAD: &str = "6daa53b5eaae0d6642b3ad846e327e899095f5c7";
+
+/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME`
+/// so the built history is reproducible. Without it the signature uses the wall
+/// clock, every run produces a different head oid, and `EXPECTED_HEAD` can never
+/// be stable. The value itself is arbitrary.
+const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
+
 struct PinBench {
-    // Keeps the on-disk repository alive for the duration of the benchmark.
-    _tmp: tempfile::TempDir,
+    // Keeps the on-disk repository (and its tempdir) alive for the duration of
+    // the benchmark.
+    _repo: josh_test_support::provision_repo::ProvisionedRepo,
     // A fresh transaction is opened from this for every iteration.
     context: josh_core::cache::TransactionContext,
     filter: josh_core::filter::Filter,
@@ -26,22 +39,42 @@ impl PinBench {
     fn setup() -> anyhow::Result<Self> {
         let _setup = tracing::info_span!(target: "bench", "setup").entered();
 
-        let tmp = tempfile::tempdir()?;
-        let repo = git2::Repository::init_bare(tmp.path())?;
+        // Pin commit timestamps before building so the head oid is reproducible
+        // and `EXPECTED_HEAD` stays valid across runs. Must run before the cache
+        // miss path invokes the build callback.
+        // SAFETY: setup runs single-threaded, before any benchmark iteration.
+        unsafe {
+            std::env::set_var("JOSH_COMMIT_TIME", JOSH_BENCH_COMMIT_TIME);
+        }
 
-        let (head, paths) = tracing::info_span!(target: "bench", "build_initial_state")
-            .in_scope(|| build_initial_state(&repo))?;
+        // Build (or reuse from cache) the bare repo. The `build_initial_state` /
+        // `build_history` pair runs only inside the callback on a cache miss; the
+        // resulting head oid is checked against `EXPECTED_HEAD` before the repo is
+        // cached and copied into a tempdir for this run.
+        let provisioned = josh_test_support::provision_repo::provision_repo(
+            "ultrawide_pin",
+            &git2::Oid::from_str(EXPECTED_HEAD).expect("EXPECTED_HEAD must be a valid oid"),
+            |repo| {
+                let (head, paths) = tracing::info_span!(target: "bench", "build_initial_state")
+                    .in_scope(|| build_initial_state(repo))?;
 
-        let head = tracing::info_span!(target: "bench", "build_history", n_paths = paths.len())
-            .in_scope(|| build_history(&repo, &paths, head))?;
+                let head =
+                    tracing::info_span!(target: "bench", "build_history", n_paths = paths.len())
+                        .in_scope(|| build_history(repo, &paths, head))?;
 
-        josh_core::cache::sled_load(tmp.path())?;
+                Ok(head)
+            },
+        )?;
+
+        let head = provisioned.head;
+        josh_core::cache::sled_load(provisioned.path())?;
+
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
                 .with_backend(josh_core::cache::SledCacheBackend::default()),
         );
 
-        let context = josh_core::cache::TransactionContext::new(tmp.path(), cache);
+        let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // The filter under benchmark: select the workspace defined by the
         // `workspace/workspace.josh` files generated throughout the history.
@@ -50,7 +83,7 @@ impl PinBench {
             .with_meta("history", "no-splice");
 
         Ok(Self {
-            _tmp: tmp,
+            _repo: provisioned,
             context,
             filter,
             head,


### PR DESCRIPTION
Introduce a caching system for bench setup

This adds a caching system for building the source repos. Works as
follows: we store a reference repo in user's home folder; when
requested, we either check that the repo has the expected OID, or
rebuild it, again checking that the expected OID is produced. For actual
testing, we copy the repo to temp dir, so that it's always starting from
a clean state. Reference repos are compacted into one packfile, and
cleaned up so no garbage remains.

Change-Id: Iceae6cc093ef01ecb06f5f558b34cac16c60e791