### PR TITLE
Measure CodSpeed benchmarks with the walltime instrument

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -16,7 +16,9 @@ permissions:
 
 jobs:
   benchmarks:
-    runs-on: ubuntu-latest
+    # Walltime measurement needs CodSpeed's bare-metal macro runners; the
+    # shared GitHub runners are too noisy for wall-clock timing.
+    runs-on: codspeed-macro
     name: Run benchmarks
     steps:
       - name: Checkout
@@ -34,5 +36,5 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@f99becdce5e5d51fd556489ebef684f4ecfd6286 # v4.18.5
         with:
-          mode: simulation
+          mode: walltime
           run: cargo codspeed run -p josh-core


### PR DESCRIPTION
Measure CodSpeed benchmarks with the walltime instrument

The benchmarks are git-heavy and make many system calls that the
simulation (instruction-counting) instrument cannot measure. Switch to
the walltime instrument, which requires CodSpeed's bare-metal macro
runners for stable wall-clock timing.

Change: codspeed-walltime-macro
Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>