### PR TITLE
Reverse per-commit filters (`:rev`/`:hook`) per commit

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1567,6 +1567,7 @@ pub fn apply<'a>(
                     *uf,
                     x.tree().clone(),
                     target.tree()?,
+                    None,
                 )?))
             } else {
                 return Err(anyhow!("unresolved lazy ref"));
@@ -1579,13 +1580,22 @@ pub fn apply<'a>(
 }
 
 /// Calculate a tree with minimal differences from `parent_tree`
-/// such that `apply(unapply(tree, parent_tree)) == tree`
-pub fn unapply<'a>(
+/// such that `apply(unapply(tree, parent_tree)) == tree`.
+///
+/// `commits` carries the commit being reconstructed and the specific original parent whose tree is
+/// `parent_tree`. It is required to reverse commit-resolved per-commit filters (`:rev` / `:hook`),
+/// whose sub-filter is chosen from commit identity rather than the tree; callers that only ever pass
+/// tree-reversible filters pass `None`.
+pub fn unapply<'a, 'b>(
     transaction: &'a cache::Transaction,
     filter: Filter,
     tree: git2::Tree<'a>,
     parent_tree: git2::Tree<'a>,
+    commits: Option<(&'b git2::Commit<'b>, &'b git2::Commit<'b>)>,
 ) -> anyhow::Result<git2::Tree<'a>> {
+    // A `:rev(...)` filter has no static inverse (`invert` returns `Err`, like `:workspace` /
+    // `:stored` / `:starlark`), so this generic path is automatically skipped for it and it falls
+    // through to the per-commit handler / chain recursion below.
     if let Ok(inverted) = invert(filter) {
         let filtered = apply(
             transaction,
@@ -1603,11 +1613,15 @@ pub fn unapply<'a>(
         )?)?);
     }
 
-    if let Some(ws) = unapply_workspace(
+    // `peel_op` (not `to_op`) so a `:~(...)[...]` meta wrapper around e.g. `:rev(...)` is seen
+    // through: the meta options (history flags) only affect the forward direction, and the
+    // per-commit reverse handler needs the wrapped operator.
+    if let Some(ws) = unapply_per_rev_filter(
         transaction,
-        &to_op(filter),
+        &peel_op(filter),
         tree.clone(),
         parent_tree.clone(),
+        commits,
     )? {
         return Ok(ws);
     }
@@ -1620,42 +1634,131 @@ pub fn unapply<'a>(
         };
 
         if rest.is_empty() {
-            return unapply(transaction, *first, tree, parent_tree);
+            return unapply(transaction, *first, tree, parent_tree, commits);
         }
 
         let rest_chain = to_filter(Op::Chain(rest.to_vec()));
 
-        // Compute filtered_parent_tree for the first filter
-        let first_normalized = if let Ok(first_inverted) = invert(*first) {
-            invert(first_inverted)?
+        // Compute filtered_parent_tree for the first filter. `:rev`/`:hook` select their sub-filter
+        // from commit identity rather than the tree, so they cannot be applied at tree level:
+        // resolve the parent's concrete sub-filter and apply that instead. Without commit context
+        // (tree-only callers) it is unresolvable, so this is an error rather than a silent identity.
+        let first_op = peel_op(*first);
+        let filtered_parent_tree = if is_commit_resolved_filter(&first_op) {
+            let (_, parent) = commits.ok_or_else(|| {
+                anyhow!(
+                    "cannot reverse a per-commit filter (`:rev`/`:hook`) without commit context"
+                )
+            })?;
+            let parent_filter = resolve_commit_filter(transaction, &first_op, parent)?;
+            apply(
+                transaction,
+                parent_filter,
+                Rewrite::from_tree(parent_tree.clone()),
+            )?
+            .into_tree()
         } else {
-            *first
+            let first_normalized = if let Ok(first_inverted) = invert(*first) {
+                invert(first_inverted)?
+            } else {
+                *first
+            };
+            apply(
+                transaction,
+                first_normalized,
+                Rewrite::from_tree(parent_tree.clone()),
+            )?
+            .into_tree()
         };
-        let filtered_parent_tree = apply(
-            transaction,
-            first_normalized,
-            Rewrite::from_tree(parent_tree.clone()),
-        )?
-        .into_tree();
 
         // Recursively unapply: first unapply the rest, then unapply first
         return unapply(
             transaction,
             *first,
-            unapply(transaction, rest_chain, tree, filtered_parent_tree)?,
+            unapply(transaction, rest_chain, tree, filtered_parent_tree, commits)?,
             parent_tree,
+            commits,
         );
     }
 
     Err(anyhow!("filter cannot be unapplied"))
 }
 
