### PR TITLE
Skip reading the roots blob when only the sequence number is needed

### DIFF
--- a/josh-core/src/cache/history_graph.rs
+++ b/josh-core/src/cache/history_graph.rs
@@ -25,9 +25,14 @@ pub struct HistoryGraphInfo {
     pub reachable_roots: Vec<git2::Oid>,
 }
 
-/// Backwards-compatible thin wrapper around [`collect_history_graph_info`].
+/// Returns just the sequence number for `input`.
+///
+/// Unlike [`collect_history_graph_info`], this never reads the roots blob: the
+/// sequence number is available directly from the cached hint, so callers that
+/// only compare sequence numbers avoid a per-commit `find_blob` + parse that
+/// would otherwise be discarded.
 pub fn compute_sequence_number(transaction: &Transaction, input: git2::Oid) -> anyhow::Result<u64> {
-    Ok(collect_history_graph_info(transaction, input)?.sequence_number)
+    Ok(ensure_hint_cached(transaction, input)?.0)
 }
 
 /// Computes sequence number and reachable roots for `input` in a single walk,


### PR DESCRIPTION
Skip reading the roots blob when only the sequence number is needed

`compute_sequence_number` routed through `collect_history_graph_info`, which
always calls `read_roots_blob` (a `find_blob` plus parse) and returns the
reachable-roots set alongside the sequence number. The sequence-number callers
discard that set, so in a long history the blob was read and parsed once per
commit for nothing -- visible as a hotspot when filtering deep histories.

The cached hint already carries the sequence number directly, so return it
from `ensure_hint_cached` without touching the roots blob, leaving
`collect_history_graph_info` as the path for callers that need the roots set.
The read scales with input commits, so the win grows as input outruns output:
~9% on the `deephistory_subdir` bench (10k commits: 217 ms -> 196 ms) and ~15%
on `deephistory_subdir_sparse` (input:output ~55:1).

Change: seq-number-skip-roots-blob
Assisted-By: Claude Opus 4.8