### PR TITLE
Add first-class workspace and agent CLI workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,16 @@ checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstyle",
  "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
 ]
 
 [[package]]
@@ -3017,6 +3027,7 @@ dependencies = [
  "arboard",
  "chrono",
  "clap",
+ "clap_complete",
  "defer",
  "dirs",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,8 +151,11 @@ features = ["max_level_trace", "release_max_level_trace"]
 
 [workspace.dependencies.clap]
 version = "4.6.0"
-features = ["derive", "env", "help", "std", "usage"]
+features = ["derive", "env", "error-context", "help", "std", "suggestions", "usage"]
 default-features = false
+
+[workspace.dependencies.clap_complete]
+version = "4.6.0"
 
 [workspace.dependencies.axum]
 version = "^0.8"

--- a/README.md
+++ b/README.md
@@ -56,16 +56,20 @@ for any subproject within the repo.
 
 Today, the Josh project ships two major components:
 
-* _josh CLI_: local tool that enables working with partial projections of Git repos. See
-  <a href="https://josh-project.github.io/josh/guide/gettingstarted.html">CLI getting started guide</a>.
+* _josh CLI_: local tool that enables working with partial projections of Git repos. See the
+  [CLI getting started guide](https://josh-project.github.io/josh/guide/gettingstarted.html).
+  Agents can install its bundled skill with `josh agent skill install` and use compact,
+  versioned output via `josh --output json --quiet`.
 * _josh-proxy_: Git HTTP and SSH proxy that provides on-the-fly transformation of history
-  for multiple users with shared cache, as well as GraphQL APIs. See
-  <a href="https://josh-project.github.io/josh/reference/proxy.html">proxy documentation</a>.
+  for multiple users with shared cache, as well as GraphQL APIs. See the
+  [proxy documentation](https://josh-project.github.io/josh/reference/proxy.html).
 
 Apart from the links above, there are a couple of core concepts that Josh relies on:
 
-* **Filters**: a way of describing the desired repository transformation: https://josh-project.github.io/josh/reference/filters.html
-* **Workspaces**: persisted, versioned filters https://josh-project.github.io/josh/guide/workspaces.html
+* **Filters**: a way of describing the desired repository transformation. See the
+  [filter reference](https://josh-project.github.io/josh/reference/filters.html).
+* **Workspaces**: persisted, versioned filters. See the
+  [workspace guide](https://josh-project.github.io/josh/guide/workspaces.html).
 
 ## FAQ
 

--- a/docs/src/guide/workspaces.md
+++ b/docs/src/guide/workspaces.md
@@ -28,7 +28,19 @@ each application only want to see the code that's relevant to them.
 
 ## Creating a workspace
 
-Clone the monorepo scoped to `application1` using the `:workspace=` filter:
+When you already have the monorepo checked out, create and preview a workspace directly:
+
+```shell
+josh workspace create application1
+josh workspace validate application1
+josh workspace checkout application1 ../application1-preview
+```
+
+`checkout` uses the working tree by default, so the preview includes the newly created, uncommitted
+`workspace.josh`. It creates a detached local worktree and does not change the current checkout.
+
+To create the workspace as a bidirectional checkout against a remote, clone the monorepo scoped to
+`application1` using the `:workspace=` filter:
 
 ```shell
 josh clone https://github.com/myorg/monorepo.git :workspace=application1 ./application1
@@ -53,6 +65,12 @@ Since `application1` depends on `library1`, create `workspace.josh` with:
 
 ```
 modules/lib1 = :/library1
+```
+
+Alternatively, from a full monorepo checkout, create the same definition without editing the file:
+
+```shell
+josh workspace create application1 --force --map modules/lib1=:/library1
 ```
 
 Commit the file:

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -9,6 +9,22 @@ It provides projection-aware equivalents of the common git operations.
 cargo install josh-cli --locked --git https://github.com/josh-project/josh.git
 ```
 
+## Global options
+
+Global options may appear before or after a subcommand.
+
+| Flag | Description |
+|------|-------------|
+| `--output <human|json|jsonl>` | Select human or versioned machine output |
+| `--pretty` | Pretty-print `--output json` instead of emitting one compact line |
+| `-q`, `--quiet` | Suppress diagnostics and omit machine-output messages |
+| `--color <auto|always|never>` | Control color in Josh and child Git processes |
+| `--no-progress` | Disable progress output and capture child process output |
+| `--non-interactive` | Disable prompts, browser launches, and credential input |
+
+`JOSH_OUTPUT`, `JOSH_COLOR`, and `JOSH_NON_INTERACTIVE` provide environment-based defaults.
+Machine output is described in [Automation and agent use](#automation-and-agent-use).
+
 ---
 
 ## josh clone
@@ -22,7 +38,7 @@ josh clone <url> <filter> <out> [options]
 | Argument | Description |
 |----------|-------------|
 | `<url>`  | Remote repository URL (HTTPS, SSH, or local path) |
-| `<filter>` | [Filter spec](./filters.md) to apply (e.g. `:/docs`, `:workspace=workspaces/myproject`) |
+| `<filter>` | [Filter spec](./filters.md), such as `:/docs` or `:workspace=workspaces/app` |
 | `<out>`  | Local directory to clone into |
 
 **Options:**
@@ -62,7 +78,7 @@ josh fetch [options]
 | Flag | Description |
 |------|-------------|
 | `-r`, `--remote <name>` | Remote name or URL to fetch from (default: `origin`) |
-| `-R`, `--ref <ref>` | Ref to fetch (default: `HEAD`) |
+| `-R`, `--ref <branch>` | Fetch one branch; `HEAD` fetches the configured set (default) |
 
 ---
 
@@ -79,7 +95,7 @@ josh pull [options]
 | Flag | Description |
 |------|-------------|
 | `-r`, `--remote <name>` | Remote name or URL to pull from (default: `origin`) |
-| `-R`, `--ref <ref>` | Ref to pull (default: `HEAD`) |
+| `-R`, `--ref <branch>` | Pull one branch; `HEAD` uses the configured upstream (default) |
 | `--rebase` | Rebase the current branch on top of the upstream branch |
 | `--autostash` | Automatically stash local changes before rebasing |
 
@@ -132,6 +148,33 @@ josh changes publish [<remote>] [<refspecs>...] [options]
 | `--atomic` | Atomic push (all-or-nothing) |
 | `--dry-run` | Show what would be pushed without actually pushing |
 
+### josh changes list
+
+List locally synchronized changes and their commits and comments.
+
+```shell
+josh changes list [--branch <branch>]
+```
+
+### josh changes comment
+
+Store a local comment or queue it for a remote forge.
+
+```shell
+josh changes comment <change> --message <text> [options]
+```
+
+Important options include `--file`, `--location <path:line>`, `--reply-to`, `--update-of`,
+`--branch`, and `--remote`.
+
+### josh changes sync
+
+Synchronize changes and review comments with the configured forge.
+
+```shell
+josh changes sync [remote] [--clean] [--local] [--push]
+```
+
 ---
 
 ## josh remote
@@ -170,6 +213,123 @@ josh remote add <name> <url> <filter> [options]
 josh remote add backend https://github.com/myorg/monorepo.git :/services/backend
 ```
 
+### josh remote list
+
+List every configured Josh remote in deterministic name order.
+
+```shell
+josh remote list
+```
+
+### josh remote show
+
+Show the URL, filter, fetch refspec, and forge integration for a remote.
+
+```shell
+josh remote show <name>
+```
+
+### josh remote set-filter
+
+Replace a remote's projection filter. The new filter must be reversible. Add `--apply` to update
+already fetched refs immediately; otherwise the next `josh fetch` applies it.
+
+```shell
+josh remote set-filter <name> <filter> [--apply]
+```
+
+### josh remote remove
+
+Remove a Josh remote, its configuration, and its private tracking refs.
+
+```shell
+josh remote remove <name> [--dry-run]
+```
+
+---
+
+## josh status
+
+Show the current branch, working-tree state, and configured Josh remotes.
+
+```shell
+josh status
+josh --output json status
+```
+
+---
+
+## josh agent skill
+
+Josh includes a concise, Agent Skills-compatible `SKILL.md`. Print it for inspection or install it
+into the directory used by an agent:
+
+```shell
+josh agent skill print
+josh agent skill install
+josh agent skill install --target .claude/skills/josh
+josh agent skill install --target /custom/agent/skills/josh
+```
+
+The default installation directory is `.agents/skills/josh`. Installation creates
+`<target>/SKILL.md`, refuses to overwrite an existing file, and supports `--force` and `--dry-run`.
+Machine output reports the installed path and skill version.
+
+---
+
+## josh workspace
+
+Create and inspect versioned projection workspaces. A workspace is represented by a
+`workspace.josh` file, so every operation remains compatible with manual file editing.
+
+### josh workspace create
+
+Create a workspace definition in the current repository. Each `--map` has the form
+`DESTINATION=FILTER` and may be repeated.
+
+```shell
+josh workspace create workspaces/frontend \
+  --map app=:/apps/frontend \
+  --map libs/shared=:/libs/shared
+```
+
+Use `--dry-run` to validate and display the definition without writing it. Existing definitions
+are protected unless `--force` is supplied.
+
+### josh workspace list and show
+
+```shell
+josh workspace list
+josh workspace list --verbose
+josh workspace show workspaces/frontend
+```
+
+`list` includes invalid definitions instead of silently skipping them.
+
+### josh workspace validate
+
+Validate syntax and reversibility. With no paths, every workspace in the working tree is checked.
+
+```shell
+josh workspace validate
+josh workspace validate workspaces/frontend workspaces/backend
+```
+
+The command exits unsuccessfully when any requested definition is invalid.
+
+### josh workspace checkout
+
+Materialize the workspace as a detached local Git worktree. The default input is `.` and therefore
+includes current working-tree changes, which makes this useful for previewing a new definition.
+
+```shell
+josh workspace checkout workspaces/frontend ../frontend-preview
+josh workspace checkout workspaces/frontend ../frontend-at-head --reference HEAD
+```
+
+This checkout is a local preview. For a bidirectional remote checkout, use `josh clone` with the
+`:workspace=<path>` filter.
+
 ---
 
 ## josh filter
@@ -184,6 +344,16 @@ josh filter <remote>
 | Argument | Description |
 |----------|-------------|
 | `<remote>` | Remote name whose filter should be re-applied |
+
+Validate or explain a filter without entering a repository:
+
+```shell
+josh filter validate ':/services/backend'
+josh filter explain ':/services/backend:prefix=src'
+josh --output json filter explain ':/services/backend'
+```
+
+Validation requires the filter to be reversible so it is safe for bidirectional CLI workflows.
 
 ---
 
@@ -200,6 +370,22 @@ josh auth logout <forge>
 
 The only currently supported forge is `github`. See
 [Forge integration](./forge.md) for full documentation.
+
+---
+
+## josh link
+
+Manage versioned links to other repositories.
+
+```shell
+josh link add <path> <url> [filter] [--target <branch>] [--mode <mode>]
+josh link fetch [filter]
+josh link update [filter]
+josh link push <path> [--force]
+```
+
+Link modes are `embedded`, `snapshot`, and `pointer`; the default is `snapshot`. Link operations
+are currently experimental and require `JOSH_EXPERIMENTAL_FEATURES=1` where noted by the command.
 
 ---
 
@@ -282,8 +468,8 @@ josh compose run [OPTIONS] [REFERENCE] [FILTER]
 
 | Argument | Description |
 |----------|-------------|
-| `[REFERENCE]` | Git ref to build from: `.` (working tree), `+` (index), `HEAD`, or any ref (default: `.`) |
-| `[FILTER]` | Filter selecting the workspace to run (default: `:+compose`, reads `compose.josh` in the repo root) |
+| `[REFERENCE]` | Input: `.`, `+`, `HEAD`, or any Git ref (default: `.`) |
+| `[FILTER]` | Workspace filter (default: `:+compose`, using `compose.josh`) |
 
 **Options:**
 
@@ -304,6 +490,71 @@ josh compose run . :+ws/test
 # Run using only staged changes
 josh compose run + :+ws/test
 ```
+
+---
+
+## Automation and agent use
+
+Use `--output json` for one versioned result document or `--output jsonl` for message events
+followed by a final result. Machine-readable results are always written to stdout, including
+failures. Human diagnostics use stderr, and failures also use a non-zero exit status.
+
+Every result contains:
+
+- `schema_version` — currently `"1"`;
+- `type` — `"result"`, `"message"`, or `"help"`;
+- `command` — a stable dotted command name such as `workspace.list`;
+- `success` — whether the command completed successfully;
+- `data` — command-specific structured data;
+- `messages` — captured human diagnostics, omitted when `--quiet` is used;
+- `error.code`, `error.message`, `error.causes`, and `error.hints` on failure.
+
+Stable error codes currently include:
+
+| Code | Meaning |
+|------|---------|
+| `cli.usage` | Command-line syntax or argument error |
+| `repository.not_found` | No Git repository was found |
+| `authentication.required` | Forge credentials are unavailable |
+| `remote.not_found` | A configured Josh remote was not found |
+| `reference.not_found` | A requested Git reference was not found |
+| `filter.invalid` | A filter is malformed or not reversible |
+| `workspace.not_found` | A workspace definition does not exist |
+| `workspace.already_exists` | Creation would overwrite a workspace |
+| `workspace.destination_exists` | A checkout destination already exists |
+| `workspace.invalid` | A workspace is malformed or cannot be materialized |
+| `clone.destination_exists` | A clone destination is not empty |
+| `agent_skill.already_exists` | Skill installation would overwrite an existing file |
+| `git.command_failed` | A child Git command failed |
+| `josh.command_failed` | An uncategorized command failure |
+
+Machine modes imply non-interactive behavior and capture child Git output. For unattended use,
+being explicit is still recommended:
+
+```shell
+josh --output json --quiet --non-interactive --no-progress workspace list
+```
+
+JSON is compact by default. Add `--pretty` for interactive inspection. `--quiet` produces the most
+context-efficient form: the versioned envelope and typed `data`, without duplicated human messages.
+
+Discover supported formats and features without entering a repository. Agents should prefer the
+brief form during capability negotiation:
+
+```shell
+josh capabilities
+josh --output json --quiet capabilities --brief
+```
+
+Generate native completions for Bash, Zsh, Fish, Elvish, or PowerShell:
+
+```shell
+josh completions bash > ~/.local/share/bash-completion/completions/josh
+josh completions zsh > ~/.zfunc/_josh
+```
+
+Consumers must reject unknown major schema versions rather than guessing their meaning. Fields may
+be added within a schema version, but existing fields will not change meaning.
 
 ---
 
@@ -353,5 +604,5 @@ josh-filter :/docs abc1234 --update refs/my/filtered
 | `-s` | Print cache statistics |
 | `-n` | Skip loading the cache |
 | `--distributed-cache` | Enable the distributed cache backend |
-| `--reverse` | Reverse-apply the filter (unapply): reconstruct upstream commits from filtered ones |
-| `--check-roundtrip` | When used with `--reverse`, verify that applying the filter to the reverse result reproduces the original commit. Exits with code 1 if the check fails. |
+| `--reverse` | Reverse-apply the filter to reconstruct upstream commits |
+| `--check-roundtrip` | Verify reverse application; exits 1 when the round trip differs |

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -16,6 +16,7 @@ log.workspace = true
 serde_json.workspace = true
 defer.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 juniper.workspace = true
 git2.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/josh-cli/skills/josh/SKILL.md
+++ b/josh-cli/skills/josh/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: josh
+description: Use Josh for filtered Git repositories, local workspaces, and structured automation.
+---
+
+# Josh
+
+Use `josh` to work with reversible projections of Git repositories. Prefer small, explicit
+commands and structured output. Do not parse human-facing text when JSON is available.
+
+## Agent contract
+
+- Run unattended commands as `josh --output json --quiet --non-interactive <command>`.
+- JSON results always go to stdout, including failures. Always check the process exit status.
+- Treat `data` as the command result. With `--quiet`, human `messages` are omitted.
+- Schema version `1` is stable. Reject unknown major schema versions.
+- Run `josh --output json --quiet capabilities --brief` once when capabilities are unknown.
+- Use scoped help such as `josh workspace create --help`; do not load the full manual by default.
+
+## Local workspace workflow
+
+Create a definition in the current monorepo:
+
+```sh
+josh workspace create workspaces/frontend \
+  --map app=:/apps/frontend \
+  --map shared=:/libs/shared
+```
+
+Validate and materialize the current working tree, including uncommitted changes:
+
+```sh
+josh workspace validate workspaces/frontend
+josh workspace checkout workspaces/frontend ../frontend-preview
+```
+
+The checkout is a detached preview. Build it with the project's normal build command. For an
+editable checkout that can synchronize with an upstream repository, use:
+
+```sh
+josh clone <url> :workspace=workspaces/frontend <directory>
+```
+
+## Repository operations
+
+Inspect state before mutation:
+
+```sh
+josh --output json --quiet status
+josh --output json --quiet remote list
+josh --output json --quiet remote show <name>
+```
+
+Use `josh fetch`, `josh pull`, and `josh push` instead of their Git equivalents for projected
+repositories. Use `josh push --dry-run` before an unfamiliar push. Do not force-push unless the user
+explicitly requests it.
+
+## Filters
+
+Quote filter expressions in the shell. Validate unfamiliar filters before using them:
+
+```sh
+josh --output json --quiet filter validate ':/services/backend'
+josh --output json --quiet filter explain ':/services/backend:prefix=src'
+```
+
+A CLI workspace filter is `:workspace=<repository-relative-path>`. A full-repository projection is
+`:/`.
+
+## Failure handling
+
+Read `error.code` first, then `error.message`, `error.causes`, and `error.hints`. Do not retry
+`authentication.required`, `filter.invalid`, or `workspace.invalid` without changing inputs. Do not
+silently add `--force`, discard changes, or overwrite an existing workspace or checkout.

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -1,17 +1,26 @@
 use anyhow::Context;
-use clap::Parser;
+use clap::error::ErrorKind;
+use clap::{CommandFactory, Parser};
 
+use josh_cli::commands::agent::AgentArgs;
 use josh_cli::commands::auth::AuthArgs;
 use josh_cli::commands::cache::CacheArgs;
+use josh_cli::commands::capabilities::CapabilitiesArgs;
 use josh_cli::commands::changes::ListArgs;
 use josh_cli::commands::comment::CommentArgs;
 use josh_cli::commands::link::LinkArgs;
 use josh_cli::commands::push::{PublishArgs, PushArgs};
 use josh_cli::commands::run::ComposeArgs;
+use josh_cli::commands::status::StatusArgs;
 use josh_cli::commands::sync::SyncArgs;
-use josh_cli::config::{RemoteConfig, read_remote_config, write_remote_config};
+use josh_cli::commands::workspace::WorkspaceArgs;
+use josh_cli::config::{
+    RemoteConfig, list_remote_names, read_remote_config, remove_remote_config, write_remote_config,
+};
 use josh_cli::forge::Forge;
-use josh_core::git::{normalize_repo_path, spawn_git_command};
+use josh_cli::output::{ColorChoice, OutputFormat, OutputOptions};
+use josh_cli::{cli_eprintln as eprintln, cli_println as println};
+use josh_core::git::{CommandColor, normalize_repo_path, spawn_git_command};
 
 #[derive(Debug, clap::Parser)]
 #[command(
@@ -21,9 +30,51 @@ use josh_core::git::{normalize_repo_path, spawn_git_command};
     long_about = None,
 )]
 pub struct Cli {
+    #[command(flatten)]
+    pub global: GlobalArgs,
+
     /// Subcommand to run
     #[command(subcommand)]
     pub command: Command,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct GlobalArgs {
+    /// Output format; JSON schemas are versioned and stable
+    #[arg(
+        long,
+        global = true,
+        value_enum,
+        default_value = "human",
+        env = "JOSH_OUTPUT"
+    )]
+    pub output: OutputFormat,
+
+    /// Pretty-print --output json instead of emitting one compact line
+    #[arg(long, global = true)]
+    pub pretty: bool,
+
+    /// Suppress diagnostics and omit messages from machine output
+    #[arg(short, long, global = true)]
+    pub quiet: bool,
+
+    /// Control color in Josh and child Git processes
+    #[arg(
+        long,
+        global = true,
+        value_enum,
+        default_value = "auto",
+        env = "JOSH_COLOR"
+    )]
+    pub color: ColorChoice,
+
+    /// Disable progress displays and capture child process output
+    #[arg(long, global = true)]
+    pub no_progress: bool,
+
+    /// Disable prompts, browser launches, and credential input
+    #[arg(long, global = true, env = "JOSH_NON_INTERACTIVE")]
+    pub non_interactive: bool,
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -52,7 +103,7 @@ pub enum RepoCommand {
     /// Manage stacked changes (publish, etc.)
     Changes(ChangesArgs),
 
-    /// Add a remote with optional projection/filtering (like `git remote add`)
+    /// Manage projection-aware remotes
     Remote(RemoteArgs),
 
     /// Apply filtering to existing refs (like `josh fetch` but without fetching)
@@ -66,13 +117,35 @@ pub enum RepoCommand {
 
     /// Run workspaces in containers
     Compose(ComposeArgs),
+
+    /// Create, inspect, validate, and check out projection workspaces
+    Workspace(WorkspaceArgs),
+
+    /// Show repository, working tree, and Josh remote status
+    Status(StatusArgs),
 }
 
 /// Commands that don't require a git repository
 #[derive(Debug, clap::Subcommand)]
 pub enum StandaloneCommand {
+    /// Install or print resources for coding agents
+    Agent(AgentArgs),
+
     /// Manage forge authentication
     Auth(AuthArgs),
+
+    /// Describe machine-readable CLI and automation capabilities
+    Capabilities(CapabilitiesArgs),
+
+    /// Generate a shell completion script
+    Completions(CompletionsArgs),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct CompletionsArgs {
+    /// Shell for which to generate completions
+    #[arg(value_enum)]
+    pub shell: clap_complete::Shell,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -103,7 +176,7 @@ pub struct PullArgs {
     #[arg(short = 'r', long = "remote", default_value = "origin")]
     pub remote: String,
 
-    /// Ref to pull (branch, tag, or commit-ish)
+    /// Branch to pull; HEAD uses the configured upstream
     #[arg(short = 'R', long = "ref", default_value = "HEAD")]
     pub rref: String,
 
@@ -122,7 +195,7 @@ pub struct FetchArgs {
     #[arg(short = 'r', long = "remote", default_value = "origin")]
     pub remote: String,
 
-    /// Ref to fetch (branch, tag, or commit-ish)
+    /// Branch to fetch; HEAD fetches the configured branch set
     #[arg(short = 'R', long = "ref", default_value = "HEAD")]
     pub rref: String,
 }
@@ -156,6 +229,46 @@ pub struct RemoteArgs {
 pub enum RemoteCommand {
     /// Add a remote with optional projection/filtering
     Add(RemoteAddArgs),
+    /// List configured Josh remotes
+    List(RemoteListArgs),
+    /// Show one configured Josh remote
+    Show(RemoteShowArgs),
+    /// Remove a Josh remote and its private refs
+    Remove(RemoteRemoveArgs),
+    /// Change the projection filter for a Josh remote
+    SetFilter(RemoteSetFilterArgs),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct RemoteListArgs {}
+
+#[derive(Debug, clap::Parser)]
+pub struct RemoteShowArgs {
+    /// Remote name
+    pub name: String,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct RemoteSetFilterArgs {
+    /// Remote name
+    pub name: String,
+
+    /// New reversible Josh filter
+    pub filter: String,
+
+    /// Re-filter already fetched refs immediately
+    #[arg(long)]
+    pub apply: bool,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct RemoteRemoveArgs {
+    /// Remote name
+    pub name: String,
+
+    /// Show what would be removed without changing the repository
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -188,39 +301,219 @@ pub struct ForgeArgs {
 }
 
 #[derive(Debug, clap::Parser)]
+#[command(
+    subcommand_precedence_over_arg = true,
+    args_conflicts_with_subcommands = true
+)]
 pub struct FilterArgs {
     /// Remote name to apply filtering to
-    #[arg()]
-    pub remote: String,
+    pub remote: Option<String>,
+
+    #[command(subcommand)]
+    pub command: Option<FilterCommand>,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum FilterCommand {
+    /// Validate that a filter parses and can be reversed
+    Validate(FilterInspectArgs),
+    /// Show a filter's canonical form, identity, and inverse
+    Explain(FilterInspectArgs),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct FilterInspectArgs {
+    /// Josh filter expression
+    pub filter: String,
 }
 
 fn main() {
+    let raw_args: Vec<String> = std::env::args().collect();
+    let requested_format = josh_cli::output::detect_format(&raw_args);
+    let requested_pretty = josh_cli::output::detect_pretty(&raw_args);
+    let cli = match Cli::try_parse_from(&raw_args) {
+        Ok(cli) => cli,
+        Err(error) => {
+            let success = matches!(
+                error.kind(),
+                ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
+            );
+            let exit_code = error.exit_code();
+            josh_cli::output::render_clap(
+                &error.to_string(),
+                requested_format,
+                requested_pretty,
+                success,
+                exit_code,
+            );
+            std::process::exit(if success { 0 } else { exit_code });
+        }
+    };
+
     env_logger::init();
-    let cli = Cli::parse();
+    let options = OutputOptions {
+        format: cli.global.output,
+        color: cli.global.color,
+        pretty: cli.global.pretty,
+        quiet: cli.global.quiet,
+        no_progress: cli.global.no_progress,
+        non_interactive: cli.global.non_interactive,
+    };
+    josh_cli::output::init(options.clone(), cli.command.path());
+    josh_core::git::configure_command_output(
+        options.format != OutputFormat::Human,
+        options.quiet,
+        options.no_progress,
+        options.non_interactive || options.format != OutputFormat::Human,
+        match options.color {
+            ColorChoice::Auto => CommandColor::Auto,
+            ColorChoice::Always => CommandColor::Always,
+            ColorChoice::Never => CommandColor::Never,
+        },
+    );
 
     let result = match &cli.command {
         Command::Standalone(cmd) => run_standalone(cmd),
         Command::Repo(cmd) => run_repo(cmd),
     };
 
-    if let Err(e) = result {
-        eprintln!("Error: {e}");
-
-        for e in e.chain() {
-            eprintln!("{e}");
+    match result {
+        Ok(()) => josh_cli::output::finish_success(),
+        Err(error) => {
+            josh_cli::output::finish_error(&error);
+            std::process::exit(1);
         }
+    }
+}
 
-        std::process::exit(1);
+impl Command {
+    fn path(&self) -> &'static str {
+        match self {
+            Command::Repo(command) => command.path(),
+            Command::Standalone(command) => command.path(),
+        }
+    }
+}
+
+impl RepoCommand {
+    fn path(&self) -> &'static str {
+        match self {
+            RepoCommand::Clone(_) => "clone",
+            RepoCommand::Fetch(_) => "fetch",
+            RepoCommand::Pull(_) => "pull",
+            RepoCommand::Push(_) => "push",
+            RepoCommand::Changes(args) => match &args.command {
+                ChangesCommand::Publish(_) => "changes.publish",
+                ChangesCommand::List(_) => "changes.list",
+                ChangesCommand::Comment(_) => "changes.comment",
+                ChangesCommand::Sync(_) => "changes.sync",
+            },
+            RepoCommand::Remote(args) => match &args.command {
+                RemoteCommand::Add(_) => "remote.add",
+                RemoteCommand::List(_) => "remote.list",
+                RemoteCommand::Show(_) => "remote.show",
+                RemoteCommand::Remove(_) => "remote.remove",
+                RemoteCommand::SetFilter(_) => "remote.set-filter",
+            },
+            RepoCommand::Filter(args) => match &args.command {
+                Some(FilterCommand::Validate(_)) => "filter.validate",
+                Some(FilterCommand::Explain(_)) => "filter.explain",
+                None => "filter",
+            },
+            RepoCommand::Link(args) => match &args.command {
+                josh_cli::commands::link::LinkCommand::Add(_) => "link.add",
+                josh_cli::commands::link::LinkCommand::Fetch(_) => "link.fetch",
+                josh_cli::commands::link::LinkCommand::Update(_) => "link.update",
+                josh_cli::commands::link::LinkCommand::Push(_) => "link.push",
+            },
+            RepoCommand::Cache(args) => match &args.command {
+                josh_cli::commands::cache::CacheCommand::Build(_) => "cache.build",
+                josh_cli::commands::cache::CacheCommand::Push(_) => "cache.push",
+                josh_cli::commands::cache::CacheCommand::Fetch(_) => "cache.fetch",
+            },
+            RepoCommand::Compose(args) => match &args.command {
+                josh_cli::commands::run::ComposeCommand::Run(_) => "compose.run",
+                josh_cli::commands::run::ComposeCommand::ListImages(_) => "compose.list-images",
+                josh_cli::commands::run::ComposeCommand::ListJobs(_) => "compose.list-jobs",
+            },
+            RepoCommand::Workspace(args) => match &args.command {
+                josh_cli::commands::workspace::WorkspaceCommand::Create(_) => "workspace.create",
+                josh_cli::commands::workspace::WorkspaceCommand::List(_) => "workspace.list",
+                josh_cli::commands::workspace::WorkspaceCommand::Show(_) => "workspace.show",
+                josh_cli::commands::workspace::WorkspaceCommand::Validate(_) => {
+                    "workspace.validate"
+                }
+                josh_cli::commands::workspace::WorkspaceCommand::Checkout(_) => {
+                    "workspace.checkout"
+                }
+            },
+            RepoCommand::Status(_) => "status",
+        }
+    }
+}
+
+impl StandaloneCommand {
+    fn path(&self) -> &'static str {
+        match self {
+            StandaloneCommand::Agent(args) => match &args.command {
+                josh_cli::commands::agent::AgentCommand::Skill(args) => match &args.command {
+                    josh_cli::commands::agent::SkillCommand::Print(_) => "agent.skill.print",
+                    josh_cli::commands::agent::SkillCommand::Install(_) => "agent.skill.install",
+                },
+            },
+            StandaloneCommand::Auth(args) => match &args.command {
+                josh_cli::commands::auth::AuthCommand::Login(_) => "auth.login",
+                josh_cli::commands::auth::AuthCommand::Logout(_) => "auth.logout",
+                josh_cli::commands::auth::AuthCommand::Debug(_) => "auth.debug",
+            },
+            StandaloneCommand::Capabilities(_) => "capabilities",
+            StandaloneCommand::Completions(_) => "completions",
+        }
     }
 }
 
 fn run_standalone(cmd: &StandaloneCommand) -> anyhow::Result<()> {
     match cmd {
+        StandaloneCommand::Agent(args) => josh_cli::commands::agent::handle_agent(args),
         StandaloneCommand::Auth(args) => josh_cli::commands::auth::handle_auth(args),
+        StandaloneCommand::Capabilities(args) => {
+            josh_cli::commands::capabilities::handle_capabilities(args)
+        }
+        StandaloneCommand::Completions(args) => handle_completions(args),
     }
 }
 
+fn handle_completions(args: &CompletionsArgs) -> anyhow::Result<()> {
+    let mut command = Cli::command();
+    let mut script = Vec::new();
+    clap_complete::generate(args.shell, &mut command, "josh", &mut script);
+    let script = String::from_utf8(script).context("Completion script was not valid UTF-8")?;
+    josh_cli::output::set_data_value(serde_json::json!({
+        "shell": args.shell.to_string(),
+        "script": script,
+    }));
+    if !josh_cli::output::is_machine()
+        && let Err(error) = josh_cli::output::raw_stdout(&script)
+        && error.kind() != std::io::ErrorKind::BrokenPipe
+    {
+        return Err(error).context("Failed to write completion script");
+    }
+    Ok(())
+}
+
 fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
+    if let RepoCommand::Status(args) = cmd {
+        let repo = git2::Repository::open_from_env().context("Not in a git repository")?;
+        return josh_cli::commands::status::handle_status(args, &repo);
+    }
+    if let RepoCommand::Filter(FilterArgs {
+        command: Some(command),
+        ..
+    }) = cmd
+    {
+        return handle_filter_inspect(command);
+    }
+
     // For clone, do the initial repo setup before creating transaction
     let repo_path = if let RepoCommand::Clone(args) = cmd {
         // For clone, we're not in a git repo initially, so clone first and use that path
@@ -264,7 +557,14 @@ fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
 
     match cmd {
         RepoCommand::Clone(args) => handle_clone(args, &transaction),
-        RepoCommand::Fetch(args) => handle_fetch(args, &transaction),
+        RepoCommand::Fetch(args) => {
+            handle_fetch(args, &transaction)?;
+            josh_cli::output::set_data_value(serde_json::json!({
+                "remote": args.remote,
+                "branch": args.rref,
+            }));
+            Ok(())
+        }
         RepoCommand::Pull(args) => handle_pull(args, &transaction),
         RepoCommand::Push(args) => josh_cli::commands::push::handle_push(args, &transaction),
         RepoCommand::Changes(args) => match &args.command {
@@ -286,7 +586,15 @@ fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
                 josh_cli::commands::comment::handle_comment(comment_args, &transaction)
             }
             ChangesCommand::Sync(sync_args) => {
-                josh_cli::commands::sync::handle_sync(sync_args, &transaction)
+                josh_cli::commands::sync::handle_sync(sync_args, &transaction)?;
+                josh_cli::output::set_data_value(serde_json::json!({
+                    "remote": sync_args.remote.as_deref().unwrap_or("origin"),
+                    "clean": sync_args.clean,
+                    "local": sync_args.local,
+                    "push": sync_args.push,
+                    "completed": true,
+                }));
+                Ok(())
             }
         },
         RepoCommand::Remote(args) => handle_remote(args, &transaction),
@@ -294,14 +602,25 @@ fn run_repo(cmd: &RepoCommand) -> anyhow::Result<()> {
         RepoCommand::Link(args) => josh_cli::commands::link::handle_link(args, &transaction),
         RepoCommand::Compose(args) => josh_cli::commands::run::handle_compose(args, &transaction),
         RepoCommand::Cache(args) => josh_cli::commands::cache::handle_cache(args, &transaction),
+        RepoCommand::Workspace(args) => {
+            josh_cli::commands::workspace::handle_workspace(args, &transaction)
+        }
+        RepoCommand::Status(args) => {
+            josh_cli::commands::status::handle_status(args, transaction.repo())
+        }
     }
 }
 
 fn to_absolute_remote_url(url: &str) -> anyhow::Result<String> {
+    let scp_like = url
+        .split_once(':')
+        .is_some_and(|(host, path)| host.contains('@') && !path.is_empty());
     if url.starts_with("http://")
         || url.starts_with("https://")
         || url.starts_with("ssh://")
+        || url.starts_with("git://")
         || url.starts_with("file://")
+        || scp_like
     {
         Ok(url.to_owned())
     } else {
@@ -320,7 +639,17 @@ fn clone_repo(args: &CloneArgs) -> anyhow::Result<std::path::PathBuf> {
     // Use the provided output directory
     let output_dir = args.out.clone();
 
-    // Create the output directory first
+    if output_dir.exists()
+        && std::fs::read_dir(&output_dir)?
+            .next()
+            .transpose()?
+            .is_some()
+    {
+        return Err(anyhow::anyhow!(
+            "Clone destination '{}' already exists and is not empty",
+            output_dir.display()
+        ));
+    }
     std::fs::create_dir_all(&output_dir)?;
 
     // Initialize a new git repository inside the directory using git2
@@ -412,6 +741,13 @@ fn handle_clone(
     };
 
     println!("Cloned repository to: {}", output_dir);
+    josh_cli::output::set_data_value(serde_json::json!({
+        "path": output_dir,
+        "remote": "origin",
+        "url": args.url,
+        "filter": args.filter,
+        "branch": default_branch,
+    }));
     Ok(())
 }
 
@@ -437,12 +773,21 @@ fn handle_pull(args: &PullArgs, transaction: &josh_core::cache::Transaction) -> 
     }
 
     git_args.push(&args.remote);
+    if args.rref != "HEAD" {
+        git_args.push(&args.rref);
+    }
 
     transaction
         .spawn_git(&git_args, &[])
         .context("git pull failed")?;
 
     eprintln!("Pulled from remote: {}", args.remote);
+    josh_cli::output::set_data_value(serde_json::json!({
+        "remote": args.remote,
+        "branch": args.rref,
+        "rebase": args.rebase,
+        "autostash": args.autostash,
+    }));
 
     Ok(())
 }
@@ -467,9 +812,22 @@ fn handle_fetch(
     } = read_remote_config(&repo_path, &args.remote)
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
 
-    // First, fetch unfiltered refs to refs/josh/remotes/*
+    // Fetch all configured branches by default, or only the explicitly requested branch.
+    let requested_refspec = if args.rref == "HEAD" {
+        ref_spec
+    } else {
+        let branch = args.rref.strip_prefix("refs/heads/").unwrap_or(&args.rref);
+        let source = format!("refs/heads/{branch}");
+        if !git2::Reference::is_valid_name(&source) {
+            return Err(anyhow::anyhow!(
+                "Invalid branch passed to --ref: '{}'",
+                args.rref
+            ));
+        }
+        format!("+{source}:refs/josh/remotes/{}/{branch}", args.remote)
+    };
     transaction
-        .spawn_git(&["fetch", &url, &ref_spec], &[])
+        .spawn_git(&["fetch", &url, &requested_refspec], &[])
         .context("git fetch to josh/remotes failed")?;
 
     // Warm the local cache from the remote before filtering
@@ -485,10 +843,14 @@ fn handle_fetch(
     // Use git ls-remote --symref to get the default branch
     // Parse the output to get the default branch name
     // Output format: "ref: refs/heads/main\t<commit-hash>"
-    let output = std::process::Command::new("git")
+    let mut command = std::process::Command::new("git");
+    command
         .args(["ls-remote", "--symref", &url, "HEAD"])
-        .current_dir(normalize_repo_path(repo.path()))
-        .output()?;
+        .current_dir(normalize_repo_path(repo.path()));
+    if josh_cli::output::is_non_interactive() {
+        command.env("GIT_TERMINAL_PROMPT", "0");
+    }
+    let output = command.output()?;
 
     if !output.status.success() {
         return Err(anyhow::anyhow!(
@@ -527,49 +889,199 @@ fn handle_remote(
     args: &RemoteArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+    let repo_path = normalize_repo_path(repo.path());
     match &args.command {
         RemoteCommand::Add(add_args) => {
-            let repo_path = normalize_repo_path(transaction.repo().path());
-            handle_remote_add_repo(add_args, &repo_path)
+            handle_remote_add_repo(add_args, &repo_path)?;
+            let config = read_remote_config(&repo_path, &add_args.name)?;
+            josh_cli::output::set_data_value(remote_json(&add_args.name, &config));
+            Ok(())
+        }
+        RemoteCommand::List(_) => {
+            let remotes = list_remote_names(&repo_path)?
+                .into_iter()
+                .map(|name| {
+                    let config = read_remote_config(&repo_path, &name)?;
+                    Ok(remote_json(&name, &config))
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            josh_cli::output::set_data_value(serde_json::Value::Array(remotes.clone()));
+            if remotes.is_empty() {
+                println!("No Josh remotes configured.");
+            } else {
+                for remote in &remotes {
+                    println!(
+                        "{}\t{}\t{}",
+                        remote["name"].as_str().unwrap_or_default(),
+                        remote["filter"].as_str().unwrap_or_default(),
+                        remote["url"].as_str().unwrap_or_default()
+                    );
+                }
+            }
+            Ok(())
+        }
+        RemoteCommand::Show(show_args) => {
+            let config = read_remote_config(&repo_path, &show_args.name)
+                .with_context(|| format!("Remote '{}' not found", show_args.name))?;
+            let data = remote_json(&show_args.name, &config);
+            josh_cli::output::set_data_value(data.clone());
+            println!("Remote: {}", show_args.name);
+            println!("URL: {}", josh_cli::output::sanitize(&config.url));
+            println!(
+                "Filter: {}",
+                josh_core::filter::spec(config.filter_with_meta.peel())
+            );
+            println!("Fetch: {}", config.ref_spec);
+            println!(
+                "Forge: {}",
+                config
+                    .forge
+                    .map(|forge| forge.to_string())
+                    .unwrap_or_else(|| "none".to_string())
+            );
+            Ok(())
+        }
+        RemoteCommand::SetFilter(set_args) => {
+            let config = read_remote_config(&repo_path, &set_args.name)
+                .with_context(|| format!("Remote '{}' not found", set_args.name))?;
+            let filter = josh_core::filter::parse(&set_args.filter)
+                .with_context(|| format!("Invalid filter '{}'", set_args.filter))?;
+            josh_core::filter::invert(filter)
+                .with_context(|| format!("Filter '{}' is not reversible", set_args.filter))?;
+            let canonical = josh_core::filter::spec(filter);
+            let default_branch = if set_args.apply {
+                Some(josh_cli::remote_ops::resolve_default_branch(
+                    repo,
+                    &set_args.name,
+                )?)
+            } else {
+                None
+            };
+
+            write_remote_config(
+                &repo_path,
+                &set_args.name,
+                &config.url,
+                &canonical,
+                &config.ref_spec,
+                config.forge,
+            )?;
+            if let Some(default_branch) = &default_branch {
+                josh_cli::remote_ops::apply_josh_filtering(
+                    transaction,
+                    filter,
+                    &set_args.name,
+                    default_branch,
+                )?;
+            }
+            josh_cli::output::set_data_value(serde_json::json!({
+                "action": "set-filter",
+                "remote": set_args.name,
+                "filter": canonical,
+                "filter_id": filter.id().to_string(),
+                "applied": set_args.apply,
+            }));
+            println!(
+                "Set filter for remote '{}' to '{}'{}",
+                set_args.name,
+                canonical,
+                if set_args.apply {
+                    " and updated filtered refs"
+                } else {
+                    ""
+                }
+            );
+            Ok(())
+        }
+        RemoteCommand::Remove(remove_args) => {
+            let config = read_remote_config(&repo_path, &remove_args.name)
+                .with_context(|| format!("Remote '{}' not found", remove_args.name))?;
+            let data = serde_json::json!({
+                "action": "remove",
+                "dry_run": remove_args.dry_run,
+                "remote": remote_json(&remove_args.name, &config),
+            });
+            josh_cli::output::set_data_value(data);
+            if remove_args.dry_run {
+                println!("Would remove Josh remote '{}'", remove_args.name);
+                return Ok(());
+            }
+
+            if repo.find_remote(&remove_args.name).is_ok() {
+                transaction
+                    .spawn_git(&["remote", "remove", &remove_args.name], &[])
+                    .context("Failed to remove Git remote")?;
+            }
+            remove_private_remote_refs(repo, &remove_args.name)?;
+            remove_remote_config(&repo_path, &remove_args.name)?;
+            println!("Removed Josh remote '{}'", remove_args.name);
+            Ok(())
         }
     }
+}
+
+fn remote_json(name: &str, config: &RemoteConfig) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "url": josh_cli::output::sanitize(&config.url),
+        "filter": josh_core::filter::spec(config.filter_with_meta.peel()),
+        "fetch": config.ref_spec,
+        "forge": config.forge.map(|forge| forge.to_string()),
+    })
+}
+
+fn remove_private_remote_refs(repo: &git2::Repository, remote: &str) -> anyhow::Result<()> {
+    let prefixes = [
+        format!("refs/josh/remotes/{remote}/"),
+        format!("refs/remotes/{remote}/"),
+        format!("refs/namespaces/josh-{remote}/"),
+    ];
+    let names = repo
+        .references()?
+        .filter_map(Result::ok)
+        .filter_map(|reference| reference.name().map(ToOwned::to_owned))
+        .filter(|name| prefixes.iter().any(|prefix| name.starts_with(prefix)))
+        .collect::<Vec<_>>();
+    for name in names {
+        if let Ok(mut reference) = repo.find_reference(&name) {
+            reference.delete()?;
+        }
+    }
+    Ok(())
 }
 
 fn handle_remote_add_repo(args: &RemoteAddArgs, repo_path: &std::path::Path) -> anyhow::Result<()> {
     let repo = git2::Repository::open(repo_path).context("Failed to open repository")?;
     let workdir = normalize_repo_path(repo_path);
 
-    // Store the remote information in .git/josh/remotes/<name>.josh file
+    let config_path = josh_cli::config::remote_config_path(repo_path, &args.name)?;
+    if config_path.exists()
+        || repo.find_remote(&args.name).is_ok()
+        || list_remote_names(repo_path)?
+            .iter()
+            .any(|name| name == &args.name)
+    {
+        return Err(anyhow::anyhow!(
+            "Remote '{}' already exists; remove it before adding it again",
+            args.name
+        ));
+    }
+
     let remote_url = to_absolute_remote_url(&args.url)?;
-
-    // Store the filter in git config per remote
     let filter_to_store = args.filter.clone();
-
-    // Store refspec (for unfiltered refs)
+    josh_core::filter::parse(&filter_to_store)
+        .with_context(|| format!("Invalid filter '{}'", filter_to_store))?;
     let refspec = format!("+refs/heads/*:refs/josh/remotes/{}/*", args.name);
-
     let forge = if args.forge_args.no_forge {
         None
     } else {
         args.forge_args
             .forge
-            .clone()
             .or_else(|| josh_cli::forge::guess_forge(&remote_url))
     };
 
-    // Write remote config to .git/josh/remotes/<name>.josh
-    write_remote_config(
-        repo_path,
-        &args.name,
-        &remote_url,
-        &filter_to_store,
-        &refspec,
-        forge,
-    )
-    .context("Failed to write remote config file")?;
-
-    // Set up a git remote that points to "." with a refspec to fetch filtered refs
-    // Add remote pointing to current directory
+    // Set up the Git transport first and roll it back if a later step fails.
     let repo_remote = to_absolute_remote_url(&workdir.display().to_string())?;
     spawn_git_command(
         repo.path(),
@@ -578,20 +1090,35 @@ fn handle_remote_add_repo(args: &RemoteAddArgs, repo_path: &std::path::Path) -> 
     )
     .context("Failed to add git remote")?;
 
-    // Set up namespace configuration for the remote
     let namespace = format!("josh-{}", args.name);
     let uploadpack_cmd = format!("env GIT_NAMESPACE={} git upload-pack", namespace);
-
-    spawn_git_command(
-        repo.path(),
-        &[
-            "config",
-            &format!("remote.{}.uploadpack", args.name),
-            &uploadpack_cmd,
-        ],
-        &[],
-    )
-    .context("Failed to set remote uploadpack")?;
+    let setup = (|| -> anyhow::Result<()> {
+        spawn_git_command(
+            repo.path(),
+            &[
+                "config",
+                &format!("remote.{}.uploadpack", args.name),
+                &uploadpack_cmd,
+            ],
+            &[],
+        )
+        .context("Failed to set remote uploadpack")?;
+        write_remote_config(
+            repo_path,
+            &args.name,
+            &remote_url,
+            &filter_to_store,
+            &refspec,
+            forge,
+        )
+        .context("Failed to write remote config file")?;
+        Ok(())
+    })();
+    if let Err(error) = setup {
+        let _ = spawn_git_command(repo.path(), &["remote", "remove", &args.name], &[]);
+        let _ = std::fs::remove_file(config_path);
+        return Err(error);
+    }
 
     eprintln!(
         "Added remote '{}' with filter '{}'",
@@ -606,30 +1133,66 @@ fn handle_filter(
     args: &FilterArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
+    if let Some(command) = &args.command {
+        return handle_filter_inspect(command);
+    }
+
+    let remote = args
+        .remote
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("A remote or filter subcommand is required"))?;
     let repo = transaction.repo();
     let repo_path = normalize_repo_path(repo.path());
 
     let RemoteConfig {
         filter_with_meta, ..
-    } = read_remote_config(&repo_path, &args.remote)
-        .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
+    } = read_remote_config(&repo_path, remote)
+        .with_context(|| format!("Failed to read remote config for '{}'", remote))?;
 
     let filter = filter_with_meta.peel();
     let filter_str = josh_core::filter::spec(filter);
 
-    println!(
-        "Applying filter '{}' to remote '{}'",
-        filter_str, args.remote
-    );
+    println!("Applying filter '{}' to remote '{}'", filter_str, remote);
+    let default_branch = josh_cli::remote_ops::resolve_default_branch(repo, remote)?;
+    josh_cli::remote_ops::apply_josh_filtering(transaction, filter, remote, &default_branch)?;
 
-    let default_branch = josh_cli::remote_ops::resolve_default_branch(repo, &args.remote)?;
+    println!("Applied filter '{}' to remote '{}'", filter_str, remote);
+    josh_cli::output::set_data_value(serde_json::json!({
+        "remote": remote,
+        "filter": filter_str,
+        "default_branch": default_branch,
+    }));
+    Ok(())
+}
 
-    josh_cli::remote_ops::apply_josh_filtering(transaction, filter, &args.remote, &default_branch)?;
+fn handle_filter_inspect(command: &FilterCommand) -> anyhow::Result<()> {
+    let (action, args) = match command {
+        FilterCommand::Validate(args) => ("validate", args),
+        FilterCommand::Explain(args) => ("explain", args),
+    };
+    let filter = josh_core::filter::parse(&args.filter)
+        .with_context(|| format!("Invalid filter '{}'", args.filter))?;
+    let inverse = josh_core::filter::invert(filter)
+        .with_context(|| format!("Filter '{}' is not reversible", args.filter))?;
+    let canonical = josh_core::filter::pretty(filter, 0);
+    let inverse_canonical = josh_core::filter::pretty(inverse, 0);
+    josh_cli::output::set_data_value(serde_json::json!({
+        "action": action,
+        "valid": true,
+        "reversible": true,
+        "filter": canonical,
+        "filter_id": filter.id().to_string(),
+        "inverse": inverse_canonical,
+        "inverse_id": inverse.id().to_string(),
+    }));
 
-    println!(
-        "Applied filter '{}' to remote '{}'",
-        filter_str, args.remote
-    );
-
+    if action == "validate" {
+        println!("valid\t{}", canonical);
+    } else {
+        println!("Filter: {}", canonical);
+        println!("ID: {}", filter.id());
+        println!("Inverse: {}", inverse_canonical);
+        println!("Inverse ID: {}", inverse.id());
+    }
     Ok(())
 }

--- a/josh-cli/src/commands/agent.rs
+++ b/josh-cli/src/commands/agent.rs
@@ -1,0 +1,185 @@
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, anyhow};
+use serde::Serialize;
+
+use crate::cli_println as println;
+
+pub const SKILL_NAME: &str = "josh";
+pub const SKILL_VERSION: &str = "1";
+pub const SKILL_CONTENT: &str = include_str!("../../skills/josh/SKILL.md");
+
+#[derive(Debug, clap::Parser)]
+pub struct AgentArgs {
+    #[command(subcommand)]
+    pub command: AgentCommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum AgentCommand {
+    /// Manage the bundled Josh agent skill
+    Skill(SkillArgs),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct SkillArgs {
+    #[command(subcommand)]
+    pub command: SkillCommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum SkillCommand {
+    /// Print the bundled SKILL.md to stdout
+    Print(SkillPrintArgs),
+    /// Install the bundled skill into an agent skill directory
+    Install(SkillInstallArgs),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct SkillPrintArgs {}
+
+#[derive(Debug, clap::Parser)]
+pub struct SkillInstallArgs {
+    /// Skill directory to create or update
+    #[arg(long, default_value = ".agents/skills/josh")]
+    pub target: PathBuf,
+
+    /// Replace an existing SKILL.md
+    #[arg(long)]
+    pub force: bool,
+
+    /// Show the destination without writing files
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct PrintedSkill<'a> {
+    name: &'static str,
+    version: &'static str,
+    content: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct InstalledSkill {
+    name: &'static str,
+    version: &'static str,
+    directory: String,
+    file: String,
+    installed: bool,
+    replaced: bool,
+    dry_run: bool,
+}
+
+pub fn handle_agent(args: &AgentArgs) -> anyhow::Result<()> {
+    match &args.command {
+        AgentCommand::Skill(args) => match &args.command {
+            SkillCommand::Print(args) => handle_print(args),
+            SkillCommand::Install(args) => handle_install(args),
+        },
+    }
+}
+
+fn handle_print(_args: &SkillPrintArgs) -> anyhow::Result<()> {
+    crate::output::set_data(&PrintedSkill {
+        name: SKILL_NAME,
+        version: SKILL_VERSION,
+        content: SKILL_CONTENT,
+    })?;
+
+    if !crate::output::is_machine()
+        && let Err(error) = crate::output::raw_stdout(SKILL_CONTENT)
+        && error.kind() != std::io::ErrorKind::BrokenPipe
+    {
+        return Err(error).context("Failed to print Josh agent skill");
+    }
+    Ok(())
+}
+
+fn absolute_target(target: &Path) -> anyhow::Result<PathBuf> {
+    if target.is_absolute() {
+        Ok(target.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(target))
+    }
+}
+
+fn atomic_write(path: &Path, content: &str) -> anyhow::Result<()> {
+    let parent = path
+        .parent()
+        .context("Skill file has no parent directory")?;
+    std::fs::create_dir_all(parent)?;
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_nanos();
+    let temporary = parent.join(format!(".SKILL.md.tmp-{}-{nonce}", std::process::id()));
+
+    let result = (|| -> anyhow::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+        #[cfg(windows)]
+        if path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        std::fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn handle_install(args: &SkillInstallArgs) -> anyhow::Result<()> {
+    let target = absolute_target(&args.target)?;
+    let file = target.join("SKILL.md");
+    let replaced = file.exists();
+    if replaced && !args.force {
+        return Err(anyhow!(
+            "Agent skill '{}' already exists; pass --force to replace it",
+            crate::output::sanitize(&file.display().to_string())
+        ));
+    }
+
+    if !args.dry_run {
+        atomic_write(&file, SKILL_CONTENT)
+            .with_context(|| format!("Failed to install agent skill at '{}'", file.display()))?;
+    }
+
+    let result = InstalledSkill {
+        name: SKILL_NAME,
+        version: SKILL_VERSION,
+        directory: crate::output::sanitize(&target.display().to_string()),
+        file: crate::output::sanitize(&file.display().to_string()),
+        installed: !args.dry_run,
+        replaced,
+        dry_run: args.dry_run,
+    };
+    crate::output::set_data(&result)?;
+
+    if args.dry_run {
+        println!("Would install Josh agent skill at {}", result.file);
+    } else if replaced {
+        println!("Updated Josh agent skill at {}", result.file);
+    } else {
+        println!("Installed Josh agent skill at {}", result.file);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_skill_has_agent_skills_frontmatter() {
+        assert!(SKILL_CONTENT.starts_with("---\nname: josh\n"));
+        assert!(SKILL_CONTENT.contains("\ndescription:"));
+        assert!(SKILL_CONTENT.ends_with('\n'));
+    }
+}

--- a/josh-cli/src/commands/auth.rs
+++ b/josh-cli/src/commands/auth.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use clap::Subcommand;
 
+use crate::cli_println as println;
 use crate::forge::Forge;
 
 #[derive(Debug, clap::Parser)]
@@ -28,21 +29,43 @@ pub struct ForgeArgs {
 }
 
 pub fn handle_auth(args: &AuthArgs) -> anyhow::Result<()> {
-    match &args.command {
-        AuthCommand::Login(forge_args) => match forge_args.forge {
-            Forge::Github => {
-                let rt =
-                    tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
-                rt.block_on(crate::forge::github::login())
+    let (action, forge) = match &args.command {
+        AuthCommand::Login(forge_args) => {
+            if crate::output::is_non_interactive() {
+                anyhow::bail!(
+                    "GitHub device login is interactive; run without --non-interactive or \
+                     configure the GH_TOKEN environment variable"
+                );
             }
-        },
-        AuthCommand::Logout(forge_args) => match forge_args.forge {
-            Forge::Github => crate::forge::github::logout(),
-        },
-        AuthCommand::Debug(forge_args) => match forge_args.forge {
-            Forge::Github => handle_debug_github_auth(),
-        },
-    }
+            match forge_args.forge {
+                Forge::Github => {
+                    let rt =
+                        tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+                    rt.block_on(crate::forge::github::login())?;
+                }
+            }
+            ("login", forge_args.forge)
+        }
+        AuthCommand::Logout(forge_args) => {
+            match forge_args.forge {
+                Forge::Github => crate::forge::github::logout()?,
+            }
+            println!("Logged out from {}.", forge_args.forge);
+            ("logout", forge_args.forge)
+        }
+        AuthCommand::Debug(forge_args) => {
+            match forge_args.forge {
+                Forge::Github => handle_debug_github_auth()?,
+            }
+            ("debug", forge_args.forge)
+        }
+    };
+    crate::output::set_data_value(serde_json::json!({
+        "action": action,
+        "forge": forge.to_string(),
+        "success": true,
+    }));
+    Ok(())
 }
 
 fn handle_debug_github_auth() -> anyhow::Result<()> {

--- a/josh-cli/src/commands/cache.rs
+++ b/josh-cli/src/commands/cache.rs
@@ -8,6 +8,7 @@ use josh_core::cache::{
 use josh_core::filter::{self, Filter, flatten_chain, from_tree};
 use josh_core::git::normalize_repo_path;
 
+use crate::cli_eprintln as eprintln;
 use crate::config::{RemoteConfig, read_remote_config};
 use crate::remote_ops;
 
@@ -216,6 +217,12 @@ fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyho
         default_branch,
         args.remote
     );
+    crate::output::set_data_value(serde_json::json!({
+        "action": "build",
+        "remote": args.remote,
+        "branch": default_branch,
+        "filters": all_step_lists.len(),
+    }));
     Ok(())
 }
 
@@ -272,6 +279,11 @@ fn handle_cache_push(args: &CachePushArgs, transaction: &Transaction) -> anyhow:
         args.remote,
         &filter.id().to_string()[..8]
     );
+    crate::output::set_data_value(serde_json::json!({
+        "action": "push",
+        "remote": args.remote,
+        "filter_id": filter.id().to_string(),
+    }));
     Ok(())
 }
 
@@ -326,5 +338,10 @@ fn handle_cache_fetch(args: &CacheFetchArgs, transaction: &Transaction) -> anyho
         args.remote,
         &filter.id().to_string()[..8]
     );
+    crate::output::set_data_value(serde_json::json!({
+        "action": "fetch",
+        "remote": args.remote,
+        "filter_id": filter.id().to_string(),
+    }));
     Ok(())
 }

--- a/josh-cli/src/commands/capabilities.rs
+++ b/josh-cli/src/commands/capabilities.rs
@@ -1,0 +1,114 @@
+use serde::Serialize;
+
+use crate::cli_println as println;
+
+#[derive(Debug, clap::Parser)]
+pub struct CapabilitiesArgs {
+    /// Return only the minimum information needed for agent negotiation
+    #[arg(long)]
+    pub brief: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct OutputCapabilities {
+    formats: [&'static str; 3],
+    schema_versions: [&'static str; 1],
+    json_errors: bool,
+    jsonl_events: bool,
+    machine_results_always_use_stdout: bool,
+    compact_json_by_default: bool,
+    data_only_with_quiet: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct AutomationCapabilities {
+    non_interactive: bool,
+    quiet: bool,
+    no_progress: bool,
+    color_control: bool,
+    stable_error_codes: bool,
+    installable_agent_skill: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct Capabilities {
+    version: &'static str,
+    output: OutputCapabilities,
+    automation: AutomationCapabilities,
+    commands: [&'static str; 16],
+}
+
+#[derive(Debug, Serialize)]
+struct BriefCapabilities {
+    version: &'static str,
+    schema_version: &'static str,
+    output_formats: [&'static str; 2],
+    agent_skill: bool,
+    workspaces: bool,
+}
+
+pub fn handle_capabilities(args: &CapabilitiesArgs) -> anyhow::Result<()> {
+    if args.brief {
+        let capabilities = BriefCapabilities {
+            version: josh_core::VERSION,
+            schema_version: crate::output::SCHEMA_VERSION,
+            output_formats: ["json", "jsonl"],
+            agent_skill: true,
+            workspaces: true,
+        };
+        crate::output::set_data(&capabilities)?;
+        println!(
+            "Josh {} schema={} output=json,jsonl agent-skill=yes workspaces=yes",
+            capabilities.version, capabilities.schema_version
+        );
+        return Ok(());
+    }
+
+    let capabilities = Capabilities {
+        version: josh_core::VERSION,
+        output: OutputCapabilities {
+            formats: ["human", "json", "jsonl"],
+            schema_versions: [crate::output::SCHEMA_VERSION],
+            json_errors: true,
+            jsonl_events: true,
+            machine_results_always_use_stdout: true,
+            compact_json_by_default: true,
+            data_only_with_quiet: true,
+        },
+        automation: AutomationCapabilities {
+            non_interactive: true,
+            quiet: true,
+            no_progress: true,
+            color_control: true,
+            stable_error_codes: true,
+            installable_agent_skill: true,
+        },
+        commands: [
+            "agent",
+            "auth",
+            "cache",
+            "capabilities",
+            "changes",
+            "clone",
+            "compose",
+            "completions",
+            "fetch",
+            "filter",
+            "link",
+            "pull",
+            "push",
+            "remote",
+            "status",
+            "workspace",
+        ],
+    };
+    crate::output::set_data(&capabilities)?;
+
+    println!("Josh {}", capabilities.version);
+    println!("Output formats: human, json, jsonl");
+    println!("Machine schema version: {}", crate::output::SCHEMA_VERSION);
+    println!("Non-interactive mode: supported");
+    println!("Workspace management: supported");
+    println!("Agent skill: installable");
+    Ok(())
+}

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -1,3 +1,5 @@
+use crate::cli_println as println;
+
 /// Arguments for `josh changes list`.
 #[derive(Debug, clap::Parser)]
 pub struct ListArgs {
@@ -22,11 +24,16 @@ pub fn handle_list(
     let changes = josh_changes::list_changes_in_scopes(repo, &scopes)?;
 
     if changes.is_empty() {
+        crate::output::set_data_value(serde_json::json!({
+            "branch": branch,
+            "changes": [],
+        }));
         println!("No local changes found for branch '{}'.", branch);
         return Ok(());
     }
 
     println!("Changes targeting '{}':\n", branch);
+    let mut output_changes = Vec::new();
 
     for change in &changes {
         let commit = repo.find_commit(change.commit())?;
@@ -42,11 +49,16 @@ pub fn handle_list(
         println!("{} {}{} ({})", id, subject, series, change.author());
 
         let contributing = change.contributing(repo)?;
+        let mut output_commits = Vec::new();
         for oid in &contributing {
             if let Ok(c) = repo.find_commit(*oid) {
                 let c_subject = c.message().unwrap_or("").lines().next().unwrap_or("");
                 let c_short = &oid.to_string()[..8];
                 println!("  {}  {}", c_short, c_subject);
+                output_commits.push(serde_json::json!({
+                    "oid": oid.to_string(),
+                    "subject": c_subject,
+                }));
             }
         }
 
@@ -56,6 +68,7 @@ pub fn handle_list(
                 josh_changes::read_comments_in_scopes(repo, cid, &scopes).unwrap_or_default()
             })
             .unwrap_or_default();
+        let mut output_comments = Vec::new();
         if !comments.is_empty() {
             println!();
             for c in &comments {
@@ -66,16 +79,46 @@ pub fn handle_list(
                     .as_ref()
                     .map(|l| format!(":{}", l.start_line))
                     .unwrap_or_default();
-                print!("    {} {}", cid, c.message.lines().next().unwrap_or(""));
-                if !file.is_empty() {
-                    print!(" ({}{})", file, line);
-                }
-                println!();
+                let location = if file.is_empty() {
+                    String::new()
+                } else {
+                    format!(" ({}{})", file, line)
+                };
+                println!(
+                    "    {} {}{}",
+                    cid,
+                    c.message.lines().next().unwrap_or(""),
+                    location
+                );
+                output_comments.push(serde_json::json!({
+                    "id": c.id,
+                    "message": c.message,
+                    "file": c.file,
+                    "location": c.location.as_ref().map(|location| serde_json::json!({
+                        "start_line": location.start_line,
+                        "end_line": location.end_line,
+                        "start_column": location.start_col,
+                        "end_column": location.end_col,
+                    })),
+                }));
             }
         }
 
+        output_changes.push(serde_json::json!({
+            "id": change.id(),
+            "subject": subject,
+            "series": change.series(),
+            "author": change.author(),
+            "commit": change.commit().to_string(),
+            "contributing_commits": output_commits,
+            "comments": output_comments,
+        }));
         println!();
     }
 
+    crate::output::set_data_value(serde_json::json!({
+        "branch": branch,
+        "changes": output_changes,
+    }));
     Ok(())
 }

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -1,3 +1,5 @@
+use crate::cli_println as println;
+
 /// Arguments for `josh changes comment`.
 #[derive(Debug, clap::Parser)]
 pub struct CommentArgs {
@@ -128,20 +130,33 @@ pub fn handle_comment(
         None => josh_changes::head_branch(repo)?,
     };
 
-    match &args.remote {
+    let scope = match &args.remote {
         Some(remote) => {
             let scope = josh_changes::ChangesRef::Remote {
                 remote: remote.clone(),
-                branch,
+                branch: branch.clone(),
             };
             josh_changes::write_outbox_comment(repo, &change, &meta, None, None, &scope)?;
             println!("Comment queued in outbox for remote '{}'.", remote);
+            format!("remote:{remote}")
         }
         None => {
-            let scope = josh_changes::ChangesRef::Local { branch };
+            let scope = josh_changes::ChangesRef::Local {
+                branch: branch.clone(),
+            };
             josh_changes::write_comment(repo, &change, &meta, None, None, &scope)?;
             println!("Comment saved (private to local ref).");
+            "local".to_string()
         }
-    }
+    };
+    crate::output::set_data_value(serde_json::json!({
+        "change": args.change,
+        "branch": branch,
+        "scope": scope,
+        "message": args.message,
+        "file": meta.file,
+        "reply_to": args.reply_to,
+        "update_of": args.update_of,
+    }));
     Ok(())
 }

--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -2,6 +2,8 @@ use anyhow::{Context, anyhow};
 
 use josh_link::make_signature;
 
+use crate::cli_eprintln as eprintln;
+
 #[derive(Debug, clap::Parser)]
 pub struct LinkArgs {
     /// Link subcommand
@@ -176,6 +178,16 @@ fn handle_link_add(
         normalized_path, args.url, filter, target, args.mode
     );
     eprintln!("Created branch: {}", branch_name);
+    crate::output::set_data_value(serde_json::json!({
+        "action": "add",
+        "path": normalized_path,
+        "url": args.url,
+        "filter": filter,
+        "target": target,
+        "mode": args.mode,
+        "commit": commit_oid.to_string(),
+        "branch": branch_name,
+    }));
 
     Ok(())
 }
@@ -210,6 +222,12 @@ fn handle_link_fetch(
 
     if link_refs.is_empty() {
         eprintln!("No .link.josh references found in history");
+        crate::output::set_data_value(serde_json::json!({
+            "action": "fetch",
+            "fetched": 0,
+            "skipped": 0,
+            "references": 0,
+        }));
         return Ok(());
     }
 
@@ -257,6 +275,12 @@ fn handle_link_fetch(
         "Done: fetched {}, skipped {} (already present)",
         fetched, skipped
     );
+    crate::output::set_data_value(serde_json::json!({
+        "action": "fetch",
+        "fetched": fetched,
+        "skipped": skipped,
+        "references": link_refs.len(),
+    }));
 
     Ok(())
 }
@@ -341,6 +365,12 @@ fn handle_link_update(
     )?
     else {
         eprintln!("All {} link file(s) already up to date", link_files.len());
+        crate::output::set_data_value(serde_json::json!({
+            "action": "update",
+            "updated": 0,
+            "links": link_files.len(),
+            "up_to_date": true,
+        }));
         return Ok(());
     };
 
@@ -355,6 +385,14 @@ fn handle_link_update(
 
     eprintln!("Updated {} link file(s)", link_files.len());
     eprintln!("Updated branch: {}", branch_name);
+    crate::output::set_data_value(serde_json::json!({
+        "action": "update",
+        "updated": link_files.len(),
+        "links": link_files.len(),
+        "up_to_date": false,
+        "branch": branch_name,
+        "commit": result.filtered_commit.to_string(),
+    }));
 
     Ok(())
 }
@@ -425,6 +463,14 @@ fn handle_link_push(
     transaction
         .spawn_git(&["push", &remote, &refspec], &[])
         .with_context(|| format!("Failed to push to '{}'", remote))?;
+    crate::output::set_data_value(serde_json::json!({
+        "action": "push",
+        "path": normalized_path,
+        "remote": remote,
+        "target": push_ref,
+        "commit": exported_commit.to_string(),
+        "force": args.force,
+    }));
 
     Ok(())
 }

--- a/josh-cli/src/commands/mod.rs
+++ b/josh-cli/src/commands/mod.rs
@@ -1,8 +1,12 @@
+pub mod agent;
 pub mod auth;
 pub mod cache;
+pub mod capabilities;
 pub mod changes;
 pub mod comment;
 pub mod link;
 pub mod push;
 pub mod run;
+pub mod status;
 pub mod sync;
+pub mod workspace;

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -3,6 +3,7 @@ use anyhow::{Context, anyhow};
 use josh_changes::{PushMode, PushRef, build_to_push};
 use josh_core::git::normalize_repo_path;
 
+use crate::cli_eprintln as eprintln;
 use crate::config::{RemoteConfig, read_remote_config};
 use crate::forge::Forge;
 
@@ -397,6 +398,20 @@ fn orchestrate_push(
 
     create_prs(&pr_infos, &url, dry_run)?;
 
+    crate::output::set_data_value(serde_json::json!({
+        "remote": remote_name,
+        "dry_run": dry_run,
+        "force": force,
+        "atomic": atomic,
+        "refs": to_push
+            .iter()
+            .map(|push_ref| serde_json::json!({
+                "oid": push_ref.oid.to_string(),
+                "destination": push_ref.ref_name,
+            }))
+            .collect::<Vec<_>>(),
+        "pull_requests": pr_infos.len(),
+    }));
     Ok(())
 }
 

--- a/josh-cli/src/commands/run.rs
+++ b/josh-cli/src/commands/run.rs
@@ -1,5 +1,7 @@
 use josh_compose::{CleanMode, RunOptions};
 
+use crate::cli_println as println;
+
 #[derive(Debug, clap::Parser)]
 pub struct ComposeArgs {
     #[command(subcommand)]
@@ -37,7 +39,8 @@ pub struct RunArgs {
     #[arg(long = "clean-all")]
     pub clean_all: bool,
 
-    /// Git revision to use as input: "." (working tree), "+" (index), or any rev (e.g. "HEAD", "HEAD~1", "main")
+    /// Git revision to use as input: "." (working tree), "+" (index), or any rev
+    /// (e.g. "HEAD", "HEAD~1", "main")
     #[arg(default_value = ".")]
     pub reference: String,
 
@@ -63,9 +66,20 @@ pub fn handle_run(
         RunOptions {
             filter_spec: args.filter.clone(),
             input_ref: args.reference.clone(),
-            clean,
+            clean: clean.clone(),
         },
-    )
+    )?;
+    crate::output::set_data_value(serde_json::json!({
+        "reference": args.reference,
+        "filter": args.filter,
+        "clean": match clean {
+            CleanMode::None => "none",
+            CleanMode::Clean => "clean",
+            CleanMode::CleanAll => "clean-all",
+        },
+        "completed": true,
+    }));
+    Ok(())
 }
 
 #[derive(Debug, clap::Parser)]
@@ -74,7 +88,8 @@ pub struct ListImagesArgs {
     #[arg(long = "all")]
     pub all: bool,
 
-    /// Git revision to use as input: "." (working tree), "+" (index), or any rev (e.g. "HEAD", "HEAD~1", "main")
+    /// Git revision to use as input: "." (working tree), "+" (index), or any rev
+    /// (e.g. "HEAD", "HEAD~1", "main")
     #[arg(default_value = ".")]
     pub reference: String,
 
@@ -97,9 +112,14 @@ pub fn handle_list_images(
         args.all,
     )?;
 
-    for oid in oids {
-        println!("ws_image_{oid}");
+    let images = oids
+        .into_iter()
+        .map(|oid| format!("ws_image_{oid}"))
+        .collect::<Vec<_>>();
+    for image in &images {
+        println!("{image}");
     }
+    crate::output::set_data_value(serde_json::json!({ "images": images }));
     Ok(())
 }
 
@@ -109,7 +129,8 @@ pub struct ListJobsArgs {
     #[arg(long = "all")]
     pub all: bool,
 
-    /// Git revision to use as input: "." (working tree), "+" (index), or any rev (e.g. "HEAD", "HEAD~1", "main")
+    /// Git revision to use as input: "." (working tree), "+" (index), or any rev
+    /// (e.g. "HEAD", "HEAD~1", "main")
     #[arg(default_value = ".")]
     pub reference: String,
 
@@ -132,8 +153,13 @@ pub fn handle_list_jobs(
         args.all,
     )?;
 
-    for oid in oids {
-        println!("{oid}");
+    let jobs = oids
+        .into_iter()
+        .map(|oid| oid.to_string())
+        .collect::<Vec<_>>();
+    for job in &jobs {
+        println!("{job}");
     }
+    crate::output::set_data_value(serde_json::json!({ "jobs": jobs }));
     Ok(())
 }

--- a/josh-cli/src/commands/status.rs
+++ b/josh-cli/src/commands/status.rs
@@ -1,0 +1,148 @@
+use anyhow::Context;
+use serde::Serialize;
+
+use crate::cli_println as println;
+use crate::config::list_remote_names;
+
+#[derive(Debug, clap::Parser)]
+pub struct StatusArgs {}
+
+#[derive(Debug, Serialize)]
+struct WorkingTreeStatus {
+    clean: bool,
+    staged: usize,
+    modified: usize,
+    untracked: usize,
+    conflicted: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct RemoteStatus {
+    name: String,
+    url: String,
+    filter: String,
+    forge: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct StatusResult {
+    repository: String,
+    branch: Option<String>,
+    detached: bool,
+    head: Option<String>,
+    working_tree: WorkingTreeStatus,
+    remotes: Vec<RemoteStatus>,
+}
+
+pub fn handle_status(_args: &StatusArgs, repo: &git2::Repository) -> anyhow::Result<()> {
+    let workdir = repo
+        .workdir()
+        .context("Status requires a non-bare Git repository")?;
+    let head = repo.head().ok();
+    let detached = repo.head_detached().unwrap_or(false);
+    let branch = if detached {
+        None
+    } else {
+        head.as_ref()
+            .and_then(|reference| reference.shorthand())
+            .map(ToOwned::to_owned)
+    };
+    let head_oid = head
+        .and_then(|reference| reference.peel_to_commit().ok())
+        .map(|commit| commit.id().to_string());
+
+    let mut options = git2::StatusOptions::new();
+    options
+        .include_untracked(true)
+        .recurse_untracked_dirs(true)
+        .renames_head_to_index(true)
+        .renames_index_to_workdir(true);
+    let statuses = repo.statuses(Some(&mut options))?;
+
+    let mut working_tree = WorkingTreeStatus {
+        clean: statuses.is_empty(),
+        staged: 0,
+        modified: 0,
+        untracked: 0,
+        conflicted: 0,
+    };
+    for entry in statuses.iter() {
+        let status = entry.status();
+        if status.is_conflicted() {
+            working_tree.conflicted += 1;
+        }
+        if status.is_index_new()
+            || status.is_index_modified()
+            || status.is_index_deleted()
+            || status.is_index_renamed()
+            || status.is_index_typechange()
+        {
+            working_tree.staged += 1;
+        }
+        if status.is_wt_modified()
+            || status.is_wt_deleted()
+            || status.is_wt_renamed()
+            || status.is_wt_typechange()
+        {
+            working_tree.modified += 1;
+        }
+        if status.is_wt_new() {
+            working_tree.untracked += 1;
+        }
+    }
+
+    let mut remotes = Vec::new();
+    for name in list_remote_names(workdir)? {
+        if let Ok(config) = crate::config::read_remote_config(workdir, &name) {
+            remotes.push(RemoteStatus {
+                name,
+                url: crate::output::sanitize(&config.url),
+                filter: josh_core::filter::spec(config.filter_with_meta.peel()),
+                forge: config.forge.map(|forge| forge.to_string()),
+            });
+        }
+    }
+
+    let result = StatusResult {
+        repository: crate::output::sanitize(&workdir.display().to_string()),
+        branch,
+        detached,
+        head: head_oid,
+        working_tree,
+        remotes,
+    };
+    crate::output::set_data(&result)?;
+
+    println!("Repository: {}", result.repository);
+    println!(
+        "Branch: {}",
+        result.branch.as_deref().unwrap_or(if result.detached {
+            "(detached)"
+        } else {
+            "(unborn)"
+        })
+    );
+    println!(
+        "Working tree: {}",
+        if result.working_tree.clean {
+            "clean".to_string()
+        } else {
+            format!(
+                "{} staged, {} modified, {} untracked, {} conflicted",
+                result.working_tree.staged,
+                result.working_tree.modified,
+                result.working_tree.untracked,
+                result.working_tree.conflicted
+            )
+        }
+    );
+    if result.remotes.is_empty() {
+        println!("Josh remotes: none");
+    } else {
+        println!("Josh remotes:");
+        for remote in &result.remotes {
+            println!("  {}  {}  {}", remote.name, remote.filter, remote.url);
+        }
+    }
+    Ok(())
+}

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -5,6 +5,7 @@ use josh_core::git::normalize_repo_path;
 use crate::config::read_remote_config;
 use crate::forge::Forge;
 use crate::forge::github;
+use crate::{cli_eprintln as eprintln, cli_println as println};
 use serde_json;
 
 /// Arguments for `josh changes sync`.

--- a/josh-cli/src/commands/workspace.rs
+++ b/josh-cli/src/commands/workspace.rs
@@ -1,0 +1,627 @@
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, anyhow};
+use serde::Serialize;
+
+use crate::{cli_eprintln as eprintln, cli_println as println};
+
+const WORKSPACE_FILE: &str = "workspace.josh";
+
+#[derive(Debug, clap::Parser)]
+pub struct WorkspaceArgs {
+    #[command(subcommand)]
+    pub command: WorkspaceCommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum WorkspaceCommand {
+    /// Create a workspace definition in the current repository
+    Create(WorkspaceCreateArgs),
+    /// List workspace definitions in the current working tree
+    List(WorkspaceListArgs),
+    /// Show a workspace definition and its canonical filter
+    Show(WorkspaceShowArgs),
+    /// Validate one or more workspace definitions
+    Validate(WorkspaceValidateArgs),
+    /// Materialize a workspace as a detached local Git worktree
+    Checkout(WorkspaceCheckoutArgs),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct WorkspaceCreateArgs {
+    /// Repository-relative directory that will contain workspace.josh
+    pub path: PathBuf,
+
+    /// Add a mapping as DESTINATION=FILTER (repeatable)
+    #[arg(long = "map", value_name = "DESTINATION=FILTER")]
+    pub mappings: Vec<String>,
+
+    /// Replace an existing workspace definition
+    #[arg(long)]
+    pub force: bool,
+
+    /// Validate and show the result without writing it
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct WorkspaceListArgs {
+    /// Include the canonical filter in human output
+    #[arg(long)]
+    pub verbose: bool,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct WorkspaceShowArgs {
+    /// Repository-relative workspace directory or workspace.josh file
+    pub path: PathBuf,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct WorkspaceValidateArgs {
+    /// Workspaces to validate; validates every discovered workspace when omitted
+    pub paths: Vec<PathBuf>,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct WorkspaceCheckoutArgs {
+    /// Repository-relative workspace directory or workspace.josh file
+    pub path: PathBuf,
+
+    /// Directory in which to materialize the filtered worktree
+    pub out: PathBuf,
+
+    /// Input revision: "." (working tree), "+" (index), or any Git revision
+    #[arg(short = 'r', long = "reference", default_value = ".")]
+    pub reference: String,
+
+    /// Resolve and filter the workspace without creating the worktree
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct WorkspaceInfo {
+    pub path: String,
+    pub file: String,
+    pub valid: bool,
+    pub reversible: bool,
+    pub filter: Option<String>,
+    pub filter_id: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CreateResult {
+    action: &'static str,
+    path: String,
+    file: String,
+    mappings: usize,
+    dry_run: bool,
+    definition: String,
+    filter: String,
+    filter_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct CheckoutResult {
+    action: &'static str,
+    workspace: String,
+    output: String,
+    reference: String,
+    commit: String,
+    dry_run: bool,
+    detached: bool,
+}
+
+pub fn handle_workspace(
+    args: &WorkspaceArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    match &args.command {
+        WorkspaceCommand::Create(args) => handle_create(args, transaction),
+        WorkspaceCommand::List(args) => handle_list(args, transaction),
+        WorkspaceCommand::Show(args) => handle_show(args, transaction),
+        WorkspaceCommand::Validate(args) => handle_validate(args, transaction),
+        WorkspaceCommand::Checkout(args) => handle_checkout(args, transaction),
+    }
+}
+
+fn repo_root(repo: &git2::Repository) -> anyhow::Result<&Path> {
+    repo.workdir()
+        .ok_or_else(|| anyhow!("Workspace commands require a non-bare Git repository"))
+}
+
+fn normalize_workspace_path(path: &Path) -> anyhow::Result<PathBuf> {
+    let path = if path.file_name().is_some_and(|name| name == WORKSPACE_FILE) {
+        path.parent().unwrap_or_else(|| Path::new("."))
+    } else {
+        path
+    };
+
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(value) => normalized.push(value),
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                return Err(anyhow!(
+                    "Workspace path '{}' must be relative and remain inside the repository",
+                    path.display()
+                ));
+            }
+        }
+    }
+    Ok(normalized)
+}
+
+fn normalize_absolute_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::RootDir | Component::Prefix(_) | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    normalized
+}
+
+fn display_path(path: &Path) -> String {
+    let value = path.display().to_string();
+    if let Ok(test_root) = std::env::var("TESTTMP") {
+        value.replace(&test_root, "${TESTTMP}")
+    } else {
+        value
+    }
+}
+
+fn workspace_name(path: &Path) -> String {
+    if path.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        path.to_string_lossy().replace('\\', "/")
+    }
+}
+
+fn workspace_file(root: &Path, path: &Path) -> anyhow::Result<(PathBuf, PathBuf)> {
+    let workspace = normalize_workspace_path(path)?;
+    Ok((workspace.clone(), root.join(workspace).join(WORKSPACE_FILE)))
+}
+
+fn validate_content(path: &Path, content: &str) -> WorkspaceInfo {
+    let workspace = workspace_name(path);
+    let file = if workspace == "." {
+        WORKSPACE_FILE.to_string()
+    } else {
+        format!("{workspace}/{WORKSPACE_FILE}")
+    };
+
+    match josh_core::filter::parse(content) {
+        Ok(filter) => match josh_core::filter::invert(filter) {
+            Ok(_) => WorkspaceInfo {
+                path: workspace,
+                file,
+                valid: true,
+                reversible: true,
+                filter: Some(josh_core::filter::pretty(filter, 0)),
+                filter_id: Some(filter.id().to_string()),
+                error: None,
+            },
+            Err(error) => WorkspaceInfo {
+                path: workspace,
+                file,
+                valid: false,
+                reversible: false,
+                filter: Some(josh_core::filter::pretty(filter, 0)),
+                filter_id: Some(filter.id().to_string()),
+                error: Some(format!("Workspace filter is not reversible: {error}")),
+            },
+        },
+        Err(error) => WorkspaceInfo {
+            path: workspace,
+            file,
+            valid: false,
+            reversible: false,
+            filter: None,
+            filter_id: None,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+fn read_workspace(root: &Path, path: &Path) -> anyhow::Result<WorkspaceInfo> {
+    let (workspace, file) = workspace_file(root, path)?;
+    let content = std::fs::read_to_string(&file)
+        .with_context(|| format!("Failed to read workspace definition '{}'", file.display()))?;
+    Ok(validate_content(&workspace, &content))
+}
+
+fn is_workspace_file(path: &Path) -> bool {
+    path.file_name().is_some_and(|name| name == WORKSPACE_FILE)
+}
+
+fn discover_workspaces(repo: &git2::Repository) -> anyhow::Result<Vec<WorkspaceInfo>> {
+    let root = repo_root(repo)?;
+    let mut relative_files = std::collections::BTreeSet::new();
+
+    // The index supplies tracked definitions without walking ignored build output directories.
+    for entry in repo.index()?.iter() {
+        let path = PathBuf::from(String::from_utf8_lossy(&entry.path).into_owned());
+        if is_workspace_file(&path) && root.join(&path).is_file() {
+            relative_files.insert(path);
+        }
+    }
+
+    // Include untracked definitions so `create` is immediately visible before a commit.
+    let mut options = git2::StatusOptions::new();
+    options.include_untracked(true).recurse_untracked_dirs(true);
+    for entry in repo.statuses(Some(&mut options))?.iter() {
+        if let Some(path) = entry.path().map(PathBuf::from)
+            && is_workspace_file(&path)
+            && root.join(&path).is_file()
+        {
+            relative_files.insert(path);
+        }
+    }
+
+    let mut workspaces = relative_files
+        .into_iter()
+        .map(|relative| {
+            let path = relative.parent().unwrap_or_else(|| Path::new("."));
+            let content = std::fs::read_to_string(root.join(&relative))?;
+            Ok(validate_content(path, &content))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    workspaces.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(workspaces)
+}
+
+fn parse_mapping(mapping: &str) -> anyhow::Result<(String, josh_core::filter::Filter)> {
+    let (destination, filter_spec) = mapping
+        .split_once('=')
+        .ok_or_else(|| anyhow!("Invalid mapping '{}'; expected DESTINATION=FILTER", mapping))?;
+    let destination = destination.trim();
+    let filter_spec = filter_spec.trim();
+
+    if destination.is_empty()
+        || destination.starts_with('/')
+        || destination.ends_with('/')
+        || destination
+            .split('/')
+            .any(|component| component.is_empty() || component == "." || component == "..")
+    {
+        return Err(anyhow!(
+            "Invalid workspace mapping destination '{}'",
+            destination
+        ));
+    }
+    if filter_spec.is_empty() {
+        return Err(anyhow!("Mapping '{}' has an empty filter", mapping));
+    }
+
+    let filter = josh_core::filter::parse(filter_spec)
+        .with_context(|| format!("Invalid filter in mapping '{}'", mapping))?;
+    josh_core::filter::invert(filter)
+        .with_context(|| format!("Filter in mapping '{}' is not reversible", mapping))?;
+    Ok((destination.to_string(), filter))
+}
+
+fn create_content(mappings: &[String]) -> anyhow::Result<(String, josh_core::filter::Filter)> {
+    if mappings.is_empty() {
+        let content = "# Empty Josh workspace\n".to_string();
+        let filter = josh_core::filter::parse(&content)?;
+        return Ok((content, filter));
+    }
+
+    let mut lines = Vec::new();
+    let mut destinations = std::collections::HashSet::new();
+    for mapping in mappings {
+        let (destination, filter) = parse_mapping(mapping)?;
+        if !destinations.insert(destination.clone()) {
+            return Err(anyhow!(
+                "Duplicate workspace mapping destination '{}'",
+                destination
+            ));
+        }
+        lines.push(format!(
+            "{} = {}",
+            destination,
+            josh_core::filter::spec(filter)
+        ));
+    }
+    let content = format!("{}\n", lines.join("\n"));
+    let filter = josh_core::filter::parse(&content)?;
+    josh_core::filter::invert(filter).context("Workspace filter is not reversible")?;
+    Ok((content, filter))
+}
+
+fn atomic_write(path: &Path, content: &str) -> anyhow::Result<()> {
+    let parent = path.parent().context("Workspace file has no parent")?;
+    std::fs::create_dir_all(parent)?;
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_nanos();
+    let temporary = parent.join(format!(
+        ".{WORKSPACE_FILE}.tmp-{}-{nonce}",
+        std::process::id()
+    ));
+
+    let result = (|| -> anyhow::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+        #[cfg(windows)]
+        if path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        std::fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result
+}
+
+fn handle_create(
+    args: &WorkspaceCreateArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let root = repo_root(transaction.repo())?;
+    let (workspace, file) = workspace_file(root, &args.path)?;
+    let existed = file.exists();
+    if existed && !args.force {
+        return Err(anyhow!(
+            "Workspace '{}' already exists; pass --force to replace it",
+            workspace_name(&workspace)
+        ));
+    }
+
+    let (content, filter) = create_content(&args.mappings)?;
+    if !args.dry_run {
+        atomic_write(&file, &content)
+            .with_context(|| format!("Failed to write workspace '{}'", file.display()))?;
+    }
+
+    let relative_file = file.strip_prefix(root).unwrap_or(&file);
+    let result = CreateResult {
+        action: if existed { "replace" } else { "create" },
+        path: workspace_name(&workspace),
+        file: relative_file.to_string_lossy().replace('\\', "/"),
+        mappings: args.mappings.len(),
+        dry_run: args.dry_run,
+        definition: content.trim_end().to_string(),
+        filter: josh_core::filter::pretty(filter, 0),
+        filter_id: filter.id().to_string(),
+    };
+    crate::output::set_data(&result)?;
+
+    if args.dry_run {
+        println!("Would create workspace '{}'", result.path);
+    } else {
+        println!("Created workspace '{}'", result.path);
+    }
+    println!("Definition: {}", result.file);
+    if !args.mappings.is_empty() {
+        println!("\n{}", result.definition);
+    }
+    Ok(())
+}
+
+fn handle_list(
+    args: &WorkspaceListArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let workspaces = discover_workspaces(transaction.repo())?;
+    crate::output::set_data(&workspaces)?;
+
+    if workspaces.is_empty() {
+        println!("No workspaces found.");
+        return Ok(());
+    }
+
+    for workspace in &workspaces {
+        println!(
+            "{}\t{}",
+            if workspace.valid { "valid" } else { "invalid" },
+            workspace.path
+        );
+        if args.verbose {
+            if let Some(filter) = &workspace.filter {
+                println!("{}", indent(filter, "  "));
+            }
+            if let Some(error) = &workspace.error {
+                println!("  Error: {error}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn indent(value: &str, prefix: &str) -> String {
+    value
+        .lines()
+        .map(|line| format!("{prefix}{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn handle_show(
+    args: &WorkspaceShowArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let workspace = read_workspace(repo_root(transaction.repo())?, &args.path)?;
+    crate::output::set_data(&workspace)?;
+
+    println!("Workspace: {}", workspace.path);
+    println!("Definition: {}", workspace.file);
+    println!(
+        "Status: {}",
+        if workspace.valid { "valid" } else { "invalid" }
+    );
+    if let Some(filter) = &workspace.filter {
+        println!("Filter:\n{}", indent(filter, "  "));
+    }
+    if let Some(error) = &workspace.error {
+        return Err(anyhow!("Invalid workspace '{}': {error}", workspace.path));
+    }
+    Ok(())
+}
+
+fn handle_validate(
+    args: &WorkspaceValidateArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let root = repo_root(transaction.repo())?;
+    let workspaces = if args.paths.is_empty() {
+        discover_workspaces(transaction.repo())?
+    } else {
+        args.paths
+            .iter()
+            .map(|path| read_workspace(root, path))
+            .collect::<anyhow::Result<Vec<_>>>()?
+    };
+    crate::output::set_data(&workspaces)?;
+
+    if workspaces.is_empty() {
+        println!("No workspaces found.");
+        return Ok(());
+    }
+
+    let mut invalid = 0;
+    for workspace in &workspaces {
+        if workspace.valid {
+            println!("valid\t{}", workspace.path);
+        } else {
+            invalid += 1;
+            println!("invalid\t{}", workspace.path);
+            if let Some(error) = &workspace.error {
+                eprintln!("Warning: {}: {error}", workspace.path);
+            }
+        }
+    }
+
+    if invalid > 0 {
+        return Err(anyhow!("{invalid} workspace definition(s) are invalid"));
+    }
+    Ok(())
+}
+
+fn handle_checkout(
+    args: &WorkspaceCheckoutArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let repo = transaction.repo();
+    let root = repo_root(repo)?;
+    let (workspace_path, _) = workspace_file(root, &args.path)?;
+    let workspace = read_workspace(root, &workspace_path)?;
+    if !workspace.valid {
+        return Err(anyhow!(
+            "Invalid workspace '{}': {}",
+            workspace.path,
+            workspace.error.as_deref().unwrap_or("unknown error")
+        ));
+    }
+
+    let input = josh_core::git::resolve_snapshot_input(repo, &args.reference)
+        .with_context(|| format!("Failed to resolve input '{}'", args.reference))?;
+    let filter = josh_core::filter::Filter::new().workspace(&workspace_path);
+    let filtered = josh_core::filter_commit(transaction, filter, input)
+        .context("Failed to materialize workspace")?;
+    if filtered == git2::Oid::zero() {
+        return Err(anyhow!(
+            "Workspace '{}' produced an empty history",
+            workspace.path
+        ));
+    }
+
+    let output = normalize_absolute_path(&if args.out.is_absolute() {
+        args.out.clone()
+    } else {
+        std::env::current_dir()?.join(&args.out)
+    });
+    if output.exists() && !args.dry_run {
+        return Err(anyhow!(
+            "Checkout destination '{}' already exists",
+            output.display()
+        ));
+    }
+
+    let result = CheckoutResult {
+        action: "checkout",
+        workspace: workspace.path.clone(),
+        output: display_path(&output),
+        reference: args.reference.clone(),
+        commit: filtered.to_string(),
+        dry_run: args.dry_run,
+        detached: true,
+    };
+    crate::output::set_data(&result)?;
+
+    if args.dry_run {
+        println!(
+            "Would check out workspace '{}' at {}",
+            workspace.path, result.output
+        );
+    } else {
+        let output_arg = output.to_string_lossy();
+        let filtered_arg = filtered.to_string();
+        transaction
+            .spawn_git(
+                &["worktree", "add", "--detach", &output_arg, &filtered_arg],
+                &[],
+            )
+            .context("Failed to create workspace worktree")?;
+        println!(
+            "Checked out workspace '{}' at {}",
+            workspace.path, result.output
+        );
+        eprintln!(
+            "This is a detached local view; use 'josh clone ... :workspace={} ...' for a \
+             bidirectional remote checkout.",
+            workspace.path
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mapping_validation() {
+        assert!(parse_mapping("src=:/apps/frontend").is_ok());
+        assert!(parse_mapping("../src=:/apps/frontend").is_err());
+        assert!(parse_mapping("src").is_err());
+        assert!(parse_mapping("src=").is_err());
+    }
+
+    #[test]
+    fn empty_workspace_is_valid() {
+        let (content, filter) = create_content(&[]).unwrap();
+        assert_eq!(content, "# Empty Josh workspace\n");
+        assert!(josh_core::filter::invert(filter).is_ok());
+    }
+
+    #[test]
+    fn workspace_path_cannot_escape_repository() {
+        assert_eq!(
+            normalize_workspace_path(Path::new("ws/app")).unwrap(),
+            Path::new("ws/app")
+        );
+        assert!(normalize_workspace_path(Path::new("../app")).is_err());
+        assert!(normalize_workspace_path(Path::new("/app")).is_err());
+    }
+}

--- a/josh-cli/src/config.rs
+++ b/josh-cli/src/config.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use anyhow::{Context, anyhow};
 
 use crate::forge::Forge;
@@ -20,6 +22,69 @@ fn remotes_dir(repo_path: &std::path::Path) -> anyhow::Result<std::path::PathBuf
         .with_context(|| format!("Failed to open repository at {}", repo_path.display()))?;
 
     Ok(repo.commondir().join("josh").join("remotes"))
+}
+
+pub fn remote_config_path(
+    repo_path: &std::path::Path,
+    remote_name: &str,
+) -> anyhow::Result<std::path::PathBuf> {
+    Ok(remotes_dir(repo_path)?.join(format!("{remote_name}.josh")))
+}
+
+pub fn list_remote_names(repo_path: &std::path::Path) -> anyhow::Result<Vec<String>> {
+    let directory = remotes_dir(repo_path)?;
+    let mut names = Vec::new();
+    let entries = match std::fs::read_dir(&directory) {
+        Ok(entries) => Some(entries),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
+
+    if let Some(entries) = entries {
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_file() {
+                continue;
+            }
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("josh") {
+                continue;
+            }
+            if let Some(name) = path.file_stem().and_then(|value| value.to_str()) {
+                names.push(name.to_string());
+            }
+        }
+    }
+    let repo = git2::Repository::open(repo_path).context("Failed to open repository")?;
+    let config = repo.config().context("Failed to read Git configuration")?;
+    if let Ok(entries) = config.entries(Some("josh-remote.*.url")) {
+        entries.for_each(|entry| {
+            if let Some(name) = entry
+                .name()
+                .and_then(|name| name.strip_prefix("josh-remote."))
+                .and_then(|name| name.strip_suffix(".url"))
+            {
+                names.push(name.to_string());
+            }
+        })?;
+    }
+
+    names.sort();
+    names.dedup();
+    Ok(names)
+}
+
+pub fn remove_remote_config(repo_path: &std::path::Path, remote_name: &str) -> anyhow::Result<()> {
+    let path = remote_config_path(repo_path, remote_name)?;
+    std::fs::remove_file(&path)
+        .with_context(|| format!("Failed to remove remote config '{}'", path.display()))?;
+
+    let repo = git2::Repository::open(repo_path).context("Failed to open repository")?;
+    let mut config = repo.config().context("Failed to read Git configuration")?;
+    for key in ["url", "filter", "fetch"] {
+        let _ = config.remove(&format!("josh-remote.{remote_name}.{key}"));
+    }
+    Ok(())
 }
 
 pub fn migrate_legacy_config(
@@ -132,6 +197,36 @@ pub fn read_remote_config(
     })
 }
 
+fn atomic_write(path: &std::path::Path, content: &str) -> anyhow::Result<()> {
+    let parent = path.parent().context("Remote config path has no parent")?;
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("Remote config path is not valid UTF-8")?;
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)?
+        .as_nanos();
+    let temporary = parent.join(format!(".{name}.tmp-{}-{nonce}", std::process::id()));
+    let result = (|| -> anyhow::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)?;
+        file.write_all(content.as_bytes())?;
+        file.sync_all()?;
+        #[cfg(windows)]
+        if path.exists() {
+            std::fs::remove_file(path)?;
+        }
+        std::fs::rename(&temporary, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temporary);
+    }
+    result
+}
+
 /// Write remote configuration to .git/josh/remotes/<name>.josh file
 pub fn write_remote_config(
     repo_path: &std::path::Path,
@@ -167,7 +262,7 @@ pub fn write_remote_config(
 
     // Write to file
     let remote_file = remotes_dir.join(format!("{}.josh", remote_name));
-    std::fs::write(&remote_file, content).with_context(|| {
+    atomic_write(&remote_file, &content).with_context(|| {
         format!(
             "Failed to write remote config file: {}",
             remote_file.display()

--- a/josh-cli/src/forge/github.rs
+++ b/josh-cli/src/forge/github.rs
@@ -6,6 +6,8 @@ use josh_github_auth::middleware::GithubAuthMiddleware;
 use josh_github_graphql::connection::GithubApiConnection;
 use josh_github_graphql::request::GITHUB_GRAPHQL_API_URL;
 
+use crate::cli_eprintln as eprintln;
+
 /// Login to GitHub using device flow and store the token.
 pub async fn login() -> anyhow::Result<()> {
     let flow = DeviceAuthFlow::new(APP_CLIENT_ID);
@@ -77,7 +79,8 @@ pub async fn make_api_connection() -> Option<GithubApiConnection> {
 
 pub fn api_connection_hint() -> String {
     format!(
-        "Couldn't create API connection; log in to GitHub with 'josh auth login github', or set {} environment variable",
+        "Couldn't create API connection; log in to GitHub with \
+         'josh auth login github', or set {} environment variable",
         GITHUB_USER_TOKEN_ENV
     )
 }

--- a/josh-cli/src/lib.rs
+++ b/josh-cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod commands;
 pub mod config;
 pub mod forge;
+pub mod output;
 pub mod remote_ops;
 
 /// Default cap (128 MiB) on a transaction's in-memory object buffer; exceeding it flushes a

--- a/josh-cli/src/output.rs
+++ b/josh-cli/src/output.rs
@@ -1,0 +1,477 @@
+use std::io::Write;
+use std::sync::{LazyLock, Mutex};
+
+use clap::ValueEnum;
+use serde::Serialize;
+use serde_json::{Value, json};
+
+pub const SCHEMA_VERSION: &str = "1";
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum OutputFormat {
+    #[default]
+    Human,
+    Json,
+    Jsonl,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum ColorChoice {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+#[derive(Clone, Debug)]
+pub struct OutputOptions {
+    pub format: OutputFormat,
+    pub color: ColorChoice,
+    pub pretty: bool,
+    pub quiet: bool,
+    pub no_progress: bool,
+    pub non_interactive: bool,
+}
+
+impl Default for OutputOptions {
+    fn default() -> Self {
+        Self {
+            format: OutputFormat::Human,
+            color: ColorChoice::Auto,
+            pretty: false,
+            quiet: false,
+            no_progress: false,
+            non_interactive: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Message {
+    level: &'static str,
+    message: String,
+}
+
+#[derive(Debug, Default)]
+struct OutputState {
+    options: OutputOptions,
+    command: String,
+    messages: Vec<Message>,
+    data: Option<Value>,
+    initialized: bool,
+}
+
+static STATE: LazyLock<Mutex<OutputState>> = LazyLock::new(|| Mutex::new(OutputState::default()));
+
+pub fn init(options: OutputOptions, command: impl Into<String>) {
+    let mut state = STATE.lock().expect("CLI output state lock poisoned");
+    *state = OutputState {
+        options,
+        command: command.into(),
+        messages: Vec::new(),
+        data: None,
+        initialized: true,
+    };
+}
+
+pub fn format() -> OutputFormat {
+    STATE
+        .lock()
+        .expect("CLI output state lock poisoned")
+        .options
+        .format
+}
+
+pub fn is_machine() -> bool {
+    format() != OutputFormat::Human
+}
+
+pub fn is_non_interactive() -> bool {
+    let state = STATE.lock().expect("CLI output state lock poisoned");
+    state.options.non_interactive || state.options.format != OutputFormat::Human
+}
+
+pub fn stdout(message: impl Into<String>) {
+    let message = message.into();
+    let mut state = STATE.lock().expect("CLI output state lock poisoned");
+
+    if !state.initialized || state.options.format == OutputFormat::Human {
+        let _ = writeln!(std::io::stdout().lock(), "{message}");
+    } else if !state.options.quiet {
+        state.messages.push(Message {
+            level: "result",
+            message,
+        });
+    }
+}
+
+pub fn stderr(message: impl Into<String>) {
+    let message = message.into();
+    let mut state = STATE.lock().expect("CLI output state lock poisoned");
+    let warning = message.starts_with("Warning:") || message.starts_with("warning:");
+
+    if !state.initialized || state.options.format == OutputFormat::Human {
+        if !state.options.quiet || warning {
+            let _ = writeln!(std::io::stderr().lock(), "{message}");
+        }
+    } else if !state.options.quiet {
+        state.messages.push(Message {
+            level: if warning { "warning" } else { "diagnostic" },
+            message,
+        });
+    }
+}
+
+pub fn raw_stdout(value: &str) -> std::io::Result<()> {
+    std::io::stdout().lock().write_all(value.as_bytes())
+}
+
+pub fn sanitize(value: &str) -> String {
+    if let Ok(test_root) = std::env::var("TESTTMP") {
+        value.replace(&test_root, "${TESTTMP}")
+    } else {
+        value.to_string()
+    }
+}
+
+pub fn warning(message: impl Into<String>) {
+    let message = message.into();
+    let message = if message.starts_with("Warning:") {
+        message
+    } else {
+        format!("Warning: {message}")
+    };
+    stderr(message);
+}
+
+pub fn set_data<T: Serialize>(data: &T) -> anyhow::Result<()> {
+    set_data_value(serde_json::to_value(data)?);
+    Ok(())
+}
+
+pub fn set_data_value(data: Value) {
+    STATE.lock().expect("CLI output state lock poisoned").data = Some(data);
+}
+
+fn error_text(error: &anyhow::Error) -> String {
+    error
+        .chain()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .to_lowercase()
+}
+
+fn hints_for(error: &anyhow::Error) -> Vec<String> {
+    let message = error_text(error);
+    let top = error.to_string().to_lowercase();
+    let mut hints = Vec::new();
+
+    if message.contains("not in a git repository") {
+        hints.push("Run this command inside a Git working tree.".to_string());
+    }
+    if top.contains("remote") && message.contains("not found") && !top.contains("--base") {
+        hints.push("Run 'josh remote list' to see configured remotes.".to_string());
+    }
+    if top.contains("workspace") && message.contains("no such file") {
+        hints.push("Run 'josh workspace list' to see discovered workspaces.".to_string());
+    }
+    if message.contains("authentication") || message.contains("log in") {
+        hints.push("Run 'josh auth login github' or configure a token.".to_string());
+    }
+
+    hints
+}
+
+fn error_code(error: &anyhow::Error) -> &'static str {
+    let message = error_text(error);
+    let top = error.to_string().to_lowercase();
+    if message.contains("not in a git repository") {
+        "repository.not_found"
+    } else if message.contains("authentication") || message.contains("log in") {
+        "authentication.required"
+    } else if top.contains("--base") && message.contains("not found") {
+        "reference.not_found"
+    } else if message.contains("remote") && message.contains("not found") {
+        "remote.not_found"
+    } else if top.contains("filter")
+        && (message.contains("failed to parse") || message.contains("invalid"))
+    {
+        "filter.invalid"
+    } else if top.contains("workspace") && message.contains("no such file") {
+        "workspace.not_found"
+    } else if top.contains("agent skill") && message.contains("already exists") {
+        "agent_skill.already_exists"
+    } else if top.contains("checkout destination") && message.contains("already exists") {
+        "workspace.destination_exists"
+    } else if top.contains("clone destination") && message.contains("already exists") {
+        "clone.destination_exists"
+    } else if top.contains("workspace") && message.contains("already exists") {
+        "workspace.already_exists"
+    } else if message.contains("invalid workspace") || top.contains("workspace") {
+        "workspace.invalid"
+    } else if message.contains("failed to parse") || message.contains("invalid filter") {
+        "filter.invalid"
+    } else if message.contains("command exited with code") {
+        "git.command_failed"
+    } else {
+        "josh.command_failed"
+    }
+}
+
+fn add_messages(value: &mut Value, state: &OutputState) {
+    if !state.options.quiet {
+        value
+            .as_object_mut()
+            .expect("result envelope is an object")
+            .insert(
+                "messages".to_string(),
+                serde_json::to_value(&state.messages)
+                    .expect("serializing CLI messages cannot fail"),
+            );
+    }
+}
+
+fn print_json(value: &Value, pretty: bool, stderr: bool) {
+    let rendered = if pretty {
+        serde_json::to_string_pretty(value)
+    } else {
+        serde_json::to_string(value)
+    }
+    .expect("serializing CLI output cannot fail");
+
+    if stderr {
+        let _ = writeln!(std::io::stderr().lock(), "{rendered}");
+    } else {
+        let _ = writeln!(std::io::stdout().lock(), "{rendered}");
+    }
+}
+
+pub fn finish_success() {
+    let state = STATE.lock().expect("CLI output state lock poisoned");
+    match state.options.format {
+        OutputFormat::Human => {}
+        OutputFormat::Json => {
+            let mut result = json!({
+                "schema_version": SCHEMA_VERSION,
+                "type": "result",
+                "command": state.command,
+                "success": true,
+                "data": state.data,
+            });
+            add_messages(&mut result, &state);
+            print_json(&result, state.options.pretty, false);
+        }
+        OutputFormat::Jsonl => {
+            for message in &state.messages {
+                print_json(
+                    &json!({
+                        "schema_version": SCHEMA_VERSION,
+                        "type": "message",
+                        "command": state.command,
+                        "level": message.level,
+                        "message": message.message,
+                    }),
+                    false,
+                    false,
+                );
+            }
+            print_json(
+                &json!({
+                    "schema_version": SCHEMA_VERSION,
+                    "type": "result",
+                    "command": state.command,
+                    "success": true,
+                    "data": state.data,
+                }),
+                false,
+                false,
+            );
+        }
+    }
+}
+
+pub fn finish_error(error: &anyhow::Error) {
+    let state = STATE.lock().expect("CLI output state lock poisoned");
+    let causes: Vec<_> = error.chain().skip(1).map(ToString::to_string).collect();
+    let hints = hints_for(error);
+
+    match state.options.format {
+        OutputFormat::Human => {
+            let mut stderr = std::io::stderr().lock();
+            let _ = writeln!(stderr, "Error: {error}");
+            if !causes.is_empty() {
+                let _ = writeln!(stderr, "Caused by:");
+                for cause in &causes {
+                    let _ = writeln!(stderr, "  {cause}");
+                }
+            }
+            for hint in &hints {
+                let _ = writeln!(stderr, "Hint: {hint}");
+            }
+        }
+        OutputFormat::Json => {
+            let mut result = json!({
+                "schema_version": SCHEMA_VERSION,
+                "type": "result",
+                "command": state.command,
+                "success": false,
+                "data": state.data,
+                "error": {
+                    "code": error_code(error),
+                    "message": error.to_string(),
+                    "causes": causes,
+                    "hints": hints,
+                },
+            });
+            add_messages(&mut result, &state);
+            print_json(&result, state.options.pretty, false);
+        }
+        OutputFormat::Jsonl => {
+            for message in &state.messages {
+                print_json(
+                    &json!({
+                        "schema_version": SCHEMA_VERSION,
+                        "type": "message",
+                        "command": state.command,
+                        "level": message.level,
+                        "message": message.message,
+                    }),
+                    false,
+                    false,
+                );
+            }
+            print_json(
+                &json!({
+                    "schema_version": SCHEMA_VERSION,
+                    "type": "result",
+                    "command": state.command,
+                    "success": false,
+                    "data": state.data,
+                    "error": {
+                        "code": error_code(error),
+                        "message": error.to_string(),
+                        "causes": causes,
+                        "hints": hints,
+                    },
+                }),
+                false,
+                false,
+            );
+        }
+    }
+}
+
+pub fn detect_pretty(args: &[String]) -> bool {
+    args.iter().any(|arg| arg == "--pretty")
+}
+
+pub fn detect_format(args: &[String]) -> OutputFormat {
+    let mut format = std::env::var("JOSH_OUTPUT")
+        .ok()
+        .and_then(|value| match value.as_str() {
+            "json" => Some(OutputFormat::Json),
+            "jsonl" => Some(OutputFormat::Jsonl),
+            "human" => Some(OutputFormat::Human),
+            _ => None,
+        })
+        .unwrap_or_default();
+
+    for (index, arg) in args.iter().enumerate() {
+        if let Some(value) = arg.strip_prefix("--output=") {
+            format = match value {
+                "json" => OutputFormat::Json,
+                "jsonl" => OutputFormat::Jsonl,
+                _ => format,
+            };
+        } else if arg == "--output"
+            && let Some(value) = args.get(index + 1)
+        {
+            format = match value.as_str() {
+                "json" => OutputFormat::Json,
+                "jsonl" => OutputFormat::Jsonl,
+                _ => format,
+            };
+        }
+    }
+
+    format
+}
+
+fn command_from_help(message: &str) -> String {
+    let Some(usage) = message
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("Usage: josh "))
+    else {
+        return "josh".to_string();
+    };
+    let parts = usage
+        .split_whitespace()
+        .take_while(|part| !part.starts_with('<') && !part.starts_with('['))
+        .filter(|part| !part.starts_with('-'))
+        .collect::<Vec<_>>();
+    if parts.is_empty() {
+        "josh".to_string()
+    } else {
+        parts.join(".")
+    }
+}
+
+pub fn render_clap(
+    message: &str,
+    format: OutputFormat,
+    pretty: bool,
+    success: bool,
+    exit_code: i32,
+) {
+    if format == OutputFormat::Human {
+        if success {
+            let _ = write!(std::io::stdout().lock(), "{message}");
+        } else {
+            let _ = write!(std::io::stderr().lock(), "{message}");
+        }
+        return;
+    }
+
+    let value = json!({
+        "schema_version": SCHEMA_VERSION,
+        "type": if success { "help" } else { "result" },
+        "command": command_from_help(message),
+        "success": success,
+        "data": if success { Some(json!({ "text": message })) } else { None },
+        "error": if success {
+            None
+        } else {
+            Some(json!({
+                "code": "cli.usage",
+                "message": message.trim(),
+                "causes": [],
+                "hints": ["Run 'josh --help' to inspect the command syntax."],
+                "exit_code": exit_code,
+            }))
+        },
+    });
+    print_json(&value, format == OutputFormat::Json && pretty, false);
+}
+
+#[macro_export]
+macro_rules! cli_println {
+    () => {
+        $crate::output::stdout(String::new())
+    };
+    ($($arg:tt)*) => {
+        $crate::output::stdout(format!($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! cli_eprintln {
+    () => {
+        $crate::output::stderr(String::new())
+    };
+    ($($arg:tt)*) => {
+        $crate::output::stderr(format!($($arg)*))
+    };
+}

--- a/josh-cli/src/remote_ops.rs
+++ b/josh-cli/src/remote_ops.rs
@@ -21,11 +21,14 @@ pub fn get_head_branch(
     repo_path: &std::path::Path,
     remote_name: &str,
 ) -> anyhow::Result<String> {
-    let output = std::process::Command::new("git")
+    let mut command = std::process::Command::new("git");
+    command
         .args(["ls-remote", "--symref", url, "HEAD"])
-        .current_dir(repo_path)
-        .output()
-        .context("Failed to run git ls-remote")?;
+        .current_dir(repo_path);
+    if crate::output::is_non_interactive() {
+        command.env("GIT_TERMINAL_PROMPT", "0");
+    }
+    let output = command.output().context("Failed to run git ls-remote")?;
 
     if output.status.success() {
         let text = String::from_utf8(output.stdout).context("Invalid ls-remote output")?;

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -2,6 +2,39 @@ use anyhow::{Context, anyhow};
 use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum CommandColor {
+    Auto = 0,
+    Always = 1,
+    Never = 2,
+}
+
+static MACHINE_OUTPUT: AtomicBool = AtomicBool::new(false);
+static QUIET_OUTPUT: AtomicBool = AtomicBool::new(false);
+static NO_PROGRESS: AtomicBool = AtomicBool::new(false);
+static NON_INTERACTIVE: AtomicBool = AtomicBool::new(false);
+static COMMAND_COLOR: AtomicU8 = AtomicU8::new(CommandColor::Auto as u8);
+
+/// Configure how Git subprocesses interact with the terminal.
+///
+/// The CLI calls this once after parsing its global output options. Atomic storage keeps the
+/// core independent from the CLI and also makes repeated configuration safe in tests.
+pub fn configure_command_output(
+    machine: bool,
+    quiet: bool,
+    no_progress: bool,
+    non_interactive: bool,
+    color: CommandColor,
+) {
+    MACHINE_OUTPUT.store(machine, Ordering::Relaxed);
+    QUIET_OUTPUT.store(quiet, Ordering::Relaxed);
+    NO_PROGRESS.store(no_progress, Ordering::Relaxed);
+    NON_INTERACTIVE.store(non_interactive, Ordering::Relaxed);
+    COMMAND_COLOR.store(color as u8, Ordering::Relaxed);
+}
 
 /// Resolve the `input_ref` argument to a commit OID.
 ///
@@ -151,18 +184,48 @@ pub fn spawn_git_command(
     // `Transaction::spawn_git` instead so the spawned `git` can see in-flight objects.
     let cwd = normalize_repo_path(repo_path);
 
+    let machine = MACHINE_OUTPUT.load(Ordering::Relaxed);
+    let quiet = QUIET_OUTPUT.load(Ordering::Relaxed);
+    let no_progress = NO_PROGRESS.load(Ordering::Relaxed);
+    let non_interactive = NON_INTERACTIVE.load(Ordering::Relaxed);
+    let color = COMMAND_COLOR.load(Ordering::Relaxed);
+
     let mut command = std::process::Command::new("git");
-    command.current_dir(cwd).args(args);
+    command.current_dir(cwd);
 
     for (key, value) in env {
         command.env(key, value);
     }
+    if non_interactive {
+        command
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GCM_INTERACTIVE", "never");
+    }
+    match color {
+        value if value == CommandColor::Always as u8 => {
+            command
+                .args(["-c", "color.ui=always"])
+                .env("CLICOLOR_FORCE", "1");
+        }
+        value if value == CommandColor::Never as u8 => {
+            command
+                .args(["-c", "color.ui=false"])
+                .env("NO_COLOR", "1")
+                .env("TERM", "dumb");
+        }
+        _ => {}
+    }
+    command.args(args);
 
-    // Check if we're in a TTY environment
-    let is_tty = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+    // Machine mode always captures child output so stdout remains a valid JSON document.
+    let is_tty = std::io::stdin().is_terminal()
+        && std::io::stdout().is_terminal()
+        && !machine
+        && !quiet
+        && !no_progress;
+    let mut captured_stderr = String::new();
 
     let status = if is_tty {
-        // In TTY: inherit stdio so users can see progress
         command
             .stdin(Stdio::inherit())
             .stdout(Stdio::inherit())
@@ -170,7 +233,6 @@ pub fn spawn_git_command(
 
         command.status()?.code()
     } else {
-        // Not in TTY: capture output and print stderr (for tests, CI, etc.)
         let output = command
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -178,16 +240,17 @@ pub fn spawn_git_command(
             .output()
             .context("failed to execute git command")?;
 
-        // Print stderr if there's any output
         if !output.stderr.is_empty() {
             let output_str = String::from_utf8_lossy(&output.stderr);
-            let output_str = if let Ok(testtmp) = std::env::var("TESTTMP") {
+            captured_stderr = if let Ok(testtmp) = std::env::var("TESTTMP") {
                 output_str.replace(&testtmp, "${TESTTMP}")
             } else {
                 output_str.to_string()
             };
 
-            eprintln!("{}", output_str);
+            if !machine && !quiet && !no_progress {
+                eprintln!("{}", captured_stderr);
+            }
         }
 
         output.status.code()
@@ -197,11 +260,12 @@ pub fn spawn_git_command(
         0 => Ok(()),
         code => {
             let command = args.join(" ");
-            Err(anyhow!(
-                "Command exited with code {}: git {}",
-                code,
-                command
-            ))
+            let error = anyhow!("Command exited with code {}: git {}", code, command);
+            if (machine || quiet || no_progress) && !captured_stderr.trim().is_empty() {
+                Err(anyhow!(captured_stderr.trim().to_string()).context(error.to_string()))
+            } else {
+                Err(error)
+            }
         }
     }
 }

--- a/tests/cli/agent-skill.t
+++ b/tests/cli/agent-skill.t
@@ -1,0 +1,56 @@
+  $ export TESTTMP=${PWD}
+
+The bundled skill is concise Agent Skills-compatible Markdown.
+
+  $ josh agent skill print > printed.md
+  $ head -4 printed.md
+  ---
+  name: josh
+  description: Use Josh for filtered Git repositories, local workspaces, and structured automation.
+  ---
+  $ test "$(wc -w < printed.md)" -lt 500 && echo concise
+  concise
+
+Install the skill into any agent-specific skill directory.
+
+  $ josh agent skill install --target skills/josh
+  Installed Josh agent skill at ${TESTTMP}/skills/josh/SKILL.md
+  $ cmp printed.md skills/josh/SKILL.md
+
+Existing skills are protected unless --force is explicit.
+
+  $ josh agent skill install --target skills/josh 2>&1
+  Error: Agent skill '${TESTTMP}/skills/josh/SKILL.md' already exists; pass --force to replace it
+  [1]
+
+  $ josh --output json --quiet agent skill install --target skills/josh > error.json
+  [1]
+  $ python3 - <<'PY'
+  > import json
+  > data = json.load(open("error.json"))
+  > print(data["command"], data["success"], data["error"]["code"])
+  > print("messages" in data)
+  > PY
+  agent.skill.install False agent_skill.already_exists
+  False
+
+  $ echo stale > skills/josh/SKILL.md
+  $ josh agent skill install --target skills/josh --force
+  Updated Josh agent skill at ${TESTTMP}/skills/josh/SKILL.md
+  $ cmp printed.md skills/josh/SKILL.md
+
+Dry-run and machine modes expose deterministic structured results.
+
+  $ josh agent skill install --target dry/josh --dry-run
+  Would install Josh agent skill at ${TESTTMP}/dry/josh/SKILL.md
+  $ test ! -e dry/josh/SKILL.md
+
+  $ josh --output json --quiet agent skill print > skill.json
+  $ python3 - <<'PY'
+  > import json
+  > data = json.load(open("skill.json"))
+  > print(data["command"], data["data"]["name"], data["data"]["version"])
+  > print("messages" in data, data["data"]["content"].startswith("---\nname: josh\n"))
+  > PY
+  agent.skill.print josh 1
+  False True

--- a/tests/cli/fetch-ref.t
+++ b/tests/cli/fetch-ref.t
@@ -1,0 +1,31 @@
+  $ export TESTTMP=${PWD}
+  $ git init -q remote
+  $ cd remote
+  $ mkdir sub1
+  $ echo content > sub1/file
+  $ git add .
+  $ git commit -q -m initial
+  $ git branch feature
+  $ cd ..
+
+An explicit --ref fetches only the requested branch.
+
+  $ git init -q repo
+  $ cd repo
+  $ git commit -q --allow-empty -m initial
+  $ josh remote add origin ${TESTTMP}/remote :/sub1
+  Added remote 'origin' with filter ':/sub1'
+  $ josh fetch --ref feature 2>/dev/null
+  $ git for-each-ref --format='%(refname)' refs/josh/remotes/origin refs/remotes/origin
+  refs/josh/remotes/origin/feature
+  refs/remotes/origin/feature
+
+Fetching the default branch later adds it without disturbing the first branch.
+
+  $ josh fetch --ref master 2>/dev/null
+  $ git for-each-ref --format='%(refname)' refs/josh/remotes/origin refs/remotes/origin
+  refs/josh/remotes/origin/feature
+  refs/josh/remotes/origin/master
+  refs/remotes/origin/HEAD
+  refs/remotes/origin/feature
+  refs/remotes/origin/master

--- a/tests/cli/filter.t
+++ b/tests/cli/filter.t
@@ -66,8 +66,9 @@ Test josh filter with non-existent remote
 
   $ josh filter nonexistent 2>&1 | sed "s|Failed to read remote config file: .*|Failed to read remote config file: *|"
   Error: Failed to read remote config for 'nonexistent'
-  Failed to read remote config for 'nonexistent'
-  Remote 'nonexistent' not found in new format (*/josh/remotes/nonexistent.josh) or legacy git config (josh-remote.nonexistent) (glob)
+  Caused by:
+    Remote 'nonexistent' not found in new format (*/josh/remotes/nonexistent.josh) or legacy git config (josh-remote.nonexistent) (glob)
+  Hint: Run 'josh remote list' to see configured remotes.
 
   $ cd ..
 

--- a/tests/cli/output.t
+++ b/tests/cli/output.t
@@ -1,0 +1,102 @@
+Capabilities are available outside a repository and describe the machine contract.
+
+  $ josh --output json capabilities > capabilities.json
+  $ python3 - <<'PY'
+  > import json
+  > data = json.load(open("capabilities.json"))
+  > print(data["schema_version"], data["type"], data["command"], data["success"])
+  > print(",".join(data["data"]["output"]["formats"]))
+  > PY
+  1 result capabilities True
+  human,json,jsonl
+  $ wc -l < capabilities.json | tr -d ' '
+  1
+
+Brief, quiet output omits duplicated messages and minimizes context use.
+
+  $ josh --output json --quiet capabilities --brief > brief.json
+  $ python3 - <<'PY'
+  > import json
+  > data = json.load(open("brief.json"))
+  > print(data["data"]["schema_version"], data["data"]["agent_skill"])
+  > print("messages" in data, sorted(data["data"]))
+  > PY
+  1 True
+  False ['agent_skill', 'output_formats', 'schema_version', 'version', 'workspaces']
+  $ wc -l < brief.json | tr -d ' '
+  1
+
+Pretty output remains available for interactive inspection.
+
+  $ josh --output json --pretty capabilities --brief > pretty.json
+  $ test "$(wc -l < pretty.json)" -gt 1 && echo pretty
+  pretty
+
+Filter validation and explanation also work outside a repository.
+
+  $ josh --output json filter explain ':/src:prefix=app' > filter.json
+  $ python3 - <<'PY'
+  > import json
+  > data = json.load(open("filter.json"))
+  > print(data["command"], data["data"]["valid"], data["data"]["filter"])
+  > PY
+  filter.explain True app = :/src
+
+Shell completions are generated without entering a repository.
+
+  $ josh completions bash | grep -q '^_josh()' && echo found
+  found
+
+Machine-readable workspace results contain typed data and capture human messages.
+
+  $ git init -q repo
+  $ cd repo
+  $ git commit -q --allow-empty -m initial
+  $ josh workspace create ws --map src=:/src >/dev/null
+  $ josh --output json workspace list > list.json
+  $ python3 - <<'PY'
+  > import json
+  > data = json.load(open("list.json"))
+  > print(data["command"], data["success"], len(data["data"]))
+  > print(data["data"][0]["path"], data["data"][0]["valid"])
+  > print(data["messages"][0]["level"])
+  > PY
+  workspace.list True 1
+  ws True
+  result
+
+JSONL emits messages followed by one final result.
+
+  $ josh --output jsonl workspace list > list.jsonl
+  $ python3 - <<'PY'
+  > import json
+  > rows = [json.loads(line) for line in open("list.jsonl")]
+  > print([row["type"] for row in rows])
+  > print(rows[-1]["command"], rows[-1]["success"])
+  > PY
+  ['message', 'result']
+  workspace.list True
+
+Runtime and argument errors are structured and use non-zero exit statuses.
+
+  $ josh --output json --quiet workspace show missing >error.json 2>stderr.txt
+  [1]
+  $ test ! -s stderr.txt
+  $ python3 - <<'PY'
+  > import json
+  > data = json.load(open("error.json"))
+  > print(data["command"], data["success"], data["error"]["code"])
+  > print("messages" in data)
+  > PY
+  workspace.show False workspace.not_found
+  False
+
+  $ josh --output json workspace show >usage.json 2>stderr.txt
+  [2]
+  $ test ! -s stderr.txt
+  $ python3 - <<'PY'
+  > import json
+  > data = json.load(open("usage.json"))
+  > print(data["command"], data["success"], data["error"]["code"])
+  > PY
+  workspace.show False cli.usage

--- a/tests/cli/pull-multiple-remotes.t
+++ b/tests/cli/pull-multiple-remotes.t
@@ -78,8 +78,8 @@
   for your current branch, you must specify a branch on the command line.
   
   Error: git pull failed
-  git pull failed
-  Command exited with code 1: git pull remote2
+  Caused by:
+    Command exited with code 1: git pull remote2
   [1]
 
   $ tree

--- a/tests/cli/push.t
+++ b/tests/cli/push.t
@@ -102,6 +102,6 @@ reverse filtering. Without --base the unfiltered base would be zero;
   $ cd ${TESTTMP}/filtered
   $ josh push origin HEAD:refs/heads/other --base=does-not-exist
   Error: Failed to resolve --base ref (looked up 'refs/josh/remotes/origin/does-not-exist')
-  Failed to resolve --base ref (looked up 'refs/josh/remotes/origin/does-not-exist')
-  * (glob)
+  Caused by:
+    * (glob)
   [1]

--- a/tests/cli/push_merge.t
+++ b/tests/cli/push_merge.t
@@ -107,5 +107,4 @@ Reject path: `--merge` against a non-existent destination ref with no
 
   $ josh push central HEAD:refs/heads/other --merge
   Error: --merge requires --base=<ref> or an existing destination ref
-  --merge requires --base=<ref> or an existing destination ref
   [1]

--- a/tests/cli/remote-management.t
+++ b/tests/cli/remote-management.t
@@ -1,0 +1,61 @@
+  $ export TESTTMP=${PWD}
+  $ git init -q upstream
+  $ cd upstream
+  $ git commit -q --allow-empty -m initial
+  $ cd ..
+  $ git init -q repo
+  $ cd repo
+  $ git commit -q --allow-empty -m initial
+
+Josh remotes can be listed and inspected.
+
+  $ josh remote add origin ../upstream :/src
+  Added remote 'origin' with filter ':/src'
+
+  $ josh remote list
+  origin	:/src	file://${TESTTMP}/upstream
+
+  $ josh remote show origin
+  Remote: origin
+  URL: file://${TESTTMP}/upstream
+  Filter: :/src
+  Fetch: +refs/heads/*:refs/josh/remotes/origin/*
+  Forge: none
+
+Status summarizes repository state and Josh remotes.
+
+  $ josh status | sed "s|${TESTTMP}|\${TESTTMP}|"
+  Repository: ${TESTTMP}/repo/
+  Branch: master
+  Working tree: clean
+  Josh remotes:
+    origin  :/src  file://${TESTTMP}/upstream
+
+Filters can be updated without editing private configuration files.
+
+  $ josh remote set-filter origin :/
+  Set filter for remote 'origin' to ':/'
+  $ josh remote show origin | grep '^Filter:'
+  Filter: :/
+
+Removal supports dry-run and cleans both Josh and Git configuration.
+
+  $ josh remote remove origin --dry-run
+  Would remove Josh remote 'origin'
+  $ git remote
+  origin
+
+  $ josh remote remove origin
+  Removed Josh remote 'origin'
+  $ josh remote list
+  No Josh remotes configured.
+  $ git remote
+
+SCP-style SSH URLs are accepted without treating them as local paths.
+
+  $ josh remote add ssh git@example.com:org/repo.git :/
+  Added remote 'ssh' with filter ':/'
+  $ josh remote show ssh | grep '^URL:'
+  URL: git@example.com:org/repo.git
+  $ josh remote remove ssh
+  Removed Josh remote 'ssh'

--- a/tests/cli/remote-migration.t
+++ b/tests/cli/remote-migration.t
@@ -34,7 +34,6 @@ Test migration from legacy git config to new file format
   $ josh filter origin
   Applying filter ':/sub1' to remote 'origin'
   Error: Could not resolve default branch from 'refs/remotes/origin/HEAD'. Has the remote been fetched?
-  Could not resolve default branch from 'refs/remotes/origin/HEAD'. Has the remote been fetched?
   [1]
 
   $ cat .git/josh/remotes/origin.josh | sed "s|file://.*/remote/libs|file://\${TESTTMP}/remote/libs|"

--- a/tests/cli/workspace.t
+++ b/tests/cli/workspace.t
@@ -1,0 +1,78 @@
+  $ export TESTTMP=${PWD}
+  $ git init -q repo
+  $ cd repo
+  $ mkdir -p apps/frontend libs/shared
+  $ echo app > apps/frontend/app.txt
+  $ echo shared > libs/shared/shared.txt
+  $ git add .
+  $ git commit -q -m "initial"
+
+Create a workspace definition with repeatable mappings.
+
+  $ josh workspace create workspaces/frontend --map app=:/apps/frontend \
+  >     --map libs/shared=:/libs/shared
+  Created workspace 'workspaces/frontend'
+  Definition: workspaces/frontend/workspace.josh
+  
+  app = :/apps/frontend
+  libs/shared = :/libs/shared
+
+  $ cat workspaces/frontend/workspace.josh
+  app = :/apps/frontend
+  libs/shared = :/libs/shared
+
+List, show, and validate workspace definitions.
+
+  $ josh workspace list
+  valid	workspaces/frontend
+
+  $ josh workspace show workspaces/frontend
+  Workspace: workspaces/frontend
+  Definition: workspaces/frontend/workspace.josh
+  Status: valid
+  Filter:
+    app = :/apps/frontend
+    ::libs/shared/
+
+  $ josh workspace validate
+  valid	workspaces/frontend
+
+Existing definitions are protected, and dry-run does not write.
+
+  $ josh workspace create workspaces/frontend 2>&1
+  Error: Workspace 'workspaces/frontend' already exists; pass --force to replace it
+  [1]
+
+  $ josh workspace create workspaces/backend --map src=:/apps/frontend --dry-run
+  Would create workspace 'workspaces/backend'
+  Definition: workspaces/backend/workspace.josh
+  
+  src = :/apps/frontend
+  $ test ! -e workspaces/backend/workspace.josh
+
+Checkout previews the current working tree, including the uncommitted definition.
+
+  $ josh workspace checkout workspaces/frontend ../frontend-preview 2>/dev/null
+  Checked out workspace 'workspaces/frontend' at ${TESTTMP}/frontend-preview (glob)
+
+  $ tree ../frontend-preview -a -I .git
+  ../frontend-preview
+  |-- app
+  |   `-- app.txt
+  |-- libs
+  |   `-- shared
+  |       `-- shared.txt
+  `-- workspace.josh
+  
+  4 directories, 3 files
+
+Invalid workspaces are visible and make validation fail.
+
+  $ mkdir workspaces/broken
+  $ echo 'not a filter =' > workspaces/broken/workspace.josh
+  $ josh workspace list
+  invalid	workspaces/broken
+  valid	workspaces/frontend
+
+  $ josh workspace validate >/dev/null 2>/dev/null
+  [1]

--- a/tests/experimental/link-add.t
+++ b/tests/experimental/link-add.t
@@ -193,15 +193,15 @@
 # Test error case - empty path
   $ josh link add "" ../remote.git
   Error: Path cannot be empty
-  Path cannot be empty
   [1]
 
 # Test error case - not in a git repository
   $ cd ..
   $ josh link add test ../remote.git
   Error: Not in a git repository
-  Not in a git repository
-  could not find repository at '.'; class=Repository (6); code=NotFound (-3)
+  Caused by:
+    could not find repository at '.'; class=Repository (6); code=NotFound (-3)
+  Hint: Run this command inside a Git working tree.
   [1]
 
   $ cd test-repo
@@ -217,7 +217,7 @@
   $ josh link --help
   Manage josh links (like `josh remote` but for links)
   
-  Usage: josh link <COMMAND>
+  Usage: josh link [OPTIONS] <COMMAND>
   
   Commands:
     add     Add a link with optional filter and target branch
@@ -227,7 +227,13 @@
     help    Print this message or the help of the given subcommand(s)
   
   Options:
-    -h, --help  Print help
+        --output <OUTPUT>  Output format; JSON schemas are versioned and stable [env: JOSH_OUTPUT=] [default: human] [possible values: human, json, jsonl]
+        --pretty           Pretty-print --output json instead of emitting one compact line
+    -q, --quiet            Suppress diagnostics and omit messages from machine output
+        --color <COLOR>    Control color in Josh and child Git processes [env: JOSH_COLOR=] [default: auto] [possible values: auto, always, never]
+        --no-progress      Disable progress displays and capture child process output
+        --non-interactive  Disable prompts, browser launches, and credential input [env: JOSH_NON_INTERACTIVE=]
+    -h, --help             Print help
 
   $ josh link add --help
   Add a link with optional filter and target branch
@@ -240,8 +246,14 @@
     [FILTER]  Optional filter to apply to the linked repository
   
   Options:
+        --output <OUTPUT>  Output format; JSON schemas are versioned and stable [env: JOSH_OUTPUT=] [default: human] [possible values: human, json, jsonl]
+        --pretty           Pretty-print --output json instead of emitting one compact line
         --target <TARGET>  Target branch to link (defaults to HEAD)
         --mode <MODE>      Link mode: embedded, snapshot, or pointer (defaults to snapshot) [default: snapshot]
+    -q, --quiet            Suppress diagnostics and omit messages from machine output
+        --color <COLOR>    Control color in Josh and child Git processes [env: JOSH_COLOR=] [default: auto] [possible values: auto, always, never]
+        --no-progress      Disable progress displays and capture child process output
+        --non-interactive  Disable prompts, browser launches, and credential input [env: JOSH_NON_INTERACTIVE=]
     -h, --help             Print help
 
 # Test josh link fetch command
@@ -318,7 +330,6 @@
 # Test error case - path that doesn't exist
   $ josh link update :/nonexistent
   Error: No .link.josh files found
-  No .link.josh files found
   [1]
 
 # Test error case - no link files found

--- a/tests/experimental/link-push-force.t
+++ b/tests/experimental/link-push-force.t
@@ -52,8 +52,8 @@
   hint: See the 'Note about fast-forwards' in 'git push --help' for details.
   
   Error: Failed to push to '../docs_repo.git'
-  Failed to push to '../docs_repo.git'
-  Command exited with code 1: git push ../docs_repo.git 449200237526b58cb91be2743ee8fef1ac989a01:refs/heads/master
+  Caused by:
+    Command exited with code 1: git push ../docs_repo.git 449200237526b58cb91be2743ee8fef1ac989a01:refs/heads/master
   [1]
 
 # Force push overwrites the remote branch


### PR DESCRIPTION
## Summary

- add local workspace create, list, show, validate, and detached checkout workflows
- add schema-v1 JSON/JSONL output, stable errors, quiet data-only mode, and optional pretty JSON
- add status, brief capabilities, filter validation/explanation, completions, and expanded remote management
- make fetch and pull reference selection functional and improve non-interactive child-process handling
- bundle a concise Agent Skills-compatible `SKILL.md` with safe print/install commands
- document human and agent workflows and cover them with CLI tests

## Agent automation

Agents can negotiate the compact contract with:

```shell
josh --output json --quiet capabilities --brief
```

The bundled skill can be installed with:

```shell
josh agent skill install
josh agent skill install --target <agent-skill-directory>/josh
```

## Testing

- `cargo test --workspace --no-fail-fast`
- `PYTHONPATH=/tmp/josh-prysk bash run-tests.sh tests/cli/agent-skill.t tests/cli/output.t tests/cli/workspace.t tests/cli/remote-management.t tests/cli/fetch-ref.t`

The complete containerized `josh compose run` suite was not run because Podman is unavailable in the
development environment.