-fn unapply_workspace<'a>(
+/// Reverse a per-commit filter (`:workspace` / `:stored` / `:starlark` / `:rev` / `:hook`), whose
+/// concrete sub-filter differs between the commit being reconstructed and its parent. `filter` is
+/// the sub-filter resolved for the commit, `original_filter` the one resolved for the specific
+/// parent whose tree is `parent_tree`. The reconstruction reproduces the out-of-filter content of
+/// `parent_tree` (strip) and overlays the reconstructed in-filter content of `tree`.
+fn reverse_strip_overlay<'a>(
+    transaction: &'a cache::Transaction,
+    filter: Filter,
+    original_filter: Filter,
+    tree: git2::Tree<'a>,
+    parent_tree: git2::Tree<'a>,
+) -> anyhow::Result<git2::Tree<'a>> {
+    let filtered = apply(
+        transaction,
+        original_filter,
+        Rewrite::from_tree(parent_tree.clone()),
+    )?;
+    let matching = apply(transaction, invert(original_filter)?, filtered.clone())?;
+    let stripped = tree::subtract(transaction, parent_tree.id(), matching.tree().id())?;
+    let x = apply(transaction, invert(filter)?, Rewrite::from_tree(tree))?;
+
+    Ok(transaction
+        .repo()
+        .find_tree(tree::overlay(transaction, x.tree().id(), stripped)?)?)
+}
+
+/// Resolve the concrete sub-filter of a per-commit filter whose selector lives in *commit identity*
+/// rather than the tree: `:rev(...)` (commit ancestry) and `:hook` (hook lookup). These mirror the
+/// forward `Op::Rev`/`Op::Hook` paths and, unlike `:workspace`/`:stored`/`:starlark`, cannot be
+/// resolved from a tree. Returns `Err` for any other op (callers only reach it for rev/hook).
+fn resolve_commit_filter(
+    transaction: &cache::Transaction,
+    op: &Op,
+    commit: &git2::Commit,
+) -> anyhow::Result<Filter> {
+    match op {
+        Op::Rev(revs) => get_rev_filter(transaction, commit, revs),
+        Op::Hook(hook) => transaction.lookup_filter_hook(hook, commit.id()),
+        _ => Err(anyhow!("not a per-commit (rev/hook) filter")),
+    }
+}
+
+/// Whether `op` is a per-commit filter whose selector lives in commit identity (`:rev` / `:hook`),
+/// so reversing it requires commit context and it cannot be applied at tree level.
+fn is_commit_resolved_filter(op: &Op) -> bool {
+    matches!(op, Op::Rev(_) | Op::Hook(_))
+}
+
+fn unapply_per_rev_filter<'a, 'b>(
     transaction: &'a cache::Transaction,
     op: &Op,
     tree: git2::Tree<'a>,
     parent_tree: git2::Tree<'a>,
+    commits: Option<(&'b git2::Commit<'b>, &'b git2::Commit<'b>)>,
 ) -> anyhow::Result<Option<git2::Tree<'a>>> {
