### PR TITLE
Apply semantic meta args of remote filters in the josh CLI

### DIFF
--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -170,6 +170,12 @@ josh remote add <name> <url> <filter> [options]
 josh remote add backend https://github.com/myorg/monorepo.git :/services/backend
 ```
 
+The filter may carry semantic meta args, e.g.
+`:~(history="keep-trivial-merges")[:/services/backend]`; they are applied whenever the
+remote's filter is used (fetch, push, cache). The meta keys `url`, `fetch` and `forge` are
+reserved: the remote config stores its transport settings under these keys, so
+`josh remote add` rejects a filter that sets one of them.
+
 ---
 
 ## josh filter

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -459,13 +459,10 @@ fn handle_fetch(
     let repo_path = normalize_repo_path(repo.path());
 
     // Read the remote configuration from .git/josh/remotes/<name>.josh
-    let RemoteConfig {
-        url,
-        ref_spec,
-        filter_with_meta,
-        ..
-    } = read_remote_config(&repo_path, &args.remote)
+    let config = read_remote_config(&repo_path, &args.remote)
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
+    let filter = config.semantic_filter();
+    let RemoteConfig { url, ref_spec, .. } = config;
 
     // First, fetch unfiltered refs to refs/josh/remotes/*
     transaction
@@ -473,7 +470,6 @@ fn handle_fetch(
         .context("git fetch to josh/remotes failed")?;
 
     // Warm the local cache from the remote before filtering
-    let filter = filter_with_meta.peel();
     if let Err(e) = josh_cli::commands::cache::fetch_remote_cache(transaction, &url, filter) {
         eprintln!("Warning: could not fetch remote cache: {e}");
     }
@@ -609,12 +605,10 @@ fn handle_filter(
     let repo = transaction.repo();
     let repo_path = normalize_repo_path(repo.path());
 
-    let RemoteConfig {
-        filter_with_meta, ..
-    } = read_remote_config(&repo_path, &args.remote)
+    let config = read_remote_config(&repo_path, &args.remote)
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
 
-    let filter = filter_with_meta.peel();
+    let filter = config.semantic_filter();
     let filter_str = josh_core::filter::spec(filter);
 
     println!(

--- a/josh-cli/src/commands/cache.rs
+++ b/josh-cli/src/commands/cache.rs
@@ -128,7 +128,7 @@ fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyho
 
     // Add the config filter as fallback if not already discovered.
     if let Ok(config) = read_remote_config(&repo_path, &args.remote) {
-        let config_filter = config.filter_with_meta.peel();
+        let config_filter = config.semantic_filter();
         let config_steps = flatten_chain(config_filter);
         let config_prefix = remote_ops::step_ref_prefix(config_steps.len() - 1, &config_steps);
         if !full_chains.contains(&config_prefix) {
@@ -223,14 +223,10 @@ fn handle_cache_push(args: &CachePushArgs, transaction: &Transaction) -> anyhow:
     let repo = transaction.repo();
     let repo_path = normalize_repo_path(repo.path());
 
-    let RemoteConfig {
-        url,
-        filter_with_meta,
-        ..
-    } = read_remote_config(&repo_path, &args.remote)
+    let config = read_remote_config(&repo_path, &args.remote)
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
-
-    let filter = filter_with_meta.peel();
+    let filter = config.semantic_filter();
+    let RemoteConfig { url, .. } = config;
     let steps = flatten_chain(filter);
 
     let default_branch = remote_ops::resolve_default_branch(repo, &args.remote)?;
@@ -310,14 +306,10 @@ fn handle_cache_fetch(args: &CacheFetchArgs, transaction: &Transaction) -> anyho
     let repo = transaction.repo();
     let repo_path = normalize_repo_path(repo.path());
 
-    let RemoteConfig {
-        url,
-        filter_with_meta,
-        ..
-    } = read_remote_config(&repo_path, &args.remote)
+    let config = read_remote_config(&repo_path, &args.remote)
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
-
-    let filter = filter_with_meta.peel();
+    let filter = config.semantic_filter();
+    let RemoteConfig { url, .. } = config;
 
     fetch_remote_cache(transaction, &url, filter)?;
 

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -327,15 +327,10 @@ fn orchestrate_push(
 
     let remote_name = remote.unwrap_or("origin");
 
-    let RemoteConfig {
-        url,
-        filter_with_meta,
-        forge,
-        ..
-    } = read_remote_config(&repo_path, remote_name)
+    let config = read_remote_config(&repo_path, remote_name)
         .with_context(|| format!("Failed to read remote config for '{}'", remote_name))?;
-
-    let filter = filter_with_meta.peel();
+    let filter = config.semantic_filter();
+    let RemoteConfig { url, forge, .. } = config;
 
     let refspecs = if refspecs_arg.is_empty() {
         let head = repo.head().context("Failed to get HEAD")?;

--- a/josh-cli/src/config.rs
+++ b/josh-cli/src/config.rs
@@ -2,11 +2,25 @@ use anyhow::{Context, anyhow};
 
 use crate::forge::Forge;
 
+/// Meta keys that configure the remote itself rather than the filter semantics.
+pub const TRANSPORT_META_KEYS: &[&str] = &["url", "fetch", "forge"];
+
 pub struct RemoteConfig {
     pub url: String,
     pub ref_spec: String,
     pub filter_with_meta: josh_core::filter::Filter,
     pub forge: Option<Forge>,
+}
+
+impl RemoteConfig {
+    /// The filter to apply: transport keys (`url`, `fetch`, `forge`) stripped,
+    /// semantic meta args (`history`, `gpgsig`, ...) retained. Semantic args
+    /// change the filtered history, so dropping them (via `peel()`) would
+    /// produce SHAs that diverge from what josh-proxy/josh-filter compute for
+    /// the same filter spec.
+    pub fn semantic_filter(&self) -> josh_core::filter::Filter {
+        self.filter_with_meta.without_meta_keys(TRANSPORT_META_KEYS)
+    }
 }
 
 /// Resolve the directory holding josh remote config files.
@@ -154,6 +168,17 @@ pub fn write_remote_config(
     // Parse the filter
     let filter_obj = josh_core::filter::parse(filter)
         .with_context(|| format!("Failed to parse filter '{}'", filter))?;
+
+    // The transport keys are owned by the remote config; a user filter that
+    // sets one of them would be silently overwritten below.
+    for key in TRANSPORT_META_KEYS {
+        if filter_obj.get_meta(key).is_some() {
+            return Err(anyhow!(
+                "Filter must not set reserved meta key '{}': it is owned by the remote config",
+                key
+            ));
+        }
+    }
 
     // Wrap the filter with metadata
     let mut filter_with_meta = filter_obj.with_meta("url", url).with_meta("fetch", fetch);

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -323,6 +323,23 @@ impl Filter {
             _ => *self,
         }
     }
+
+    /// Remove the given keys from this filter's outermost Meta wrapper, keeping
+    /// all other metadata in place. If no metadata remains the Meta wrapper is
+    /// dropped entirely. Metadata nested deeper inside the filter is untouched.
+    pub fn without_meta_keys(self, keys: &[&str]) -> Filter {
+        match to_op(self) {
+            Op::Meta(mut meta, inner_filter) => {
+                meta.retain(|k, _| !keys.contains(&k.as_str()));
+                if meta.is_empty() {
+                    inner_filter
+                } else {
+                    to_filter(Op::Meta(meta, inner_filter))
+                }
+            }
+            _ => self,
+        }
+    }
 }
 
 impl std::fmt::Debug for Filter {

--- a/tests/cli/cache.t
+++ b/tests/cli/cache.t
@@ -149,3 +149,42 @@ After fetching, both sets of intermediate refs should be present locally
   2
 
   $ cd ${TESTTMP}
+
+Semantic meta args section: the cache must be keyed on the filter including its
+semantic args (history=...), not the peeled filter
+
+  $ git init -q local5 1>/dev/null
+  $ cd local5
+  $ josh remote add origin ${TESTTMP}/remote/libs ':~(history="keep-trivial-merges")[:/sub1]'
+  Added remote 'origin' with filter ':~(history="keep-trivial-merges")[:/sub1]'
+
+  $ josh fetch 2>/dev/null
+
+  $ josh cache build
+  Built cache for 1 filter(s) on branch 'master' for remote 'origin'
+
+The filtered ref is keyed by the meta-carrying filter id, distinct from the
+plain :/sub1 id (bf567e0f...)
+
+  $ git for-each-ref --format='%(refname)' 'refs/josh/filtered/'
+  refs/josh/filtered/24ccd8d89e1e9751b3e5ae070b6435989121c346/heads/master
+
+  $ josh cache push 2>/dev/null
+
+  $ git ls-remote ${TESTTMP}/remote/libs 'refs/josh/filtered/*' | wc -l | tr -d ' '
+  3
+
+A fresh clone with the same filter can fetch that cache
+
+  $ cd ${TESTTMP}
+  $ git init -q local6 1>/dev/null
+  $ cd local6
+  $ josh remote add origin ${TESTTMP}/remote/libs ':~(history="keep-trivial-merges")[:/sub1]'
+  Added remote 'origin' with filter ':~(history="keep-trivial-merges")[:/sub1]'
+
+  $ josh cache fetch 2>/dev/null
+
+  $ git for-each-ref --format='%(refname)' 'refs/josh/filtered/'
+  refs/josh/filtered/24ccd8d89e1e9751b3e5ae070b6435989121c346/heads/master
+
+  $ cd ${TESTTMP}

--- a/tests/cli/remote-filter-meta.t
+++ b/tests/cli/remote-filter-meta.t
@@ -1,0 +1,230 @@
+Semantic meta args (history=..., gpgsig=...) in a remote's filter must be applied
+when filtering, not stripped together with the transport keys (url, fetch, forge)
+that the remote config stores in the same meta block.
+
+  $ export TESTTMP=${PWD}
+
+  $ cd ${TESTTMP}
+  $ mkdir remote
+  $ cd remote
+  $ git init -q libs 1> /dev/null
+  $ cd libs
+
+The push roundtrip below pushes to this non-bare repo's checked-out branch
+
+  $ git config receive.denyCurrentBranch ignore
+
+Base commit inside the filtered subtree
+
+  $ mkdir sub1
+  $ echo contents1 > sub1/file1
+  $ git add sub1
+  $ git commit -m "add file1" 1> /dev/null
+
+A feature branch that only touches files OUTSIDE sub1/ ...
+
+  $ git checkout -q -b branch1
+  $ echo outside > outside_file
+  $ git add outside_file
+  $ git commit -m "add outside_file" 1> /dev/null
+
+... merged into a master that also advanced inside sub1/. The merge is
+trivial under :/sub1 (does not change the filtered tree), so it is elided by
+default and kept with history="keep-trivial-merges".
+
+  $ git checkout -q master
+  $ echo contents2 > sub1/file2
+  $ git add sub1
+  $ git commit -m "add file2" 1> /dev/null
+
+  $ git merge -q branch1 --no-ff
+  $ git log --graph --pretty=%s
+  *   Merge branch 'branch1'
+  |\  
+  | * add outside_file
+  * | add file2
+  |/  
+  * add file1
+
+  $ cd ${TESTTMP}
+
+Clone with the meta args: the kept merge must show up in the filtered history
+
+  $ josh clone ${TESTTMP}/remote/libs ':~(history="keep-trivial-merges",gpgsig="norm-lf")[:/sub1]' libs
+  Added remote 'origin' with filter ':~(history="keep-trivial-merges",gpgsig="norm-lf")[:/sub1]'
+  From file://${TESTTMP}/remote/libs
+   * [new branch]      branch1    -> refs/josh/remotes/origin/branch1
+   * [new branch]      master     -> refs/josh/remotes/origin/master
+  
+  From file://${TESTTMP}/libs
+   * [new branch]      branch1    -> origin/branch1
+   * [new branch]      master     -> origin/master
+  
+  Fetched from remote: origin
+  Already on 'master'
+  
+  Cloned repository to: ${TESTTMP}/libs/
+
+  $ cd libs
+  $ git log --graph --pretty=%s origin/master
+  *   Merge branch 'branch1'
+  |\  
+  * | add file2
+  |/  
+  * add file1
+
+Equivalence with josh-filter: the CLI's filtered head must be SHA-identical to
+what josh-filter produces for the same spec in the source repo
+
+  $ cd ${TESTTMP}/remote/libs
+  $ josh-filter -s ':~(history="keep-trivial-merges",gpgsig="norm-lf")[:/sub1]' master --update refs/heads/expected 1> /dev/null
+  $ git rev-parse expected
+  2fa5077e262980fdd1efebd9093f1be9b9a2192c
+
+  $ cd ${TESTTMP}/libs
+  $ git rev-parse origin/master
+  2fa5077e262980fdd1efebd9093f1be9b9a2192c
+
+Counter-check: without the meta args the merge is elided (proves the setup
+distinguishes the two and the args do not leak into the plain path)
+
+  $ cd ${TESTTMP}
+  $ josh clone ${TESTTMP}/remote/libs ':/sub1' libs-plain
+  Added remote 'origin' with filter ':/sub1'
+  From file://${TESTTMP}/remote/libs
+   * [new branch]      branch1    -> refs/josh/remotes/origin/branch1
+   * [new branch]      expected   -> refs/josh/remotes/origin/expected
+   * [new branch]      master     -> refs/josh/remotes/origin/master
+  
+  From file://${TESTTMP}/libs-plain
+   * [new branch]      branch1    -> origin/branch1
+   * [new branch]      master     -> origin/master
+  
+  Fetched from remote: origin
+  Already on 'master'
+  
+  Cloned repository to: ${TESTTMP}/libs-plain/
+
+  $ cd libs-plain
+  $ git log --graph --pretty=%s origin/master
+  * add file2
+  * add file1
+
+Incremental fetch: another trivial-under-filter merge upstream must also be kept
+
+  $ cd ${TESTTMP}/remote/libs
+  $ git checkout -q -b branch2
+  $ echo outside2 > outside_file2
+  $ git add outside_file2
+  $ git commit -m "add outside_file2" 1> /dev/null
+  $ git checkout -q master
+  $ echo contents3 > sub1/file3
+  $ git add sub1
+  $ git commit -m "add file3" 1> /dev/null
+  $ git merge -q branch2 --no-ff
+
+  $ cd ${TESTTMP}/libs
+  $ josh fetch
+  From file://${TESTTMP}/remote/libs
+   * [new branch]      branch2    -> refs/josh/remotes/origin/branch2
+   * [new branch]      expected   -> refs/josh/remotes/origin/expected
+     0823744..5c2a751  master     -> refs/josh/remotes/origin/master
+  
+  From file://${TESTTMP}/libs
+     2fa5077..c2a3e28  master     -> origin/master
+   * [new branch]      branch2    -> origin/branch2
+  
+  Fetched from remote: origin
+
+  $ git log --graph --pretty=%s origin/master
+  *   Merge branch 'branch2'
+  |\  
+  * | add file3
+  |/  
+  *   Merge branch 'branch1'
+  |\  
+  * | add file2
+  |/  
+  * add file1
+
+josh filter prints the spec including the semantic args
+
+  $ josh filter origin
+  Applying filter ':~(gpgsig="norm-lf",history="keep-trivial-merges")[:/sub1]' to remote 'origin'
+  Applied filter ':~(gpgsig="norm-lf",history="keep-trivial-merges")[:/sub1]' to remote 'origin'
+
+Push roundtrip: reverse filtering must use the same semantic filter
+
+  $ git checkout -q -b work origin/master
+  $ echo pushed > pushed_file
+  $ git add pushed_file
+  $ git commit -m "add pushed_file" 1> /dev/null
+  $ josh push origin work:refs/heads/master
+  Pushing eb7746f155f6de988eaa9727a78c4449017e23b3 to origin/refs/heads/master
+  To file://${TESTTMP}/remote/libs
+     5c2a751..eb7746f  eb7746f155f6de988eaa9727a78c4449017e23b3 -> master
+  
+  Pushed 1 ref(s) to origin
+
+  $ cd ${TESTTMP}/remote/libs
+  $ git log --pretty=%s -1 master
+  add pushed_file
+  $ git show --pretty=%s --stat master
+  add pushed_file
+  
+   sub1/pushed_file | 1 +
+   1 file changed, 1 insertion(+)
+
+A fetch after the push is a fast-forward onto the pushed commit
+
+  $ cd ${TESTTMP}/libs
+  $ josh fetch
+  From file://${TESTTMP}/remote/libs
+     5c2a751..eb7746f  master     -> refs/josh/remotes/origin/master
+  
+  From file://${TESTTMP}/libs
+     c2a3e28..7c8cc20  master     -> origin/master
+  
+  Fetched from remote: origin
+  $ git log --pretty=%s -1 origin/master
+  add pushed_file
+
+Chain filter with meta args: stepwise application by the CLI must equal the
+composed application josh-filter performs
+
+  $ cd ${TESTTMP}
+  $ josh clone ${TESTTMP}/remote/libs ':~(history="keep-trivial-merges")[:/sub1:prefix=libs]' libs-chain
+  Added remote 'origin' with filter ':~(history="keep-trivial-merges")[:/sub1:prefix=libs]'
+  From file://${TESTTMP}/remote/libs
+   * [new branch]      branch1    -> refs/josh/remotes/origin/branch1
+   * [new branch]      branch2    -> refs/josh/remotes/origin/branch2
+   * [new branch]      expected   -> refs/josh/remotes/origin/expected
+   * [new branch]      master     -> refs/josh/remotes/origin/master
+  
+  From file://${TESTTMP}/libs-chain
+   * [new branch]      branch1    -> origin/branch1
+   * [new branch]      branch2    -> origin/branch2
+   * [new branch]      master     -> origin/master
+  
+  Fetched from remote: origin
+  Already on 'master'
+  
+  Cloned repository to: ${TESTTMP}/libs-chain/
+
+  $ cd ${TESTTMP}/remote/libs
+  $ josh-filter -s ':~(history="keep-trivial-merges")[:/sub1:prefix=libs]' master --update refs/heads/expected-chain 1> /dev/null
+  $ git rev-parse expected-chain
+  963f9f17ffd626f046558444e2474f1b223bc272
+
+  $ cd ${TESTTMP}/libs-chain
+  $ git rev-parse origin/master
+  963f9f17ffd626f046558444e2474f1b223bc272
+
+Reserved transport keys are rejected in user filters
+
+  $ cd ${TESTTMP}
+  $ josh clone ${TESTTMP}/remote/libs ':~(url="ha")[:/sub1]' libs-bad
+  Error: Failed to write remote config file
+  Failed to write remote config file
+  Filter must not set reserved meta key 'url': it is owned by the remote config
+  [1]


### PR DESCRIPTION
Apply semantic meta args of remote filters in the josh CLI

A remote configured with a filter carrying semantic meta args, e.g.
':~(history="keep-trivial-merges")[:/sub1]', stored the args but ignored
them: the config folds transport metadata (url, fetch, forge) into the
same ':~()' Meta block, and every command stripped the whole block with
Filter::peel() before filtering, so the CLI's history was not
SHA-interoperable with proxy-produced repos.

Add Filter::without_meta_keys() and RemoteConfig::semantic_filter(),
which drop only the transport keys, and use it at all six peel() call
sites (fetch, filter, push, cache build/push/fetch). The transport keys
are now reserved: 'josh remote add' rejects a filter that sets them.

The regression test asserts the CLI's stepwise application produces
heads SHA-identical to josh-filter's composed application, for both a
single-step filter and a chain.

Change: cli-semantic-meta-args
Assisted-By: Claude Fable 5 (claude-fable-5)