### PR TITLE
Replace the bloom filter trigram index with an exact inverted index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,13 +3426,12 @@ name = "josh-search"
 version = "26.7.28"
 dependencies = [
  "anyhow",
- "bitvec",
  "criterion2",
  "git2",
- "hex",
  "josh-core",
  "josh-test-support",
  "rand 0.10.1",
+ "tempfile",
  "tracing",
 ]
 

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -113,11 +113,6 @@ fn make_app() -> clap::Command {
                 .short('g'),
         )
         .arg(
-            clap::Arg::new("max_comp")
-                .long("max_comp")
-                .short('m'),
-        )
-        .arg(
             clap::Arg::new("reverse").action(clap::ArgAction::SetTrue).long("reverse").help(
                 "reverse-apply the filter to the output reference to update the input reference",
             ),
@@ -375,11 +370,6 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     if let Some(searchstring) = args.get_one::<String>("search") {
         let ifilterobj = filterobj.chain(josh_core::filter::parse(":SQUASH:INDEX")?);
 
-        let max_complexity: usize = args
-            .get_one::<String>("max_comp")
-            .unwrap_or(&"6".to_string())
-            .parse()?;
-
         let commit = repo.revparse_single(&input_ref)?.peel_to_commit()?;
 
         let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit.id())?;
@@ -393,8 +383,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         let index_tree = repo.find_commit(index_commit)?.tree()?;
 
         /* let start = std::time::Instant::now(); */
-        let candidates =
-            josh_search::search_candidates(&repo, &index_tree, searchstring, max_complexity)?;
+        let candidates = josh_search::search_candidates(&repo, &index_tree, &tree, searchstring)?;
         let matches = josh_search::search_matches(&repo, &tree, searchstring, &candidates)?;
         /* let duration = start.elapsed(); */
 

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -423,13 +423,7 @@ impl Revision {
         Ok(Some(warnings))
     }
 
-    fn search(
-        &self,
-        string: String,
-        max_complexity: Option<i32>,
-        context: &Context,
-    ) -> FieldResult<Option<Vec<SearchResult>>> {
-        let max_complexity = max_complexity.unwrap_or(6) as usize;
+    fn search(&self, string: String, context: &Context) -> FieldResult<Option<Vec<SearchResult>>> {
         let transaction = context.transaction.lock().unwrap();
         let ifilterobj = filter::parse(":SQUASH:INDEX")?;
         let tree = transaction.repo().find_commit(self.commit_id)?.tree()?;
@@ -441,8 +435,8 @@ impl Revision {
         let candidates = josh_search::search_candidates(
             transaction.repo(),
             index_tree.tree(),
+            x.tree(),
             &string,
-            max_complexity,
         )?;
         let results =
             josh_search::search_matches(transaction.repo(), x.tree(), &string, &candidates)?;

--- a/josh-search/Cargo.toml
+++ b/josh-search/Cargo.toml
@@ -15,13 +15,12 @@ harness = false
 
 [dependencies]
 anyhow.workspace = true
-bitvec = "1.0.1"
 git2.workspace = true
-hex.workspace = true
 
 [dev-dependencies]
 criterion2 = { version = "3.0.3" }
 rand = "0.10.1"
+tempfile.workspace = true
 tracing.workspace = true
 josh-core.workspace = true
 josh-test-support = { path = "../devtools/josh-test-support" }

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -29,11 +29,11 @@ const LEAF_FILES: usize = 25;
 const LEAVES_PER_TOP: usize = 16;
 
 // File content: WORDS_PER_FILE words (8 per line, ~2 KB per file) sampled with a skewed
-// distribution from a fixed vocabulary of VOCAB_SIZE lowercase words. The bounded vocabulary is
-// load-bearing: a file is stored at ordinal `a` of the index only if its trigram bloom filter
-// fits within `4^(3+a)/2` set bytes, and uniformly random text saturates every ordinal below
-// MAX_ORD, making files unfindable. ~1-2k distinct trigrams per file lands files around ord 3-5.
-// The rare-needle candidate gate in `setup` is the tripwire if these constants degenerate.
+// distribution from a fixed vocabulary of VOCAB_SIZE lowercase words. The bounded vocabulary
+// (originally required by the bloom indexer's saturation ceiling) is kept unchanged so results
+// stay comparable with the pre-rework baseline; ~1-2k distinct trigrams per file is also a
+// realistic density for source code. The rare-needle candidate gate in `setup` is the tripwire
+// if these constants degenerate.
 const WORDS_PER_FILE: usize = 300;
 const WORDS_PER_LINE: usize = 8;
 const VOCAB_SIZE: usize = 512;
@@ -42,9 +42,6 @@ const VOCAB_SIZE: usize = 512;
 // ~CHURN_FRACTION of the files (at least one).
 const K_CHURN: usize = if cfg!(debug_assertions) { 3 } else { 20 };
 const CHURN_FRACTION: f64 = 0.01;
-
-// Search depth, matching the default of `josh-filter --search` (`max_comp`).
-const MAX_ORD: usize = 6;
 
 // Needles for the search group, planted keyed on file index (not revision) so churn commits
 // preserve them: NEEDLE_RARE in exactly one file, NEEDLE_COMMON in every COMMON_EVERY-th file,
@@ -129,10 +126,10 @@ fn vocabulary() -> Vec<String> {
 fn file_content(vocab: &[String], n_files: usize, i: usize, revision: usize) -> String {
     let mut rng = StdRng::seed_from_u64(((i as u64) << 8) | revision as u64);
 
-    // Needles go at the very start of the file: the per-file bloom filter is emitted in chunks
-    // as it saturates, and the current search misses a needle whose trigrams straddle a chunk
-    // boundary. Planting needles in the first chunk keeps the correctness gates exact instead of
-    // depending on where chunk boundaries happen to fall.
+    // Needles go at the very start of the file. Historical: the bloom indexer emitted per-file
+    // filters in chunks and missed needles whose trigrams straddled a chunk boundary, so the
+    // fixture planted them in the first chunk. The exact index has no such failure mode, but the
+    // placement is kept so the content stays byte-identical to the pre-rework baseline.
     let mut lines = vec![];
     if i == n_files / 2 {
         lines.push(format!("marker {} end", NEEDLE_RARE));
@@ -273,15 +270,15 @@ fn recover_chain(repo: &git2::Repository, n_files: usize) -> anyhow::Result<Vec<
     Ok(chain)
 }
 
-/// End-to-end search exactly as `josh-filter --search` performs it: bloom-filtered candidate
-/// selection over the index tree, then exact matching over the source tree.
+/// End-to-end search exactly as `josh-filter --search` performs it: candidate selection over
+/// the index tree, then exact matching over the source tree.
 fn search(
     repo: &git2::Repository,
     index_tree: &git2::Tree,
     source_tree: &git2::Tree,
     needle: &str,
 ) -> anyhow::Result<(Vec<String>, Vec<(String, Vec<(usize, String)>)>)> {
-    let candidates = josh_search::search_candidates(repo, index_tree, needle, MAX_ORD)?;
+    let candidates = josh_search::search_candidates(repo, index_tree, source_tree, needle)?;
     let matches = josh_search::search_matches(repo, source_tree, needle, &candidates)?;
     Ok((candidates, matches))
 }
@@ -343,9 +340,9 @@ impl TrigramBench {
             transaction.flush_mem_odb()?;
 
             // Gate: the rare needle is found in exactly its planted file, with a tight
-            // candidate set. A blown-up candidate list means the bloom filters have degenerated
-            // (e.g. per-file trigram saturation pushed files past MAX_ORD) and the search
-            // numbers would be meaningless.
+            // candidate set. A blown-up candidate list means candidate selection has
+            // degenerated and the search numbers would be meaningless. (The bound is kept at
+            // the pre-rework value of 5; the exact index should always produce exactly 1.)
             let rare_path = path_for(n_files / 2).to_string_lossy().into_owned();
             let (candidates, matches) = search(repo, &index_tree, &tip_tree, NEEDLE_RARE)?;
             anyhow::ensure!(
@@ -354,7 +351,7 @@ impl TrigramBench {
             );
             anyhow::ensure!(
                 candidates.len() <= 5,
-                "rare needle produced {} candidates -- bloom filters degenerated",
+                "rare needle produced {} candidates -- candidate selection degenerated",
                 candidates.len()
             );
 
@@ -487,9 +484,7 @@ fn trigram_benches(c: &mut Criterion) {
     // End-to-end search over the pre-built index: candidate selection plus exact matching, for a
     // needle in one file, in every COMMON_EVERY-th file, and in none. Search has no result
     // memoization and reads only git objects, so the cache reset is for uniformity with the
-    // other groups, not correctness. Note that `trigram_search` currently opens a fresh
-    // repository handle per directory per ordinal; pre-rework numbers are expected to be
-    // dominated by that.
+    // other groups, not correctness.
     let mut group = c.benchmark_group("trigram_search");
     group.sample_size(10);
     for case in &bench.cases {

--- a/josh-search/src/lib.rs
+++ b/josh-search/src/lib.rs
@@ -1,17 +1,30 @@
 //! Trigram based code search index for git repositories.
 //!
-//! The index of a tree is itself a git tree, holding per-directory bloom filters over the
-//! trigrams of the directory's files (`OWN<n>`), of all descendant files (`SUB<n>`), and
-//! per-file filter chunks (`BLOBS<n>`) at 8 saturation ordinals. Searching walks the index tree,
-//! pruning directories whose filters cannot contain the search string's trigrams, and returns
-//! candidate file paths for exact verification.
+//! The index of a tree is itself a git tree: an exact inverted index mapping every trigram
+//! (3-byte window of file content) to the set of files containing it. For a trigram with bytes
+//! `(b1, b2, b3)`, the index contains
+//!
+//! ```text
+//! <hex(b1)>/<hex(b2)>/<hex(b3)>/path/to/file
+//! ```
+//!
+//! with the empty blob as the leaf marker. The subtree below a trigram's three "spine" levels
+//! mirrors the source tree's structure restricted to files containing that trigram. Mirrors are
+//! built compositionally — a directory's mirror references its children's mirrors by oid — so
+//! git's content addressing shares identical file sets across trigrams and across commits.
+//!
+//! Searching extracts the query's trigrams, resolves each with a single three-level lookup, and
+//! intersects the mirror subtrees; the resulting candidate files are exact (files containing all
+//! query trigrams), leaving only string-level verification to [`search_matches`].
 //!
 //! This crate is independent of the josh filter machinery: it operates on plain [`git2`] objects
 //! and memoizes tree-to-index mappings through the [`IndexCache`] trait the caller provides.
 
 use anyhow::anyhow;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-const FILE_FILTER_SIZE: usize = 64;
+const BLOB_MODE: i32 = 0o0100644;
+const TREE_MODE: i32 = 0o0040000;
 
 /// Memoization of tree oid -> index tree oid mappings, provided by the caller.
 ///
@@ -24,6 +37,32 @@ pub trait IndexCache {
 
 fn empty_tree_id() -> git2::Oid {
     git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap()
+}
+
+/// All distinct trigrams of `content`: 3-byte windows that are valid UTF-8. Used identically on
+/// the index side and the query side, which is what makes the index exact — UTF-8 validity of a
+/// window depends only on its own bytes, so a query trigram is found in every file containing
+/// the query string.
+fn distinct_trigrams(content: &str) -> BTreeSet<[u8; 3]> {
+    content
+        .as_bytes()
+        .windows(3)
+        .filter(|w| std::str::from_utf8(w).is_ok())
+        .map(|w| [w[0], w[1], w[2]])
+        .collect()
+}
+
+fn decode_hex_name(name: &str) -> Option<u8> {
+    // Spines are written with lowercase hex only; reject anything else (incl. uppercase) so
+    // encoding and decoding stay bijective.
+    if name.len() != 2
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+    {
+        return None;
+    }
+    u8::from_str_radix(name, 16).ok()
 }
 
 /// Read the blob at `name` in `tree` as text, or "" if it is absent, binary or not UTF-8.
@@ -47,53 +86,138 @@ fn get_blob(repo: &git2::Repository, tree: &git2::Tree, name: &str) -> String {
     content.to_owned()
 }
 
-/// Insert a blob entry into the root of `tree`, returning the new tree.
-fn insert_blob<'a>(
-    repo: &'a git2::Repository,
-    tree: &git2::Tree,
-    name: &str,
-    blob: git2::Oid,
-) -> anyhow::Result<git2::Tree<'a>> {
-    let mut builder = repo.treebuilder(Some(tree))?;
-    builder.insert(name, blob, 0o0100644)?;
-    Ok(repo.find_tree(builder.write()?)?)
-}
+/// Per-directory posting map: trigram -> (entry name -> (oid, filemode)). For an own file the
+/// oid is the empty blob; for a child directory it is the child's mirror subtree for that
+/// trigram.
+type Postings = BTreeMap<[u8; 3], BTreeMap<String, (git2::Oid, i32)>>;
 
-#[allow(clippy::many_single_char_names)]
-fn hash_bits(s: &str, size: usize) -> [usize; 3] {
-    let size = size * 8;
-    let size = size / 2;
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::Hasher;
-    let mut hasher = DefaultHasher::new();
-    hasher.write(s.as_bytes());
-    let r = hasher.finish() as usize;
-    let n = 8 * usize::pow(4, 10);
-
-    let (a, b, c) = (r % size, (r / n) % size, ((r / n) / n) % size);
-
-    if s.chars().any(|x| !char::is_alphabetic(x)) {
-        [a + size, b + size, c + size]
-    } else {
-        [a, b, c]
+/// Iterate the `(trigram, mirror_oid)` leaves of an index tree's spine.
+fn for_each_spine_leaf(
+    repo: &git2::Repository,
+    index: &git2::Tree,
+    mut f: impl FnMut([u8; 3], git2::Oid) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    for e1 in index.iter() {
+        let b1 = e1
+            .name()
+            .and_then(decode_hex_name)
+            .ok_or_else(|| anyhow!("invalid spine entry"))?;
+        let t1 = repo.find_tree(e1.id())?;
+        for e2 in t1.iter() {
+            let b2 = e2
+                .name()
+                .and_then(decode_hex_name)
+                .ok_or_else(|| anyhow!("invalid spine entry"))?;
+            let t2 = repo.find_tree(e2.id())?;
+            for e3 in t2.iter() {
+                let b3 = e3
+                    .name()
+                    .and_then(decode_hex_name)
+                    .ok_or_else(|| anyhow!("invalid spine entry"))?;
+                f([b1, b2, b3], e3.id())?;
+            }
+        }
     }
+    Ok(())
 }
 
-pub fn make_dir_trigram_filter(searchstring: &str, size: usize, bits: &[usize]) -> Vec<u8> {
-    let mut arr_own = vec![0u8; size];
-    let abf = bitvec::slice::BitSlice::<_, bitvec::order::Msb0>::from_slice_mut(&mut arr_own);
+/// Write one tree from `(name, oid, filemode)` entries.
+fn write_tree(
+    repo: &git2::Repository,
+    entries: &[(String, git2::Oid, i32)],
+) -> anyhow::Result<git2::Oid> {
+    let mut builder = repo.treebuilder(None)?;
+    for (name, oid, mode) in entries {
+        builder.insert(name, *oid, *mode)?;
+    }
+    Ok(builder.write()?)
+}
 
-    for t in searchstring
-        .as_bytes()
-        .windows(3)
-        .filter_map(|x| std::str::from_utf8(x).ok())
-    {
-        for bit in bits {
-            abf.set(hash_bits(t, size)[*bit], true);
+/// Build the index of `tree`'s postings: the c1/c2/c3 spine with each trigram's mirror subtree
+/// below it. Mirrors identical across trigrams (same file set) are written once and shared.
+fn write_spine(repo: &git2::Repository, postings: &Postings) -> anyhow::Result<git2::Oid> {
+    if postings.is_empty() {
+        return Ok(empty_tree_id());
+    }
+
+    // trigram mirror oids, deduped by entry list: trigrams occurring in the same set of files
+    // share one mirror tree.
+    let mut mirror_cache: HashMap<Vec<(String, git2::Oid, i32)>, git2::Oid> = HashMap::new();
+
+    // b1 -> b2 -> b3 -> mirror oid
+    let mut spine: BTreeMap<u8, BTreeMap<u8, Vec<(String, git2::Oid, i32)>>> = BTreeMap::new();
+    for (t, files) in postings {
+        let entries: Vec<_> = files
+            .iter()
+            .map(|(name, (oid, mode))| (name.clone(), *oid, *mode))
+            .collect();
+        let mirror = match mirror_cache.get(&entries) {
+            Some(oid) => *oid,
+            None => {
+                let oid = write_tree(repo, &entries)?;
+                mirror_cache.insert(entries, oid);
+                oid
+            }
+        };
+        spine
+            .entry(t[0])
+            .or_default()
+            .entry(t[1])
+            .or_default()
+            .push((format!("{:02x}", t[2]), mirror, TREE_MODE));
+    }
+
+    let mut c1_entries = vec![];
+    for (b1, c2s) in &spine {
+        let mut c2_entries = vec![];
+        for (b2, c3s) in c2s {
+            c2_entries.push((format!("{:02x}", b2), write_tree(repo, c3s)?, TREE_MODE));
+        }
+        c1_entries.push((
+            format!("{:02x}", b1),
+            write_tree(repo, &c2_entries)?,
+            TREE_MODE,
+        ));
+    }
+    write_tree(repo, &c1_entries)
+}
+
+/// Build the index of one directory: own files contribute empty-blob postings, child
+/// directories contribute their (memoized) index's mirror subtrees by oid.
+fn build_index(
+    repo: &git2::Repository,
+    cache: &dyn IndexCache,
+    tree: &git2::Tree,
+    empty_blob: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    let mut postings = Postings::new();
+
+    for entry in tree.iter() {
+        let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
+
+        if entry.kind() == Some(git2::ObjectType::Blob) {
+            let content = get_blob(repo, tree, name);
+            for t in distinct_trigrams(&content) {
+                postings
+                    .entry(t)
+                    .or_default()
+                    .insert(name.to_owned(), (empty_blob, BLOB_MODE));
+            }
+        }
+
+        if entry.kind() == Some(git2::ObjectType::Tree) {
+            let child = trigram_index(repo, cache, repo.find_tree(entry.id())?)?;
+            for_each_spine_leaf(repo, &child, |t, mirror| {
+                postings
+                    .entry(t)
+                    .or_default()
+                    .insert(name.to_owned(), (mirror, TREE_MODE));
+                Ok(())
+            })?;
         }
     }
 
-    arr_own.to_vec()
+    write_spine(repo, &postings)
 }
 
 pub fn trigram_index<'a>(
@@ -104,188 +228,132 @@ pub fn trigram_index<'a>(
     if let Some(cached) = cache.get_index(tree.id()) {
         return Ok(repo.find_tree(cached)?);
     }
-
-    let mut arrs_own = vec![vec![]; 8];
-    let mut arrs_sub = vec![vec![]; 8];
-
-    let mut files = vec![vec![]; 8];
-
-    // The subtree children go into this builder (written once after the loop); the per-level
-    // OWN/SUB/BLOBS index blobs are added to the resulting tree afterward.
-    let mut builder = repo.treebuilder(None)?;
-
-    /* 'entry: */
-    for entry in tree.iter() {
-        let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
-        if entry.kind() == Some(git2::ObjectType::Blob) {
-            let b = get_blob(repo, &tree, name);
-
-            let mut file_chunks = vec![name.to_string()];
-
-            let trigrams: Vec<_> = b
-                .as_bytes()
-                .windows(3)
-                .filter_map(|x| std::str::from_utf8(x).ok())
-                .collect();
-
-            //let mut histogram = std::collections::HashMap::new();
-
-            //for trigram in trigrams.iter() {
-            //    let counter = histogram.entry(trigram).or_insert(0);
-            //    *counter += 1;
-            //}
-
-            //let mut freq: Vec<_> = histogram.iter().map(|(a,b)| (b,a)).collect();
-            //freq.sort();
-
-            //let mut hbf =
-            //    bitvec::array::BitArray::<bitvec::order::Msb0, _>::new([0u8; FILE_FILTER_SIZE]);
-            //for (_,trigram) in freq.iter().rev() {
-            //    hbf.set(hash_bits(trigram)[2] % (FILE_FILTER_SIZE * 8), true);
-            //    if hbf.count_ones() > FILE_FILTER_SIZE * 4 {
-            //        break;
-            //    }
-            //}
-
-            //let filefilter = hex::encode(hbf.as_buffer());
-            //file_chunks.push(format!("{}", filefilter));
-
-            let mut bf =
-                bitvec::array::BitArray::<_, bitvec::order::Msb0>::new([0u8; FILE_FILTER_SIZE]);
-            let mut i = 0;
-            for trigram in trigrams {
-                //if hbf[hash_bits(trigram)[2] % (FILE_FILTER_SIZE * 8)] {
-                //    continue;
-                //}
-                bf.set(hash_bits(trigram, FILE_FILTER_SIZE)[2], true);
-
-                if bf.count_ones() > FILE_FILTER_SIZE * 4 {
-                    let filefilter = hex::encode(bf.into_inner());
-                    file_chunks.push(format!("{} {:04x}", filefilter, i));
-                    i = 0;
-                    bf.fill(false);
-                }
-                i += 1;
-            }
-
-            //if bf.count_ones() > 0 {
-            let filefilter = hex::encode(bf.into_inner());
-            file_chunks.push(format!("{} {:04x}", filefilter, i));
-            //}
-            file_chunks.push("".to_string());
-
-            'arrsub: for a in 0..arrs_sub.len() {
-                let dir_filter_size = usize::pow(4, 3 + a as u32);
-                let dtf = make_dir_trigram_filter(&b, dir_filter_size, &[0, 1, 2]);
-                let abf = bitvec::slice::BitSlice::<_, bitvec::order::Msb0>::from_slice(&dtf);
-
-                if abf.count_ones() > dir_filter_size / 2 {
-                    continue 'arrsub;
-                }
-
-                arrs_own[a].resize(dtf.len(), 0);
-                for (a, b) in arrs_own[a].iter_mut().zip(dtf.iter()) {
-                    *a |= b;
-                }
-
-                files[a].append(&mut file_chunks);
-
-                break 'arrsub;
-            }
-        }
-
-        if entry.kind() == Some(git2::ObjectType::Tree) {
-            let s = trigram_index(repo, cache, repo.find_tree(entry.id())?)?;
-
-            for (a, arr_sub) in arrs_sub.iter_mut().enumerate() {
-                let b = get_blob(repo, &s, &format!("OWN{}", a));
-                let hd = hex::decode(b.lines().collect::<Vec<_>>().join(""))?;
-                let new_size = std::cmp::max(hd.len(), arr_sub.len());
-                arr_sub.resize(new_size, 0);
-                for (a, &b) in arr_sub.iter_mut().zip(hd.iter()) {
-                    *a |= b;
-                }
-
-                let b = get_blob(repo, &s, &format!("SUB{}", a));
-                let hd = hex::decode(b.lines().collect::<Vec<_>>().join(""))?;
-                let new_size = std::cmp::max(hd.len(), arr_sub.len());
-                arr_sub.resize(new_size, 0);
-                for (a, &b) in arr_sub.iter_mut().zip(hd.iter()) {
-                    *a |= b;
-                }
-            }
-
-            if s.id() != empty_tree_id() {
-                builder.insert(name, s.id(), 0o0040000).ok();
-            }
-        }
-    }
-
-    let mut result = repo.find_tree(builder.write()?)?;
-
-    for a in 0..arrs_sub.len() {
-        if arrs_own[a].iter().any(|x| *x != 0) {
-            result = insert_blob(
-                repo,
-                &result,
-                &format!("OWN{}", a),
-                repo.blob(
-                    arrs_own[a]
-                        .chunks(64)
-                        .map(hex::encode)
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                        .as_bytes(),
-                )?,
-            )
-            .unwrap();
-        }
-        if arrs_sub[a].iter().any(|x| *x != 0) {
-            result = insert_blob(
-                repo,
-                &result,
-                &format!("SUB{}", a),
-                repo.blob(
-                    arrs_sub[a]
-                        .chunks(64)
-                        .map(hex::encode)
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                        .as_bytes(),
-                )?,
-            )
-            .unwrap();
-        }
-        if !files[a].is_empty() {
-            result = insert_blob(
-                repo,
-                &result,
-                &format!("BLOBS{}", a),
-                repo.blob(files[a].join("\n").as_bytes())?,
-            )
-            .unwrap();
-        }
-    }
-    cache.set_index(tree.id(), result.id());
-    Ok(result)
+    let empty_blob = repo.blob(b"")?;
+    let result = build_index(repo, cache, &tree, empty_blob)?;
+    cache.set_index(tree.id(), result);
+    Ok(repo.find_tree(result)?)
 }
 
+/// Exact candidate files for `searchstring`: files containing every trigram of the query.
+///
+/// Queries shorter than three bytes (or without any valid-UTF-8 window) have no trigrams; every
+/// file of `source_tree` is a candidate then, and [`search_matches`] does the filtering.
 pub fn search_candidates(
     repo: &git2::Repository,
-    tree: &git2::Tree,
+    index_tree: &git2::Tree,
+    source_tree: &git2::Tree,
     searchstring: &str,
-    max_ord: usize,
 ) -> anyhow::Result<Vec<String>> {
-    let ff = make_dir_trigram_filter(searchstring, FILE_FILTER_SIZE, &[2]);
+    let trigrams = distinct_trigrams(searchstring);
 
     let mut results = vec![];
-
-    for ord in 0..max_ord {
-        let dir_filter_size = usize::pow(4, 3 + ord as u32);
-        let df = make_dir_trigram_filter(searchstring, dir_filter_size, &[0, 1, 2]);
-        trigram_search(repo, tree.clone(), "", &df, &ff, &mut results, ord)?;
+    if trigrams.is_empty() {
+        collect_paths(repo, source_tree.id(), "", &mut results)?;
+        return Ok(results);
     }
+
+    let mut roots = vec![];
+    for t in &trigrams {
+        let path = format!("{:02x}/{:02x}/{:02x}", t[0], t[1], t[2]);
+        match index_tree.get_path(std::path::Path::new(&path)) {
+            Ok(entry) => roots.push(entry.id()),
+            // A trigram absent from the index cannot occur in any file.
+            Err(_) => return Ok(vec![]),
+        }
+    }
+    roots.sort();
+    roots.dedup();
+
+    // Cap the intersection width: any subset of trigrams yields a superset of candidates, and
+    // search_matches verifies exactly anyway. Keep the mirrors with the fewest entries — they
+    // constrain the most.
+    const MAX_INTERSECT: usize = 16;
+    if roots.len() > MAX_INTERSECT {
+        let mut sized = roots
+            .iter()
+            .map(|&oid| anyhow::Ok((repo.find_tree(oid)?.len(), oid)))
+            .collect::<Result<Vec<_>, _>>()?;
+        sized.sort();
+        roots = sized
+            .into_iter()
+            .take(MAX_INTERSECT)
+            .map(|(_, oid)| oid)
+            .collect();
+    }
+
+    intersect_walk(repo, &roots, "", &mut results)?;
     Ok(results)
+}
+
+/// Emit every file path present in ALL of the mirror trees `roots`.
+fn intersect_walk(
+    repo: &git2::Repository,
+    roots: &[git2::Oid],
+    prefix: &str,
+    out: &mut Vec<String>,
+) -> anyhow::Result<()> {
+    // Content addressing fast path: identical mirrors (trigrams with the same file set)
+    // intersect to themselves.
+    if roots.iter().all(|oid| *oid == roots[0]) {
+        return collect_paths(repo, roots[0], prefix, out);
+    }
+
+    let trees = roots
+        .iter()
+        .map(|oid| repo.find_tree(*oid))
+        .collect::<Result<Vec<_>, _>>()?;
+    let smallest = trees
+        .iter()
+        .min_by_key(|t| t.len())
+        .expect("roots is never empty");
+
+    'entry: for entry in smallest.iter() {
+        let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
+
+        let mut child_roots = Vec::with_capacity(trees.len());
+        for tree in &trees {
+            match tree.get_name(name) {
+                Some(other) if other.kind() == entry.kind() => child_roots.push(other.id()),
+                _ => continue 'entry,
+            }
+        }
+
+        let path = join_path(prefix, name);
+        match entry.kind() {
+            Some(git2::ObjectType::Tree) => intersect_walk(repo, &child_roots, &path, out)?,
+            Some(git2::ObjectType::Blob) => out.push(path),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Emit every blob path under `oid` (a tree), prefixed with `prefix`.
+fn collect_paths(
+    repo: &git2::Repository,
+    oid: git2::Oid,
+    prefix: &str,
+    out: &mut Vec<String>,
+) -> anyhow::Result<()> {
+    let tree = repo.find_tree(oid)?;
+    for entry in tree.iter() {
+        let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
+        let path = join_path(prefix, name);
+        match entry.kind() {
+            Some(git2::ObjectType::Tree) => collect_paths(repo, entry.id(), &path, out)?,
+            Some(git2::ObjectType::Blob) => out.push(path),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn join_path(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_owned()
+    } else {
+        format!("{}/{}", prefix, name)
+    }
 }
 
 type SearchMatchesResult = Vec<(String, Vec<(usize, String)>)>;
@@ -338,121 +406,107 @@ fn get_blob_path(repo: &git2::Repository, tree: &git2::Tree, path: &std::path::P
     content.to_owned()
 }
 
-pub fn trigram_search<'a>(
-    repo: &'a git2::Repository,
-    tree: git2::Tree<'a>,
-    root: &str,
-    dir_filter: &[u8],
-    file_filter: &[u8],
-    results: &mut Vec<String>,
-    ord: usize,
-) -> anyhow::Result<()> {
-    let hd = {
-        if let Some(blob) = tree
-            .get_name(&format!("OWN{}", ord))
-            .map(|x| repo.find_blob(x.id()))
-        {
-            let blob = blob?;
-            let b = unsafe { std::str::from_utf8_unchecked(blob.content()) };
-            hex::decode(b.lines().collect::<Vec<_>>().join(""))?
-        } else {
-            vec![]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_names_round_trip() {
+        for b in 0..=255u8 {
+            assert_eq!(decode_hex_name(&format!("{:02x}", b)), Some(b));
         }
-    };
+        assert_eq!(decode_hex_name("g0"), None);
+        assert_eq!(decode_hex_name("0"), None);
+        assert_eq!(decode_hex_name("000"), None);
+        // Uppercase never appears in written spines; reject to keep encode/decode bijective.
+        assert_eq!(decode_hex_name("0A"), None);
+    }
 
-    let dmatch = if !hd.is_empty() {
-        let mut dmatch = true;
-        for (a, b) in dir_filter.iter().zip(hd.iter()) {
-            if a & b != *a {
-                dmatch = false;
-                break;
-            }
+    #[test]
+    fn distinct_trigrams_basics() {
+        assert!(distinct_trigrams("").is_empty());
+        assert!(distinct_trigrams("ab").is_empty());
+        assert_eq!(
+            distinct_trigrams("abc"),
+            BTreeSet::from([[b'a', b'b', b'c']])
+        );
+        // Repeated windows collapse.
+        assert_eq!(distinct_trigrams("aaaa"), BTreeSet::from([[b'a'; 3]]));
+        // Multibyte: only valid UTF-8 windows are kept. "é" is 2 bytes; the windows straddling
+        // its bytes are not valid UTF-8 strings except where they align.
+        let t = distinct_trigrams("aéb");
+        assert!(t.contains(&[b'a', 0xc3, 0xa9]));
+        assert!(t.contains(&[0xc3, 0xa9, b'b']));
+        assert_eq!(t.len(), 2);
+    }
+
+    struct MapCache(std::cell::RefCell<std::collections::HashMap<git2::Oid, git2::Oid>>);
+
+    impl IndexCache for MapCache {
+        fn get_index(&self, tree: git2::Oid) -> Option<git2::Oid> {
+            self.0.borrow().get(&tree).copied()
         }
-        dmatch
-    } else {
-        false
-    };
-
-    if dmatch {
-        let b = get_blob(repo, &tree, &format!("BLOBS{}", ord));
-
-        let mut filename = None;
-        let mut skip = false;
-
-        for line in b.lines() {
-            if line.is_empty() {
-                skip = false;
-                filename = None;
-            } else if filename.is_none() {
-                filename = Some(line);
-            } else if !skip {
-                let hd = hex::decode(&line[..FILE_FILTER_SIZE * 2])?;
-
-                let mut fmatch = true;
-                for (a, b) in file_filter.iter().zip(hd.iter()) {
-                    if a & b != *a {
-                        fmatch = false;
-                        break;
-                    }
-                }
-
-                if fmatch && let Some(filename) = filename {
-                    results.push(format!(
-                        "{}{}{}",
-                        root,
-                        if root.is_empty() { "" } else { "/" },
-                        filename
-                    ));
-                    skip = true;
-                }
-            }
+        fn set_index(&self, tree: git2::Oid, index: git2::Oid) {
+            self.0.borrow_mut().insert(tree, index);
         }
     }
 
-    let hd = {
-        if let Some(blob) = tree
-            .get_name(&format!("SUB{}", ord))
-            .map(|x| repo.find_blob(x.id()))
-        {
-            let blob = blob?;
-            let b = unsafe { std::str::from_utf8_unchecked(blob.content()) };
-            hex::decode(b.lines().collect::<Vec<_>>().join(""))?
-        } else {
-            return Ok(());
-        }
-    };
-
-    {
-        for (a, b) in dir_filter.iter().zip(hd.iter()) {
-            if a & b != *a {
-                return Ok(());
-            }
-        }
+    fn test_repo() -> (tempfile::TempDir, git2::Repository) {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(tmp.path()).unwrap();
+        (tmp, repo)
     }
 
-    let trees = tree
-        .iter()
-        .filter(|x| x.kind() == Some(git2::ObjectType::Tree))
-        .filter(|x| x.name().is_some())
-        .map(|x| (x.id(), x.name().unwrap().to_string()))
-        .collect::<Vec<_>>();
-
-    // A fresh repository handle per directory, mirroring the sub-transaction the pre-crate-move
-    // implementation opened here. This keeps the performance profile of the recursion unchanged
-    // until the indexer rework addresses it deliberately.
-    let sub_repo = git2::Repository::open(repo.path())?;
-    for (id, name) in &trees {
-        let s = sub_repo.find_tree(*id)?;
-
-        trigram_search(
-            &sub_repo,
-            s,
-            &format!("{}{}{}", root, if root.is_empty() { "" } else { "/" }, name),
-            dir_filter,
-            file_filter,
-            results,
-            ord,
-        )?;
+    fn commit_tree<'a>(repo: &'a git2::Repository, files: &[(&str, &str)]) -> git2::Tree<'a> {
+        let mut builder = git2::build::TreeUpdateBuilder::new();
+        for (path, content) in files {
+            let oid = repo.blob(content.as_bytes()).unwrap();
+            builder.upsert(std::path::Path::new(path), oid, git2::FileMode::Blob);
+        }
+        let baseline = repo
+            .find_tree(repo.treebuilder(None).unwrap().write().unwrap())
+            .unwrap();
+        let oid = builder.create_updated(repo, &baseline).unwrap();
+        repo.find_tree(oid).unwrap()
     }
-    Ok(())
+
+    #[test]
+    fn index_and_search_end_to_end() {
+        let (_tmp, repo) = test_repo();
+        let cache = MapCache(Default::default());
+
+        let tree = commit_tree(
+            &repo,
+            &[
+                ("sub1/file1", "First Test document"),
+                ("sub1/file2", "Another document"),
+                ("sub2/file3", "One more to see what happens"),
+            ],
+        );
+
+        let index = trigram_index(&repo, &cache, tree.clone()).unwrap();
+
+        // "Tes" lives at 54/65/73 ('T' escapes nothing -- hex spine).
+        assert!(
+            index
+                .get_path(std::path::Path::new("54/65/73/sub1/file1"))
+                .is_ok()
+        );
+
+        let candidates = search_candidates(&repo, &index, &tree, "document").unwrap();
+        assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
+
+        let candidates = search_candidates(&repo, &index, &tree, "missingword").unwrap();
+        assert!(candidates.is_empty());
+
+        // Short query: every file is a candidate.
+        let candidates = search_candidates(&repo, &index, &tree, "e").unwrap();
+        assert_eq!(candidates.len(), 3);
+
+        // Indexing is deterministic and memoization-independent: a cold rebuild of the same
+        // tree yields the same oid.
+        let cold = MapCache(Default::default());
+        let index2 = trigram_index(&repo, &cold, tree).unwrap();
+        assert_eq!(index.id(), index2.id());
+    }
 }

--- a/tests/experimental/indexer.t
+++ b/tests/experimental/indexer.t
@@ -19,7 +19,7 @@
   $ git commit -m "add file3" 1> /dev/null
 
   $ josh-filter -s :INDEX --update refs/heads/index
-  7f9854361a53e0a7faa7428a5909267f6e04fb99
+  ce00c6cd65dea70a35eeaa9283741bcd3f901991
   [3] :INDEX
   [3] reachable_roots
   [3] sequence_number
@@ -116,55 +116,252 @@
   }
 
   $ git diff ${EMPTY_TREE}..refs/heads/index
-  diff --git a/SUB1 b/SUB1
+  diff --git a/0a/20/6f/sub1/file2 b/0a/20/6f/sub1/file2
   new file mode 100644
-  index 0000000..095149c
-  --- /dev/null
-  +++ b/SUB1
-  @@ -0,0 +1,4 @@
-  +c002000000000010080000000022080000000020210000200048000000000000240004080023000800200884002055080000000210000000400008000000000a
-  +0020060802054480a0a80001240001004805000030000000800002000ca004040220228040010000000080000000001040100030100202000003204020202020
-  +0000100000000000580000200850081040000000023c01004090020000084200a0000104040122000000000000000008400c204000000880140000c41a540400
-  +000004910100600000000000c00060020000808000020610c004800008a0000410000000201208000a8080000810001280001600201810400000010000100000
-  \ No newline at end of file
-  diff --git a/sub1/BLOBS1 b/sub1/BLOBS1
+  index 0000000..e69de29
+  diff --git a/0a/20/74/sub1/file2 b/0a/20/74/sub1/file2
   new file mode 100644
-  index 0000000..1114b0c
-  --- /dev/null
-  +++ b/sub1/BLOBS1
-  @@ -0,0 +1,5 @@
-  +file1
-  +00000200000100008880800000000000000000023000020000000200000000000000000000000000008000008000000000000000000402004000000000000000 0011
-  +
-  +file2
-  +000206000000008088208080200008080000000020000200000008000400200ca000000004030800020000200810000200002000000002400004010010e00000 002a
-  diff --git a/sub1/OWN1 b/sub1/OWN1
+  index 0000000..e69de29
+  diff --git a/20/0a/20/sub1/file2 b/20/0a/20/sub1/file2
   new file mode 100644
-  index 0000000..2e96f2e
-  --- /dev/null
-  +++ b/sub1/OWN1
-  @@ -0,0 +1,4 @@
-  +c002000000000010080000000022080000000020200000000040000000000000000004000021000800000884002001080000000200000000400008000000000a
-  +0020060800054080a0a80001240001000805000020000000000002000ca000040220208040010000000080000000000040100000100202000000204020002020
-  +0000000000000000400000200810001000000000021c01004010000000084200a00000040401020000000000000000084008204000000880140000401a540400
-  +0000041000002000000000008000600200008000000002004004800008a0000000000000200208000a8080000810001200001400000810400000010000100000
-  \ No newline at end of file
-  diff --git a/sub2/BLOBS1 b/sub2/BLOBS1
+  index 0000000..e69de29
+  diff --git a/20/54/65/sub1/file1 b/20/54/65/sub1/file1
   new file mode 100644
-  index 0000000..d93ea49
-  --- /dev/null
-  +++ b/sub2/BLOBS1
-  @@ -0,0 +1,2 @@
-  +file3
-  +24000008000000000000000400000000400000002100000080020000002020000000100105100000080000000040000240000000200004008004000002800000 001a
-  diff --git a/sub2/OWN1 b/sub2/OWN1
+  index 0000000..e69de29
+  diff --git a/20/64/6f/sub1/file1 b/20/64/6f/sub1/file1
   new file mode 100644
-  index 0000000..bbd3d20
-  --- /dev/null
-  +++ b/sub2/OWN1
-  @@ -0,0 +1,4 @@
-  +80000000000000000000000000000000000000002100002000080000000000002400000800020000002000040000540000000000100000000000000000000000
-  +00000000020104008000000000000000480000001000000080000000000004000000020040000000000000000000001000000030000000000003000000202000
-  +00001000000000001800000000400800400000000220000000800200000800000000010004002200000000000000000000040000000000000000008402000400
-  +00000481010040000000000040000002000000800002041080040000008000041000000000100000000000000000000080001200201000000000000000100000
-  \ No newline at end of file
+  index 0000000..e69de29
+  diff --git a/20/64/6f/sub1/file2 b/20/64/6f/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/20/68/61/sub2/file3 b/20/68/61/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/20/6c/69/sub1/file2 b/20/6c/69/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/20/6d/6f/sub1/file2 b/20/6d/6f/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/20/6d/6f/sub2/file3 b/20/6d/6f/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/20/6f/6e/sub1/file2 b/20/6f/6e/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/20/73/65/sub2/file3 b/20/73/65/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/20/74/68/sub1/file2 b/20/74/68/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/20/74/6f/sub2/file3 b/20/74/6f/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/20/77/68/sub2/file3 b/20/77/68/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/20/77/69/sub1/file2 b/20/77/69/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/41/6e/6f/sub1/file2 b/41/6e/6f/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/46/69/72/sub1/file1 b/46/69/72/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/4f/6e/65/sub2/file3 b/4f/6e/65/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/54/65/73/sub1/file1 b/54/65/73/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/61/6e/20/sub1/file2 b/61/6e/20/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/61/70/70/sub2/file3 b/61/70/70/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/61/74/20/sub2/file3 b/61/74/20/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/63/75/6d/sub1/file1 b/63/75/6d/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/63/75/6d/sub1/file2 b/63/75/6d/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/64/6f/63/sub1/file1 b/64/6f/63/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/64/6f/63/sub1/file2 b/64/6f/63/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/20/0a/sub1/file2 b/65/20/0a/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/20/6c/sub1/file2 b/65/20/6c/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/20/6d/sub2/file3 b/65/20/6d/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/20/74/sub2/file3 b/65/20/74/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/20/77/sub2/file3 b/65/20/77/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/65/20/sub2/file3 b/65/65/20/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/6e/73/sub2/file3 b/65/6e/73/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/6e/74/sub1/file1 b/65/6e/74/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/6e/74/sub1/file2 b/65/6e/74/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/72/20/sub1/file2 b/65/72/20/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/65/73/74/sub1/file1 b/65/73/74/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/68/20/6d/sub1/file2 b/68/20/6d/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/68/61/6e/sub1/file2 b/68/61/6e/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/68/61/70/sub2/file3 b/68/61/70/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/68/61/74/sub2/file3 b/68/61/74/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/68/65/72/sub1/file2 b/68/65/72/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/69/6e/65/sub1/file2 b/69/6e/65/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/69/72/73/sub1/file1 b/69/72/73/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/69/74/68/sub1/file2 b/69/74/68/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6c/69/6e/sub1/file2 b/6c/69/6e/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6d/65/6e/sub1/file1 b/6d/65/6e/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6d/65/6e/sub1/file2 b/6d/65/6e/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6d/6f/72/sub1/file2 b/6d/6f/72/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6d/6f/72/sub2/file3 b/6d/6f/72/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6e/20/0a/sub1/file2 b/6e/20/0a/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6e/65/20/sub1/file2 b/6e/65/20/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6e/65/20/sub2/file3 b/6e/65/20/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6e/6f/74/sub1/file2 b/6e/6f/74/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6e/74/20/sub1/file2 b/6e/74/20/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6f/20/73/sub2/file3 b/6f/20/73/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6f/63/75/sub1/file1 b/6f/63/75/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6f/63/75/sub1/file2 b/6f/63/75/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6f/6e/65/sub1/file2 b/6f/6e/65/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6f/72/65/sub1/file2 b/6f/72/65/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6f/72/65/sub2/file3 b/6f/72/65/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/6f/74/68/sub1/file2 b/6f/74/68/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/70/65/6e/sub2/file3 b/70/65/6e/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/70/70/65/sub2/file3 b/70/70/65/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/72/20/64/sub1/file2 b/72/20/64/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/72/65/20/sub1/file2 b/72/65/20/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/72/65/20/sub2/file3 b/72/65/20/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/72/73/74/sub1/file1 b/72/73/74/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/73/65/65/sub2/file3 b/73/65/65/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/73/74/20/sub1/file1 b/73/74/20/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/74/20/54/sub1/file1 b/74/20/54/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/74/20/64/sub1/file1 b/74/20/64/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/74/20/68/sub2/file3 b/74/20/68/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/74/20/77/sub1/file2 b/74/20/77/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/74/68/20/sub1/file2 b/74/68/20/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/74/68/61/sub1/file2 b/74/68/61/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/74/68/65/sub1/file2 b/74/68/65/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/74/6f/20/sub2/file3 b/74/6f/20/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/75/6d/65/sub1/file1 b/75/6d/65/sub1/file1
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/75/6d/65/sub1/file2 b/75/6d/65/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/77/68/61/sub2/file3 b/77/68/61/sub2/file3
+  new file mode 100644
+  index 0000000..e69de29
+  diff --git a/77/69/74/sub1/file2 b/77/69/74/sub1/file2
+  new file mode 100644
+  index 0000000..e69de29

--- a/tests/proxy/graphql_schema.t
+++ b/tests/proxy/graphql_schema.t
@@ -1530,16 +1530,6 @@
                         "ofType": null
                       }
                     }
-                  },
-                  {
-                    "defaultValue": null,
-                    "description": null,
-                    "name": "maxComplexity",
-                    "type": {
-                      "kind": "SCALAR",
-                      "name": "Int",
-                      "ofType": null
-                    }
                   }
                 ],
                 "deprecationReason": null,


### PR DESCRIPTION
Replace the bloom filter trigram index with an exact inverted index

The index of a tree is now an exact inverted index, itself stored as a
git tree: for every trigram of a file's content the index contains
hex(b1)/hex(b2)/hex(b3)/path/to/file with the empty blob as leaf
marker. The subtree below a trigram's three spine levels mirrors the
source tree restricted to files containing that trigram, and a
directory's mirror references its children's mirrors by oid, so git's
content addressing shares identical file sets across trigrams and
across commits (all six trigrams of "document" point at one shared
mirror). Searching resolves each query trigram with a single
three-level lookup and intersects the mirrors, with an equal-oid fast
path; queries with no trigrams (shorter than three bytes) fall back to
enumerating the source tree.

This fixes the failure modes of the bloom design: needles straddling a
per-file filter chunk boundary can no longer be missed, files with
many distinct trigrams no longer saturate past the search depth, and
candidates are exact so the ordinal/search-depth machinery disappears
entirely. The --max_comp CLI flag and the maxComplexity GraphQL
argument are removed with it, and search no longer opens a repository
handle per directory.

Indexing is still recursive per subtree with IndexCache memoization
and produces canonical trees: a node exists iff a posting lives under
it, making the index a pure function of tree content (the bench gate
verifies incremental and cold builds agree bit-for-bit). A diff-based
incremental fast path is planned as a follow-up.

This commit does not change CACHE_VERSION; the later trigram format
changes each bump it, which is what invalidates stale persisted
_trigram_index entries. indexer.t pins that all search results are
byte-identical to before; its recorded index diff now shows the
readable hex-spine layout, and graphql_schema.t drops the removed
maxComplexity argument.

Change: trigram-exact-index

Assisted-By: Claude (claude-fable-5)