### PR TITLE
Build tree results with a single tree builder

### DIFF
--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -15,7 +15,7 @@ pub fn pathstree<'a>(
     }
 
     let tree = repo.find_tree(input)?;
-    let mut result = empty(repo);
+    let mut builder = repo.treebuilder(None)?;
 
     for entry in tree.iter() {
         let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
@@ -31,13 +31,9 @@ pub fn pathstree<'a>(
             } else {
                 path_string.to_string()
             };
-            result = replace_child(
-                repo,
-                Path::new(name),
-                repo.blob(file_contents.as_bytes())?,
-                0o0100644,
-                &result,
-            )?;
+            builder
+                .insert(name, repo.blob(file_contents.as_bytes())?, 0o0100644)
+                .ok();
         }
 
         if entry.kind() == Some(git2::ObjectType::Tree) {
@@ -49,10 +45,11 @@ pub fn pathstree<'a>(
             .id();
 
             if s != empty_id() {
-                result = replace_child(repo, Path::new(name), s, 0o0040000, &result)?;
+                builder.insert(name, s, 0o0040000).ok();
             }
         }
     }
+    let result = repo.find_tree(builder.write()?)?;
     transaction.insert_paths((input, root.to_string()), result.id());
     Ok(result)
 }
@@ -66,7 +63,7 @@ pub fn regex_replace<'a>(
     let repo = transaction.repo();
 
     let tree = repo.find_tree(input)?;
-    let mut result = tree::empty(repo);
+    let mut builder = repo.treebuilder(None)?;
 
     for entry in tree.iter() {
         let name = entry.name().ok_or(anyhow!("no name"))?;
@@ -74,24 +71,20 @@ pub fn regex_replace<'a>(
             let file_contents = get_blob(repo, &tree, std::path::Path::new(&name));
             let replaced = regex.replacen(&file_contents, 0, replacement);
 
-            result = replace_child(
-                repo,
-                std::path::Path::new(name),
-                repo.blob(replaced.as_bytes())?,
-                entry.filemode(),
-                &result,
-            )?;
+            builder
+                .insert(name, repo.blob(replaced.as_bytes())?, entry.filemode())
+                .ok();
         }
 
         if entry.kind() == Some(git2::ObjectType::Tree) {
             let s = regex_replace(entry.id(), regex, replacement, transaction)?.id();
 
             if s != tree::empty_id() {
-                result = replace_child(repo, std::path::Path::new(name), s, 0o0040000, &result)?;
+                builder.insert(name, s, 0o0040000).ok();
             }
         }
     }
-    Ok(result)
+    Ok(repo.find_tree(builder.write()?)?)
 }
 
 pub fn remove_pred<'a>(
@@ -108,20 +101,14 @@ pub fn remove_pred<'a>(
     rs_tracing::trace_scoped!("remove_pred X", "root": root);
 
     let tree = repo.find_tree(input)?;
-    let mut result = empty(repo);
+    let mut builder = repo.treebuilder(None)?;
 
     for entry in tree.iter() {
         let name = entry.name().ok_or_else(|| anyhow!("INVALID_FILENAME"))?;
         let path = std::path::PathBuf::from(root).join(name);
 
         if entry.kind() == Some(git2::ObjectType::Blob) && pred(&path, true) {
-            result = replace_child(
-                repo,
-                Path::new(entry.name().ok_or_else(|| anyhow!("no name"))?),
-                entry.id(),
-                entry.filemode(),
-                &result,
-            )?;
+            builder.insert(name, entry.id(), entry.filemode()).ok();
         }
 
         if entry.kind() == Some(git2::ObjectType::Tree) {
@@ -130,12 +117,7 @@ pub fn remove_pred<'a>(
             } else {
                 remove_pred(
                     transaction,
-                    &format!(
-                        "{}{}{}",
-                        root,
-                        if root.is_empty() { "" } else { "/" },
-                        entry.name().ok_or_else(|| anyhow!("no name"))?
-                    ),
+                    &format!("{}{}{}", root, if root.is_empty() { "" } else { "/" }, name),
                     entry.id(),
                     &pred,
                     key,
@@ -144,17 +126,12 @@ pub fn remove_pred<'a>(
             };
 
             if s != empty_id() {
-                result = replace_child(
-                    repo,
-                    Path::new(entry.name().ok_or_else(|| anyhow!("no name"))?),
-                    s,
-                    0o0040000,
-                    &result,
-                )?;
+                builder.insert(name, s, 0o0040000).ok();
             }
         }
     }
 