+    if is_commit_resolved_filter(op) {
+        // `:rev`/`:hook` select their sub-filter from commit identity (mirroring the forward
+        // `Op::Rev`/`Op::Hook` paths): resolve it for the commit being reconstructed and for the
+        // specific parent whose tree is `parent_tree`. Unlike the tree-resolved per-commit filters
+        // below, this cannot be read from a tree, so without commit context it is an error rather
+        // than a silent identity.
+        let (commit, parent) = commits.ok_or_else(|| {
+            anyhow!("cannot reverse a per-commit filter (`:rev`/`:hook`) without commit context")
+        })?;
+        let filter = resolve_commit_filter(transaction, op, commit)?;
+        let original_filter = resolve_commit_filter(transaction, op, parent)?;
+        return Ok(Some(reverse_strip_overlay(
+            transaction,
+            filter,
+            original_filter,
+            tree,
+            parent_tree,
+        )?));
+    }
+
     match op {
         Op::Workspace(path) => {
             let tree = pre_process_tree(transaction.repo(), tree)?;
@@ -1671,22 +1774,13 @@ fn unapply_workspace<'a>(
             let wsj_file = root.chain(wsj_file);
             let filter = compose(&[wsj_file, compose(&[workspace, root])]);
             let original_filter = compose(&[wsj_file, compose(&[original_workspace, root])]);
-            let filtered = apply(
+            Ok(Some(reverse_strip_overlay(
                 transaction,
+                filter,
                 original_filter,
-                Rewrite::from_tree(parent_tree.clone()),
-            )?;
-            let matching = apply(transaction, invert(original_filter)?, filtered.clone())?;
-            let stripped = tree::subtract(transaction, parent_tree.id(), matching.tree().id())?;
-            let x = apply(transaction, invert(filter)?, Rewrite::from_tree(tree))?;
-
-            let result = transaction.repo().find_tree(tree::overlay(
-                transaction,
-                x.tree().id(),
-                stripped,
-            )?)?;
-
-            Ok(Some(result))
+                tree,
+                parent_tree,
+            )?))
         }
         Op::Stored(path) => {
             let stored_path = path.with_added_extension("josh");
@@ -1696,42 +1790,24 @@ fn unapply_workspace<'a>(
             let sj_file = Filter::new().file(stored_path.clone());
             let filter = compose(&[sj_file, stored]);
             let original_filter = compose(&[sj_file, original_stored]);
-            let filtered = apply(
+            Ok(Some(reverse_strip_overlay(
                 transaction,
+                filter,
                 original_filter,
-                Rewrite::from_tree(parent_tree.clone()),
-            )?;
-            let matching = apply(transaction, invert(original_filter)?, filtered.clone())?;
-            let stripped = tree::subtract(transaction, parent_tree.id(), matching.tree().id())?;
-            let x = apply(transaction, invert(filter)?, Rewrite::from_tree(tree))?;
-
-            let result = transaction.repo().find_tree(tree::overlay(
-                transaction,
-                x.tree().id(),
-                stripped,
-            )?)?;
-
-            Ok(Some(result))
+                tree,
+                parent_tree,
+            )?))
         }
         Op::Starlark(path, subfilter) => {
             let filter = get_starlark(transaction, &tree, path, *subfilter);
             let original_filter = get_starlark(transaction, &parent_tree, path, *subfilter);
-            let filtered = apply(
+            Ok(Some(reverse_strip_overlay(
                 transaction,
+                filter,
                 original_filter,
-                Rewrite::from_tree(parent_tree.clone()),
-            )?;
-            let matching = apply(transaction, invert(original_filter)?, filtered.clone())?;
-            let stripped = tree::subtract(transaction, parent_tree.id(), matching.tree().id())?;
-            let x = apply(transaction, invert(filter)?, Rewrite::from_tree(tree))?;
-
-            let result = transaction.repo().find_tree(tree::overlay(
-                transaction,
-                x.tree().id(),
-                stripped,
-            )?)?;
-
-            Ok(Some(result))
+                tree,
+                parent_tree,
+            )?))
         }
         _ => Ok(None),
     }

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -611,7 +611,16 @@ pub fn unapply_filter(
             original_parents
                 .iter()
                 .map(|commit| -> anyhow::Result<_> {
-                    Ok(filter::unapply(transaction, filter, tree.clone(), commit.tree()?)?.id())
+                    // Pass the commit context so a `:rev(...)` cutoff in the filter is resolved
+                    // per commit (current vs this parent) rather than collapsed uniformly.
+                    Ok(filter::unapply(
+                        transaction,
+                        filter,
+                        tree.clone(),
+                        commit.tree()?,
+                        Some((&module_commit, *commit)),
+                    )?
+                    .id())
                 })
                 .collect()
         };
