### PR TITLE
Add rustc-josh-sync benchmark replaying real rust-lang subtree syncs

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,3 +3,32 @@ To run the benchmark:
 ```
 pixi run select-folders
 ```
+
+## rustc-josh-sync
+
+End-to-end replay of real rust-lang subtree syncs (rustc-dev-guide, stdarch,
+compiler-builtins, miri), both directions, cold and warm cache. Two tools are
+compared: `josh-proxy` (the production setup, server-side filtering) and the
+`josh` CLI (client-side filtering). Select with `SYNC_TOOLS=proxy,cli`.
+
+```
+pixi run rustc-josh-sync
+```
+
+Quick subset run:
+
+```
+SYNC_REPLAY_DEPTH=3 SYNC_SUBTREES=miri pixi run rustc-josh-sync
+```
+
+To benchmark a different josh version (e.g. for regression comparisons), pass
+its commit SHA; all caches are keyed by it:
+
+```
+SYNC_JOSH_COMMIT=<sha> pixi run rustc-josh-sync
+```
+
+Results land in `target/rustc_josh_sync_samples.json` and
+`target/rustc_josh_sync.png`. The first run fetches rust-lang/rust (cached
+under `target/rust-lang-source/`) and mines the historical sync events from it
+(cached as `target/rustc-josh-sync/manifest-*.json`).

--- a/benchmarks/bench/build.py
+++ b/benchmarks/bench/build.py
@@ -1,5 +1,6 @@
-"""Building the josh-filter binary under test."""
+"""Building the josh binaries under test."""
 
+import subprocess
 from pathlib import Path
 
 from bench.git import fetch_repo
@@ -22,3 +23,42 @@ def build_josh_filter(commit: str, target_dir: str | Path) -> Path:
         cwd=str(repo),
     )
     return Path(repo) / "target" / "release" / "josh-filter"
+
+
+def _checked_out_at(repo: Path, commit: str) -> bool:
+    """True if `repo` is a git checkout with HEAD at `commit`."""
+    p = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True, text=True,
+    )
+    return p.returncode == 0 and p.stdout.strip() == commit
+
+
+def build_josh_proxy(commit: str, target_dir: str | Path) -> dict[str, Path]:
+    """Fetch josh at `commit`; build the binaries the sync scenario needs.
+
+    Builds josh-proxy and the josh CLI (the subjects under test), josh-filter
+    (reference filtered histories) and axum-cgi-server (serves the upstream
+    mirror over HTTP, as josh-proxy only accepts http/ssh remotes). Returns
+    binary name -> path.
+
+    Unlike :func:`build_josh_filter` the checkout is NOT recreated when it is
+    already at `commit`: full scenario runs take hours, and keeping the cargo
+    target dir makes the rebuild incremental.
+    """
+    repo = Path(target_dir) / "josh-bin"
+    if not _checked_out_at(repo, commit):
+        repo = fetch_repo(
+            "https://github.com/josh-project/josh",
+            "josh-bin",
+            commit,
+            target_dir,
+        )
+    run(
+        "cargo build --release --target-dir=target"
+        " --bin josh-proxy --bin josh-filter --bin axum-cgi-server --bin josh",
+        cwd=str(repo),
+    )
+    release = Path(repo) / "target" / "release"
+    names = ("josh-proxy", "josh-filter", "axum-cgi-server", "josh")
+    return {name: release / name for name in names}

--- a/benchmarks/bench/build.py
+++ b/benchmarks/bench/build.py
@@ -1,9 +1,23 @@
-"""Building the josh-filter binary under test."""
+"""Building the josh binaries under test."""
 
 from pathlib import Path
 
 from bench.git import fetch_repo
 from bench.shell import run
+
+JOSH_REMOTE = "https://github.com/josh-project/josh"
+
+
+def _build_josh(commit: str, target_dir: str | Path, bins: tuple[str, ...]) -> Path:
+    """Fetch josh at `commit`, build `bins` in release mode; return the bin dir.
+
+    `fetch_repo` leaves an already-fetched checkout alone, so the cargo target
+    dir inside it survives across runs and rebuilds are incremental.
+    """
+    repo = fetch_repo(JOSH_REMOTE, "josh-bin", commit, target_dir)
+    selected = " ".join(f"--bin {name}" for name in bins)
+    run(f"cargo build --release --target-dir=target {selected}", cwd=str(repo))
+    return Path(repo) / "target" / "release"
 
 
 def build_josh_filter(commit: str, target_dir: str | Path) -> Path:
@@ -11,14 +25,17 @@ def build_josh_filter(commit: str, target_dir: str | Path) -> Path:
 
     Returns the path to the compiled `josh-filter` binary.
     """
-    repo = fetch_repo(
-        "https://github.com/josh-project/josh",
-        "josh-bin",
-        commit,
-        target_dir,
-    )
-    run(
-        "cargo build --bin josh-filter --release --target-dir=target",
-        cwd=str(repo),
-    )
-    return Path(repo) / "target" / "release" / "josh-filter"
+    return _build_josh(commit, target_dir, ("josh-filter",)) / "josh-filter"
+
+
+def build_josh_proxy(commit: str, target_dir: str | Path) -> dict[str, Path]:
+    """Fetch josh at `commit`; build the binaries the sync scenario needs.
+
+    Builds josh-proxy and the josh CLI (the subjects under test), josh-filter
+    (reference filtered histories) and axum-cgi-server (serves the upstream
+    mirror over HTTP, as josh-proxy only accepts http/ssh remotes). Returns
+    binary name -> path.
+    """
+    names = ("josh-proxy", "josh-filter", "axum-cgi-server", "josh")
+    release = _build_josh(commit, target_dir, names)
+    return {name: release / name for name in names}

--- a/benchmarks/bench/chart.py
+++ b/benchmarks/bench/chart.py
@@ -116,6 +116,65 @@ def comparison_chart(results: list[ToolResult]) -> alt.LayerChart:
     )
 
 
+def grouped_chart(
+    data: pd.DataFrame,
+    series_order: list[str],
+    title: str,
+) -> alt.LayerChart:
+    """Log-scale bars grouped by `group` with one bar per `series`.
+
+    `data` needs columns ``group``, ``series`` and ``elapsed_s``. Groups keep
+    their order of first appearance; the y ceiling is computed from the data
+    (cold full-history syncs can exceed the default LOG_CEIL).
+    """
+    data = data.copy()
+    data["elapsed_human"] = data["elapsed_s"].map(format_duration)
+    group_order = list(dict.fromkeys(data["group"]))
+
+    ceil = 10 ** math.ceil(math.log10(max(data["elapsed_s"].max(), 1.0)))
+    scale = alt.Scale(type="log", domain=[LOG_FLOOR, ceil])
+    ticks = _decade_ticks(LOG_FLOOR, ceil)
+
+    x = alt.X("group:N", sort=group_order, title=None)
+    offset = alt.XOffset("series:N", sort=series_order)
+
+    bars = alt.Chart(data).mark_bar().encode(
+        x=x,
+        xOffset=offset,
+        y=alt.Y(
+            "elapsed_s:Q",
+            scale=scale,
+            axis=alt.Axis(
+                values=ticks,
+                labelExpr=_label_expr_from(ticks, format_duration),
+                grid=True,
+                title="Elapsed time (log scale)",
+            ),
+        ),
+        y2=alt.Y2(datum=LOG_FLOOR),
+        color=alt.Color("series:N", sort=series_order, title=None),
+        tooltip=[
+            alt.Tooltip("group:N", title="Subtree"),
+            alt.Tooltip("series:N", title="Series"),
+            alt.Tooltip("elapsed_human:N", title="Elapsed"),
+        ],
+    )
+    labels = alt.Chart(data).mark_text(dy=-4, baseline="bottom", fontSize=9).encode(
+        x=alt.X("group:N", sort=group_order, axis=None),
+        xOffset=offset,
+        y=alt.Y("elapsed_s:Q", scale=scale, axis=None),
+        text=alt.Text("elapsed_human:N"),
+    )
+    return alt.layer(
+        _minor_grid(scale, LOG_FLOOR, ceil),
+        bars,
+        labels,
+    ).resolve_scale(x="independent", y="independent").properties(
+        title=title,
+        width=600,
+    )
+
+
 def save_chart(chart: alt.LayerChart, path: str | Path) -> Path:
     """Render `chart` to `path` (PNG via vl-convert), creating parent dirs."""
     path = Path(path)

--- a/benchmarks/bench/git.py
+++ b/benchmarks/bench/git.py
@@ -2,10 +2,42 @@
 
 import os
 import shutil
+import subprocess
 from pathlib import Path
 
 from bench.result import ToolResult
 from bench.shell import run
+
+
+def ref_exists(repo: str | Path, ref: str) -> bool:
+    """True if `ref` resolves in `repo`."""
+    return (
+        subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--verify", "-q", ref],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def repo_at(repo: str | Path, revision: str, bare: bool = False) -> bool:
+    """True if `repo` is a repo of the requested kind with `HEAD` at `revision`."""
+    repo = Path(repo)
+    # `git -C` walks up to an enclosing repo, so make sure `repo` is a repo root.
+    if not (repo / ".git").exists() and not (repo / "objects").exists():
+        return False
+    p = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD", "--is-bare-repository"],
+        capture_output=True,
+        text=True,
+    )
+    out = p.stdout.split()
+    return (
+        p.returncode == 0
+        and len(out) == 2
+        and out[0] == revision
+        and (out[1] == "true") == bare
+    )
 
 
 def fetch_repo(
@@ -15,15 +47,26 @@ def fetch_repo(
     target_dir: str | Path,
     *,
     bare: bool = False,
+    force: bool = False,
 ) -> Path:
-    """Fetch `revision` from `remote` into `target_dir/name`, returning its path.
+    """Ensure `target_dir/name` is a repo at `revision`, returning its path.
 
-    The destination is recreated from scratch each time. When `bare` is set the
-    result is a bare repository with `HEAD` pointing at `revision` via
-    `refs/heads/main`, so object-level tools (josh-filter) that read `HEAD`
-    resolve it without a checkout.
+    An assertion rather than a command: when the destination is already a repo
+    of the requested kind with `HEAD` at `revision` it is returned unchanged, so
+    whatever a caller keeps inside it (e.g. a cargo target dir) survives.
+    Otherwise it is fetched from `remote` from scratch, which also replaces the
+    leftovers of an interrupted earlier fetch -- `HEAD` only reaches `revision`
+    once the fetch completed. `force` refetches unconditionally.
+
+    `revision` must be a full commit sha, as `HEAD` is compared against it
+    literally. When `bare` is set the result is a bare repository with `HEAD`
+    pointing at `revision` via `refs/heads/main`, so object-level tools
+    (josh-filter) that read `HEAD` resolve it without a checkout.
     """
     repo_dir = Path(target_dir) / name
