### PR TITLE
Add the Select filter as the complement of Exclude

### DIFF
--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -102,6 +102,7 @@ struct Transaction2 {
     commit_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
     apply_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
     subtract_map: HashMap<(git2::Oid, git2::Oid), git2::Oid>,
+    intersect_map: HashMap<(git2::Oid, git2::Oid), git2::Oid>,
     overlay_map: HashMap<(git2::Oid, git2::Oid), git2::Oid>,
     unapply_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
     legalize_map: HashMap<(crate::filter::Filter, git2::Oid), crate::filter::Filter>,
@@ -170,6 +171,7 @@ impl Transaction {
                 commit_map: HashMap::new(),
                 apply_map: HashMap::new(),
                 subtract_map: HashMap::new(),
+                intersect_map: HashMap::new(),
                 overlay_map: HashMap::new(),
                 unapply_map: HashMap::new(),
                 legalize_map: HashMap::new(),
@@ -296,6 +298,16 @@ impl Transaction {
     pub fn get_subtract(&self, from: (git2::Oid, git2::Oid)) -> Option<git2::Oid> {
         let t2 = self.t2.borrow_mut();
         t2.subtract_map.get(&from).cloned()
+    }
+
+    pub fn insert_intersect(&self, from: (git2::Oid, git2::Oid), to: git2::Oid) {
+        let mut t2 = self.t2.borrow_mut();
+        t2.intersect_map.insert(from, to);
+    }
+
+    pub fn get_intersect(&self, from: (git2::Oid, git2::Oid)) -> Option<git2::Oid> {
+        let t2 = self.t2.borrow_mut();
+        t2.intersect_map.get(&from).cloned()
     }
 
     pub fn insert_overlay(&self, from: (git2::Oid, git2::Oid), to: git2::Oid) {

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -187,7 +187,7 @@ fn lazy_refs2(op: &Op) -> Vec<String> {
                     acc
                 })
         }
-        Op::Exclude(filter) | Op::Pin(filter) => lazy_refs(*filter),
+        Op::Exclude(filter) | Op::Select(filter) | Op::Pin(filter) => lazy_refs(*filter),
         Op::Chain(filters) => {
             let mut av = vec![];
             for filter in filters {
@@ -243,6 +243,7 @@ fn resolve_refs2(refs: &std::collections::HashMap<String, git2::Oid>, op: &Op) -
             Op::Compose(filters.iter().map(|f| resolve_refs(refs, *f)).collect())
         }
         Op::Exclude(filter) => Op::Exclude(resolve_refs(refs, *filter)),
+        Op::Select(filter) => Op::Select(resolve_refs(refs, *filter)),
         Op::Pin(filter) => Op::Pin(resolve_refs(refs, *filter)),
         Op::Chain(filters) => Op::Chain(filters.iter().map(|f| resolve_refs(refs, *f)).collect()),
         Op::Subtract(a, b) => Op::Subtract(resolve_refs(refs, *a), resolve_refs(refs, *b)),
@@ -1461,6 +1462,11 @@ pub fn apply<'a>(
                 bf,
             )?)?))
         }
+        Op::Select(b) => {
+            let bf = apply(transaction, *b, x.clone())?.tree().id();
+            let inside = tree::intersect(transaction, x.tree().id(), bf)?;
+            Ok(x.clone().with_tree(repo.find_tree(inside)?))
+        }
 
         Op::Paths => Ok(x
             .clone()
@@ -1972,6 +1978,7 @@ where
         )),
         Op::Subtract(a, b) => to_filter(Op::Subtract(legalize_pin(a, c), legalize_pin(b, c))),
         Op::Exclude(f) => to_filter(Op::Exclude(legalize_pin(f, c))),
+        Op::Select(f) => to_filter(Op::Select(legalize_pin(f, c))),
         Op::Meta(meta, f) => to_filter(Op::Meta(meta, legalize_pin(f, c))),
         Op::Pin(f) => c(f),
         _ => f,
@@ -1983,7 +1990,7 @@ fn needs_legalization(f: Filter) -> bool {
         Op::Stored(_) | Op::Starlark(_, _) => true,
         Op::Compose(filters) | Op::Chain(filters) => filters.iter().any(|&f| needs_legalization(f)),
         Op::Subtract(a, b) => needs_legalization(a) || needs_legalization(b),
-        Op::Exclude(f) | Op::Pin(f) | Op::TreeId(_, f) => needs_legalization(f),
+        Op::Exclude(f) | Op::Select(f) | Op::Pin(f) | Op::TreeId(_, f) => needs_legalization(f),
         Op::Meta(_, f) => needs_legalization(f),
         _ => false,
     }