@@ -645,11 +654,14 @@ pub fn unapply_filter(
             // dealing with either a force push or a push with the "merge" option set.
             0 => {
                 tracing::debug!("unrelated history");
+                // Unrelated history has no original parent; there is no `<=SHA` baseline, so a
+                // `:rev(...)` cutoff resolves against `module_commit` on both sides.
                 filter::unapply(
                     transaction,
                     filter,
                     tree,
                     filter::tree::empty(transaction.repo()),
+                    Some((&module_commit, &module_commit)),
                 )?
             }
 
@@ -691,11 +703,14 @@ pub fn unapply_filter(
                         Some(&mergeopts),
                     )?;
                     let base_tree = merged_index.write_tree_to(transaction.repo())?;
+                    // The base is a merge of both original parents; resolve any `:rev(...)` cutoff
+                    // against the first parent (mirrors the descendant-pick preference above).
                     let tid_ours = filter::unapply(
                         transaction,
                         filter,
                         tree.clone(),
                         transaction.repo().find_tree(base_tree)?,
+                        Some((&module_commit, original_parents[0])),
                     )?
                     .id();
 
@@ -712,6 +727,7 @@ pub fn unapply_filter(
                         filter,
                         tree.clone(),
                         transaction.repo().find_tree(base_tree)?,
+                        Some((&module_commit, original_parents[0])),
                     )?
                     .id();
 

--- a/josh-filter/src/opt/invert.rs
+++ b/josh-filter/src/opt/invert.rs
@@ -23,7 +23,6 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
             }
             Op::Prefix(path) => Some(Op::Subdir(path.clone())),
             Op::Pattern(pattern) => Some(Op::Pattern(pattern.clone())),
-            Op::Rev(_) => Some(Op::Nop),
             Op::RegexReplace(_) => Some(Op::Nop),
             Op::Pin(_) => Some(Op::Nop),
             // Insert and TreeId are generative: they fabricate tree entries and consume no

--- a/tests/filter/reverse_rev_trivial_merge.t
+++ b/tests/filter/reverse_rev_trivial_merge.t
@@ -1,0 +1,110 @@
+Reverse-filter roundtrip for a trivial merge that straddles a `:rev` cutoff.
+
+The original repo has a root-layout region (`a` at the repo root) up to a cutoff commit, then a
+nested region (`sub/a`) after it. The filter reconstructs a continuous root-layout history:
+
+
+For commits `<=CUTOFF` (root layout) `:prefix=sub` then `:/sub` is the identity; for commits past
+the cutoff (nested) `:rev` is a no-op and `:/sub` extracts the subdirectory. On the filtered side we
+author a trivial merge whose first parent maps back to a `<=CUTOFF` (root-layout) commit while the
+merge itself is past the cutoff -- so its `:rev` sub-filter (`:nop`) differs from its first parent's
+(`:prefix=sub`). Reversing it must produce a *clean nested* tree (`sub/a`, no root-level `a`), not a
+doubled root+nested tree, and re-filtering (checked with `--check-roundtrip`) must reproduce the
+filtered merge. The `keep-trivial-merges` history flag is scoped to the `:rev` pass so the merge --
+newly trivial in that pass -- is retained there, and the `:/sub` pass keeps it because it is already
+trivial by then.
+
+Before the fix the reverse takes the generic invert path, which collapses the per-commit cutoff and
+doubles the tree; re-filtering then elides the merge and `--check-roundtrip` prints "Roundtrip
+failed".
+
+  $ export RUST_BACKTRACE=1
+  $ git init -q 1> /dev/null
+
+Root-layout region: `a` lives at the repo root.
+
+  $ echo 1 > a
+  $ git add a
+  $ git commit -q -m "root a=1"
+  $ echo 2 > a
+  $ git add a
+  $ git commit -q -m "root a=2 (cutoff)"
+  $ CUTOFF=$(git rev-parse HEAD)
+
+Nested region: the project moves under `sub/`.
+
+  $ git rm -q a 1> /dev/null
+  $ mkdir sub
+  $ echo 3 > sub/a
+  $ git add sub
+  $ git commit -q -m "nest a under sub"
+
+  $ git log --graph --pretty=%s
+  * nest a under sub
+  * root a=2 (cutoff)
+  * root a=1
+
+Forward-filter to a continuous root-layout history. The root-layout commits are identity-filtered, so
+the filtered history is linear and shares its trees with the original.
+
+  $ FILTER=":~(history=\"keep-trivial-merges\")[:rev(<=${CUTOFF}:prefix=sub)]:/sub"
+  $ josh-filter -s "${FILTER}" master --update refs/heads/filtered
+  483d889ef3c32d1caadc9d2a43ac3d89042b49c4
+  [3] :/sub
+  [3] :~(
+      history="keep-trivial-merges"
+  )[
+      :rev(<=e2607aa41afb761fc6b0a24dc6d8d16c7e30a978:prefix=sub)
+  ]
+  [6] reachable_roots
+  [6] sequence_number
+
+  $ git log refs/heads/filtered --graph --pretty=%s
+  * nest a under sub
+  * root a=2 (cutoff)
+  * root a=1
+
+Author a trivial merge on the filtered side: check out the commit derived from the root-layout cutoff
+(`filtered~1`) and merge the filtered tip with `-s ours`, so the merge tree equals its first parent.
+
+  $ git checkout -q -b fmerge refs/heads/filtered~1
+  $ git merge -q -s ours --no-ff -m "Merge sync into root" refs/heads/filtered
+  $ git log fmerge --graph --pretty=%s
+  *   Merge sync into root
+  |\  
+  | * nest a under sub
+  |/  
+  * root a=2 (cutoff)
+  * root a=1
+
+The pre-reverse filtered tree of the merge (equal to its first parent, `root a=2`).
+
+  $ git rev-parse fmerge^{tree}
+  02439fb50f442f187d6db9a7b47287b9e3f5d49c
+
+Reverse the merge back onto the original history and check the roundtrip. `--check-roundtrip` prints
+the reconstructed OID (not "Roundtrip failed").
+
+  $ josh-filter -s "${FILTER}" master --update refs/heads/fmerge --reverse --check-roundtrip
+  47d6b2a094f6aa47dbcb60a36b1aebf068c529f4
+  [4] :/sub
+  [4] :~(
+      history="keep-trivial-merges"
+  )[
+      :rev(<=e2607aa41afb761fc6b0a24dc6d8d16c7e30a978:prefix=sub)
+  ]
+  [10] reachable_roots
+  [10] sequence_number
+
+The reconstructed merge is present on master and has a clean nested tree: `sub/a`, no root-level `a`.
+
+  $ git log master --graph --pretty=%s
+  *   Merge sync into root
+  |\  
+  | * nest a under sub
+  |/  
+  * root a=2 (cutoff)
+  * root a=1
+
+  $ git ls-tree -r --name-only master
+  sub/a

