### PR TITLE
Build the pin overlay with a single tree intersect

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2149,11 +2149,12 @@ fn per_rev_filter(
 
             let parent = transaction.repo().find_commit(parent)?;
 
-            let pin_overlay = tree::populate(
-                transaction,
-                tree::pathstree("", pin_subtract.tree.id(), transaction)?.id(),
-                parent.tree_id(),
-            )?;
+            // Re-content the pinned path set from the parent's filtered tree: keep exactly the
+            // parent's entries whose path is pinned. Equivalent to the older
+            // `populate(pathstree(pin_subtract), parent)` spelling of "select the pinned paths out
+            // of the previous tree", but in a single path-intersection pass.
+            let pin_overlay =
+                tree::intersect(transaction, parent.tree_id(), pin_subtract.tree.id())?;
 
             Some((pin_subtract.tree.id(), pin_overlay))
         } else {


### PR DESCRIPTION
Build the pin overlay with a single tree intersect

`:pin` re-contents its held-back paths from the parent's filtered tree.
That "select the pinned paths out of the previous tree" step was spelled
as `populate(pathstree(pin_subtract), parent)`: `pathstree` reduces the
pinned region to a path-set marker tree and `populate` refills it from the
parent. With the dedicated `tree::intersect` helper this is just
`intersect(parent, pin_subtract)` -- keep the parent's entries whose path
is pinned -- in a single path-intersection pass, dropping the intermediate
path-string tree and the populate walk.

Change: pin-overlay-intersect
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>