@@ -2034,6 +2041,7 @@ fn legalize_stored(t: &cache::Transaction, f: Filter, tree: &git2::Tree) -> anyh
             legalize_stored(t, b, tree)?,
         )),
         Op::Exclude(f) => to_filter(Op::Exclude(legalize_stored(t, f, tree)?)),
+        Op::Select(f) => to_filter(Op::Select(legalize_stored(t, f, tree)?)),
         Op::Meta(meta, f) => to_filter(Op::Meta(meta, legalize_stored(t, f, tree)?)),
         Op::Pin(f) => to_filter(Op::Pin(legalize_stored(t, f, tree)?)),
         Op::Stored(path) => get_stored(t, tree, &path),

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -205,6 +205,57 @@ pub fn subtract(
     Ok(empty_id())
 }
 
+/// Intersect two trees by path: keep every entry of `input1` whose path also exists in `input2`,
+/// carrying `input1`'s content and mode. This is the exact complement of [`subtract`] over `input1`
+/// -- `subtract` drops the shared paths, `intersect` keeps them -- so
+/// `intersect(a, b) == subtract(a, subtract(a, b))`. Computing it directly (rather than via that
+/// double subtract) matters for performance: the double subtract's outer step iterates `a`'s
+/// complement, which is nearly all of `a`, whereas this iterates only `input2`. Selecting a small
+/// set of paths out of a large tree therefore costs O(input2) instead of O(input1).
+pub fn intersect(
+    transaction: &cache::Transaction,
+    input1: git2::Oid,
+    input2: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    let repo = transaction.repo();
+    // Identical (sub)trees intersect to themselves; an empty side leaves nothing to keep.
+    if input1 == input2 {
+        return Ok(input1);
+    }
+    if input1 == empty_id() || input2 == empty_id() {
+        return Ok(empty_id());
+    }
+
+    if let Some(cached) = transaction.get_intersect((input1, input2)) {
+        return Ok(cached);
+    }
+
+    let result = if let (Ok(tree1), Ok(tree2)) = (repo.find_tree(input1), repo.find_tree(input2)) {
+        rs_tracing::trace_scoped!("intersect fast");
+        let mut result_tree = empty(repo);
+        // Iterate the selector (`input2`) so cost tracks the selected set, not the full `input1`.
+        for entry in tree2.iter() {
+            let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
+            if let Some(e1) = tree1.get_name(name) {
+                let child = intersect(transaction, e1.id(), entry.id())?;
+                if child != empty_id() && child != git2::Oid::zero() {
+                    result_tree =
+                        replace_child(repo, Path::new(name), child, e1.filemode(), &result_tree)?;
+                }
+            }
+        }
+        result_tree.id()
+    } else {
+        // At least one side is a blob at this already-name-matched path, so the path exists in both;
+        // keep `input1`'s content, matching the path-based semantics of the tree case.
+        input1
+    };
+
+    transaction.insert_intersect((input1, input2), result);
+
+    Ok(result)
+}
+
 fn replace_child<'a>(
     repo: &'a git2::Repository,
     child: &Path,

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -76,6 +76,10 @@ impl Filter {
         self.chain(to_filter(Op::Exclude(other)))
     }
 