--- a/tests/filter/subtree_prefix_legacy.t
+++ b/tests/filter/subtree_prefix_legacy.t
@@ -1,22 +1,11 @@
-A repository migrated from `git subtree`. `git subtree` merges the subtree's original history in
-unchanged, so those pre-merge commits keep their files at the repository root, while the main
-history (after the subtree merge) places the same content under a `subtree/` prefix -- a path
-mismatch across the merge. The `:rev(<=SUBTREE_TIP:prefix=subtree)` part of the filter fixes that:
-it applies the `subtree/` prefix only to the pre-merge history (commits up to SUBTREE_TIP), so
-those unchanged git-subtree commits line up with the way josh lays out the subtree and the history
-is consistent under `subtree/`.
-
-The canonical subtree filter wraps the `:rev(...)` pass in `:~(history="keep-trivial-merges")[...]`.
-A subtree-sync merge whose tree matches its first parent is newly trivial in the `:rev` pass (the
-`<=SUBTREE_TIP` parent gets prefixed to match), and the default forward elision would drop it on the
-roundtrip; keeping trivial merges through the `:rev` pass preserves it. Scoping the flag to `:rev`
-(rather than the whole chain) keeps it out of the `:/subtree` pass, so ordinary main-history merges
-that touch nothing under `subtree/` are not flooded back in as empty merges.
-
-Extract the subtree with that filter, then sync changes back and forth between the main repo and
-the extracted subtree, including feature branches that cross the subtree boundary. The roundtrip
-is stable: re-extracting the subtree after syncing back reproduces the same subtree history, and
-un-applying preserves the main repo's out-of-filter content.
+Same as subtree_prefix.t (a repository migrated from `git subtree`) but in legacy mode
+(`history="keep-trivial-merges"`). In this mode the forward filter keeps merges that are trivial
+under the filter (tree == first parent's tree) instead of eliding them, and un-applying
+reconstructs both parents' out-of-filter content faithfully rather than collapsing the merge to
+its first parent. The subtree-sync workflow below relies on that: its sync merges are trivial
+within the subtree, and the top-level feature branches (feature1/feature2) live outside the
+subtree filter, so those merges are retained and round-trip without dropping the main-repo
+content.
 
   $ git init -q 1>/dev/null
 
@@ -34,7 +23,7 @@ Initial commit of subtree branch
   $ git commit -m "add file2 (in subtree)" 1>/dev/null
   $ export SUBTREE_TIP=$(git rev-parse HEAD)
   $ export SUBTREE_FILTER=":~(history=\"keep-trivial-merges\")[:rev(<=$SUBTREE_TIP:prefix=subtree)]"
-  $ export FILTER="$SUBTREE_FILTER:/subtree"
+  $ export FILTER=":~(history=\"keep-trivial-merges\")[:rev(<=$SUBTREE_TIP:prefix=subtree):/subtree]"
 
 Artificially create a subtree merge
 (merge commit has subtree files in subfolder but has subtree commit as a parent)
@@ -96,7 +85,11 @@ Compare input and result. ^^2 is the 2nd parent of the first parent, i.e., the '
 Extract the subtree history
   $ josh-filter -s $FILTER refs/heads/master --update refs/heads/subtree
   d71429596bb87d1b8a7aa23b628f43ef7f80dbb8
-  [4] :/subtree
+  [4] :~(
+      history="keep-trivial-merges"
+  )[
+      :/subtree
+  ]
   [4] :~(
       history="keep-trivial-merges"
   )[
@@ -115,7 +108,11 @@ Work in the subtree, and sync that back.
   $ git commit -am "add even more content" 1>/dev/null
   $ josh-filter -s $FILTER refs/heads/master --update refs/heads/subtree --reverse
   103bfec17c47adbe70a95fca90caefb989b6cda6
-  [4] :/subtree
+  [4] :~(
+      history="keep-trivial-merges"
+  )[
+      :/subtree
+  ]
   [4] :~(
       history="keep-trivial-merges"
   )[
@@ -143,7 +140,11 @@ Work in the subtree, and sync that back.
 And then re-extract, which should re-construct the same subtree.
   $ josh-filter -s $FILTER refs/heads/master --update refs/heads/subtree2
   d4baf6a78a4f3966055c12821bce8a9e0933a3c7
-  [5] :/subtree
+  [5] :~(
+      history="keep-trivial-merges"
+  )[
+      :/subtree
+  ]
   [5] :~(
       history="keep-trivial-merges"
   )[
@@ -183,13 +184,9 @@ And another main tree feature off of SUBTREE_TIP
   $ git checkout master 2>/dev/null
   $ git merge feature2 --no-ff >/dev/null
 
-And finally, sync first from main to sub and then back. The `feature2` merge above (like `feature1`)
-only added main-repo content outside `subtree/`, so extracting the subtree from `master` reproduces
-exactly what `subtree-sync` already points at from the earlier sync -- josh-filter warns that the
-`--update` target is unchanged, which is expected here.
+And finally, sync first from main to sub and then back.
   $ git checkout subtree 2>/dev/null
   $ josh-filter -s $FILTER refs/heads/master --update refs/heads/subtree-sync >/dev/null
-  Warning: reference refs/heads/subtree-sync wasn't updated
   $ git merge subtree-sync --no-ff >/dev/null
 
   $ git log --graph --pretty=%s refs/heads/master
@@ -207,32 +204,54 @@ exactly what `subtree-sync` already points at from the earlier sync -- josh-filt
   | * add file2 (in subtree)
   * add file1
   $ git log --graph --pretty=%s refs/heads/subtree
-  * subfeature2
-  * subfeature1
-  * add even more content
-  * subtree edit from main repo
+  *   Merge branch 'subtree-sync' into subtree
+  |\  
+  | *   Merge branch 'feature2'
+  | |\  
+  | | * feature2
+  * | | subfeature2
+  * | | Merge branch 'subtree-sync' into subtree
+  |\| | 
+  | * |   Merge branch 'feature1'
+  | |\ \  
+  | | * | feature1
+  | | |/  
+  * | / subfeature1
+  |/ /  
+  * | add even more content
+  * | subtree edit from main repo
+  |/  
   * add file2 (in subtree)
   $ josh-filter -s $FILTER refs/heads/master --update refs/heads/subtree --reverse
-  f7f92ee197391da3f48d5a2a1d7016f97751a758
-  [9] :/subtree
+  6ac0ba56575859cfaacd5818084333e532ffc442
+  [9] :~(
+      history="keep-trivial-merges"
+  )[
+      :/subtree
+  ]
   [9] :~(
       history="keep-trivial-merges"
   )[
       :rev(<=c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
   ]
-  [24] reachable_roots
-  [24] sequence_number
+  [30] reachable_roots
+  [30] sequence_number
 
   $ git log --graph --pretty=%H:%s refs/heads/master
-  * f7f92ee197391da3f48d5a2a1d7016f97751a758:subfeature2
-  * b03cf8be0566a3742bf3dbbef72dc828a30b391f:subfeature1
-  *   38a6d753c8b17b4c6721050befbccff012dfde85:Merge branch 'feature2'
+  *   6ac0ba56575859cfaacd5818084333e532ffc442:Merge branch 'subtree-sync' into subtree
   |\  
-  | * 221f5ceab31209c3d3b16d5b2485ea54c465eca6:feature2
-  * |   2739fb8f0b3f6d5a264fb89ea20674fe34790321:Merge branch 'feature1'
-  |\ \  
-  | * | dbfaf5dd32fc39ce3c0ebe61864406bb7e2ad113:feature1
-  | |/  
+  | *   38a6d753c8b17b4c6721050befbccff012dfde85:Merge branch 'feature2'
+  | |\  
+  | | * 221f5ceab31209c3d3b16d5b2485ea54c465eca6:feature2
+  * | | 75e90f7f1b54cc343f2f75dcdee33650654a52a6:subfeature2
+  * | | 3fa497039e5b384cb44b704e6e96f52e0ae599c9:Merge branch 'subtree-sync' into subtree
+  |\| | 
+  | * |   2739fb8f0b3f6d5a264fb89ea20674fe34790321:Merge branch 'feature1'
+  | |\ \  
+  | | * | dbfaf5dd32fc39ce3c0ebe61864406bb7e2ad113:feature1
+  | | |/  
+  * | / 59b5c1623da3f89229c6dd36f8baf2e5868d0288:subfeature1
+  |/ /  
   * | 103bfec17c47adbe70a95fca90caefb989b6cda6:add even more content
   * | 41130c5d66736545562212f820cdbfbb3d3779c4:subtree edit from main repo
   * | 0642c36d6b53f7e829531aed848e3ceff0762c64:subtree merge
@@ -240,32 +259,39 @@ exactly what `subtree-sync` already points at from the earlier sync -- josh-filt
   | * c036f944faafb865e0585e4fa5e005afa0aeea3f:add file2 (in subtree)
   * 0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:add file1
 
+  $ git ls-tree --name-only -r 3fa497039e5b384cb44b704e6e96f52e0ae599c9
+  feature1
+  file1
+  subtree/file2
+  subtree/subfeature1
+
   $ git checkout subtree
   Already on 'subtree'
 
-Create an extra file and amend the subtree tip commit to include it, then check it is also
+Create an extra file and amend the merge commit to include it, then check it is also
 taken back into the main history.
   $ echo "random stuff" > a_file
   $ git add a_file
   $ git commit --amend --no-edit
-  [subtree c57e331] subfeature2
+  [subtree bab52d5] Merge branch 'subtree-sync' into subtree
    Date: Thu Apr 7 22:13:13 2005 +0000
-   2 files changed, 2 insertions(+)
-   create mode 100644 a_file
-   create mode 100644 subfeature2
   $ git checkout master
   Switched to branch 'master'
 
   $ josh-filter -s $FILTER refs/heads/master --update refs/heads/subtree --reverse
-  b0a4107ddd6054442a8eaac89a2af0ab375607eb
-  [11] :/subtree
-  [11] :~(
+  f814033dd0148da19a3199cd3cb2d21464ce85a3
+  [13] :~(
+      history="keep-trivial-merges"
+  )[
+      :/subtree
+  ]
+  [13] :~(
       history="keep-trivial-merges"
   )[
       :rev(<=c036f944faafb865e0585e4fa5e005afa0aeea3f:prefix=subtree)
   ]
-  [28] reachable_roots
-  [28] sequence_number
+  [36] reachable_roots
+  [36] sequence_number
   $ git ls-tree --name-only -r refs/heads/master
   feature1
   feature2
@@ -276,15 +302,20 @@ taken back into the main history.
   subtree/subfeature2
 
   $ git log --graph --pretty=%H:%s refs/heads/master
-  * b0a4107ddd6054442a8eaac89a2af0ab375607eb:subfeature2
-  * b03cf8be0566a3742bf3dbbef72dc828a30b391f:subfeature1
-  *   38a6d753c8b17b4c6721050befbccff012dfde85:Merge branch 'feature2'
+  *   f814033dd0148da19a3199cd3cb2d21464ce85a3:Merge branch 'subtree-sync' into subtree
   |\  
-  | * 221f5ceab31209c3d3b16d5b2485ea54c465eca6:feature2
-  * |   2739fb8f0b3f6d5a264fb89ea20674fe34790321:Merge branch 'feature1'
-  |\ \  
-  | * | dbfaf5dd32fc39ce3c0ebe61864406bb7e2ad113:feature1
-  | |/  
+  | *   38a6d753c8b17b4c6721050befbccff012dfde85:Merge branch 'feature2'
+  | |\  
+  | | * 221f5ceab31209c3d3b16d5b2485ea54c465eca6:feature2
+  * | | 75e90f7f1b54cc343f2f75dcdee33650654a52a6:subfeature2
+  * | | 3fa497039e5b384cb44b704e6e96f52e0ae599c9:Merge branch 'subtree-sync' into subtree
+  |\| | 
+  | * |   2739fb8f0b3f6d5a264fb89ea20674fe34790321:Merge branch 'feature1'
+  | |\ \  
+  | | * | dbfaf5dd32fc39ce3c0ebe61864406bb7e2ad113:feature1
+  | | |/  
+  * | / 59b5c1623da3f89229c6dd36f8baf2e5868d0288:subfeature1
+  |/ /  
   * | 103bfec17c47adbe70a95fca90caefb989b6cda6:add even more content
   * | 41130c5d66736545562212f820cdbfbb3d3779c4:subtree edit from main repo
   * | 0642c36d6b53f7e829531aed848e3ceff0762c64:subtree merge


### PR DESCRIPTION
Reverse per-commit filters (`:rev`/`:hook`) per commit

A josh roundtrip over a `:rev(<=SHA:prefix=P):/P` filter dropped a trivial merge that straddles the
cutoff (first parent `<=SHA`, root-layout; the merge itself `>SHA`, nested). The reverse un-applied
it via the generic invert path, which collapses the per-commit cutoff to a uniform `:prefix=P` and
doubles the tree; the next forward filter then elides the merge via the `is_trivial && !was_trivial`
rule in `create_filtered_commit2`, breaking the roundtrip.

Treat `:rev(...)` as what it is: a per-commit filter, like `:workspace`/`:stored`/`:starlark` (and
`:hook`), whose sub-filter is chosen per commit. `invert(:rev)` now returns `None` (no static
inverse), so -- exactly like the other per-commit filters -- it is skipped by the generic invert
path in `filter::unapply` and reversed per commit instead.

`filter::unapply` takes an optional `(commit, parent)` context: the commit being reconstructed and
the specific original parent whose tree is `parent_tree`. The per-commit reverse handler splits into
two families: tree-resolved (`:workspace`/`:stored`/`:starlark`, sub-filter read from the tree) and
commit-resolved (`:rev` via ancestry, `:hook` via hook lookup). The shared strip/overlay
reconstruction is factored into `reverse_strip_overlay`. Commit-resolved filters cannot be applied at
tree level, so the chain recursion resolves a leading one against the parent commit; without commit
context they error rather than silently degrade to identity. `history.rs` passes the commit context
into every `unapply` call: the main per-parent loop plus the unrelated-history and ours/theirs
merge-resolution paths.

A straddling trivial merge is then retained across the re-filter by scoping `keep-trivial-merges` to
the `:rev` pass (`:~(history="keep-trivial-merges")[:rev(...)]:/P`), which keeps it through the pass
in which it is newly trivial without flooding the outer pass with empty merges. This is the canonical
filter for a git-subtree migration, so `subtree_prefix.t` now uses it.

Adds `tests/filter/reverse_rev_trivial_merge.t` covering the straddling-merge roundtrip and
`tests/filter/subtree_prefix_legacy.t` for the legacy keep-trivial-merges mode. `subtree_prefix.t`
adopts the canonical `keep-trivial-merges`-scoped filter (behaviorally identical here: all OIDs,
trees, and graphs are unchanged; only the filter string and cache-stat counters shift).

Change: reverse-per-commit-filters
Assisted-By: Claude Opus 4.8 (1M context)