+    let result = repo.find_tree(builder.write()?)?;
     transaction.insert_glob((input, key), result.id());
     Ok(result)
 }
@@ -181,23 +158,26 @@ pub fn subtract(
             return Ok(input1);
         }
         rs_tracing::trace_scoped!("subtract fast");
-        let mut result_tree = tree1.clone();
+        // Start from `tree1` and drop or replace each path that also appears in `tree2`.
+        let mut builder = repo.treebuilder(Some(&tree1))?;
 
         for entry in tree2.iter() {
-            if let Some(e) = tree1.get_name(entry.name().ok_or_else(|| anyhow!("no name"))?) {
-                result_tree = replace_child(
-                    repo,
-                    Path::new(entry.name().ok_or_else(|| anyhow!("no name"))?),
-                    subtract(transaction, e.id(), entry.id())?,
-                    e.filemode(),
-                    &result_tree,
-                )?;
+            let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
+            if let Some(e) = tree1.get_name(name) {
+                let sub = subtract(transaction, e.id(), entry.id())?;
+                if sub == empty_id() || sub == git2::Oid::zero() {
+                    builder.remove(name).ok();
+                } else {
+                    builder.insert(name, sub, e.filemode()).ok();
+                }
             }
         }
 
-        transaction.insert_subtract((input1, input2), result_tree.id());
+        let result = builder.write()?;
 
-        return Ok(result_tree.id());
+        transaction.insert_subtract((input1, input2), result);
+
+        return Ok(result);
     }
 
     transaction.insert_subtract((input1, input2), empty_id());
@@ -232,19 +212,19 @@ pub fn intersect(
 
     let result = if let (Ok(tree1), Ok(tree2)) = (repo.find_tree(input1), repo.find_tree(input2)) {
         rs_tracing::trace_scoped!("intersect fast");
-        let mut result_tree = empty(repo);
-        // Iterate the selector (`input2`) so cost tracks the selected set, not the full `input1`.
+        // Iterate the selector (`input2`), keeping each of its paths that also exists in `tree1`
+        // with `tree1`'s content; cost tracks the size of the selected set.
+        let mut builder = repo.treebuilder(None)?;
         for entry in tree2.iter() {
             let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
             if let Some(e1) = tree1.get_name(name) {
                 let child = intersect(transaction, e1.id(), entry.id())?;
                 if child != empty_id() && child != git2::Oid::zero() {
-                    result_tree =
-                        replace_child(repo, Path::new(name), child, e1.filemode(), &result_tree)?;
+                    builder.insert(name, child, e1.filemode()).ok();
                 }
             }
         }
-        result_tree.id()
+        builder.write()?
     } else {
         // At least one side is a blob at this already-name-matched path, so the path exists in both;
         // keep `input1`'s content, matching the path-based semantics of the tree case.
@@ -509,7 +489,9 @@ pub fn trigram_index<'a>(
 
     let mut files = vec![vec![]; 8];
 
-    let mut result = empty(repo);
+    // The subtree children go into this builder (written once after the loop); the per-level
+    // OWN/SUB/BLOBS index blobs are added to the resulting tree afterward.
+    let mut builder = repo.treebuilder(None)?;
 
     /* 'entry: */
     for entry in tree.iter() {
@@ -613,10 +595,12 @@ pub fn trigram_index<'a>(
             }
 
             if s.id() != empty_id() {
-                result = replace_child(repo, Path::new(name), s.id(), 0o0040000, &result)?;
+                builder.insert(name, s.id(), 0o0040000).ok();
             }
         }
     }
