### PR TITLE
Run CodSpeed benchmarks only on master pushes

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -3,9 +3,6 @@ name: codspeed
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ '**' ]
-    types: [opened, synchronize, reopened, ready_for_review]
   # `workflow_dispatch` allows CodSpeed to trigger backtest performance
   # analysis in order to generate initial data.
   workflow_dispatch:
@@ -21,7 +18,6 @@ jobs:
   benchmarks:
     runs-on: ubuntu-latest
     name: Run benchmarks
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Run CodSpeed benchmarks only on master pushes

Drop the pull_request trigger so benchmarks no longer run on PRs, and
remove the now-redundant draft-PR guard on the job. Benchmarks run only
when commits land on master (plus workflow_dispatch for backtests).

Change: codspeed-master-only
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>