### PR TITLE
Avoid using libgit2 built-in cache in favor of custom LRU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -815,7 +815,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1265,7 +1265,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1402,7 +1402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2454,6 +2454,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "headers"
@@ -2860,7 +2865,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2914,7 +2919,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3296,6 +3301,7 @@ dependencies = [
  "git2",
  "libgit2-sys",
  "log",
+ "lru",
  "tempfile",
 ]
 
@@ -3676,11 +3682,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -3829,7 +3835,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4774,7 +4780,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4831,7 +4837,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5238,7 +5244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5458,7 +5464,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6243,7 +6249,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ gix-object = "0.56.0"
 gix-config = "0.52.0"
 gix-submodule = "0.26.0"
 libc = "0.2.184"
+lru = "0.18.1"
 regex = "1.12.3"
 serde = { version = "1.0.228", features = ["std", "derive"] }
 serde_json = "1.0.149"

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -152,11 +152,18 @@ impl Transaction {
         mem_odb_limit: Option<usize>,
         ephemeral: bool,
     ) -> Transaction {
-        // Disable libgit2's strict object creation globally: josh only ever writes objects
-        // whose referenced objects it has just produced or read, so the per-write existence
-        // checks are pure overhead. This is a process-wide C global, set exactly once.
-        static STRICT_OBJECT_CREATION_OFF: std::sync::Once = std::sync::Once::new();
-        STRICT_OBJECT_CREATION_OFF.call_once(|| git2::opts::strict_object_creation(false));
+        static GIT2_SET_GLOBAL_OPTS: std::sync::Once = std::sync::Once::new();
+        GIT2_SET_GLOBAL_OPTS.call_once(|| {
+            // Disable libgit2's strict object creation globally: josh only ever writes objects
+            // whose referenced objects it has just produced or read, so the per-write existence
+            // checks are pure overhead. This is a process-wide C global, set exactly once.
+            git2::opts::strict_object_creation(false);
+
+            // Disable libgit2's parsed object cache. The cache has a limited size,
+            // and the way the eviction mechanism works when eviction is needed
+            // creates frequent cache misses.
+            git2::opts::enable_caching(false);
+        });
 
         let mem_odb = josh_memodb::MemOdb::new(mem_odb_limit, repo.path().to_owned());
         mem_odb.register(&repo);

--- a/josh-memodb/Cargo.toml
+++ b/josh-memodb/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2024"
 libgit2-sys = "0.18"
 git2.workspace = true
 log.workspace = true
+lru.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/josh-memodb/src/lib.rs
+++ b/josh-memodb/src/lib.rs
@@ -10,6 +10,7 @@ mod flusher;
 pub mod hash;
 pub mod mem_odb;
 mod odb_backend;
+pub mod odb_cache;
 pub mod pack;
 
 pub use hash::PassthroughHasher;

--- a/josh-memodb/src/odb_backend.rs
+++ b/josh-memodb/src/odb_backend.rs
@@ -22,6 +22,7 @@
 use std::ffi::{c_int, c_void};
 use std::ptr;
 
+use crate::odb_cache::{CacheObjectData, ObjectCache};
 use git2::{ErrorCode, ObjectType, Oid};
 use libgit2_sys as raw;
 
@@ -48,6 +49,7 @@ pub trait OdbBackend {
 struct RawOdbBackend {
     raw: raw::git_odb_backend,
     obj: Box<dyn OdbBackend>,
+    cache: ObjectCache,
     /// The repository's original on-disk ODB (loose + pack), kept as an owned reference so read-side
     /// callbacks can delegate to it on a memory miss. Released in [`backend_free`].
     delegate: *mut raw::git_odb,
@@ -68,8 +70,8 @@ impl RawOdbBackend {
         oid: *const raw::git_oid,
     ) -> c_int {
         let (wrapper, roid) = unsafe { (RawOdbBackend::from_raw(backend), oid_from_raw(oid)) };
-        match wrapper.obj.read(roid) {
-            Ok((data, kind)) => unsafe {
+        if let Some((kind, data)) = wrapper.cache.load(unsafe { *oid }) {
+            unsafe {
                 let len = data.len();
                 let buf = raw::git_odb_backend_data_alloc(backend, len);
                 if buf.is_null() {
@@ -78,32 +80,75 @@ impl RawOdbBackend {
                 ptr::copy_nonoverlapping(data.as_ptr(), buf as *mut u8, len);
                 *data_p = buf;
                 *len_p = len;
-                *kind_p = kind.raw();
+                *kind_p = kind;
+                return raw::GIT_OK;
+            }
+        }
+
+        match wrapper.obj.read(roid) {
+            Ok((data, kind)) => {
+                let kind_raw = kind.raw();
+                let len = data.len();
+
+                // Copy into libgit2's buffer first (unavoidable: libgit2 owns that allocation),
+                // then hand the bytes we already own to the cache.
+                unsafe {
+                    let buf = raw::git_odb_backend_data_alloc(backend, len);
+                    if buf.is_null() {
+                        return raw::GIT_ERROR;
+                    }
+                    ptr::copy_nonoverlapping(data.as_ptr(), buf as *mut u8, len);
+                    *data_p = buf;
+                    *len_p = len;
+                    *kind_p = kind_raw;
+                }
+
+                // `into_boxed_slice` is zero-copy here — `data` came from a clone,
+                // so its capacity equals its length.
+                debug_assert_eq!(data.capacity(), data.len());
+                wrapper
+                    .cache
+                    .store(unsafe { *oid }, kind_raw, CacheObjectData::Allocated(data));
                 raw::GIT_OK
-            },
-            Err(err) if is_not_found(&err) && !wrapper.delegate.is_null() => unsafe {
+            }
+            Err(err) if is_not_found(&err) && !wrapper.delegate.is_null() => {
                 // Memory miss: read through to the original on-disk ODB and copy its bytes into a
                 // backend-owned buffer (libgit2 frees `*data_p` via the backend's allocator).
-                let mut obj: *mut raw::git_odb_object = ptr::null_mut();
-                let rc = raw::git_odb_read(&mut obj, wrapper.delegate, oid);
-                if rc != 0 {
-                    return rc;
-                }
-                let src = raw::git_odb_object_data(obj) as *const u8;
-                let len = raw::git_odb_object_size(obj);
-                let kind = raw::git_odb_object_type(obj);
-                let buf = raw::git_odb_backend_data_alloc(backend, len);
-                if buf.is_null() {
+                let obj = unsafe {
+                    let mut obj: *mut raw::git_odb_object = ptr::null_mut();
+                    let rc = raw::git_odb_read(&mut obj, wrapper.delegate, oid);
+                    if rc != 0 {
+                        return rc;
+                    }
+                    obj
+                };
+
+                let (src, len, kind) = unsafe {
+                    let src = raw::git_odb_object_data(obj) as *const u8;
+                    let len = raw::git_odb_object_size(obj);
+                    let kind = raw::git_odb_object_type(obj);
+                    (src, len, kind)
+                };
+
+                let data_slice = unsafe { std::slice::from_raw_parts(src, len) };
+                wrapper
+                    .cache
+                    .store(unsafe { *oid }, kind, CacheObjectData::Ref(data_slice));
+
+                unsafe {
+                    let buf = raw::git_odb_backend_data_alloc(backend, len);
+                    if buf.is_null() {
+                        raw::git_odb_object_free(obj);
+                        return raw::GIT_ERROR;
+                    }
+                    ptr::copy_nonoverlapping(src, buf as *mut u8, len);
+                    *data_p = buf;
+                    *len_p = len;
+                    *kind_p = kind;
                     raw::git_odb_object_free(obj);
-                    return raw::GIT_ERROR;
+                    raw::GIT_OK
                 }
-                ptr::copy_nonoverlapping(src, buf as *mut u8, len);
-                *data_p = buf;
-                *len_p = len;
-                *kind_p = kind;
-                raw::git_odb_object_free(obj);
-                raw::GIT_OK
-            },
+            }
             Err(err) => err.raw_code(),
         }
     }
@@ -262,6 +307,7 @@ fn new(
     };
     let wrapper = RawOdbBackend {
         raw: backend,
+        cache: ObjectCache::default(),
         obj: Box::new(callee),
         delegate,
     };

--- a/josh-memodb/src/odb_cache.rs
+++ b/josh-memodb/src/odb_cache.rs
@@ -1,0 +1,107 @@
+use crate::PassthroughHasher;
+use libgit2_sys as raw;
+use std::hash::{BuildHasherDefault, Hasher};
+
+// In context of josh, most often per transaction
+const OBJECT_CACHE_SIZE: usize = 300 * 1024 * 1024;
+
+#[derive(Clone, Copy)]
+struct ObjectCacheKey(raw::git_oid);
+
+impl PartialEq<Self> for ObjectCacheKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.id == other.0.id
+    }
+}
+
+impl From<raw::git_oid> for ObjectCacheKey {
+    fn from(value: raw::git_oid) -> Self {
+        ObjectCacheKey(value)
+    }
+}
+
+impl Eq for ObjectCacheKey {}
+
+impl std::hash::Hash for ObjectCacheKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Bare write of the 20 raw bytes. `<[u8; 20]>::hash` would emit a length
+        // prefix plus per-byte writes, which `PassthroughHasher` rejects (it
+        // expects a single already-uniform digest). This mirrors `git2::Oid::hash`.
+        state.write(&self.0.id);
+    }
+}
+
+pub struct ObjectCache {
+    data: lru::LruCache<
+        ObjectCacheKey,
+        (raw::git_object_t, Box<[u8]>),
+        BuildHasherDefault<PassthroughHasher>,
+    >,
+    size: usize,
+    target_size: usize,
+}
+
+impl Default for ObjectCache {
+    fn default() -> Self {
+        ObjectCache {
+            data: lru::LruCache::unbounded_with_hasher(
+                BuildHasherDefault::<PassthroughHasher>::new(),
+            ),
+            size: 0,
+            target_size: OBJECT_CACHE_SIZE,
+        }
+    }
+}
+
+pub enum CacheObjectData<'a> {
+    Allocated(Vec<u8>),
+    Ref(&'a [u8]),
+}
+
+impl<'a> CacheObjectData<'a> {
+    pub fn len(&self) -> usize {
+        match self {
+            CacheObjectData::Allocated(data) => data.len(),
+            CacheObjectData::Ref(data) => data.len(),
+        }
+    }
+}
+
+impl ObjectCache {
+    pub fn store(&mut self, id: raw::git_oid, kind: raw::git_object_t, data: CacheObjectData) {
+        // Consider size of key too, even though it's not stored
+        // exactly the same way; this is to avoid blowing
+        // up the cache with lots of very small objects
+        const KEY_SIZE: usize = size_of::<u64>();
+
+        let len = data.len();
+        let id = ObjectCacheKey::from(id);
+
+        // Avoid double-lookup in the hashmap while at the same
+        // time gating allocation triggered by .into() behind
+        // existence check
+        self.data.get_or_insert_mut_ref(&id, || {
+            self.size += len + KEY_SIZE;
+
+            let data = match data {
+                CacheObjectData::Allocated(data) => data.into_boxed_slice(),
+                CacheObjectData::Ref(data) => data.into(),
+            };
+
+            (kind, data)
+        });
+
+        while self.size > self.target_size
+            && let Some((_, (_, data))) = self.data.pop_lru()
+        {
+            self.size -= data.len() + KEY_SIZE;
+        }
+    }
+
+    pub fn load(&mut self, id: raw::git_oid) -> Option<(raw::git_object_t, &[u8])> {
+        let id = ObjectCacheKey::from(id);
+        self.data
+            .get(&id)
+            .map(|(object_type, data)| (*object_type, data.as_ref()))
+    }
+}

--- a/josh-proxy/Cargo.toml
+++ b/josh-proxy/Cargo.toml
@@ -11,7 +11,7 @@ version = "26.7.19"
 
 [dependencies]
 sha2 = "0.11.0"
-lru = "0.16.3"
+lru.workspace = true
 axum = { version = "^0.8", features = ["macros"] }
 axum-extra = { version = "^0.12", features = ["typed-header", "erased-json"] }
 tower-http = { version = "0.6", features = ["trace"] }


### PR DESCRIPTION
Avoid using libgit2 built-in cache in favor of custom LRU

Change-Id: Ie2bcd0e97503fe28af2e27ffce7e846ada41110a