+
+    let mut result = repo.find_tree(builder.write()?)?;
 
     for a in 0..arrs_sub.len() {
         if arrs_own[a].iter().any(|x| *x != 0) {

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -462,8 +462,8 @@
       |       |-- pack-1a631b5bbd2b05937baaaa4ddeaa4c1b500cb2a7.pack
       |       |-- pack-4ee9e150f10f6cd4ae11c19ac760d7e412da64e6.idx
       |       |-- pack-4ee9e150f10f6cd4ae11c19ac760d7e412da64e6.pack
-      |       |-- pack-66f14bc6d6708cd5fbe113e5b5a7355273ea8ec2.idx
-      |       |-- pack-66f14bc6d6708cd5fbe113e5b5a7355273ea8ec2.pack
+      |       |-- pack-6de58fb128833690095d24aea26698bddf4b092e.idx
+      |       |-- pack-6de58fb128833690095d24aea26698bddf4b092e.pack
       |       |-- pack-e429893378822d8bd667854bb44a9481094ddf8e.idx
       |       `-- pack-e429893378822d8bd667854bb44a9481094ddf8e.pack
       `-- refs

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -326,12 +326,12 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-4378f3c9eee002d89f697838daffcaa2c8886b64.idx
-      |       |-- pack-4378f3c9eee002d89f697838daffcaa2c8886b64.pack
       |       |-- pack-5d11ca698a761cfb0102d4d44599349077fbafb5.idx
       |       |-- pack-5d11ca698a761cfb0102d4d44599349077fbafb5.pack
       |       |-- pack-cf634696f53f4ca2e6072988b224113252440145.idx
-      |       `-- pack-cf634696f53f4ca2e6072988b224113252440145.pack
+      |       |-- pack-cf634696f53f4ca2e6072988b224113252440145.pack
+      |       |-- pack-e5529b295aa82690ce40a2abeefb9ae9bdfe2288.idx
+      |       `-- pack-e5529b295aa82690ce40a2abeefb9ae9bdfe2288.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -591,8 +591,6 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
       |   |-- info
       |   `-- pack
-      |       |-- pack-035feff92861c255244681ddc84b90e321ec6b35.idx
-      |       |-- pack-035feff92861c255244681ddc84b90e321ec6b35.pack
       |       |-- pack-0a5087aa14c50693a3d73b25e94466c4b21c7d30.idx
       |       |-- pack-0a5087aa14c50693a3d73b25e94466c4b21c7d30.pack
       |       |-- pack-132b596594e7cf7bc3af1b2c7a24fdf62d759469.idx
@@ -601,12 +599,14 @@ Note that ws/d/ is now present in the ws
       |       |-- pack-369060c82a79aba08c50857e8818b02e9fb2578f.pack
       |       |-- pack-56434dd1073324f0c25f881a1c87eff63af5c27e.idx
       |       |-- pack-56434dd1073324f0c25f881a1c87eff63af5c27e.pack
-      |       |-- pack-7014dc333fab5e96e9d4838c01b668dbd434774b.idx
-      |       |-- pack-7014dc333fab5e96e9d4838c01b668dbd434774b.pack
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
+      |       |-- pack-78f8060245d0cbe6e14e9baffbd43827973328cd.idx
+      |       |-- pack-78f8060245d0cbe6e14e9baffbd43827973328cd.pack
       |       |-- pack-ac69f084a822e26e92fcd950197630c5d06a5ddf.idx
-      |       `-- pack-ac69f084a822e26e92fcd950197630c5d06a5ddf.pack
+      |       |-- pack-ac69f084a822e26e92fcd950197630c5d06a5ddf.pack
+      |       |-- pack-f856631ca92126724726c23f44d834967dbcc5de.idx
+      |       `-- pack-f856631ca92126724726c23f44d834967dbcc5de.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -313,12 +313,12 @@
       |   `-- pack
       |       |-- pack-020a9c25afd039b7908829ed180c3c5b5c2aeb43.idx
       |       |-- pack-020a9c25afd039b7908829ed180c3c5b5c2aeb43.pack
-      |       |-- pack-206ba4dfaf5b6561e1fa899650b6e690c0f674f7.idx
-      |       |-- pack-206ba4dfaf5b6561e1fa899650b6e690c0f674f7.pack
       |       |-- pack-5e1711c1c8fd3c58e9ecf87c44dda797a57b4d09.idx
       |       |-- pack-5e1711c1c8fd3c58e9ecf87c44dda797a57b4d09.pack
       |       |-- pack-810042fcc342c573b7d491be291eac8697326115.idx
       |       |-- pack-810042fcc342c573b7d491be291eac8697326115.pack
+      |       |-- pack-8f2ab97436b3ff8e62f3dce0c1093ce4832bca89.idx
+      |       |-- pack-8f2ab97436b3ff8e62f3dce0c1093ce4832bca89.pack
       |       |-- pack-b531b8e915c7145f1ef6b21dba15bd66a73cdc32.idx
       |       |-- pack-b531b8e915c7145f1ef6b21dba15bd66a73cdc32.pack
       |       |-- pack-f3754114f5e623d4b9710175aed17f8bd2ce1f30.idx

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -380,6 +380,8 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
+      |       |-- pack-61cee1ce849190d88cdfb51f8fd8aea0bcfd8e63.idx
+      |       |-- pack-61cee1ce849190d88cdfb51f8fd8aea0bcfd8e63.pack
       |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.idx
       |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.pack
       |       |-- pack-7aa46131845bcb33ada5dd9264a54f6bda553621.idx
@@ -387,9 +389,7 @@
       |       |-- pack-969240cacd518199eb056a306b470700114f2177.idx
       |       |-- pack-969240cacd518199eb056a306b470700114f2177.pack
       |       |-- pack-b0339b769beb47ea5c28c0a4f4379ab2d18a4b29.idx
-      |       |-- pack-b0339b769beb47ea5c28c0a4f4379ab2d18a4b29.pack
-      |       |-- pack-d61f3c8dbb59af6cc0c1604d99c262527ccad92e.idx
-      |       `-- pack-d61f3c8dbb59af6cc0c1604d99c262527ccad92e.pack
+      |       `-- pack-b0339b769beb47ea5c28c0a4f4379ab2d18a4b29.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -597,18 +597,18 @@ Note that ws/d/ is now present in the ws
       |   `-- pack
       |       |-- pack-133a4127e8d4c9bdc124e21786a688c4e8f778c9.idx
       |       |-- pack-133a4127e8d4c9bdc124e21786a688c4e8f778c9.pack
-      |       |-- pack-14805803f920d9666668bc656d8f0515ee1bd064.idx
-      |       |-- pack-14805803f920d9666668bc656d8f0515ee1bd064.pack
+      |       |-- pack-59055e54f993a526fd1b0200427456390db5dd2d.idx
+      |       |-- pack-59055e54f993a526fd1b0200427456390db5dd2d.pack
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
       |       |-- pack-9344ad8c1e2b9aca23229bfb5dfbc1a19f64e2dc.idx
       |       |-- pack-9344ad8c1e2b9aca23229bfb5dfbc1a19f64e2dc.pack
       |       |-- pack-af3e3339c7bd303ace0b6210e7f1c13374606269.idx
       |       |-- pack-af3e3339c7bd303ace0b6210e7f1c13374606269.pack
-      |       |-- pack-bbd5e1b2aa5ccd4e9879b7d452262fea964c8044.idx
-      |       |-- pack-bbd5e1b2aa5ccd4e9879b7d452262fea964c8044.pack
       |       |-- pack-dc4dca83cf9851930e174c49e92f2de588f25e71.idx
       |       |-- pack-dc4dca83cf9851930e174c49e92f2de588f25e71.pack
+      |       |-- pack-e27bba3e1cb78d1a86c190a38d3a40070fef9b53.idx
+      |       |-- pack-e27bba3e1cb78d1a86c190a38d3a40070fef9b53.pack
       |       |-- pack-fb51f94a07756db0b90e50e60315402cd82f9ac3.idx
       |       `-- pack-fb51f94a07756db0b90e50e60315402cd82f9ac3.pack
       `-- refs

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -361,8 +361,8 @@
       |   `-- pack
       |       |-- pack-89f5d1c01530839eab589ceec8565f11ff4679a5.idx
       |       |-- pack-89f5d1c01530839eab589ceec8565f11ff4679a5.pack
-      |       |-- pack-a3e156efacbcda80b8277b4b01596dd8366d6c94.idx
-      |       |-- pack-a3e156efacbcda80b8277b4b01596dd8366d6c94.pack
+      |       |-- pack-a75d3ca2392eb679cf1dc24a3496576475f5e849.idx
+      |       |-- pack-a75d3ca2392eb679cf1dc24a3496576475f5e849.pack
       |       |-- pack-c455f6d9504526b7c14867a795a5b2e27610956a.idx
       |       `-- pack-c455f6d9504526b7c14867a795a5b2e27610956a.pack
       `-- refs

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -450,14 +450,14 @@ Note that ws/d/ is now present in the ws
       |   `-- pack
       |       |-- pack-003dec79becceac35fcf4dc6da69067da9076b43.idx
       |       |-- pack-003dec79becceac35fcf4dc6da69067da9076b43.pack
+      |       |-- pack-1ea36f2d466e060c9ea31389ae1b3cd2ef9ee1a0.idx
+      |       |-- pack-1ea36f2d466e060c9ea31389ae1b3cd2ef9ee1a0.pack
+      |       |-- pack-3bb8600225cc4139a131c5413ee7275d07ccd58a.idx
+      |       |-- pack-3bb8600225cc4139a131c5413ee7275d07ccd58a.pack
       |       |-- pack-5f43de7285cc69f6f7f779f1c22bbcc404fea509.idx
       |       |-- pack-5f43de7285cc69f6f7f779f1c22bbcc404fea509.pack
       |       |-- pack-78ce499d43b7df7a0b507140d5134ff90a058eeb.idx
-      |       |-- pack-78ce499d43b7df7a0b507140d5134ff90a058eeb.pack
-      |       |-- pack-84f244e975f0cef0625d4b0763f10884293e2c92.idx
-      |       |-- pack-84f244e975f0cef0625d4b0763f10884293e2c92.pack
-      |       |-- pack-e876a75ec76e589fce94f48879886deedaa62f4c.idx
-      |       `-- pack-e876a75ec76e589fce94f48879886deedaa62f4c.pack
+      |       `-- pack-78ce499d43b7df7a0b507140d5134ff90a058eeb.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -350,12 +350,12 @@
       |   `-- pack
       |       |-- pack-4ee5410a0d07448774a9d777901482c58c903f84.idx
       |       |-- pack-4ee5410a0d07448774a9d777901482c58c903f84.pack
+      |       |-- pack-61cee1ce849190d88cdfb51f8fd8aea0bcfd8e63.idx
+      |       |-- pack-61cee1ce849190d88cdfb51f8fd8aea0bcfd8e63.pack
       |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.idx
       |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.pack
       |       |-- pack-969240cacd518199eb056a306b470700114f2177.idx
-      |       |-- pack-969240cacd518199eb056a306b470700114f2177.pack
-      |       |-- pack-d61f3c8dbb59af6cc0c1604d99c262527ccad92e.idx
-      |       `-- pack-d61f3c8dbb59af6cc0c1604d99c262527ccad92e.pack
+      |       `-- pack-969240cacd518199eb056a306b470700114f2177.pack
       `-- refs
           |-- heads
           |-- namespaces


### PR DESCRIPTION
Build tree results with a single tree builder

`subtract`, `intersect`, `pathstree`, `regex_replace`, `remove_pred`, and
`trigram_index` reconstructed their result one entry at a time, re-seeding
and writing a `TreeBuilder` on every entry -- quadratic in the number of
entries and dominant on wide trees (e.g. a large `:pin` region rebuilt per
commit).

Each now collects its children into a single builder and writes the tree
once, the shape `overlay` already used. For `trigram_index` the builder
holds the subtree children and the fixed per-level index blobs are added to
the resulting tree afterward.

Output trees are byte-identical. The throwaway intermediate trees the old
per-entry path used to write are no longer created; that leaner object
store shifts the packfile set snapshotted by a handful of workspace and
marker proxy tests, whose expected listings are updated to match.

Change: single-builder-tree-ops
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>