### PR TITLE
Remove rs_tracing in favor of samply for profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,7 +3035,6 @@ dependencies = [
  "log",
  "reqwest 0.13.2",
  "reqwest-middleware",
- "rs_tracing",
  "serde",
  "serde_json",
  "tokio",
@@ -3098,7 +3097,6 @@ dependencies = [
  "pest_derive",
  "rand 0.10.1",
  "regex",
- "rs_tracing",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -3275,7 +3273,6 @@ dependencies = [
  "josh-core",
  "juniper",
  "regex",
- "rs_tracing",
  "serde_json",
  "serde_yaml",
  "strfmt",
@@ -4744,16 +4741,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rs_tracing"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b121670da627e1c0110e7972c9db150dd7f8704dc073cce32c3db9cb7861e0"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ gix-config = "0.52.0"
 gix-submodule = "0.26.0"
 libc = "0.2.184"
 regex = "1.12.3"
-rs_tracing = { version = "1.1.0", features = ["rs_tracing"] }
 serde = { version = "1.0.228", features = ["std", "derive"] }
 serde_json = "1.0.149"
 serde_yaml = "0.9.34"

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -16,7 +16,6 @@ log.workspace = true
 serde_json.workspace = true
 defer.workspace = true
 clap.workspace = true
-rs_tracing.workspace = true
 juniper.workspace = true
 git2.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -1,8 +1,5 @@
 #![warn(unused_extern_crates)]
 
-#[macro_use]
-extern crate rs_tracing;
-
 use anyhow::Context;
 use std::fs::read_to_string;
 use std::io::Write;
@@ -72,12 +69,6 @@ fn make_app() -> clap::Command {
                 .action(clap::ArgAction::SetTrue)
                 .help("Populate the cache with probable filters")
                 .short('d'),
-        )
-        .arg(
-            clap::Arg::new("trace")
-                .action(clap::ArgAction::SetTrue)
-                .help("Write a trace in chrome tracing format")
-                .short('t'),
         )
         .arg(
             clap::Arg::new("print-filter")
@@ -179,10 +170,6 @@ impl josh_core::cache::FilterHook for GitNotesFilterHook {
 
 fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     let args = make_app().get_matches_from(args);
-
-    if args.get_flag("trace") {
-        rs_tracing::open_trace_file!(".").unwrap();
-    }
 
     if args.get_flag("version") {
         println!("Version: {}", josh_core::VERSION);
@@ -320,9 +307,6 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     };
 
     let finish = defer::defer(|| {
-        if args.get_flag("trace") {
-            rs_tracing::close_trace_file!();
-        }
         if args.get_flag("cache-stats") {
             josh_core::cache::sled_print_stats().expect("failed to collect cache stats");
         }

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -55,7 +55,6 @@ gix-hash.workspace = true
 hex.workspace = true
 log.workspace = true
 regex.workspace = true
-rs_tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -642,8 +642,6 @@ pub fn apply_to_commit2(
         }
     };
 
-    rs_tracing::trace_scoped!("apply_to_commit", "spec": spec(filter), "commit": commit.id().to_string());
-
     let rewrite_data = match &op {
         Op::Squash(Some(ids)) => {
             if let Some(sq) = ids.get(&LazyRef::Resolved(commit.id())) {
@@ -923,7 +921,6 @@ pub fn apply_to_commit2(
             let parent_filters = commit
                 .parents()
                 .map(|parent| {
-                    rs_tracing::trace_scoped!("parent", "id": parent.id().to_string());
                     let pcw = get_workspace(
                         transaction,
                         &parent.tree().unwrap_or_else(|_| tree::empty(repo)),
@@ -941,7 +938,6 @@ pub fn apply_to_commit2(
             let parent_filters = commit
                 .parents()
                 .map(|parent| {
-                    rs_tracing::trace_scoped!("parent", "id": parent.id().to_string());
                     let pcs = get_stored(
                         transaction,
                         &parent.tree().unwrap_or_else(|_| tree::empty(repo)),
@@ -960,7 +956,6 @@ pub fn apply_to_commit2(
             let parent_filters = commit
                 .parents()
                 .map(|parent| {
-                    rs_tracing::trace_scoped!("parent", "id": parent.id().to_string());
                     let pcs = get_starlark(
                         transaction,
                         &parent.tree().unwrap_or_else(|_| tree::empty(repo)),
@@ -1084,7 +1079,6 @@ pub fn apply_to_commit2(
     let tree_data = rewrite_data;
 
     let filtered_parent_ids = {
-        rs_tracing::trace_scoped!("filtered_parent_ids", "n": commit.parent_ids().len());
         commit
             .parents()
             .map(|x| transaction.get(filter, x.id()))

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -95,7 +95,6 @@ pub fn remove_pred<'a>(
     if let Some(cached) = transaction.get_glob((input, key)) {
         return Ok(repo.find_tree(cached)?);
     }
-    rs_tracing::trace_scoped!("remove_pred X", "root": root);
 
     let tree = repo.find_tree(input)?;
     let mut builder = repo.treebuilder(None)?;
@@ -154,7 +153,6 @@ pub fn subtract(
         if input2 == empty_id() {
             return Ok(input1);
         }
-        rs_tracing::trace_scoped!("subtract fast");
         // Start from `tree1` and drop or replace each path that also appears in `tree2`.
         let mut builder = repo.treebuilder(Some(&tree1))?;
 
@@ -208,7 +206,6 @@ pub fn intersect(
     }
 
     let result = if let (Ok(tree1), Ok(tree2)) = (repo.find_tree(input1), repo.find_tree(input2)) {
-        rs_tracing::trace_scoped!("intersect fast");
         // Iterate the selector (`input2`), keeping each of its paths that also exists in `tree1`
         // with `tree1`'s content; cost tracks the size of the selected set.
         let mut builder = repo.treebuilder(None)?;
@@ -283,7 +280,6 @@ pub fn diff_paths(
     input2: git2::Oid,
     root: &str,
 ) -> anyhow::Result<Vec<(String, i32)>> {
-    rs_tracing::trace_scoped!("diff_paths");
     if input1 == input2 {
         return Ok(vec![]);
     }
@@ -389,15 +385,9 @@ pub fn overlay(
     }
 
     if let (Ok(tree1), Ok(tree2)) = (repo.find_tree(input1), repo.find_tree(input2)) {
-        rs_tracing::trace_begin!( "overlay",
-            "overlay_a": format!("{}", input1),
-            "overlay_b": format!("{}", input2),
-            "overlay_ab": format!("{} - {}", input1, input2));
         let mut builder = repo.treebuilder(Some(&tree1))?;
 
-        let mut i = 0;
         for entry in tree2.iter() {
-            i += 1;
             let (id, mode) =
                 if let Some(e) = tree1.get_name(entry.name().ok_or_else(|| anyhow!("no name"))?) {
                     (overlay(transaction, e.id(), entry.id())?, e.filemode())
@@ -413,7 +403,6 @@ pub fn overlay(
         }
 
         let rid = builder.write()?;
-        rs_tracing::trace_end!( "overlay", "count":i);
 
         transaction.insert_overlay((input1, input2), rid);
         return Ok(rid);
@@ -516,8 +505,6 @@ pub fn populate(
     paths: git2::Oid,
     content: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    rs_tracing::trace_scoped!("repopulate");
-
     if let Some(cached) = transaction.get_populate((paths, content)) {
         return Ok(cached);
     }
@@ -556,7 +543,6 @@ pub fn compose_fast(
     transaction: &cache::Transaction,
     trees: Vec<git2::Oid>,
 ) -> anyhow::Result<git2::Tree<'_>> {
-    rs_tracing::trace_scoped!("compose_fast");
     let repo = transaction.repo();
     let mut result = empty_id();
     for tree in trees {
@@ -570,7 +556,6 @@ pub fn compose<'a>(
     transaction: &'a cache::Transaction,
     trees: Vec<(&Filter, git2::Tree<'a>)>,
 ) -> anyhow::Result<git2::Tree<'a>> {
-    rs_tracing::trace_scoped!("compose");
     let repo = transaction.repo();
     let mut result = empty(repo);
     let mut taken = empty(repo);

--- a/josh-core/src/filter/trigram.rs
+++ b/josh-core/src/filter/trigram.rs
@@ -278,12 +278,9 @@ pub fn trigram_search<'a>(
     results: &mut Vec<String>,
     ord: usize,
 ) -> anyhow::Result<()> {
-    rs_tracing::trace_scoped!("trigram_search", "ord": ord, "root": root);
     let repo = transaction.repo();
 
     let hd = {
-        rs_tracing::trace_scoped!("get blob own");
-
         if let Some(blob) = tree
             .get_name(&format!("OWN{}", ord))
             .map(|x| repo.find_blob(x.id()))
@@ -297,7 +294,6 @@ pub fn trigram_search<'a>(
     };
 
     let dmatch = if !hd.is_empty() {
-        rs_tracing::trace_scoped!("dmatch own");
         let mut dmatch = true;
         for (a, b) in dir_filter.iter().zip(hd.iter()) {
             if a & b != *a {
@@ -311,7 +307,6 @@ pub fn trigram_search<'a>(
     };
 
     if dmatch {
-        rs_tracing::trace_scoped!("search blobs");
         let b = get_blob(repo, &tree, Path::new(&format!("BLOBS{}", ord)));
 
         let mut filename = None;
@@ -348,15 +343,12 @@ pub fn trigram_search<'a>(
     }
 
     let hd = {
-        rs_tracing::trace_scoped!("get blob sub");
-
         if let Some(blob) = tree
             .get_name(&format!("SUB{}", ord))
             .map(|x| repo.find_blob(x.id()))
         {
             let blob = blob?;
             let b = unsafe { std::str::from_utf8_unchecked(blob.content()) };
-            rs_tracing::trace_scoped!("hex decode sub");
             hex::decode(b.lines().collect::<Vec<_>>().join(""))?
         } else {
             return Ok(());
@@ -364,16 +356,12 @@ pub fn trigram_search<'a>(
     };
 
     {
-        rs_tracing::trace_scoped!("dmatch sub");
-
         for (a, b) in dir_filter.iter().zip(hd.iter()) {
             if a & b != *a {
                 return Ok(());
             }
         }
     }
-
-    rs_tracing::trace_scoped!("down iter");
 
     let rpath = transaction.repo().path();
 

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -20,8 +20,6 @@ pub fn walk2(
     input: git2::Oid,
     transaction: &cache::Transaction,
 ) -> anyhow::Result<()> {
-    rs_tracing::trace_scoped!("walk2","spec":filter::spec(filter), "id": input.to_string());
-
     if transaction.known(filter, input)? {
         return Ok(());
     }

--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -212,7 +212,7 @@ pub fn get_info(
         commit
             .parent_ids()
             .map(|x| {
-                json!({
+                serde_json::json!({
                     "commit": x.to_string(),
                     "tree": transaction.repo().find_commit(x)
                         .map(|c| { c.tree_id() })
@@ -224,20 +224,20 @@ pub fn get_info(
     };
 
     let t = if let Ok(filtered) = transaction.repo().find_commit(filtered) {
-        json!({
+        serde_json::json!({
             "commit": filtered.id().to_string(),
             "tree": filtered.tree_id().to_string(),
             "parents": parent_ids(&filtered),
         })
     } else {
-        json!({
+        serde_json::json!({
             "commit": git2::Oid::zero().to_string(),
             "tree": git2::Oid::zero().to_string(),
-            "parents": json!([]),
+            "parents": serde_json::json!([]),
         })
     };
 
-    let s = json!({
+    let s = serde_json::json!({
         "commit": commit.id().to_string(),
         "tree": commit.tree_id().to_string(),
         "parents": parent_ids(&commit),

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -14,9 +14,6 @@ macro_rules! ok_or {
     };
 }
 
-#[macro_use]
-extern crate rs_tracing;
-
 pub mod cache;
 pub mod filter;
 pub mod git;
@@ -194,7 +191,6 @@ pub fn filter_refs(
     filterobj: filter::Filter,
     refs: &[(String, git2::Oid)],
 ) -> (Vec<(String, git2::Oid)>, Vec<(String, anyhow::Error)>) {
-    rs_tracing::trace_scoped!("filter_refs", "spec": filter::spec(filterobj));
     let s = tracing::Span::current();
     let _e = s.enter();
     let mut updated = vec![];

--- a/josh-graphql/Cargo.toml
+++ b/josh-graphql/Cargo.toml
@@ -14,7 +14,6 @@ strfmt = "0.2.4"
 anyhow.workspace = true
 juniper.workspace = true
 git2.workspace = true
-rs_tracing.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -101,7 +101,6 @@ impl Revision {
     }
 
     fn hash(&self, context: &Context) -> FieldResult<String> {
-        rs_tracing::trace_scoped!("hash");
         let transaction = context.transaction.lock().unwrap();
         let commit = transaction.repo().find_commit(self.commit_id)?;
         let filter_commit = filter::apply_to_commit(self.filter, &commit, &transaction)?;
@@ -223,7 +222,6 @@ impl Revision {
         offset: Option<i32>,
         context: &Context,
     ) -> FieldResult<Vec<Revision>> {
-        rs_tracing::trace_scoped!("history");
         let limit = limit.unwrap_or(1) as usize;
         let offset = offset.unwrap_or(0) as usize;
         let transaction = context.transaction.lock().unwrap();
@@ -241,7 +239,6 @@ impl Revision {
 
         let mut contained_in = self.commit_id;
         let mut ids = {
-            rs_tracing::trace_scoped!("walk");
             walk.skip(offset)
                 .take(limit)
                 .map(|id| id.unwrap_or(git2::Oid::zero()))
@@ -249,7 +246,6 @@ impl Revision {
         };
 
         {
-            rs_tracing::trace_scoped!("walk");
             for i in 0..ids.len() {
                 let orig =
                     history::find_original(&transaction, self.filter, contained_in, ids[i], true)?;
@@ -677,8 +673,8 @@ impl Path {
     ) -> FieldResult<Document> {
         self.internal_serialize(context, |transaction, id| {
             let blob = transaction.repo().find_blob(id)?;
-            let value =
-                str_to_value(std::str::from_utf8(blob.content())?).unwrap_or_else(|_| json!({}));
+            let value = str_to_value(std::str::from_utf8(blob.content())?)
+                .unwrap_or_else(|_| serde_json::json!({}));
             Ok(Document { id, value })
         })
     }
@@ -759,7 +755,7 @@ impl Document {
         if let Some(pointer) = pointer {
             self.value
                 .pointer(&pointer)
-                .unwrap_or(&json!({}))
+                .unwrap_or(&serde_json::json!({}))
                 .to_owned()
         } else {
             self.value.clone()

--- a/josh-graphql/src/lib.rs
+++ b/josh-graphql/src/lib.rs
@@ -1,5 +1,2 @@
 pub mod graphql;
 pub use graphql::{commit_schema, context, repo_schema};
-
-#[macro_use]
-extern crate rs_tracing;


### PR DESCRIPTION
Remove rs_tracing in favor of samply for profiling

Delete the rs_tracing dependency and all trace_scoped!/trace_begin!/
trace_end! call sites, along with the -t/--trace flag of josh-filter
that wrote chrome tracing files. Profiling is now done with samply.

housekeeping.rs and graphql.rs implicitly relied on the json! macro
re-exported through #[macro_use] extern crate rs_tracing; they now use
serde_json::json! explicitly.

Change: remove-rs-tracing

Assisted-By: Claude Fable 5 <noreply@anthropic.com>