+
+    if not force and repo_at(repo_dir, revision, bare):
+        return repo_dir
 
     if repo_dir.exists():
         shutil.rmtree(repo_dir)

--- a/benchmarks/bench/preparation/rust_lang/rust_prepare.py
+++ b/benchmarks/bench/preparation/rust_lang/rust_prepare.py
@@ -13,10 +13,9 @@ See :mod:`bench.preparation.rust_lang.inject_filter` for the injection mechanism
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 
-from bench.git import clone_pristine, fetch_repo
+from bench.git import clone_pristine, fetch_repo, ref_exists, repo_at
 from bench.preparation.rust_lang.inject_filter import DEFAULT_REF, inject_filter
 from bench.shell import run
 
@@ -24,31 +23,6 @@ from bench.shell import run
 # after the first fetch so the large download only happens once.
 RUST_REMOTE = "https://github.com/rust-lang/rust"
 RUST_REVISION = "656ccbe796ff98def9b555c118e1620c5389e3b2"
-
-
-def _reachable(repo: Path, revision: str) -> bool:
-    """True if `repo` exists as a git repo and contains `revision`."""
-    if not (repo / "objects").exists():
-        return False
-    # `cat-file -e` exits 0 iff the object is present.
-    return (
-        subprocess.run(
-            ["git", "-C", str(repo), "cat-file", "-e", revision],
-            capture_output=True,
-        ).returncode
-        == 0
-    )
-
-
-def _ref_exists(repo: Path, ref: str) -> bool:
-    """True if `ref` resolves in `repo`."""
-    return (
-        subprocess.run(
-            ["git", "-C", str(repo), "rev-parse", "--verify", "-q", ref],
-            capture_output=True,
-        ).returncode
-        == 0
-    )
 
 
 def prepare_rust_source(
@@ -62,9 +36,9 @@ def prepare_rust_source(
     """Clone rust-lang at `revision` into a cached, repacked repo; return its path.
 
     The cache lives at ``<target_dir>/rust-lang-source/<short-sha>``. On a cache
-    hit (the dir exists and contains `revision`, and `force` is False) the existing
-    repo is reused unchanged. On a miss it is fetched (bare by default) and
-    repacked into a single pack.
+    hit (the dir is a repo at `revision`, and `force` is False) the existing repo
+    is reused unchanged. On a miss it is fetched (bare by default) and repacked
+    into a single pack.
 
     Pass ``remote=<path>`` to clone from a local checkout (e.g. a
     ``~/Projects/rust-lang`` clone) instead of github, avoiding the network fetch.
@@ -75,13 +49,15 @@ def prepare_rust_source(
     target_dir = Path(target_dir)
     cache_dir = target_dir / "rust-lang-source" / revision[:12]
 
-    if not force and _reachable(cache_dir, revision):
+    if not force and repo_at(cache_dir, revision, bare):
         return cache_dir
 
-    # fetch_repo recreates cache_dir from scratch, so a partial/interrupted
-    # cache is replaced cleanly. It creates `<target_dir>/<name>`; pass the
-    # cache dir as (parent, leaf name).
-    fetch_repo(remote, cache_dir.name, revision, cache_dir.parent, bare=bare)
+    # Reaching here means the cache is not valid, so refetch from scratch
+    # (force) rather than let fetch_repo's own hit check skip it. fetch_repo
+    # creates `<target_dir>/<name>`; pass the cache dir as (parent, leaf name).
+    fetch_repo(
+        remote, cache_dir.name, revision, cache_dir.parent, bare=bare, force=True
+    )
 
     # Consolidate into one tight pack for faster subsequent reads.
     run("git repack -a -d -q", cwd=str(cache_dir))
@@ -116,7 +92,7 @@ def prepare_injected_repo(
     target_dir = Path(target_dir)
     injected_dir = target_dir / "rust-lang-injected" / revision[:12]
 
-    if not force and _ref_exists(injected_dir, DEFAULT_REF):
+    if not force and ref_exists(injected_dir, DEFAULT_REF):
         return injected_dir
 
     source = prepare_rust_source(

--- a/benchmarks/bench/preparation/rustc_josh_sync/config.py
+++ b/benchmarks/bench/preparation/rustc_josh_sync/config.py
@@ -1,0 +1,91 @@
+"""Subtree definitions and josh filter construction for the rustc-josh-sync scenario.
+
+rust-lang syncs subtrees of rust-lang/rust with the `rustc-josh-sync` tool
+(https://github.com/rust-lang/josh-sync). Each synced subtree carries its sync
+configuration at ``<path>/josh-sync.toml`` inside rust-lang/rust, so the exact
+filter each repo uses can be read from the pinned tree instead of hardcoding it.
+
+The filter construction below is a direct port of josh-sync's ``config.rs``
+(``construct_josh_filter`` / ``convert_rev_syntax`` / ``wrap_compat``) so the
+benchmark filters match production byte for byte.
+"""
+
+import os
+import re
+import tomllib
+from pathlib import Path
+
+from bench.shell import run
+
+RUST_REMOTE = "https://github.com/rust-lang/rust"
+
+# rust-lang/rust main tip as of 2026-07-19. Newer than the rust-lang scenario's
+# pin on purpose: stdarch/compiler-builtins only adopted josh-sync in 2025, and
+# the replay mining needs >= 10 syncs per subtree in both directions.
+RUST_REVISION = "234c31cd674e11703f15d290cba7ff81dfe8b4b8"
+
+# josh built at this commit is both the subject under test (josh-proxy, josh
+# CLI) and the producer of the reference filtered histories (josh-filter);
+# keeping it one commit makes SHA-exact verification possible. Pinned to
+# master as of 2026-07-19, which includes the fix for the CLI dropping
+# semantic meta args ("Apply semantic meta args of remote filters in the josh
+# CLI") -- older commits fail the CLI pass's SHA-exact verification.
+# Override with SYNC_JOSH_COMMIT (a full commit SHA) to benchmark another josh
+# version; filtered-history and manifest caches are keyed by it, so runs with
+# different versions do not mix.
+JOSH_COMMIT = os.environ.get(
+    "SYNC_JOSH_COMMIT", "d7649b7e1ad59537b7b2ed131e5bfb974fe0c5b4"
+)
+
+# Served under this path so proxy URLs match production shape
+# (http://<josh>/rust-lang/rust.git<filter>.git).
+UPSTREAM_REPO = "rust-lang/rust"
+
+# Benchmarked subtrees: name -> path inside rust-lang/rust.
+SUBTREES = {
+    "rustc-dev-guide": "src/doc/rustc-dev-guide",
+    "stdarch": "library/stdarch",
+    "compiler-builtins": "library/compiler-builtins",
+    "miri": "src/tools/miri",
+}
+
+
+def load_filter(rust_repo: str | Path, revision: str, path: str) -> str:
+    """Build the exact josh filter rustc-josh-sync would use for `path`.
+
+    Reads ``<path>/josh-sync.toml`` from `revision` in `rust_repo` and applies
+    the same construction as josh-sync's ``JoshConfig::construct_josh_filter``.
+    """
+    raw = run(f"git show {revision}:{path}/josh-sync.toml", cwd=str(rust_repo))
+    config = tomllib.loads(raw)
+
+    cfg_path, cfg_filter = config.get("path"), config.get("filter")
+    if cfg_filter is not None and cfg_path is None:
+        spec = cfg_filter
+    elif cfg_path is not None and cfg_filter is None:
+        spec = f":/{cfg_path}"
+    else:
+        raise ValueError(f"{path}/josh-sync.toml must set exactly one of path/filter")
+
+    return _wrap_compat(_convert_rev_syntax(spec))
+
+
+# ``:rev(<sha>:<filter>)`` in josh-sync configs uses a legacy syntax; josh
+# itself expects ``:rev(<=<sha>:<filter>)``, and the all-zero SHA means "the
+# root" and is spelled ``_``. Port of josh-sync's ``convert_rev_syntax``.
+_REV_BLOCK = re.compile(r":rev\([^)]*\)")
+_REV_ENTRY = re.compile(r"([,(])(0{40}|[0-9a-f]{40}):")
+
+
+def _convert_rev_syntax(spec: str) -> str:
+    def convert_entry(m: re.Match[str]) -> str:
+        delim, sha = m.group(1), m.group(2)
+        if set(sha) == {"0"}:
+            return f"{delim}_:"
+        return f"{delim}<={sha}:"
+
+    return _REV_BLOCK.sub(lambda m: _REV_ENTRY.sub(convert_entry, m.group(0)), spec)
+
+
+def _wrap_compat(spec: str) -> str:
+    return f':~(history="keep-trivial-merges",gpgsig="norm-lf")[{spec}]'

--- a/benchmarks/bench/preparation/rustc_josh_sync/mine.py
+++ b/benchmarks/bench/preparation/rustc_josh_sync/mine.py
@@ -1,0 +1,247 @@
+"""Mine real historical sync events out of rust-lang/rust history.
+
+Both directions of the rustc-josh-sync workflow leave durable traces:
+
+- A *pull* records itself in the subtree repo as a "Prepare for merging" commit
+  (writing the pulled rust SHA into ``rust-version``) followed by a merge of the
+  filtered rust history. Those commits get pushed back to rust-lang/rust on the
+  next push, so they are visible in our filtered history. Detection goes by the
+  ``rust-version`` content change, not the message, so older pre-josh-sync
+  "Rustup" pulls (miri) are found too.
+- A *push* lands in rust-lang/rust as a bors merge of the reverse-filtered
+  subtree branch: a merge on main whose diff is confined to the subtree path and
+  bumps ``<path>/rust-version``. Its second parent is the PR head produced by
+  josh, and the ``rust-version`` blob in it names the rust base the push was
+  built on.
+
+The result is a manifest (cached as JSON under ``target/rustc-josh-sync/``)
+listing, per subtree, the most recent `depth` events per direction in replay
+order: pulls oldest to newest (the oldest is the cold sample -- a full-history
+pull, comparable across subtrees), then pushes oldest to newest.
+"""
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+from bench.preparation.rustc_josh_sync.config import RUST_REVISION
+from bench.shell import run
+
+_SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _git(repo: Path, args: str) -> str:
+    return run(f"git {args}", cwd=str(repo))
+
+
+def _object_exists(repo: Path, obj: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "-C", str(repo), "cat-file", "-e", obj], capture_output=True
+        ).returncode
+        == 0
+    )
+
+
+def mine_pulls(filtered: Path, source: Path, depth: int) -> list[dict]:
+    """Find historical pulls in the filtered (subtree-side) history, newest first.
+
+    Prepare commits and their pull merges live in the second-parent subgraphs of
+    the filtered history (they reached rust-lang/rust inside push PR branches),
+    so the whole DAG is walked, not just the first-parent chain.
+    """
+    parents: dict[str, list[str]] = {}
+    children: dict[str, list[str]] = {}
+    for line in _git(filtered, "rev-list --parents refs/heads/filtered").splitlines():
+        row = line.split()
+        parents[row[0]] = row[1:]
+        for p in row[1:]:
+            children.setdefault(p, []).append(row[0])
+
+    # All non-merge commits (anywhere in the DAG) that changed rust-version,
+    # newest first; prepare commits are the ones setting it to a commit SHA.
+    candidates = _git(
+        filtered,
+        "log --full-history --no-merges --format=%H refs/heads/filtered -- rust-version",
+    ).split()
+
+    events: list[dict] = []
+    seen: set[str] = set()
+    for c in candidates:
+        if len(events) >= depth:
+            break
+        if len(parents[c]) != 1:
+            continue
+        pulled = _git(filtered, f"show {c}:rust-version").strip()
+        if not _SHA40.match(pulled):
+            continue
+        # The pull merge is the merge child whose first parent is the prepare
+        # commit; it keeps the prepare commit's rust-version.
+        merge = next(
+            (
+                h
+                for h in children.get(c, [])
+                if len(parents[h]) >= 2 and parents[h][0] == c
+            ),
+            None,
+        )
+        if merge is None or merge in seen:
+            continue
+        if _git(filtered, f"show {merge}:rust-version").strip() != pulled:
+            continue
+        if not _object_exists(source, pulled):  # pulled rust commit not in the mirror
+            continue
+        seen.add(merge)
+        events.append({
+            "kind": "pull",
+            "ts": int(_git(filtered, f"log -1 --format=%ct {merge}").strip()),
+            "hist_prepare": c,
+            "base_subtree": parents[c][0],
+            "pulled_rust_sha": pulled,
+            "hist_merge": merge,
+            "hist_merge_tree": _git(filtered, f"rev-parse {merge}^{{tree}}").strip(),
+            "hist_fetch_head": parents[merge][1],
+            "merge_msg": _git(filtered, f"log -1 --format=%s {merge}").strip(),
+        })
+    return events
+
+
+def _confined_sync_merge(source: Path, merge: str, path: str) -> bool:
+    """True if `merge` brings only changes under `path`, including rust-version."""
+    names = _git(source, f"diff --name-only {merge}^1 {merge}").splitlines()
+    return (
+        bool(names)
+        and all(n.startswith(f"{path}/") for n in names)
+        and f"{path}/rust-version" in names
+    )
+
+
+def mine_pushes(
+    source: Path, filtered: Path, josh_filter: Path, filter_spec: str, path: str, depth: int
+) -> list[dict]:
+    """Find historical pushes for subtree `path` on rust-lang/rust main, newest first.
+
+    A push lands either as a direct bors merge of the subtree-update PR, or --
+    more commonly -- inside a rollup, as a "Rollup merge of #NNN" commit on the
+    rollup branch. ``-m`` diffs merges against their first parent, so the outer
+    walk finds every main-branch merge that bumped ``rust-version``; if that
+    merge is not itself confined to the subtree it is a rollup, and the actual
+    subtree-update merge is looked up on the rollup branch the same way.
+    """
+    outers = _git(
+        source,
+        "log --first-parent -m --merges --format='%H %ct'"
+        f" refs/heads/main -- {path}/rust-version",
+    ).splitlines()
+
+    events: list[dict] = []
+    seen: set[str] = set()
+    for line in outers:
+        if len(events) >= depth:
+            break
+        outer, ts = line.split()
+        merge = outer
+        if not _confined_sync_merge(source, merge, path):
+            inner = _git(
+                source,
+                f"log -n 1 --first-parent -m --merges --format=%H {outer}^2"
+                f" -- {path}/rust-version",
+            ).strip()
+            if not inner or not _confined_sync_merge(source, inner, path):
+                continue
+            merge = inner
+            # The inner merge must be the one responsible for the outer bump.
+            if _git(source, f"show {merge}:{path}/rust-version") != _git(
+                source, f"show {outer}:{path}/rust-version"
+            ):
+                continue
+        if merge in seen:
+            continue
+        seen.add(merge)
+        base = _git(source, f"show {merge}^2:{path}/rust-version").strip()
+        if not _SHA40.match(base) or not _object_exists(source, base):
+            continue
+        pr_head = _git(source, f"rev-parse {merge}^2").strip()
+
+        # The subtree-side branch head that was pushed = the filtered image of
+        # the PR head. Incremental thanks to josh-filter's persistent cache in
+        # the filtered repo (only the PR-side commits are new).
+        _git(filtered, f"update-ref refs/mining/tmp {pr_head}")
+        run(
+            f"{josh_filter} -s '{filter_spec}' refs/mining/tmp --update refs/mining/out",
+            cwd=str(filtered),
+        )
+        events.append({
+            "kind": "push",
+            "ts": int(ts),
+            "hist_rust_merge": merge,
+            "hist_pr_head": pr_head,
+            "hist_pr_tree": _git(source, f"rev-parse {pr_head}^{{tree}}").strip(),
+            "base_rust_sha": base,
+            "subtree_head": _git(filtered, "rev-parse refs/mining/out").strip(),
+        })
+    return events
+
+
+def _assemble(pulls: list[dict], pushes: list[dict]) -> list[dict]:
+    """Order events for replay: all pulls oldest to newest, then all pushes.
+
+    The oldest pull comes first so the cold sample is a full-history pull for
+    every subtree. Pushes follow against the then-warm cache, which matches
+    production: sync cadences differ per direction (miri pulls daily but pushes
+    rarely), and whenever a push happens the proxy has long been warmed by the
+    pulls in between. Replays are independent (each event carries its own base
+    refs), so cross-direction calendar order does not matter.
+    """
+    return sorted(pulls, key=lambda e: e["ts"]) + sorted(pushes, key=lambda e: e["ts"])
+
+
+def mine_subtree(
+    name: str,
+    source: Path,
+    filtered: Path,
+    filter_spec: str,
+    path: str,
+    josh_filter: Path,
+    josh_commit: str,
+    depth: int,
+    target_dir: Path,
+) -> dict:
+    """Build (or load the cached) replay manifest for one subtree.
+
+    Cached per subtree, keyed by the rust pin, the josh commit (it produced the
+    filtered history the events reference) and the depth.
+    """
+    cache = (
+        target_dir
+        / "rustc-josh-sync"
+        / f"manifest-{name}-{RUST_REVISION[:12]}-{josh_commit[:12]}-d{depth}.json"
+    )
+    if cache.exists():
+        return json.loads(cache.read_text())
+
+    pulls = mine_pulls(filtered, source, depth)
+    pushes = mine_pushes(source, filtered, josh_filter, filter_spec, path, depth)
+    events = _assemble(pulls, pushes)
+    counts = {
+        "pull": sum(e["kind"] == "pull" for e in events),
+        "push": sum(e["kind"] == "push" for e in events),
+    }
+    for kind in ("pull", "push"):
+        if counts[kind] < depth:
+            print(f"warning: {name}: only {counts[kind]} {kind} events (wanted {depth})")
+    print(f"mined {name}: {counts['pull']} pulls, {counts['push']} pushes")
+
+    manifest = {
+        "rust_revision": RUST_REVISION,
+        "josh_commit": josh_commit,
+        "depth": depth,
+        "filter": filter_spec,
+        "path": path,
+        "counts": counts,
+        "events": events,
+    }
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(manifest, indent=2))
+    return manifest

--- a/benchmarks/bench/preparation/rustc_josh_sync/mine.py
+++ b/benchmarks/bench/preparation/rustc_josh_sync/mine.py
@@ -1,0 +1,245 @@
+"""Mine real historical sync events out of rust-lang/rust history.
+
+Both directions of the rustc-josh-sync workflow leave durable traces:
+
+- A *pull* records itself in the subtree repo as a "Prepare for merging" commit
+  (writing the pulled rust SHA into ``rust-version``) followed by a merge of the
+  filtered rust history. Those commits get pushed back to rust-lang/rust on the
+  next push, so they are visible in our filtered history. Detection goes by the
+  ``rust-version`` content change, not the message, so older pre-josh-sync
+  "Rustup" pulls (miri) are found too.
+- A *push* lands in rust-lang/rust as a bors merge of the reverse-filtered
+  subtree branch: a merge on main whose diff is confined to the subtree path and
+  bumps ``<path>/rust-version``. Its second parent is the PR head produced by
+  josh, and the ``rust-version`` blob in it names the rust base the push was
+  built on.
+
+The result is a manifest (cached as JSON under ``target/rustc-josh-sync/``)
+listing, per subtree, the most recent `depth` events per direction in replay
+order: pulls oldest to newest (the oldest is the cold sample -- a full-history
+pull, comparable across subtrees), then pushes oldest to newest.
+"""
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+from bench.preparation.rustc_josh_sync.config import RUST_REVISION
+from bench.shell import run
+
+_SHA40 = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _git(repo: Path, args: str) -> str:
+    return run(f"git {args}", cwd=str(repo))
+
+
+def _object_exists(repo: Path, obj: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "-C", str(repo), "cat-file", "-e", obj], capture_output=True
+        ).returncode
+        == 0
+    )
+
+
+def mine_pulls(filtered: Path, source: Path, depth: int) -> list[dict]:
+    """Find historical pulls in the filtered (subtree-side) history, newest first.
+
+    Prepare commits and their pull merges live in the second-parent subgraphs of
+    the filtered history (they reached rust-lang/rust inside push PR branches),
+    so the whole DAG is walked, not just the first-parent chain.
+    """
+    parents: dict[str, list[str]] = {}
+    children: dict[str, list[str]] = {}
+    for line in _git(filtered, "rev-list --parents refs/heads/filtered").splitlines():
+        row = line.split()
+        parents[row[0]] = row[1:]
+        for p in row[1:]:
+            children.setdefault(p, []).append(row[0])
+
+    candidates = _git(
+        filtered,
+        "log --full-history --no-merges --format=%H refs/heads/filtered -- rust-version",
+    ).split()
+
+    events: list[dict] = []
+    seen: set[str] = set()
+    for c in candidates:
+        if len(events) >= depth:
+            break
+        if len(parents[c]) != 1:
+            continue
+        pulled = _git(filtered, f"show {c}:rust-version").strip()
+        if not _SHA40.match(pulled):
+            continue
+        # The pull merge is the merge child whose first parent is the prepare
+        # commit; it keeps the prepare commit's rust-version.
+        merge = next(
+            (
+                h
+                for h in children.get(c, [])
+                if len(parents[h]) >= 2 and parents[h][0] == c
+            ),
+            None,
+        )
+        if merge is None or merge in seen:
+            continue
+        if _git(filtered, f"show {merge}:rust-version").strip() != pulled:
+            continue
+        if not _object_exists(source, pulled):
+            continue
+        seen.add(merge)
+        events.append({
+            "kind": "pull",
+            "ts": int(_git(filtered, f"log -1 --format=%ct {merge}").strip()),
+            "hist_prepare": c,
+            "base_subtree": parents[c][0],
+            "pulled_rust_sha": pulled,
+            "hist_merge": merge,
+            "hist_merge_tree": _git(filtered, f"rev-parse {merge}^{{tree}}").strip(),
+            "hist_fetch_head": parents[merge][1],
+            "merge_msg": _git(filtered, f"log -1 --format=%s {merge}").strip(),
+        })
+    return events
+
+
+def _confined_sync_merge(source: Path, merge: str, path: str) -> bool:
+    """True if `merge` brings only changes under `path`, including rust-version."""
+    names = _git(source, f"diff --name-only {merge}^1 {merge}").splitlines()
+    return (
+        bool(names)
+        and all(n.startswith(f"{path}/") for n in names)
+        and f"{path}/rust-version" in names
+    )
+
+
+def mine_pushes(
+    source: Path, filtered: Path, josh_filter: Path, filter_spec: str, path: str, depth: int
+) -> list[dict]:
+    """Find historical pushes for subtree `path` on rust-lang/rust main, newest first.
+
+    A push lands either as a direct bors merge of the subtree-update PR, or --
+    more commonly -- inside a rollup, as a "Rollup merge of #NNN" commit on the
+    rollup branch. ``-m`` diffs merges against their first parent, so the outer
+    walk finds every main-branch merge that bumped ``rust-version``; if that
+    merge is not itself confined to the subtree it is a rollup, and the actual
+    subtree-update merge is looked up on the rollup branch the same way.
+    """
+    outers = _git(
+        source,
+        "log --first-parent -m --merges --format='%H %ct'"
+        f" refs/heads/main -- {path}/rust-version",
+    ).splitlines()
+
+    events: list[dict] = []
+    seen: set[str] = set()
+    for line in outers:
+        if len(events) >= depth:
+            break
+        outer, ts = line.split()
+        merge = outer
+        if not _confined_sync_merge(source, merge, path):
+            inner = _git(
+                source,
+                f"log -n 1 --first-parent -m --merges --format=%H {outer}^2"
+                f" -- {path}/rust-version",
+            ).strip()
+            if not inner or not _confined_sync_merge(source, inner, path):
+                continue
+            merge = inner
+            # The inner merge must be the one responsible for the outer bump.
+            if _git(source, f"show {merge}:{path}/rust-version") != _git(
+                source, f"show {outer}:{path}/rust-version"
+            ):
+                continue
+        if merge in seen:
+            continue
+        seen.add(merge)
+        base = _git(source, f"show {merge}^2:{path}/rust-version").strip()
+        if not _SHA40.match(base) or not _object_exists(source, base):
+            continue
+        pr_head = _git(source, f"rev-parse {merge}^2").strip()
+
+        # The subtree-side branch head that was pushed = the filtered image of
+        # the PR head. Incremental thanks to josh-filter's persistent cache in
+        # the filtered repo (only the PR-side commits are new).
+        _git(filtered, f"update-ref refs/mining/tmp {pr_head}")
+        run(
+            f"{josh_filter} -s '{filter_spec}' refs/mining/tmp --update refs/mining/out",
+            cwd=str(filtered),
+        )
+        events.append({
+            "kind": "push",
+            "ts": int(ts),
+            "hist_rust_merge": merge,
+            "hist_pr_head": pr_head,
+            "hist_pr_tree": _git(source, f"rev-parse {pr_head}^{{tree}}").strip(),
+            "base_rust_sha": base,
+            "subtree_head": _git(filtered, "rev-parse refs/mining/out").strip(),
+        })
+    return events
+
+
+def _assemble(pulls: list[dict], pushes: list[dict]) -> list[dict]:
+    """Order events for replay: all pulls oldest to newest, then all pushes.
+
+    The oldest pull comes first so the cold sample is a full-history pull for
+    every subtree. Pushes follow against the then-warm cache, which matches
+    production: sync cadences differ per direction (miri pulls daily but pushes
+    rarely), and whenever a push happens the proxy has long been warmed by the
+    pulls in between. Replays are independent (each event carries its own base
+    refs), so cross-direction calendar order does not matter.
+    """
+    return sorted(pulls, key=lambda e: e["ts"]) + sorted(pushes, key=lambda e: e["ts"])
+
+
+def mine_subtree(
+    name: str,
+    source: Path,
+    filtered: Path,
+    filter_spec: str,
+    path: str,
+    josh_filter: Path,
+    josh_commit: str,
+    depth: int,
+    target_dir: Path,
+) -> dict:
+    """Build (or load the cached) replay manifest for one subtree.
+
+    The cache key includes the josh commit because it produced the filtered
+    history the events reference.
+    """
+    cache = (
+        target_dir
+        / "rustc-josh-sync"
+        / f"manifest-{name}-{RUST_REVISION[:12]}-{josh_commit[:12]}-d{depth}.json"
+    )
+    if cache.exists():
+        return json.loads(cache.read_text())
+
+    pulls = mine_pulls(filtered, source, depth)
+    pushes = mine_pushes(source, filtered, josh_filter, filter_spec, path, depth)
+    events = _assemble(pulls, pushes)
+    counts = {
+        "pull": sum(e["kind"] == "pull" for e in events),
+        "push": sum(e["kind"] == "push" for e in events),
+    }
+    for kind in ("pull", "push"):
+        if counts[kind] < depth:
+            print(f"warning: {name}: only {counts[kind]} {kind} events (wanted {depth})")
+    print(f"mined {name}: {counts['pull']} pulls, {counts['push']} pushes")
+
+    manifest = {
+        "rust_revision": RUST_REVISION,
+        "josh_commit": josh_commit,
+        "depth": depth,
+        "filter": filter_spec,
+        "path": path,
+        "counts": counts,
+        "events": events,
+    }
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(json.dumps(manifest, indent=2))
+    return manifest

--- a/benchmarks/bench/preparation/rustc_josh_sync/prepare.py
+++ b/benchmarks/bench/preparation/rustc_josh_sync/prepare.py
@@ -1,0 +1,113 @@
+"""Prepare the repos the rustc-josh-sync scenario replays against.
+
+All of this is untimed preparation:
+
+- an *upstream mirror* of rust-lang/rust served over HTTP behind josh-proxy,
+  standing in for github.com/rust-lang/rust (and, for pushes, for the user's
+  fork -- push branches are created directly on the mirror);
+- per subtree, a persistent *filtered repo*: the rust history filtered with the
+  production josh-sync filter. For josh-synced repos this IS the subtree repo's
+  history (josh's roundtrip property), so it both serves as the mining substrate
+  and stands in for the subtree GitHub repo -- no subtree clones needed;
+- per subtree, a throwaway *work clone* of the filtered repo playing the role of
+  the developer's subtree checkout during replays.
+"""
+
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from bench.git import clone_pristine
+from bench.preparation.rustc_josh_sync.config import JOSH_COMMIT, RUST_REVISION
+from bench.shell import run
+
+
+def remove_dir(path: Path) -> None:
+    """Remove `path` recursively, tolerating transient APFS ENOTEMPTY races."""
+    for _ in range(3):
+        try:
+            if path.exists():
+                shutil.rmtree(path)
+            return
+        except OSError:
+            time.sleep(0.2)
+    run(f"rm -rf {path}")
+
+
+def _ref_exists(repo: Path, ref: str) -> bool:
+    """True if `ref` resolves in `repo`."""
+    return (
+        subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--verify", "-q", ref],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def prepare_upstream(source: Path, work_dir: Path) -> tuple[Path, Path]:
+    """Create the served upstream mirror; return (serve_root, repo_path).
+
+    The mirror is recreated per run (replays mutate its branches). It lives at
+    ``<serve_root>/rust-lang/rust.git`` so proxy URLs match the production
+    shape. ``uploadpack.allowAnySHA1InWant`` lets josh-proxy fetch the mined
+    historical (non-tip) commits addressed by ``@sha`` URLs.
+    """
+    serve_root = work_dir / "upstream"
+    repo = serve_root / "rust-lang" / "rust.git"
+    clone_pristine(source, repo, bare=True)
+    run("git config http.receivepack true", cwd=str(repo))
+    run("git config uploadpack.allowAnySHA1InWant true", cwd=str(repo))
+    run("git symbolic-ref HEAD refs/heads/main", cwd=str(repo))
+    return serve_root, repo
+
+
+def prepare_filtered(
+    josh_filter: Path,
+    source: Path,
+    name: str,
+    filter_spec: str,
+    target_dir: Path,
+) -> Path:
+    """Materialize the filtered (subtree-side) history for `name`; return the repo.
+
+    Cached at ``target/rustc-josh-sync/filtered/<name>-<rust-sha>-<josh-sha>``,
+    keyed by the rust pin and the josh version producing it (different josh
+    versions may filter to different SHAs); on a hit (``refs/heads/filtered``
+    exists) the repo is returned unchanged. josh-filter's persistent cache
+    lives inside this repo, so later incremental filter runs during mining are
+    cheap. This cache is entirely separate from josh-proxy's ``--local``
+    cache: it never warms the proxy, so cold measurements stay cold.
+    """
+    repo = (
+        target_dir
+        / "rustc-josh-sync"
+        / "filtered"
+        / f"{name}-{RUST_REVISION[:12]}-{JOSH_COMMIT[:12]}"
+    )
+    if _ref_exists(repo, "refs/heads/filtered"):
+        return repo
+
+    clone_pristine(source, repo, bare=True)
+    run(
+        f"{josh_filter} -s '{filter_spec}' refs/heads/main --update refs/heads/filtered",
+        cwd=str(repo),
+    )
+    return repo
+
+
+def prepare_work_clone(filtered: Path, name: str, work_dir: Path) -> Path:
+    """Create the developer-checkout stand-in for `name`; return its path.
+
+    Recreated per run. ``--shared`` keeps it cheap and makes every historical
+    subtree-side commit addressable in the clone (mined events reference them).
+    """
+    dest = work_dir / "work" / name
+    remove_dir(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    run(f"git clone -q --shared --branch filtered {filtered} {dest}")
+    run("git config user.name 'Josh Benchmark'", cwd=str(dest))
+    run("git config user.email 'josh-bench@example.com'", cwd=str(dest))
+    run("git config commit.gpgsign false", cwd=str(dest))
+    return dest

--- a/benchmarks/bench/preparation/rustc_josh_sync/prepare.py
+++ b/benchmarks/bench/preparation/rustc_josh_sync/prepare.py
@@ -1,0 +1,92 @@
+"""Prepare the repos the rustc-josh-sync scenario replays against.
+
+All of this is untimed preparation:
+
+- an *upstream mirror* of rust-lang/rust served over HTTP behind josh-proxy,
+  standing in for github.com/rust-lang/rust (and, for pushes, for the user's
+  fork -- push branches are created directly on the mirror);
+- per subtree, a persistent *filtered repo*: the rust history filtered with the
+  production josh-sync filter. For josh-synced repos this IS the subtree repo's
+  history (josh's roundtrip property), so it both serves as the mining substrate
+  and stands in for the subtree GitHub repo -- no subtree clones needed;
+- per subtree, a throwaway *work clone* of the filtered repo playing the role of
+  the developer's subtree checkout during replays.
+"""
+
+import shutil
+from pathlib import Path
+
+from bench.git import clone_pristine, ref_exists
+from bench.preparation.rustc_josh_sync.config import JOSH_COMMIT, RUST_REVISION
+from bench.shell import run
+
+
+def remove_dir(path: Path) -> None:
+    """Remove `path` recursively; a no-op when it does not exist."""
+    if path.exists():
+        shutil.rmtree(path)
+
+
+def prepare_upstream(source: Path, work_dir: Path) -> tuple[Path, Path]:
+    """Create the served upstream mirror; return (serve_root, repo_path).
+
+    The mirror is recreated per run (replays mutate its branches). It lives at
+    ``<serve_root>/rust-lang/rust.git`` so proxy URLs match the production
+    shape. ``uploadpack.allowAnySHA1InWant`` lets josh-proxy fetch the mined
+    historical (non-tip) commits addressed by ``@sha`` URLs.
+    """
+    serve_root = work_dir / "upstream"
+    repo = serve_root / "rust-lang" / "rust.git"
+    clone_pristine(source, repo, bare=True)
+    run("git config http.receivepack true", cwd=str(repo))
+    run("git config uploadpack.allowAnySHA1InWant true", cwd=str(repo))
+    run("git symbolic-ref HEAD refs/heads/main", cwd=str(repo))
+    return serve_root, repo
+
+
+def prepare_filtered(
+    josh_filter: Path,
+    source: Path,
+    name: str,
+    filter_spec: str,
+    target_dir: Path,
+) -> Path:
+    """Materialize the filtered (subtree-side) history for `name`; return the repo.
+
+    The cache key includes the josh version producing the history (different
+    josh versions may filter to different SHAs). josh-filter's persistent
+    cache lives inside this repo, making the incremental filter runs during
+    mining cheap; it is entirely separate from josh-proxy's ``--local`` cache,
+    so cold proxy measurements stay cold.
+    """
+    repo = (
+        target_dir
+        / "rustc-josh-sync"
+        / "filtered"
+        / f"{name}-{RUST_REVISION[:12]}-{JOSH_COMMIT[:12]}"
+    )
+    if ref_exists(repo, "refs/heads/filtered"):
+        return repo
+
+    clone_pristine(source, repo, bare=True)
+    run(
+        f"{josh_filter} -s '{filter_spec}' refs/heads/main --update refs/heads/filtered",
+        cwd=str(repo),
+    )
+    return repo
+
+
+def prepare_work_clone(filtered: Path, name: str, work_dir: Path) -> Path:
+    """Create the developer-checkout stand-in for `name`; return its path.
+
+    Recreated per run. ``--shared`` keeps it cheap and makes every historical
+    subtree-side commit addressable in the clone (mined events reference them).
+    """
+    dest = work_dir / "work" / name
+    remove_dir(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    run(f"git clone -q --shared --branch filtered {filtered} {dest}")
+    run("git config user.name 'Josh Benchmark'", cwd=str(dest))
+    run("git config user.email 'josh-bench@example.com'", cwd=str(dest))
+    run("git config commit.gpgsign false", cwd=str(dest))
+    return dest

--- a/benchmarks/bench/proxy.py
+++ b/benchmarks/bench/proxy.py
@@ -1,0 +1,170 @@
+"""Running josh-proxy (plus a local git HTTP server) for benchmark scenarios.
+
+josh-proxy only accepts http(s)/ssh remotes, so the upstream mirror is served
+over local HTTP with the workspace's axum-cgi-server wrapping git http-backend,
+mirroring ``tests/proxy/setup_test_env.sh``. The git HTTP server is usable on
+its own (``GitHttpServer``) for tools that talk to the upstream directly, like
+the josh CLI.
+"""
+
+import os
+import signal
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+_READY_TIMEOUT = 60.0
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_http(url: str, proc: subprocess.Popen, what: str, log: Path) -> None:
+    """Poll `url` until it answers (any HTTP status) or `proc` dies."""
+    deadline = time.monotonic() + _READY_TIMEOUT
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(f"{what} exited (status {proc.returncode}); log: {log}")
+        try:
+            with urllib.request.urlopen(url, timeout=1):
+                return
+        except urllib.error.HTTPError:
+            return  # server is up; an error status is still an answer
+        except OSError:
+            time.sleep(0.1)
+    raise RuntimeError(f"{what} did not become ready within {_READY_TIMEOUT}s; log: {log}")
+
+
+class _Service:
+    """Shared process-lifecycle plumbing for the servers below."""
+
+    def __init__(self, log_dir: str | Path) -> None:
+        self.log_dir = Path(log_dir)
+        self._procs: list[tuple[str, subprocess.Popen]] = []
+        self._logs: list[object] = []
+
+    def _spawn(self, name: str, cmd: list[str], env: dict[str, str]) -> subprocess.Popen:
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        log = open(self.log_dir / f"{name}.log", "w")
+        self._logs.append(log)
+        proc = subprocess.Popen(cmd, env=env, stdout=log, stderr=subprocess.STDOUT)
+        self._procs.append((name, proc))
+        return proc
+
+    def _shutdown(self) -> None:
+        for _, proc in reversed(self._procs):
+            if proc.poll() is None:
+                proc.send_signal(signal.SIGTERM)
+        deadline = time.monotonic() + 10
+        for _, proc in self._procs:
+            try:
+                proc.wait(timeout=max(0.1, deadline - time.monotonic()))
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+        for log in self._logs:
+            log.close()
+        self._procs, self._logs = [], []
+
+
+class GitHttpServer(_Service):
+    """Context manager serving the bare repos under `serve_root` over HTTP."""
+
+    def __init__(
+        self, binaries: dict[str, Path], serve_root: str | Path, log_dir: str | Path
+    ) -> None:
+        super().__init__(log_dir)
+        self.binaries = binaries
+        self.serve_root = Path(serve_root)
+        self.port = 0
+
+    def __enter__(self) -> "GitHttpServer":
+        self.port = _free_port()
+        env = {
+            **os.environ,
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_PROJECT_ROOT": str(self.serve_root),
+            "GIT_HTTP_EXPORT_ALL": "1",
+        }
+        httpd = self._spawn("axum-cgi-server", [
+            str(self.binaries["axum-cgi-server"]),
+            f"--port={self.port}",
+            f"--dir={self.serve_root}",
+            "--cmd=git",
+            "--args=http-backend",
+        ], env)
+        _wait_http(
+            f"http://localhost:{self.port}/",
+            httpd, "axum-cgi-server", self.log_dir / "axum-cgi-server.log",
+        )
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._shutdown()
+
+    def url(self, repo: str) -> str:
+        """Plain (unfiltered) HTTP URL for `repo`."""
+        return f"http://localhost:{self.port}/{repo}.git"
+
+
+class JoshProxy(_Service):
+    """Context manager running axum-cgi-server + josh-proxy over `serve_root`.
+
+    `serve_root` is a directory of bare repos; a repo at
+    ``<serve_root>/rust-lang/rust.git`` is reachable through the proxy as
+    ``http://localhost:<port>/rust-lang/rust.git<filter>.git``. `cache_dir` is
+    josh-proxy's ``--local`` state: pass a fresh dir for a cold cache, keep it
+    across syncs for a warm one.
+    """
+
+    def __init__(
+        self,
+        binaries: dict[str, Path],
+        serve_root: str | Path,
+        cache_dir: str | Path,
+        log_dir: str | Path,
+    ) -> None:
+        super().__init__(log_dir)
+        self.binaries = binaries
+        self.serve_root = Path(serve_root)
+        self.cache_dir = Path(cache_dir)
+        self.git_server = GitHttpServer(binaries, serve_root, log_dir)
+        self.josh_port = 0
+
+    def __enter__(self) -> "JoshProxy":
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.git_server.__enter__()
+
+        self.josh_port = _free_port()
+        proxy = self._spawn("josh-proxy", [
+            str(self.binaries["josh-proxy"]),
+            f"--port={self.josh_port}",
+            f"--local={self.cache_dir}",
+            f"--remote=http://localhost:{self.git_server.port}",
+            "--no-background",
+        ], {**os.environ, "GIT_CONFIG_NOSYSTEM": "1"})
+        _wait_http(
+            f"http://localhost:{self.josh_port}/",
+            proxy, "josh-proxy", self.log_dir / "josh-proxy.log",
+        )
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self._shutdown()
+        self.git_server.__exit__(*exc)
+
+    def url(self, repo: str, filter_spec: str, at: str | None = None) -> str:
+        """Proxy URL for `repo` filtered by `filter_spec`, optionally at commit `at`.
+
+        The filter is percent-encoded exactly as rustc-josh-sync encodes it.
+        """
+        rev = f"@{at}" if at else ""
+        quoted = urllib.parse.quote(filter_spec, safe="")
+        return f"http://localhost:{self.josh_port}/{repo}.git{rev}{quoted}.git"

--- a/benchmarks/bench/scenarios/__init__.py
+++ b/benchmarks/bench/scenarios/__init__.py
@@ -2,9 +2,10 @@
 
 from collections.abc import Callable
 
-from bench.scenarios import rust_lang, select_folders
+from bench.scenarios import rust_lang, rustc_josh_sync, select_folders
 
 SCENARIOS: dict[str, Callable[[], object]] = {
     "select-folders": select_folders.run,
     "rust-lang": rust_lang.run,
+    "rustc-josh-sync": rustc_josh_sync.run,
 }

--- a/benchmarks/bench/scenarios/rustc_josh_sync.py
+++ b/benchmarks/bench/scenarios/rustc_josh_sync.py
@@ -1,0 +1,225 @@
+"""rustc-josh-sync: replay real rust-lang subtree syncs through josh.
+
+End-to-end benchmark of the workflow rust-lang uses to sync subtrees
+(rustc-dev-guide, stdarch, compiler-builtins, miri) with rust-lang/rust via the
+`rustc-josh-sync` tool. Real historical syncs are mined from the sync commits in
+rust-lang/rust history and replayed in both directions against a locally served
+mirror, once per tool:
+
+- ``proxy``: the production setup -- git talks to a josh-proxy which filters
+  server-side (pull) and reverse-filters pushes onto rust history. Replays
+  against the production-filter reference (compat wrapper included).
+- ``cli``: the josh CLI in the subtree checkout talking directly to the
+  unfiltered upstream -- ``josh fetch`` transfers the raw history and filters
+  locally, ``josh push`` reverse-filters locally.
+
+Per subtree and tool the replay starts cold (fresh proxy cache / fresh work
+repo, so the first event -- always a pull -- pays the full-history cost) and
+stays warm for the remaining events, matching the steady state of
+josh.rust-lang.org for the proxy and of a long-lived checkout for the CLI.
+
+Environment knobs:
+- ``SYNC_REPLAY_DEPTH``: historical syncs per subtree per direction (default 10)
+- ``SYNC_SUBTREES``: comma-separated subset of subtrees for quick runs
+- ``SYNC_TOOLS``: comma-separated subset of {proxy, cli} (default both)
+- ``SYNC_JOSH_COMMIT``: josh version to benchmark (see config.py)
+"""
+
+import json
+import os
+import statistics
+
+import pandas as pd
+
+from bench.build import build_josh_proxy
+from bench.chart import grouped_chart, save_chart
+from bench.duration import format_duration
+from bench.paths import OUTPUT_DIR, TARGET_DIR
+from bench.preparation.rust_lang.rust_prepare import prepare_rust_source
+from bench.preparation.rustc_josh_sync.config import (
+    JOSH_COMMIT,
+    RUST_REMOTE,
+    RUST_REVISION,
+    SUBTREES,
+    UPSTREAM_REPO,
+    load_filter,
+)
+from bench.preparation.rustc_josh_sync.mine import mine_subtree
+from bench.preparation.rustc_josh_sync.prepare import (
+    prepare_filtered,
+    prepare_upstream,
+    prepare_work_clone,
+    remove_dir,
+)
+from bench.proxy import GitHttpServer, JoshProxy
+from bench.tools.josh_cli_sync import replay_pull_cli, replay_push_cli, setup_cli_remote
+from bench.tools.josh_proxy_sync import SyncSample, replay_pull, replay_push
+
+TOOLS = ("proxy", "cli")
+
+# Chart series, ordered so adjacent bars compare the two tools.
+SERIES = [
+    "proxy pull (cold)", "cli pull (cold)",
+    "proxy pull (warm)", "cli pull (warm)",
+    "proxy push (warm)", "cli push (warm)",
+]
+
+
+def _selected(env: str, known: tuple[str, ...] | dict) -> list[str]:
+    picked = os.environ.get(env)
+    if not picked:
+        return list(known)
+    names = [n.strip() for n in picked.split(",") if n.strip()]
+    unknown = [n for n in names if n not in known]
+    if unknown:
+        raise SystemExit(f"unknown {env} entries {unknown}; known: {', '.join(known)}")
+    return names
+
+
+def _replay_proxy(binaries, serve_root, upstream, work, manifest, name, work_dir):
+    samples = []
+    cache_dir = work_dir / "cache" / name
+    remove_dir(cache_dir)  # fresh proxy cache: first event is cold
+    with JoshProxy(binaries, serve_root, cache_dir, work_dir / "logs" / name) as proxy:
+        for i, ev in enumerate(manifest["events"]):
+            if ev["kind"] == "pull":
+                elapsed, verified = replay_pull(proxy, work, manifest["filter"], ev)
+            else:
+                elapsed, verified = replay_push(
+                    proxy, work, upstream, manifest["filter"], ev,
+                    branch=f"bench-proxy-{name}-{i}",
+                )
+            samples.append(("proxy", i, ev, elapsed, verified))
+    return samples
+
+
+def _replay_cli(binaries, serve_root, upstream, work, manifest, name, work_dir):
+    samples = []
+    josh = binaries["josh"]
+    with GitHttpServer(binaries, serve_root, work_dir / "logs" / f"{name}-cli") as gitd:
+        setup_cli_remote(josh, work, gitd.url(UPSTREAM_REPO), manifest["filter"])
+        for i, ev in enumerate(manifest["events"]):
+            if ev["kind"] == "pull":
+                # One advancing pull branch per subtree, like a real upstream.
+                elapsed, verified = replay_pull_cli(
+                    josh, work, upstream, ev, branch=f"sync-cli-{name}"
+                )
+            else:
+                elapsed, verified = replay_push_cli(
+                    josh, work, upstream, ev, branch=f"bench-cli-{name}-{i}"
+                )
+            samples.append(("cli", i, ev, elapsed, verified))
+    return samples
+
+
+def run() -> list[SyncSample]:
+    depth = int(os.environ.get("SYNC_REPLAY_DEPTH", "10"))
+    names = _selected("SYNC_SUBTREES", SUBTREES)
+    tools = _selected("SYNC_TOOLS", TOOLS)
+
+    binaries = build_josh_proxy(JOSH_COMMIT, TARGET_DIR)
+    source = prepare_rust_source(TARGET_DIR, revision=RUST_REVISION, remote=RUST_REMOTE)
+
+    manifests = {}
+    for name in names:
+        spec = load_filter(source, RUST_REVISION, SUBTREES[name])
+        filtered = prepare_filtered(binaries["josh-filter"], source, name, spec, TARGET_DIR)
+        manifests[name] = (
+            mine_subtree(
+                name, source, filtered, spec, SUBTREES[name],
+                binaries["josh-filter"], JOSH_COMMIT, depth, TARGET_DIR,
+            ),
+            filtered,
+        )
+
+    work_dir = TARGET_DIR / "work" / "rustc_josh_sync"
+    serve_root, upstream = prepare_upstream(source, work_dir)
+    replayers = {"proxy": _replay_proxy, "cli": _replay_cli}
+
+    samples: list[SyncSample] = []
+    for name in names:
+        for tool in tools:
+            manifest, filtered = manifests[name]
+            # A fresh work clone per pass: the CLI's caches live in the repo,
+            # and both tools must start equally cold.
+            work = prepare_work_clone(filtered, name, work_dir)
+            raw = replayers[tool](
+                binaries, serve_root, upstream, work, manifest, name, work_dir
+            )
+            for tool_name, i, ev, elapsed, verified in raw:
+                cache = "cold" if i == 0 else "warm"
+                samples.append(
+                    SyncSample(tool_name, name, ev["kind"], cache, elapsed, ev, verified)
+                )
+                note = "" if verified == "ok" else f"  [warn: {verified}]"
+                print(
+                    f"{name}/{tool_name}: {ev['kind']} {cache} "
+                    f"{format_duration(elapsed)}{note}",
+                    flush=True,
+                )
+
+    _report(samples, names, tools)
+    return samples
+
+
+def _stats(values: list[float]) -> str:
+    if not values:
+        return "-"
+    med = statistics.median(values)
+    return f"{format_duration(med)} (min {format_duration(min(values))}, " \
+           f"max {format_duration(max(values))}, n={len(values)})"
+
+
+def _report(samples: list[SyncSample], names: list[str], tools: list[str]) -> None:
+    raw = [
+        {
+            "tool": s.tool,
+            "subtree": s.subtree,
+            "direction": s.direction,
+            "cache": s.cache,
+            "elapsed_s": s.elapsed,
+            "verified": s.verified,
+            "event": s.event.get("hist_merge") or s.event.get("hist_rust_merge"),
+        }
+        for s in samples
+    ]
+    out = OUTPUT_DIR / "rustc_josh_sync_samples.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(raw, indent=2))
+    print(f"\nsamples written to {out}")
+
+    rows = []
+    for name in names:
+        print(f"{name}:")
+        for tool in tools:
+            picked = [s for s in samples if s.subtree == name and s.tool == tool]
+            cold = [s.elapsed for s in picked if s.cache == "cold"]
+            warm_pull = [
+                s.elapsed for s in picked if s.cache == "warm" and s.direction == "pull"
+            ]
+            warm_push = [
+                s.elapsed for s in picked if s.cache == "warm" and s.direction == "push"
+            ]
+            print(f"  {tool} pull cold: {format_duration(cold[0]) if cold else '-'}")
+            print(f"  {tool} pull warm: {_stats(warm_pull)}")
+            print(f"  {tool} push warm: {_stats(warm_push)}")
+            for series, values, is_cold in (
+                (f"{tool} pull (cold)", cold, True),
+                (f"{tool} pull (warm)", warm_pull, False),
+                (f"{tool} push (warm)", warm_push, False),
+            ):
+                if values:
+                    rows.append({
+                        "group": name,
+                        "series": series,
+                        "elapsed_s": values[0] if is_cold else statistics.median(values),
+                    })
+
+    warnings = [s for s in samples if s.verified != "ok"]
+    if warnings:
+        print(f"\n{len(warnings)} of {len(samples)} replays had verification warnings")
+
+    chart = grouped_chart(
+        pd.DataFrame(rows), SERIES, "rustc-josh-sync replays through josh (lower is better)"
+    )
+    print(f"chart written to {save_chart(chart, OUTPUT_DIR / 'rustc_josh_sync.png')}")

--- a/benchmarks/bench/tools/josh_cli_sync.py
+++ b/benchmarks/bench/tools/josh_cli_sync.py
@@ -1,0 +1,110 @@
+"""Replay historical rustc-josh-sync pulls and pushes with the josh CLI.
+
+Same events as :mod:`bench.tools.josh_proxy_sync`, but instead of a josh-proxy
+between the developer and the upstream, the subtree checkout uses the josh CLI
+directly against the (unfiltered) upstream: ``josh fetch`` fetches the raw
+history and filters it locally, ``josh push`` reverse-filters locally and
+pushes the reconstructed rust commits.
+
+The CLI applies the configured remote filter including its semantic
+``:~(history=...,gpgsig=...)`` meta args (fixed in "Apply semantic meta args
+of remote filters in the josh CLI"; older versions dropped them and cannot
+run this pass -- their SHA-exact verification fails on the first pull), so
+with the production compat filter its output is SHA-identical to the
+proxy/josh-filter reference and both pulls and pushes replay with SHA-exact
+verification.
+
+Timing mirrors the proxy runner: the josh command(s) doing the sync work are
+timed, local bookkeeping (branch setup, the merge commit) and verification are
+not. For pulls that is ``josh fetch``; a cold fetch transfers the full rust
+history and filters it from scratch (the CLI's caches live in the work repo,
+which starts fresh). For pushes it is ``josh fetch`` of the base branch plus
+``josh push`` -- the CLI needs the raw base locally for reverse filtering,
+work the proxy performs server-side inside its timed push.
+"""
+
+import shlex
+from pathlib import Path
+
+from bench.shell import run
+from bench.timing import Timer
+
+
+def _git(repo: Path, args: str) -> str:
+    return run(f"git {args}", cwd=str(repo))
+
+
+def setup_cli_remote(
+    josh: Path, work: Path, upstream_url: str, filter_spec: str, remote: str = "upstream"
+) -> None:
+    """Configure the josh remote for the upstream mirror in the work clone."""
+    run(
+        f"{josh} remote add {remote} {shlex.quote(upstream_url)} {shlex.quote(filter_spec)}",
+        cwd=str(work),
+    )
+
+
+def replay_pull_cli(
+    josh: Path, work: Path, upstream: Path, ev: dict, branch: str
+) -> tuple[float, str]:
+    """Replay a pull with the josh CLI; return (elapsed, verification status).
+
+    The upstream state at the historical pull is presented as `branch` in the
+    mirror; the historical "Prepare for merging" commit (plain-filter dialect)
+    is reused as-is, so the replayed merge must reproduce the historical tree.
+    """
+    _git(upstream, f"update-ref refs/heads/{branch} {ev['pulled_rust_sha']}")
+    _git(work, f"checkout -q -B replay {ev['hist_prepare']}")
+    _git(work, "clean -fdq")
+
+    with Timer() as t:
+        run(f"{josh} fetch -r upstream -R {branch}", cwd=str(work))
+
+    fetched = _git(work, f"rev-parse refs/remotes/upstream/{branch}").strip()
+    if fetched != ev["hist_fetch_head"]:
+        raise RuntimeError(
+            f"cli pull {ev['hist_merge'][:12]}: josh fetch produced {fetched[:12]}, "
+            f"reference has {ev['hist_fetch_head'][:12]}"
+        )
+
+    verified = "ok"
+    msg = shlex.quote(ev["merge_msg"] or "Merge from rust-lang/rust")
+    try:
+        _git(work, f"merge -q --no-ff --no-verify -m {msg} {fetched}")
+    except RuntimeError:
+        _git(work, "merge --abort")
+        verified = "merge conflict (historical resolution not reproducible)"
+    else:
+        tree = _git(work, "rev-parse HEAD^{tree}").strip()
+        if tree != ev["hist_merge_tree"]:
+            verified = f"merge tree {tree[:12]} != historical {ev['hist_merge_tree'][:12]}"
+    return t.elapsed, verified
+
+
+def replay_push_cli(
+    josh: Path, work: Path, upstream: Path, ev: dict, branch: str
+) -> tuple[float, str]:
+    """Replay a push with the josh CLI; return (elapsed, verification status)."""
+    _git(upstream, f"update-ref refs/heads/{branch} {ev['base_rust_sha']}")
+    # josh push takes a local ref, not a raw SHA.
+    _git(work, f"branch -f cli-push {ev['subtree_head']}")
+
+    with Timer() as t:
+        run(f"{josh} fetch -r upstream -R {branch}", cwd=str(work))
+        run(f"{josh} push upstream cli-push:refs/heads/{branch}", cwd=str(work))
+
+    verified = "ok"
+    pushed_tree = _git(upstream, f"rev-parse refs/heads/{branch}^{{tree}}").strip()
+    if pushed_tree != ev["hist_pr_tree"]:
+        verified = (
+            f"pushed rust tree {pushed_tree[:12]} != historical PR head tree "
+            f"{ev['hist_pr_tree'][:12]}"
+        )
+    else:
+        # Roundtrip like rustc-josh-sync's: filtering the branch josh just
+        # created must give back exactly the head we pushed.
+        run(f"{josh} fetch -r upstream -R {branch}", cwd=str(work))
+        roundtrip = _git(work, f"rev-parse refs/remotes/upstream/{branch}").strip()
+        if roundtrip != ev["subtree_head"]:
+            verified = f"roundtrip {roundtrip[:12]} != pushed {ev['subtree_head'][:12]}"
+    return t.elapsed, verified

--- a/benchmarks/bench/tools/josh_proxy_sync.py
+++ b/benchmarks/bench/tools/josh_proxy_sync.py
@@ -1,0 +1,109 @@
+"""Replay one historical rustc-josh-sync pull or push through josh-proxy.
+
+Only the single git command that exercises josh is timed: the ``git fetch`` of
+the filtered history (pull) or the ``git push`` that josh reverse-filters onto
+rust-lang/rust (push). Local bookkeeping (checkouts, the merge commit) and the
+verification against the historical result are untimed.
+"""
+
+import shlex
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from bench.preparation.rustc_josh_sync.config import UPSTREAM_REPO
+from bench.proxy import JoshProxy
+from bench.shell import run
+from bench.timing import Timer
+
+
+@dataclass
+class SyncSample:
+    """One replayed sync: what ran it and how long the josh step took."""
+
+    tool: str  # "proxy" | "cli"
+    subtree: str
+    direction: str  # "pull" | "push"
+    cache: str  # "cold" | "warm"
+    elapsed: float
+    event: dict = field(repr=False)
+    verified: str = "ok"  # "ok" | warning text
+
+
+def _git(repo: Path, args: str) -> str:
+    return run(f"git {args}", cwd=str(repo))
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+def replay_pull(
+    proxy: JoshProxy, work: Path, filter_spec: str, ev: dict
+) -> tuple[float, str]:
+    """Replay a pull; return (elapsed seconds of the fetch, verification status).
+
+    The historical "Prepare for merging" commit is reused as-is (it lives in the
+    filtered history the work clone shares), so the replayed merge must
+    reproduce the historical merge tree exactly.
+    """
+    _git(work, f"checkout -q -B replay {ev['hist_prepare']}")
+    _git(work, "clean -fdq")
+
+    url = proxy.url(UPSTREAM_REPO, filter_spec, at=ev["pulled_rust_sha"])
+    with Timer() as t:
+        _git(work, f"fetch -q {shlex.quote(url)}")
+
+    fetched = _git(work, "rev-parse FETCH_HEAD").strip()
+    if fetched != ev["hist_fetch_head"]:
+        raise VerificationError(
+            f"pull {ev['hist_merge'][:12]}: proxy served {fetched[:12]}, history has "
+            f"{ev['hist_fetch_head'][:12]} -- josh version/filter drift?"
+        )
+
+    verified = "ok"
+    msg = shlex.quote(ev["merge_msg"] or "Merge from rust-lang/rust")
+    try:
+        _git(work, f"merge -q --no-ff --no-verify -m {msg} FETCH_HEAD")
+    except RuntimeError:
+        # The historical merge had manual conflict resolutions; the fetch (the
+        # timed josh work) already succeeded, so keep the sample.
+        _git(work, "merge --abort")
+        verified = "merge conflict (historical resolution not reproducible)"
+    else:
+        tree = _git(work, "rev-parse HEAD^{tree}").strip()
+        if tree != ev["hist_merge_tree"]:
+            verified = f"merge tree {tree[:12]} != historical {ev['hist_merge_tree'][:12]}"
+    return t.elapsed, verified
+
+
+def replay_push(
+    proxy: JoshProxy, work: Path, upstream: Path, filter_spec: str, ev: dict, branch: str
+) -> tuple[float, str]:
+    """Replay a push; return (elapsed seconds of the push, verification status).
+
+    The push branch is created on the upstream mirror at the rust base the real
+    sync used (rustc-josh-sync pushes that base to the user's fork first), then
+    the historical subtree head is pushed through the proxy, which
+    reverse-filters it onto that base.
+    """
+    _git(upstream, f"update-ref refs/heads/{branch} {ev['base_rust_sha']}")
+
+    url = proxy.url(UPSTREAM_REPO, filter_spec)
+    with Timer() as t:
+        _git(work, f"push -q {shlex.quote(url)} {ev['subtree_head']}:refs/heads/{branch}")
+
+    verified = "ok"
+    pushed_tree = _git(upstream, f"rev-parse refs/heads/{branch}^{{tree}}").strip()
+    if pushed_tree != ev["hist_pr_tree"]:
+        verified = (
+            f"pushed rust tree {pushed_tree[:12]} != historical PR head tree "
+            f"{ev['hist_pr_tree'][:12]}"
+        )
+    else:
+        # Roundtrip check like rustc-josh-sync's: the filtered view of the
+        # branch josh just created must be exactly the head we pushed.
+        out = _git(work, f"ls-remote {shlex.quote(url)} refs/heads/{branch}")
+        roundtrip = out.split()[0] if out.split() else "<missing>"
+        if roundtrip != ev["subtree_head"]:
+            verified = f"roundtrip {roundtrip[:12]} != pushed {ev['subtree_head'][:12]}"
+    return t.elapsed, verified

--- a/benchmarks/pixi.toml
+++ b/benchmarks/pixi.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 [tasks]
 select-folders = "python -m bench select-folders"
 rust-lang = "python -m bench rust-lang"
+rustc-josh-sync = "python -m bench rustc-josh-sync"
 
 [dependencies]
 python = ">=3.14.6,<3.15"


### PR DESCRIPTION
Add rustc-josh-sync benchmark replaying real rust-lang subtree syncs

Mine the historical pulls and pushes of the josh-synced subtrees
(rustc-dev-guide, stdarch, compiler-builtins, miri) from rust-lang/rust
history and replay them against a locally served mirror, once through
josh-proxy (the production setup) and once with the josh CLI. Only the
git/josh command performing the sync is timed; each subtree/tool pass
starts cold and stays warm, and every replay is verified against the
historical results.

Run with `pixi run rustc-josh-sync`; see benchmarks/README.md for the knobs.

Change: rustc-josh-sync-benchmark
Assisted-By: Claude Fable 5 (claude-fable-5), Claude Opus 5 (claude-opus-5)