### PR TITLE
Update tests-per-category.star for the blob to insert rename

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ env:
   # for any branch and the binary is not rebuilt for every PR / merge-queue
   # run). Bump when a backward-incompatible change to `josh compose` requires
   # it; the new SHA must also already be on `origin/master`.
-  JOSH_BOOTSTRAP_SHA: caf2143216c07d2775fe566e52989fcb1b9d417c
+  JOSH_BOOTSTRAP_SHA: 1471ea656cc52eecd43010d58989bb946186cf28
 
 jobs:
   test:

--- a/ws/tests-per-category.star
+++ b/ws/tests-per-category.star
@@ -33,13 +33,13 @@ def generate_test_nodes():
         ]).prefix("inputs")
 
         metadata = compose([
-            filter.blob("label", category),
-            filter.blob("output", "workdir"),
+            filter.insert("label", category),
+            filter.insert("output", "workdir"),
             filter.treeid("image", filter.stored("images/prysk-test-local")),
         ])
 
         if is_experimental:
-            env = filter.blob("JOSH_EXPERIMENTAL_FEATURES", "1").prefix("env")
+            env = filter.insert("JOSH_EXPERIMENTAL_FEATURES", "1").prefix("env")
             test_node = compose([metadata, inputs, worktree, env])
         else:
             test_node = compose([metadata, inputs, worktree])


### PR DESCRIPTION
Update tests-per-category.star for the blob to insert rename

Commit 33c5c808 renamed the Starlark-exposed Filter method "blob" to "insert", but this script
still called filter.blob(...). Starlark evaluation then failed with 'Object of type `Filter` has
no attribute `blob`', and get_starlark() silently degraded the failing filter to :empty. As a
result the per-category prysk test jobs (cli, cq, experimental, filter, proxy) disappeared from
the composed workspace and "josh compose run" stopped executing any prysk tests, running only
cargo-test-run and fmt.

Also bump JOSH_BOOTSTRAP_SHA to current origin/master (1471ea65): the CI bootstrap josh evaluates
this script, so it must be built from a commit that already contains the starlark rename. The
previous pin (caf21432) predates the rename and would silently drop the prysk jobs again in CI.

Change: star-blob-insert-rename
Assisted-By: Claude Fable 5 <noreply@anthropic.com>