### PR TITLE
Patch the trigram index from a tree diff when a recent base exists

### DIFF
--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -574,6 +574,18 @@ impl Transaction {
     }
 }
 
+/// Number of `(tree, index)` pairs remembered as diff bases for josh-search's incremental fast
+/// path. A small ring rather than a single pointer: the `_trigram_index` sled tree is shared
+/// across every filter spec indexed through one josh cache, and alternating specs would thrash
+/// a single slot.
+const RECENT_INDEX_SLOTS: usize = 4;
+
+/// Sled keys for the recent-pair ring. 8 bytes long, so they can never collide with the 20-byte
+/// oid keys of the memoization entries in the same tree.
+fn recent_index_key(slot: usize) -> Vec<u8> {
+    format!("_recent{}", slot).into_bytes()
+}
+
 /// Back josh-search's index memoization with the persistent trigram sled tree, so `:INDEX` (and
 /// any other in-transaction indexing) stays incremental across transactions and processes.
 impl josh_search::IndexCache for Transaction {
@@ -583,5 +595,40 @@ impl josh_search::IndexCache for Transaction {
 
     fn set_index(&self, tree: git2::Oid, index: git2::Oid) {
         self.insert_trigram_index(tree, index)
+    }
+
+    fn get_recent(&self) -> Vec<(git2::Oid, git2::Oid)> {
+        let t2 = self.t2.borrow();
+        (0..RECENT_INDEX_SLOTS)
+            .filter_map(|slot| {
+                t2.trigram_index_tree
+                    .get(recent_index_key(slot))
+                    .unwrap()
+                    .filter(|v| v.len() == 40)
+                    .map(|v| {
+                        (
+                            git2::Oid::from_bytes(&v[..20]).unwrap(),
+                            git2::Oid::from_bytes(&v[20..]).unwrap(),
+                        )
+                    })
+            })
+            .collect()
+    }
+
+    fn set_recent(&self, tree: git2::Oid, index: git2::Oid) {
+        let mut pairs = josh_search::IndexCache::get_recent(self);
+        pairs.retain(|(t, _)| *t != tree);
+        pairs.insert(0, (tree, index));
+        pairs.truncate(RECENT_INDEX_SLOTS);
+
+        let t2 = self.t2.borrow();
+        for (slot, (t, i)) in pairs.iter().enumerate() {
+            let mut value = Vec::with_capacity(40);
+            value.extend_from_slice(t.as_bytes());
+            value.extend_from_slice(i.as_bytes());
+            t2.trigram_index_tree
+                .insert(recent_index_key(slot), value)
+                .unwrap();
+        }
     }
 }

--- a/josh-search/src/lib.rs
+++ b/josh-search/src/lib.rs
@@ -33,6 +33,15 @@ const TREE_MODE: i32 = 0o0040000;
 pub trait IndexCache {
     fn get_index(&self, tree: git2::Oid) -> Option<git2::Oid>;
     fn set_index(&self, tree: git2::Oid, index: git2::Oid);
+
+    /// Recently indexed `(tree, index)` pairs, most recent first. [`trigram_index`] uses them as
+    /// diff bases: when the tree to index differs from a recent one in only a few files, the
+    /// recent index is patched instead of rebuilt. The default (no memory) disables that fast
+    /// path; correctness does not depend on it.
+    fn get_recent(&self) -> Vec<(git2::Oid, git2::Oid)> {
+        vec![]
+    }
+    fn set_recent(&self, _tree: git2::Oid, _index: git2::Oid) {}
 }
 
 fn empty_tree_id() -> git2::Oid {
@@ -206,8 +215,8 @@ fn build_index(
         }
 
         if entry.kind() == Some(git2::ObjectType::Tree) {
-            let child = trigram_index(repo, cache, repo.find_tree(entry.id())?)?;
-            for_each_spine_leaf(repo, &child, |t, mirror| {
+            let child = index_subtree(repo, cache, &repo.find_tree(entry.id())?, empty_blob)?;
+            for_each_spine_leaf(repo, &repo.find_tree(child)?, |t, mirror| {
                 postings
                     .entry(t)
                     .or_default()
@@ -220,6 +229,271 @@ fn build_index(
     write_spine(repo, &postings)
 }
 
+/// Memoized recursive indexing of a subtree. Unlike the public [`trigram_index`], this never
+/// attempts the diff fast path and never touches the recent ring: subtrees are memoized per oid
+/// and are not useful diff bases.
+fn index_subtree(
+    repo: &git2::Repository,
+    cache: &dyn IndexCache,
+    tree: &git2::Tree,
+    empty_blob: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    if let Some(cached) = cache.get_index(tree.id()) {
+        return Ok(cached);
+    }
+    let result = build_index(repo, cache, tree, empty_blob)?;
+    cache.set_index(tree.id(), result);
+    Ok(result)
+}
+
+/// Trigrams of the blob `oid`, subject to the same gate as [`get_blob`] (binary or non-UTF-8
+/// content indexes as empty). Must stay in sync with how [`build_index`] reads file content, or
+/// the diff fast path diverges from cold builds.
+fn blob_trigrams(repo: &git2::Repository, oid: git2::Oid) -> BTreeSet<[u8; 3]> {
+    let Ok(blob) = repo.find_blob(oid) else {
+        return BTreeSet::new();
+    };
+    if blob.is_binary() {
+        return BTreeSet::new();
+    }
+    let Ok(content) = std::str::from_utf8(blob.content()) else {
+        return BTreeSet::new();
+    };
+    distinct_trigrams(content)
+}
+
+/// A blob changed between two source trees: its path, and its oid on the old and new side
+/// (`None` = absent on that side).
+type BlobChange = (String, Option<git2::Oid>, Option<git2::Oid>);
+
+/// Emit every blob under `oid` as one-sided [`BlobChange`]s (`old` side if `as_old`).
+fn collect_blob_changes(
+    repo: &git2::Repository,
+    oid: git2::Oid,
+    prefix: &str,
+    as_old: bool,
+    out: &mut Vec<BlobChange>,
+) -> anyhow::Result<()> {
+    let tree = repo.find_tree(oid)?;
+    for entry in tree.iter() {
+        let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
+        let path = join_path(prefix, name);
+        match entry.kind() {
+            Some(git2::ObjectType::Tree) => {
+                collect_blob_changes(repo, entry.id(), &path, as_old, out)?
+            }
+            Some(git2::ObjectType::Blob) => out.push(if as_old {
+                (path, Some(entry.id()), None)
+            } else {
+                (path, None, Some(entry.id()))
+            }),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Collect the blobs differing between the trees `old` and `new` into `out`. Returns false
+/// (giving up on the diff) once more than `limit` changed blobs accumulate.
+fn tree_diff(
+    repo: &git2::Repository,
+    old: git2::Oid,
+    new: git2::Oid,
+    limit: usize,
+    prefix: &str,
+    out: &mut Vec<BlobChange>,
+) -> anyhow::Result<bool> {
+    if old == new {
+        return Ok(true);
+    }
+    let old_tree = repo.find_tree(old)?;
+    let new_tree = repo.find_tree(new)?;
+
+    // Entries the indexer cares about, by name: blobs and trees only (submodules etc. are not
+    // indexed and diff as absent).
+    let relevant = |tree: &git2::Tree| -> BTreeMap<String, (git2::Oid, git2::ObjectType)> {
+        tree.iter()
+            .filter_map(|e| match (e.name(), e.kind()) {
+                (Some(name), Some(kind))
+                    if kind == git2::ObjectType::Blob || kind == git2::ObjectType::Tree =>
+                {
+                    Some((name.to_owned(), (e.id(), kind)))
+                }
+                _ => None,
+            })
+            .collect()
+    };
+    let old_entries = relevant(&old_tree);
+    let new_entries = relevant(&new_tree);
+
+    let names: BTreeSet<&String> = old_entries.keys().chain(new_entries.keys()).collect();
+    for name in names {
+        let path = join_path(prefix, name);
+        use git2::ObjectType::{Blob, Tree};
+        match (old_entries.get(name), new_entries.get(name)) {
+            (Some((a, ka)), Some((b, kb))) if a == b && ka == kb => {}
+            (Some((a, Tree)), Some((b, Tree))) => {
+                if !tree_diff(repo, *a, *b, limit, &path, out)? {
+                    return Ok(false);
+                }
+            }
+            (Some((a, Blob)), Some((b, Blob))) => out.push((path, Some(*a), Some(*b))),
+            // One-sided or kind-changed: everything on the old side is removed, everything on
+            // the new side added.
+            (old_side, new_side) => {
+                match old_side {
+                    Some((a, Blob)) => out.push((path.clone(), Some(*a), None)),
+                    Some((a, Tree)) => collect_blob_changes(repo, *a, &path, true, out)?,
+                    _ => {}
+                }
+                match new_side {
+                    Some((b, Blob)) => out.push((path.clone(), None, Some(*b))),
+                    Some((b, Tree)) => collect_blob_changes(repo, *b, &path, false, out)?,
+                    _ => {}
+                }
+            }
+        }
+        if out.len() > limit {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+/// Insert (`present`) or remove the empty-blob leaf at `path` inside the mirror tree `tree_oid`,
+/// creating intermediate directories on insert and pruning directories that become empty on
+/// removal. Returns the new tree oid; `empty_tree_id()` means the subtree vanished entirely and
+/// the caller must drop its entry (the canonical form never contains empty directories).
+fn set_leaf(
+    repo: &git2::Repository,
+    tree_oid: git2::Oid,
+    path: &[&str],
+    present: bool,
+    empty_blob: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    let tree = repo.find_tree(tree_oid)?;
+    let (name, rest) = path.split_first().expect("path is never empty");
+    let mut builder = repo.treebuilder(Some(&tree))?;
+
+    if rest.is_empty() {
+        if present {
+            builder.insert(name, empty_blob, BLOB_MODE)?;
+        } else if tree.get_name(name).is_some() {
+            builder.remove(name)?;
+        }
+    } else {
+        let child = tree
+            .get_name(name)
+            .map(|e| e.id())
+            .unwrap_or_else(empty_tree_id);
+        let child = set_leaf(repo, child, rest, present, empty_blob)?;
+        if child == empty_tree_id() {
+            if tree.get_name(name).is_some() {
+                builder.remove(name)?;
+            }
+        } else {
+            builder.insert(name, child, TREE_MODE)?;
+        }
+    }
+    Ok(builder.write()?)
+}
+
+/// Produce the index of a tree that differs from an already indexed one by `changes`, patching
+/// `prev_index` posting by posting. Produces the same canonical form as a cold build, so the
+/// resulting oid is bit-identical to what [`build_index`] would return.
+fn patch_index(
+    repo: &git2::Repository,
+    prev_index: git2::Oid,
+    changes: &[BlobChange],
+    empty_blob: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    // Make sure the empty tree object exists: set_leaf and the spine patching below look it up.
+    repo.treebuilder(None)?.write()?;
+
+    // trigram -> (path, add/remove), grouped so every touched spine node is rewritten once.
+    let mut edits: BTreeMap<[u8; 3], Vec<(&str, bool)>> = BTreeMap::new();
+    for (path, old_oid, new_oid) in changes {
+        let old_t = old_oid.map(|o| blob_trigrams(repo, o)).unwrap_or_default();
+        let new_t = new_oid.map(|o| blob_trigrams(repo, o)).unwrap_or_default();
+        for t in old_t.difference(&new_t) {
+            edits.entry(*t).or_default().push((path, false));
+        }
+        for t in new_t.difference(&old_t) {
+            edits.entry(*t).or_default().push((path, true));
+        }
+    }
+
+    let index_tree = repo.find_tree(prev_index)?;
+    let mut c1_builder = repo.treebuilder(Some(&index_tree))?;
+
+    let mut edits = edits.into_iter().peekable();
+    while let Some(&([b1, _, _], _)) = edits.peek() {
+        let c1_name = format!("{:02x}", b1);
+        let c1_oid = index_tree
+            .get_name(&c1_name)
+            .map(|e| e.id())
+            .unwrap_or_else(empty_tree_id);
+        let c1_tree = repo.find_tree(c1_oid)?;
+        let mut c2_builder = repo.treebuilder(Some(&c1_tree))?;
+
+        while let Some(&([e1, b2, _], _)) = edits.peek() {
+            if e1 != b1 {
+                break;
+            }
+            let c2_name = format!("{:02x}", b2);
+            let c2_oid = c1_tree
+                .get_name(&c2_name)
+                .map(|e| e.id())
+                .unwrap_or_else(empty_tree_id);
+            let c2_tree = repo.find_tree(c2_oid)?;
+            let mut c3_builder = repo.treebuilder(Some(&c2_tree))?;
+
+            while let Some(&([e1, e2, b3], _)) = edits.peek() {
+                if e1 != b1 || e2 != b2 {
+                    break;
+                }
+                let (_, path_edits) = edits.next().unwrap();
+                let c3_name = format!("{:02x}", b3);
+                let mut mirror = c2_tree
+                    .get_name(&c3_name)
+                    .map(|e| e.id())
+                    .unwrap_or_else(empty_tree_id);
+                for (path, present) in path_edits {
+                    let components: Vec<&str> = path.split('/').collect();
+                    mirror = set_leaf(repo, mirror, &components, present, empty_blob)?;
+                }
+                if mirror == empty_tree_id() {
+                    if c2_tree.get_name(&c3_name).is_some() {
+                        c3_builder.remove(&c3_name)?;
+                    }
+                } else {
+                    c3_builder.insert(&c3_name, mirror, TREE_MODE)?;
+                }
+            }
+
+            let new_c2 = c3_builder.write()?;
+            if new_c2 == empty_tree_id() {
+                if c1_tree.get_name(&c2_name).is_some() {
+                    c2_builder.remove(&c2_name)?;
+                }
+            } else {
+                c2_builder.insert(&c2_name, new_c2, TREE_MODE)?;
+            }
+        }
+
+        let new_c1 = c2_builder.write()?;
+        if new_c1 == empty_tree_id() {
+            if index_tree.get_name(&c1_name).is_some() {
+                c1_builder.remove(&c1_name)?;
+            }
+        } else {
+            c1_builder.insert(&c1_name, new_c1, TREE_MODE)?;
+        }
+    }
+
+    Ok(c1_builder.write()?)
+}
+
 pub fn trigram_index<'a>(
     repo: &'a git2::Repository,
     cache: &dyn IndexCache,
@@ -229,8 +503,29 @@ pub fn trigram_index<'a>(
         return Ok(repo.find_tree(cached)?);
     }
     let empty_blob = repo.blob(b"")?;
-    let result = build_index(repo, cache, &tree, empty_blob)?;
+
+    // Fast path: if the tree differs from a recently indexed one in only a few files, patch
+    // that index instead of rebuilding. Only tried at the root — the recursion below deals in
+    // subtrees, which are memoized per oid and never good diff bases.
+    const DIFF_LIMIT: usize = 256;
+    let mut result = None;
+    for (prev_tree, prev_index) in cache.get_recent() {
+        let mut changes = vec![];
+        if prev_tree != tree.id()
+            && tree_diff(repo, prev_tree, tree.id(), DIFF_LIMIT, "", &mut changes)?
+        {
+            result = Some(patch_index(repo, prev_index, &changes, empty_blob)?);
+            break;
+        }
+    }
+
+    let result = match result {
+        Some(result) => result,
+        None => build_index(repo, cache, &tree, empty_blob)?,
+    };
+
     cache.set_index(tree.id(), result);
+    cache.set_recent(tree.id(), result);
     Ok(repo.find_tree(result)?)
 }
 
@@ -440,14 +735,24 @@ mod tests {
         assert_eq!(t.len(), 2);
     }
 
-    struct MapCache(std::cell::RefCell<std::collections::HashMap<git2::Oid, git2::Oid>>);
+    #[derive(Default)]
+    struct MapCache {
+        map: std::cell::RefCell<std::collections::HashMap<git2::Oid, git2::Oid>>,
+        recent: std::cell::RefCell<Vec<(git2::Oid, git2::Oid)>>,
+    }
 
     impl IndexCache for MapCache {
         fn get_index(&self, tree: git2::Oid) -> Option<git2::Oid> {
-            self.0.borrow().get(&tree).copied()
+            self.map.borrow().get(&tree).copied()
         }
         fn set_index(&self, tree: git2::Oid, index: git2::Oid) {
-            self.0.borrow_mut().insert(tree, index);
+            self.map.borrow_mut().insert(tree, index);
+        }
+        fn get_recent(&self) -> Vec<(git2::Oid, git2::Oid)> {
+            self.recent.borrow().clone()
+        }
+        fn set_recent(&self, tree: git2::Oid, index: git2::Oid) {
+            self.recent.borrow_mut().insert(0, (tree, index));
         }
     }
 
@@ -473,7 +778,7 @@ mod tests {
     #[test]
     fn index_and_search_end_to_end() {
         let (_tmp, repo) = test_repo();
-        let cache = MapCache(Default::default());
+        let cache = MapCache::default();
 
         let tree = commit_tree(
             &repo,
@@ -505,8 +810,55 @@ mod tests {
 
         // Indexing is deterministic and memoization-independent: a cold rebuild of the same
         // tree yields the same oid.
-        let cold = MapCache(Default::default());
+        let cold = MapCache::default();
         let index2 = trigram_index(&repo, &cold, tree).unwrap();
         assert_eq!(index.id(), index2.id());
+    }
+
+    #[test]
+    fn patched_index_equals_cold_build() {
+        let (_tmp, repo) = test_repo();
+        let cache = MapCache::default();
+
+        let tree_a = commit_tree(
+            &repo,
+            &[
+                ("sub1/keep", "the quick brown fox"),
+                ("sub1/gone", "unique zebra content"),
+                ("sub2/mod", "alpha beta gamma"),
+            ],
+        );
+        trigram_index(&repo, &cache, tree_a).unwrap();
+        assert_eq!(cache.get_recent().len(), 1);
+
+        // One file modified, one removed (its unique trigrams must be pruned from the spine),
+        // one added in a fresh directory.
+        let tree_b = commit_tree(
+            &repo,
+            &[
+                ("sub1/keep", "the quick brown fox"),
+                ("sub2/mod", "alpha beta delta"),
+                ("sub3/new", "fresh addition here"),
+            ],
+        );
+        let index_b = trigram_index(&repo, &cache, tree_b.clone()).unwrap();
+
+        // The diff fast path was actually taken: a cold build would have recursed and memoized
+        // sub3's subtree index, the patch path never does.
+        let sub3 = tree_b.get_name("sub3").unwrap().id();
+        assert!(cache.get_index(sub3).is_none());
+
+        // Patched and cold-built indexes agree bit for bit.
+        let cold = MapCache::default();
+        let index_b_cold = trigram_index(&repo, &cold, tree_b.clone()).unwrap();
+        assert_eq!(index_b.id(), index_b_cold.id());
+
+        // And the patched index searches correctly.
+        let hits = search_candidates(&repo, &index_b, &tree_b, "delta").unwrap();
+        assert_eq!(hits, vec!["sub2/mod"]);
+        let hits = search_candidates(&repo, &index_b, &tree_b, "zebra").unwrap();
+        assert!(hits.is_empty());
+        let hits = search_candidates(&repo, &index_b, &tree_b, "addition").unwrap();
+        assert_eq!(hits, vec!["sub3/new"]);
     }
 }

--- a/tests/experimental/indexer.t
+++ b/tests/experimental/indexer.t
@@ -23,7 +23,7 @@
   [3] :INDEX
   [3] reachable_roots
   [3] sequence_number
-  [6] _trigram_index
+  [8] _trigram_index
 
   $ josh-filter :/ --search "Another"
   sub1/file2:1: Another document with more 


### PR DESCRIPTION
Patch the trigram index from a tree diff when a recent base exists

Indexing a tree that differs from an already indexed one in only a few
files no longer rebuilds the index through the per-subtree recursion:
trigram_index now remembers a small ring of recently indexed
(tree, index) pairs through two new defaulted IndexCache methods, and
when an early-aborting tree diff against one of them stays under 256
changed blobs, the previous index is patched posting by posting
instead. Removals prune every directory that becomes empty, so the
patched index keeps the canonical form and its oid is bit-identical to
a cold build -- enforced by a unit test and by the bench setup gate
that compares the patched churn-chain tip against a cold build.

This makes per-commit incremental indexing cost proportional to the
churn, not to the total trigram mass near the tree root: the recursive
path recomputes every ancestor directory's spine, which for the bench's
10k-file case took ~2.4s per one-percent churn commit.

The Transaction implementation stores the ring in the _trigram_index
sled tree under short sentinel keys that cannot collide with its
20-byte oid keys; a ring rather than a single pointer because that tree
is shared across all filter specs indexed through one josh cache. The
indexer.t count line moves accordingly (ring entries live in the same
tree, and the patch path memoizes fewer subtree mappings).

Change: trigram-index-diff-path

Assisted-By: Claude (claude-fable-5)