### PR TITLE
Propagate cache backend errors instead of panicking

### DIFF
--- a/josh-core/src/cache/history_graph.rs
+++ b/josh-core/src/cache/history_graph.rs
@@ -106,7 +106,7 @@ fn ensure_hint_cached(
     transaction: &Transaction,
     input: git2::Oid,
 ) -> anyhow::Result<(u64, git2::Oid)> {
-    if let Some(hint) = try_read_cached_hint(transaction, input) {
+    if let Some(hint) = try_read_cached_hint(transaction, input)? {
         return Ok(hint);
     }
 
@@ -121,11 +121,11 @@ fn ensure_hint_cached(
     let parents_hint: Option<Vec<(u64, git2::Oid)>> = parent_ids
         .iter()
         .map(|p| try_read_cached_hint(transaction, *p))
-        .collect();
+        .collect::<anyhow::Result<_>>()?;
 
     if let Some(parents_hint) = parents_hint {
         let hint = derive_from_parents(transaction.repo(), input, &parents_hint)?;
-        store_hint(transaction, input, hint);
+        store_hint(transaction, input, hint)?;
         return Ok(hint);
     }
 
@@ -137,9 +137,16 @@ fn ensure_hint_cached(
     // Hide ancestors that already have *both* pieces cached. Hiding on seq#
     // alone would skip commits with cached seq# but missing roots, leaving
     // their roots unpopulated.
+    // The callback cannot propagate errors, so treat a failed lookup as "not
+    // cached": the walk then visits the commit and the fallible body reports
+    // the same error properly.
     let mut hide = |id| {
-        transaction.known(crate::filter::sequence_number(), id)
-            && transaction.known(crate::filter::reachable_roots(), id)
+        transaction
+            .known(crate::filter::sequence_number(), id)
+            .unwrap_or(false)
+            && transaction
+                .known(crate::filter::reachable_roots(), id)
+                .unwrap_or(false)
     };
     let walk = walk.with_hide_callback(&mut hide)?;
 
@@ -149,15 +156,15 @@ fn ensure_hint_cached(
         let parents_hint: Vec<(u64, git2::Oid)> = c_commit
             .parent_ids()
             .map(|p| {
-                try_read_cached_hint(transaction, p)
+                try_read_cached_hint(transaction, p)?
                     .ok_or_else(|| anyhow!("parent {} hint missing during walk for {}", p, oid))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
         let hint = derive_from_parents(transaction.repo(), oid, &parents_hint)?;
-        store_hint(transaction, oid, hint);
+        store_hint(transaction, oid, hint)?;
     }
 
-    try_read_cached_hint(transaction, input)
+    try_read_cached_hint(transaction, input)?
         .ok_or_else(|| anyhow!("missing graph info after walk for {}", input))
 }
 
@@ -197,21 +204,33 @@ fn derive_from_parents(
     Ok((seq, roots_blob))
 }
 
-fn try_read_cached_hint(transaction: &Transaction, input: git2::Oid) -> Option<(u64, git2::Oid)> {
-    let seq = transaction.get(crate::filter::sequence_number(), input)?;
-    let roots_blob = transaction.get(crate::filter::reachable_roots(), input)?;
-    Some((u64_from_oid(seq), roots_blob))
+fn try_read_cached_hint(
+    transaction: &Transaction,
+    input: git2::Oid,
+) -> anyhow::Result<Option<(u64, git2::Oid)>> {
+    let Some(seq) = transaction.get(crate::filter::sequence_number(), input)? else {
+        return Ok(None);
+    };
+    let Some(roots_blob) = transaction.get(crate::filter::reachable_roots(), input)? else {
+        return Ok(None);
+    };
+    Ok(Some((u64_from_oid(seq), roots_blob)))
 }
 
-fn store_hint(transaction: &Transaction, input: git2::Oid, hint: (u64, git2::Oid)) {
+fn store_hint(
+    transaction: &Transaction,
+    input: git2::Oid,
+    hint: (u64, git2::Oid),
+) -> anyhow::Result<()> {
     let (seq, roots_blob) = hint;
     transaction.insert(
         crate::filter::sequence_number(),
         input,
         oid_from_u64(seq),
         true,
-    );
-    transaction.insert(crate::filter::reachable_roots(), input, roots_blob, true);
+    )?;
+    transaction.insert(crate::filter::reachable_roots(), input, roots_blob, true)?;
+    Ok(())
 }
 
 fn write_roots_blob(repo: &git2::Repository, roots: &[git2::Oid]) -> anyhow::Result<git2::Oid> {

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -466,11 +466,11 @@ impl Transaction {
         from: git2::Oid,
         to: git2::Oid,
         store: bool,
-    ) {
+    ) -> anyhow::Result<()> {
         let sequence_number = if filter != crate::filter::sequence_number()
             && filter != crate::filter::reachable_roots()
         {
-            compute_sequence_number(self, from).expect("compute_sequence_number failed")
+            compute_sequence_number(self, from)?
         } else {
             0
         };
@@ -484,46 +484,58 @@ impl Transaction {
         // random extra commits (probability 1/256) to avoid long searches for filters that reduce
         // the history length by a very large factor.
         if store || from.as_bytes()[0] == 0 {
-            t2.cache
-                .write_all(filter, from, to, sequence_number)
-                .expect("Failed to write cache");
+            t2.cache.write_all(filter, from, to, sequence_number)?;
         }
+        Ok(())
     }
 
-    pub fn get_missing(&self) -> Vec<(usize, crate::filter::Filter, git2::Oid)> {
-        let mut missing = self.t2.borrow().missing.clone();
-        missing.retain(|(_, f, i)| !self.known(*f, *i));
-        missing.sort_by_key(|(l, f, i)| (*f, *i, *l));
-        missing.dedup_by_key(|(_, f, i)| (*f, *i));
-        missing.sort();
-        self.t2.borrow_mut().missing = missing.clone();
-        missing
+    pub fn get_missing(&self) -> anyhow::Result<Vec<(usize, crate::filter::Filter, git2::Oid)>> {
+        let missing = self.t2.borrow().missing.clone();
+        let mut retained = Vec::with_capacity(missing.len());
+        for (level, f, i) in missing {
+            if !self.known(f, i)? {
+                retained.push((level, f, i));
+            }
+        }
+        retained.sort_by_key(|(l, f, i)| (*f, *i, *l));
+        retained.dedup_by_key(|(_, f, i)| (*f, *i));
+        retained.sort();
+        self.t2.borrow_mut().missing = retained.clone();
+        Ok(retained)
     }
 
-    pub fn known(&self, filter: crate::filter::Filter, from: git2::Oid) -> bool {
-        self.get2(filter, from).is_some()
+    pub fn known(&self, filter: crate::filter::Filter, from: git2::Oid) -> anyhow::Result<bool> {
+        Ok(self.get2(filter, from)?.is_some())
     }
 
-    pub fn get(&self, filter: crate::filter::Filter, from: git2::Oid) -> Option<git2::Oid> {
-        if let Some(x) = self.get2(filter, from) {
-            Some(x)
+    pub fn get(
+        &self,
+        filter: crate::filter::Filter,
+        from: git2::Oid,
+    ) -> anyhow::Result<Option<git2::Oid>> {
+        if let Some(x) = self.get2(filter, from)? {
+            Ok(Some(x))
         } else {
             let mut t2 = self.t2.borrow_mut();
             let nesting_level = t2.nesting_level;
             t2.misses += 1;
             t2.missing.push((nesting_level, filter, from));
-            None
+            Ok(None)
         }
     }
 
-    fn get2(&self, filter: crate::filter::Filter, from: git2::Oid) -> Option<git2::Oid> {
+    fn get2(
+        &self,
+        filter: crate::filter::Filter,
+        from: git2::Oid,
+    ) -> anyhow::Result<Option<git2::Oid>> {
         if filter.is_nop() {
-            return Some(from);
+            return Ok(Some(from));
         }
         let sequence_number = if filter != crate::filter::sequence_number()
             && filter != crate::filter::reachable_roots()
         {
-            compute_sequence_number(self, from).expect("compute_sequence_number failed")
+            compute_sequence_number(self, from)?
         } else {
             0
         };
@@ -531,29 +543,26 @@ impl Transaction {
         if let Some(m) = t2.commit_map.get(&filter.id())
             && let Some(oid) = m.get(&from).cloned()
         {
-            return Some(oid);
+            return Ok(Some(oid));
         }
 
-        let oid = t2
-            .cache
-            .read_propagate(filter, from, sequence_number)
-            .expect("Failed to read from cache backend");
+        let oid = t2.cache.read_propagate(filter, from, sequence_number)?;
 
         if let Some(oid) = oid {
             if oid == git2::Oid::zero() {
-                return Some(oid);
+                return Ok(Some(oid));
             }
             if filter == crate::filter::sequence_number() {
-                return Some(oid);
+                return Ok(Some(oid));
             }
 
-            if self.repo.odb().unwrap().exists(oid) {
+            if self.repo.odb()?.exists(oid) {
                 // Only report an object as cached if it exists in the object database.
                 // This forces a rebuild in case the object was garbage collected.
-                return Some(oid);
+                return Ok(Some(oid));
             }
         }
 
-        None
+        Ok(None)
     }
 }

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -391,7 +391,7 @@ pub fn apply_to_commit(
             return Ok(id);
         }
 
-        let missing = transaction.get_missing();
+        let missing = transaction.get_missing()?;
 
         let max_level = missing.last().map(|(w, _, _)| *w).unwrap_or(0);
 
@@ -623,18 +623,18 @@ pub fn apply_to_commit2(
             .transpose();
         }
         Op::Downstack(LazyRef::Resolved(base)) => {
-            if let Some(oid) = transaction.get(filter, commit.id()) {
+            if let Some(oid) = transaction.get(filter, commit.id())? {
                 return Ok(Some(oid));
             }
             let new_oid = downstack(repo, transaction, commit.id(), *base)?;
-            transaction.insert(filter, commit.id(), new_oid, false);
+            transaction.insert(filter, commit.id(), new_oid, false)?;
             return Ok(Some(new_oid));
         }
         Op::Downstack(LazyRef::Lazy(_)) => {
             return Err(anyhow!("`:_=...` with unresolved base ref"));
         }
         _ => {
-            if let Some(oid) = transaction.get(filter, commit.id()) {
+            if let Some(oid) = transaction.get(filter, commit.id())? {
                 return Ok(Some(oid));
             }
             // Continue to process the filter if not cached
@@ -677,7 +677,7 @@ pub fn apply_to_commit2(
             } else {
                 if let Some(parent) = commit.parents().next() {
                     return Ok(
-                        if let Some(fparent) = transaction.get(filter, parent.id()) {
+                        if let Some(fparent) = transaction.get(filter, parent.id())? {
                             Some(history::drop_commit(
                                 commit,
                                 vec![fparent],
@@ -701,7 +701,7 @@ pub fn apply_to_commit2(
             let p: Vec<_> = commit.parent_ids().collect();
 
             if p.len() > 1 {
-                let parent = some_or!(transaction.get(filter, p[0]), {
+                let parent = some_or!(transaction.get(filter, p[0])?, {
                     return Ok(None);
                 });
 
@@ -725,7 +725,7 @@ pub fn apply_to_commit2(
                 commit
                     .parents()
                     .map(|x| transaction.get(filter, x.id()))
-                    .collect::<Option<_>>()
+                    .collect::<anyhow::Result<Option<_>>>()?
             };
 
             let mut filtered_parent_ids: Vec<git2::Oid> =
@@ -781,7 +781,7 @@ pub fn apply_to_commit2(
                 commit
                     .parents()
                     .map(|x| transaction.get(filter, x.id()))
-                    .collect::<Option<_>>()
+                    .collect::<anyhow::Result<Option<_>>>()?
             };
 
             let mut filtered_parent_ids: Vec<git2::Oid> =
@@ -792,7 +792,7 @@ pub fn apply_to_commit2(
                 if let Some(commit_str) = link_file.get_meta("commit") {
                     if let Ok(commit_oid) = git2::Oid::from_str(&commit_str) {
                         if let Some(cmt) =
-                            transaction.get(to_filter(Op::Prefix(link_path)), commit_oid)
+                            transaction.get(to_filter(Op::Prefix(link_path)), commit_oid)?
                         {
                             link_parents.push(cmt);
                         } else {
@@ -859,7 +859,7 @@ pub fn apply_to_commit2(
                 let normal_parents = commit
                     .parent_ids()
                     .map(|parent| transaction.get(filter, parent))
-                    .collect::<Option<Vec<git2::Oid>>>();
+                    .collect::<anyhow::Result<Option<Vec<git2::Oid>>>>()?;
 
                 let normal_parents = some_or!(normal_parents, { return Ok(None) });
 
@@ -910,7 +910,7 @@ pub fn apply_to_commit2(
             if let Some((redirect, _)) = resolve_workspace_redirect(repo, &commit.tree()?, ws_path)
             {
                 if let Some(r) = apply_to_commit2(redirect, commit, transaction)? {
-                    transaction.insert(filter, commit.id(), r, true);
+                    transaction.insert(filter, commit.id(), r, true)?;
                     return Ok(Some(r));
                 } else {
                     return Ok(None);
@@ -989,7 +989,7 @@ pub fn apply_to_commit2(
             let filtered_parent_ids = commit
                 .parents()
                 .map(|x| transaction.get(filter, x.id()))
-                .collect::<Option<Vec<_>>>();
+                .collect::<anyhow::Result<Option<Vec<_>>>>()?;
 
             let filtered_parent_ids = some_or!(filtered_parent_ids, { return Ok(None) });
 
@@ -1038,10 +1038,10 @@ pub fn apply_to_commit2(
                                 if commit.id() == link_commit {
                                     let unapply =
                                         to_filter(Op::Unapply(LazyRef::Resolved(parent.id()), *uf));
-                                    let r = some_or!(transaction.get(unapply, link_commit), {
+                                    let r = some_or!(transaction.get(unapply, link_commit)?, {
                                         return Ok(None);
                                     });
-                                    transaction.insert(filter, commit.id(), r, true);
+                                    transaction.insert(filter, commit.id(), r, true)?;
                                     return Ok(Some(r));
                                 }
                             }
@@ -1066,10 +1066,10 @@ pub fn apply_to_commit2(
                 let unapply = to_filter(Op::Unapply(LazyRef::Resolved(commit.id()), subdir));
                 if let Some(commit_str) = link.get_meta("commit") {
                     if let Ok(commit_oid) = git2::Oid::from_str(&commit_str) {
-                        let r = some_or!(transaction.get(unapply, commit_oid), {
+                        let r = some_or!(transaction.get(unapply, commit_oid)?, {
                             return Ok(None);
                         });
-                        transaction.insert(filter, commit.id(), r, true);
+                        transaction.insert(filter, commit.id(), r, true)?;
                         return Ok(Some(r));
                     }
                 }
@@ -1087,7 +1087,7 @@ pub fn apply_to_commit2(
         commit
             .parents()
             .map(|x| transaction.get(filter, x.id()))
-            .collect::<Option<_>>()
+            .collect::<anyhow::Result<Option<_>>>()?
     };
 
     let filtered_parent_ids = some_or!(filtered_parent_ids, { return Ok(None) });
@@ -2135,7 +2135,7 @@ fn per_rev_filter(
     let normal_parents = commit
         .parent_ids()
         .map(|parent| transaction.get(filter, parent))
-        .collect::<Option<Vec<git2::Oid>>>();
+        .collect::<anyhow::Result<Option<Vec<git2::Oid>>>>()?;
     let normal_parents = some_or!(normal_parents, { return Ok(None) });
 
     // Special case: `:pin` filter needs to be aware of filtered history

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -22,7 +22,7 @@ pub fn walk2(
 ) -> anyhow::Result<()> {
     rs_tracing::trace_scoped!("walk2","spec":filter::spec(filter), "id": input.to_string());
 
-    if transaction.known(filter, input) {
+    if transaction.known(filter, input)? {
         return Ok(());
     }
 
@@ -40,13 +40,14 @@ pub fn walk2(
         walk.push(input)?;
         walk
     };
-    let mut hide_callback = |id| transaction.known(filter, id);
+    // The callback cannot propagate errors, so treat a failed lookup as "not known": the walk
+    // then visits the commit and the fallible body reports the same error properly.
+    let mut hide_callback = |id| transaction.known(filter, id).unwrap_or(false);
     let walk = walk.with_hide_callback(&mut hide_callback)?;
 
     log::info!(
         "Walking {} commits for: {} {:?}",
-        crate::cache::compute_sequence_number(transaction, input)
-            .expect("compute_sequence_number failed"),
+        crate::cache::compute_sequence_number(transaction, input)?,
         filter::spec(filter),
         input_commit,
     );
@@ -816,7 +817,7 @@ pub fn drop_commit(
         git2::Oid::zero()
     };
 
-    transaction.insert(filter, original_commit.id(), r, false);
+    transaction.insert(filter, original_commit.id(), r, false)?;
 
     Ok(r)
 }
@@ -839,7 +840,7 @@ pub fn create_filtered_commit_with_meta(
 
     let store = is_new || original_commit.parent_ids().len() != 1;
 
-    transaction.insert(filter, original_commit.id(), r, store);
+    transaction.insert(filter, original_commit.id(), r, store)?;
 
     Ok(r)
 }


### PR DESCRIPTION
Propagate cache backend errors instead of panicking

Transaction::insert, get, known and get_missing swallowed cache backend
failures with expect(), turning any backend error (e.g. a distributed cache
that cannot map a filter to a persistable tree id) into a process panic.

Return anyhow::Result from these methods and propagate errors through the
callers, which are all already fallible. The revwalk hide callbacks in walk2
and ensure_hint_cached cannot propagate, so they treat a failed lookup as "not
cached"; the walk then visits the commit and the fallible body reports the
same error properly.

Change: graceful-cache-backend-errors
Assisted-By: Claude Fable 5 (claude-fable-5)