+    pub fn select(self, other: Filter) -> Filter {
+        self.chain(to_filter(Op::Select(other)))
+    }
+
     /// Chain a filter that pins the result of `other`, holding back entries that
     /// would otherwise change across revisions
     pub fn pin(self, other: Filter) -> Filter {

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -62,6 +62,10 @@ fn pretty2(op: &Op, indent: usize, compose: bool) -> String {
             Op::Compose(filters) => ff(&filters, "exclude", indent),
             b => format!(":exclude[{}]", pretty2(&b, indent, false)),
         },
+        Op::Select(bf) => match to_op(*bf) {
+            Op::Compose(filters) => ff(&filters, "select", indent),
+            b => format!(":select[{}]", pretty2(&b, indent, false)),
+        },
         Op::Pin(filter) => match to_op(*filter) {
             Op::Compose(filters) => ff(&filters, "pin", indent),
             b => format!(":pin[{}]", pretty2(&b, indent, false)),
@@ -169,6 +173,9 @@ pub(crate) fn spec2(op: &Op) -> String {
         }
         Op::Exclude(b) => {
             format!(":exclude[{}]", spec(*b))
+        }
+        Op::Select(b) => {
+            format!(":select[{}]", spec(*b))
         }
         Op::Pin(filter) => {
             format!(":pin[{}]", spec(*filter))

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -243,6 +243,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
                     match *cmd {
                         "pin" => Ok(to_filter(Op::Pin(to_filter(Op::Compose(g))))),
                         "exclude" => Ok(to_filter(Op::Exclude(to_filter(Op::Compose(g))))),
+                        "select" => Ok(to_filter(Op::Select(to_filter(Op::Compose(g))))),
                         "linear" => Ok(to_filter(Op::Compose(g)).linear()),
                         "invert" => {
                             let filter = to_filter(Op::Compose(g));

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -153,6 +153,7 @@ pub enum Op {
     Chain(Vec<Filter>),
     Subtract(Filter, Filter),
     Exclude(Filter),
+    Select(Filter),
     Pin(Filter),
 
     Downstack(LazyRef),

--- a/josh-filter/src/opt/flatten.rs
+++ b/josh-filter/src/opt/flatten.rs
@@ -94,6 +94,7 @@ fn flatten_impl(filter: Filter, full: bool) -> Filter {
         }
         Op::Subtract(a, b) => Op::Subtract(flatten_impl(*a, full), flatten_impl(*b, full)),
         Op::Exclude(b) => Op::Exclude(flatten_impl(*b, full)),
+        Op::Select(b) => Op::Select(flatten_impl(*b, full)),
         Op::Pin(b) => Op::Pin(flatten_impl(*b, full)),
         Op::Starlark(path, sub) => Op::Starlark(path.clone(), flatten_impl(*sub, full)),
         Op::TreeId(path, sub) => Op::TreeId(path.clone(), flatten_impl(*sub, full)),

--- a/josh-filter/src/opt/invert.rs
+++ b/josh-filter/src/opt/invert.rs
@@ -57,6 +57,7 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
                     .collect::<Result<Vec<_>, _>>()?,
             ),
             Op::Exclude(filter) => Op::Exclude(invert(*filter)?),
+            Op::Select(filter) => Op::Select(invert(*filter)?),
             _ => return Err(anyhow!("no invert {:?}", filter)),
         });
 

--- a/josh-filter/src/opt/simplify.rs
+++ b/josh-filter/src/opt/simplify.rs
@@ -67,6 +67,7 @@ pub fn simplify(filter: Filter) -> Filter {
         }
         Op::Subtract(a, b) => Op::Subtract(simplify(*a), simplify(*b)),
         Op::Exclude(b) => Op::Exclude(simplify(*b)),
+        Op::Select(b) => Op::Select(simplify(*b)),
         Op::Pin(b) => Op::Pin(simplify(*b)),
         Op::Starlark(path, sub) => Op::Starlark(path.clone(), simplify(*sub)),
         Op::TreeId(path, sub) => Op::TreeId(path.clone(), simplify(*sub)),

--- a/josh-filter/src/opt/step.rs
+++ b/josh-filter/src/opt/step.rs
@@ -176,6 +176,9 @@ pub(super) fn step(filter: Filter) -> Filter {
         Op::Exclude(b) if *b == to_filter(Op::Nop) => Op::Empty,
         Op::Exclude(b) | Op::Pin(b) if *b == to_filter(Op::Empty) => Op::Nop,
         Op::Exclude(b) => Op::Exclude(step(*b)),
+        Op::Select(b) if *b == to_filter(Op::Empty) => Op::Empty,
+        Op::Select(b) if *b == to_filter(Op::Nop) => Op::Nop,
+        Op::Select(b) => Op::Select(step(*b)),
         Op::Pin(b) => Op::Pin(step(*b)),
         Op::Starlark(path, sub) => Op::Starlark(path.clone(), step(*sub)),
         Op::TreeId(path, sub) => Op::TreeId(path.clone(), step(*sub)),
@@ -189,6 +192,12 @@ pub(super) fn step(filter: Filter) -> Filter {
                 (Op::Message(..), Op::Message(..)) => Op::Empty,
                 (_, Op::Nop) => Op::Empty,
                 (a, Op::Empty) => a,
+                // `Select(F)` and `Exclude(F)` partition the input tree by path: one keeps exactly
+                // the paths `F` selects, the other keeps exactly the rest. Subtracting the excluded
+                // (complement) side from the selected side therefore removes nothing, leaving just
+                // `Select(F)` -- and collapsing the full `Op::Subtract` machinery (four sub-applies)
+                // down to a single `Select`.
+                (Op::Select(sa), Op::Exclude(sb)) if sa == sb => Op::Select(sa),
                 (Op::Chain(a_filters), Op::Chain(b_filters))
                     if !a_filters.is_empty()
                         && !b_filters.is_empty()

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -52,6 +52,7 @@ fn child_filters(op: &Op) -> Vec<Filter> {
     match op {
         Op::Meta(_, f)
         | Op::Exclude(f)
+        | Op::Select(f)
         | Op::Pin(f)
         | Op::Starlark(_, f)
         | Op::TreeId(_, f)
@@ -365,6 +366,10 @@ impl InMemoryBuilder {
             Op::Exclude(b) => {
                 let params_tree = self.build_filter_params(&[*b])?;
                 push_tree_entries(&mut entries, [("exclude", params_tree)]);
+            }
+            Op::Select(b) => {
+                let params_tree = self.build_filter_params(&[*b])?;
+                push_tree_entries(&mut entries, [("select", params_tree)]);
             }
             Op::Pin(b) => {
                 let params_tree = self.build_filter_params(&[*b])?;
@@ -939,6 +944,17 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
                 Ok(Op::Exclude(to_filter(filter)))
             } else {
                 Err(anyhow!("exclude: expected 1 entry"))
+            }
+        }
+        "select" => {
+            let select_tree = repo.find_tree(entry.id())?;
+            if select_tree.len() == 1 {
+                let filter_tree =
+                    repo.find_tree(select_tree.get_name("0").context("select: missing 0")?.id())?;
+                let filter = from_tree2(repo, filter_tree.id())?;
+                Ok(Op::Select(to_filter(filter)))
+            } else {
+                Err(anyhow!("select: expected 1 entry"))
             }
         }
         "pin" => {

--- a/tests/filter/select.t
+++ b/tests/filter/select.t
@@ -1,0 +1,60 @@
+  $ export TESTTMP=${PWD}
+
+  $ cd ${TESTTMP}
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1
+  $ echo contents1 > sub1/file1
+  $ echo contents3 > sub1/file3
+  $ git add sub1
+  $ git commit -m "add sub1" 1> /dev/null
+
+  $ mkdir sub2
+  $ echo contents2 > sub2/file2
+  $ git add sub2
+  $ git commit -m "add file2" 1> /dev/null
+
+select keeps only the paths matched by the inner filter (the complement of exclude):
+
+  $ josh-filter -s :select[::sub2/] master --update refs/heads/selected
+  02bc56535aa5b74aa2b6de2a1bb66fbc465f8ca2
+  [2] :select[::sub2/]
+  [2] reachable_roots
+  [2] sequence_number
+  $ git checkout selected 1> /dev/null
+  Switched to branch 'selected'
+  $ tree
+  .
+  `-- sub2
+      `-- file2
+  
+  2 directories, 1 file
+
+  $ cat sub2/file2
+  contents2
+
+selecting into a subtree keeps only the matched file, dropping siblings and other trees:
+
+  $ git checkout master 1> /dev/null
+  Switched to branch 'master'
+  $ josh-filter :select[::sub1/file1] master --update refs/heads/selected_file
+  179c05ebefb1e481a31334cdf6dc552e28e28151
+  $ git checkout selected_file 1> /dev/null
+  Switched to branch 'selected_file'
+  $ tree
+  .
+  `-- sub1
+      `-- file1
+  
+  2 directories, 1 file
+
+
+:select[::sub2/] and :exclude[::sub1/] produce the same tree:
+
+  $ git checkout master 1> /dev/null
+  Switched to branch 'master'
+  $ josh-filter :exclude[::sub1/] master --update refs/heads/excluded
+  02bc56535aa5b74aa2b6de2a1bb66fbc465f8ca2
+  $ test $(git rev-parse selected) = $(git rev-parse excluded) && echo SAME
+  SAME


### PR DESCRIPTION
Add the Select filter as the complement of Exclude

`:select[F]` applies the inner filter F to the input tree and keeps only
the paths present in F's result, dropping everything else. It is the exact
set-complement of `:exclude[F]`, which removes those same paths.

The apply logic uses a dedicated `tree::intersect` helper (with its own
transaction cache) that keeps the paths of `X` present in `F(X)` by
iterating only `F(X)`. Computing the intersection directly this way --
rather than via a double subtraction `X - (X - F(X))` -- avoids the outer
subtract's walk over `X`'s near-whole complement, so selecting a small set
of paths out of a large tree costs O(F(X)) instead of O(X).

Because `Select(F)` and `Exclude(F)` are exact complements, the optimizer
also simplifies `Subtract(Select(F), Exclude(F))` to `Select(F)`.

Every other site is a direct mirror of the existing `Op::Exclude`
handling: parser, pretty-printer, spec, persistence, the optimization
passes, and the ref/legalization recursion groupings.

Change: add-select-filter
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>