### PR TITLE
Support inserting a tree at the root with `:$.=<oid>`

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1383,11 +1383,13 @@ pub fn apply<'a>(
             )?))
         }
         Op::Insert(dest_path, content) => {
-            let (oid, mode) = match content {
-                InsertContent::Inline(s) => (repo.blob(s.as_bytes())?, git2::FileMode::Blob.into()),
+            let (oid, mode, is_tree) = match content {
+                InsertContent::Inline(s) => {
+                    (repo.blob(s.as_bytes())?, git2::FileMode::Blob.into(), false)
+                }
                 InsertContent::Oid(oid) => match repo.find_object(*oid, None)?.kind() {
-                    Some(git2::ObjectType::Blob) => (*oid, git2::FileMode::Blob.into()),
-                    Some(git2::ObjectType::Tree) => (*oid, git2::FileMode::Tree.into()),
+                    Some(git2::ObjectType::Blob) => (*oid, git2::FileMode::Blob.into(), false),
+                    Some(git2::ObjectType::Tree) => (*oid, git2::FileMode::Tree.into(), true),
                     _ => {
                         return Err(anyhow::anyhow!(
                             "insert: {} is neither a blob nor a tree",
@@ -1396,6 +1398,17 @@ pub fn apply<'a>(
                     }
                 },
             };
+            // `:$.=<oid>` replaces the whole output tree with the referenced object. Only a
+            // tree is valid at the root; a blob there is rejected (it would otherwise be
+            // silently dropped, since git trees cannot have a blob at their root).
+            if dest_path.as_path() == std::path::Path::new(".") {
+                if is_tree {
+                    return Ok(x.clone().with_tree(repo.find_tree(oid)?));
+                }
+                return Err(anyhow::anyhow!(
+                    "insert: `:$.=<oid>` requires a tree; a blob cannot be placed at the tree root"
+                ));
+            }
             Ok(x.clone().with_tree(tree::insert(
                 repo,
                 &tree::empty(repo),

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -175,7 +175,8 @@ impl Filter {
     /// Chain a filter that inserts an existing object (referenced by its OID) at the specified
     /// path. Syntax: `:$path=<sha>`. The object may be a blob or a tree; the kind is resolved
     /// from the repository at apply time. Useful for large blobs or whole subtrees that should
-    /// not be inlined as a string.
+    /// not be inlined as a string. The special path `.` replaces the whole tree with the
+    /// referenced object and therefore requires a tree OID (a blob at the root is rejected).
     pub fn insert_oid(
         self,
         path: impl Into<std::path::PathBuf>,

--- a/tests/filter/insert.t
+++ b/tests/filter/insert.t
@@ -21,6 +21,10 @@ Roundtrip: blob specified by sha renders as bare hex
   $ josh-filter -p ':$added.txt=e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
   :$added.txt=e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 
+Roundtrip: root insert renders as :$.=<hex>
+  $ josh-filter -p ':$.=e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
+  :$.=e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+
 A multi-component path is split into a leaf blob followed by a prefix
   $ josh-filter -p ':$a/b/c.txt="hello"'
   a/b = :$c.txt="hello"
@@ -157,3 +161,17 @@ Apply: a tree referenced by sha is inserted as a subtree at the destination path
   $ josh-filter -s ":\$sub=$TREE" master --update refs/josh/filter/tree 1> /dev/null
   $ git show josh/filter/tree:sub/sub1/file1
   contents1
+
+Apply: a tree referenced by sha at `.` replaces the whole output tree
+  $ TREE=$(git rev-parse 'HEAD^{tree}')
+  $ josh-filter -s ":\$.=$TREE" master --update refs/josh/filter/root 1> /dev/null
+  $ git show josh/filter/root:sub1/file1
+  contents1
+
+Apply: a blob referenced by sha at `.` is rejected (a blob cannot sit at the tree root)
+  $ OID=$(printf 'big content' | git hash-object -w --stdin)
+  $ josh-filter -s ":\$.=$OID" master --update refs/josh/filter/rootblob 2>&1 >/dev/null; echo "exit:$?"
+  *requires a tree* (glob)
+  exit:1
+  $ git rev-parse --verify -q refs/josh/filter/rootblob > /dev/null; echo "ref:$?"
+  ref:1


### PR DESCRIPTION
Support inserting a tree at the root with `:$.=<oid>`

The Insert filter already resolved a bare OID to a blob or a tree and
inserted it at subpaths, but the root path `.` was broken: `tree::insert`
tried to create a git tree entry named `.`, which `TreeBuilder` rejects.
The error was swallowed by `.ok()`, so `:$.=<oid>` silently produced an
empty tree.

Special-case the root path in the `Op::Insert` apply arm: a tree OID
replaces the whole output tree with the referenced tree, and a blob
(inline or OID) is now an explicit error, since a git tree cannot hold a
blob at its root.

Change: insert-tree-at-root
Assisted-By: Claude Opus 4.8 (1M context)