### PR TITLE
Add a cli-nodc variant to the rustc-josh-sync benchmark

### DIFF
--- a/benchmarks/bench/preparation/rustc_josh_sync/config.py
+++ b/benchmarks/bench/preparation/rustc_josh_sync/config.py
@@ -29,12 +29,13 @@ RUST_REVISION = "234c31cd674e11703f15d290cba7ff81dfe8b4b8"
 # keeping it one commit makes SHA-exact verification possible. Pinned to
 # master as of 2026-07-19, which includes the fix for the CLI dropping
 # semantic meta args ("Apply semantic meta args of remote filters in the josh
-# CLI") -- older commits fail the CLI pass's SHA-exact verification.
+# CLI") -- older commits fail the CLI pass's SHA-exact verification -- and the
+# global --no-distributed-cache flag the cli-nodc pass needs.
 # Override with SYNC_JOSH_COMMIT (a full commit SHA) to benchmark another josh
 # version; filtered-history and manifest caches are keyed by it, so runs with
 # different versions do not mix.
 JOSH_COMMIT = os.environ.get(
-    "SYNC_JOSH_COMMIT", "d7649b7e1ad59537b7b2ed131e5bfb974fe0c5b4"
+    "SYNC_JOSH_COMMIT", "eb9f86385cb5f49c39b0a16584c6fb65c1be8ab6"
 )
 
 # Served under this path so proxy URLs match production shape

--- a/benchmarks/bench/scenarios/rustc_josh_sync.py
+++ b/benchmarks/bench/scenarios/rustc_josh_sync.py
@@ -12,6 +12,9 @@ mirror, once per tool:
 - ``cli``: the josh CLI in the subtree checkout talking directly to the
   unfiltered upstream -- ``josh fetch`` transfers the raw history and filters
   locally, ``josh push`` reverse-filters locally.
+- ``cli-nodc``: same as ``cli`` but with ``--no-distributed-cache``, which
+  drops the DistributedCacheBackend from the cache stack and skips fetching
+  the remote josh cache before filtering.
 
 Per subtree and tool the replay starts cold (fresh proxy cache / fresh work
 repo, so the first event -- always a pull -- pays the full-history cost) and
@@ -21,10 +24,12 @@ josh.rust-lang.org for the proxy and of a long-lived checkout for the CLI.
 Environment knobs:
 - ``SYNC_REPLAY_DEPTH``: historical syncs per subtree per direction (default 10)
 - ``SYNC_SUBTREES``: comma-separated subset of subtrees for quick runs
-- ``SYNC_TOOLS``: comma-separated subset of {proxy, cli} (default both)
+- ``SYNC_TOOLS``: comma-separated subset of {proxy, cli, cli-nodc}
+  (default all)
 - ``SYNC_JOSH_COMMIT``: josh version to benchmark (see config.py)
 """
 
+import functools
 import json
 import os
 import statistics
@@ -55,13 +60,13 @@ from bench.proxy import GitHttpServer, JoshProxy
 from bench.tools.josh_cli_sync import replay_pull_cli, replay_push_cli, setup_cli_remote
 from bench.tools.josh_proxy_sync import SyncSample, replay_pull, replay_push
 
-TOOLS = ("proxy", "cli")
+TOOLS = ("proxy", "cli", "cli-nodc")
 
-# Chart series, ordered so adjacent bars compare the two tools.
+# Chart series, ordered so adjacent bars compare the tools.
 SERIES = [
-    "proxy pull (cold)", "cli pull (cold)",
-    "proxy pull (warm)", "cli pull (warm)",
-    "proxy push (warm)", "cli push (warm)",
+    "proxy pull (cold)", "cli pull (cold)", "cli-nodc pull (cold)",
+    "proxy pull (warm)", "cli pull (warm)", "cli-nodc pull (warm)",
+    "proxy push (warm)", "cli push (warm)", "cli-nodc push (warm)",
 ]
 
 
@@ -93,22 +98,29 @@ def _replay_proxy(binaries, serve_root, upstream, work, manifest, name, work_dir
     return samples
 
 
-def _replay_cli(binaries, serve_root, upstream, work, manifest, name, work_dir):
+def _replay_cli(
+    binaries, serve_root, upstream, work, manifest, name, work_dir,
+    tool="cli", josh_args="",
+):
     samples = []
-    josh = binaries["josh"]
-    with GitHttpServer(binaries, serve_root, work_dir / "logs" / f"{name}-cli") as gitd:
+    # The runner interpolates `josh` into shell commands, so global flags can
+    # ride along with the binary path.
+    josh = f"{binaries['josh']} {josh_args}".strip()
+    with GitHttpServer(
+        binaries, serve_root, work_dir / "logs" / f"{name}-{tool}"
+    ) as gitd:
         setup_cli_remote(josh, work, gitd.url(UPSTREAM_REPO), manifest["filter"])
         for i, ev in enumerate(manifest["events"]):
             if ev["kind"] == "pull":
                 # One advancing pull branch per subtree, like a real upstream.
                 elapsed, verified = replay_pull_cli(
-                    josh, work, upstream, ev, branch=f"sync-cli-{name}"
+                    josh, work, upstream, ev, branch=f"sync-{tool}-{name}"
                 )
             else:
                 elapsed, verified = replay_push_cli(
-                    josh, work, upstream, ev, branch=f"bench-cli-{name}-{i}"
+                    josh, work, upstream, ev, branch=f"bench-{tool}-{name}-{i}"
                 )
-            samples.append(("cli", i, ev, elapsed, verified))
+            samples.append((tool, i, ev, elapsed, verified))
     return samples
 
 
@@ -134,7 +146,13 @@ def run() -> list[SyncSample]:
 
     work_dir = TARGET_DIR / "work" / "rustc_josh_sync"
     serve_root, upstream = prepare_upstream(source, work_dir)
-    replayers = {"proxy": _replay_proxy, "cli": _replay_cli}
+    replayers = {
+        "proxy": _replay_proxy,
+        "cli": _replay_cli,
+        "cli-nodc": functools.partial(
+            _replay_cli, tool="cli-nodc", josh_args="--no-distributed-cache"
+        ),
+    }
 
     samples: list[SyncSample] = []
     for name in names:

--- a/benchmarks/bench/tools/josh_cli_sync.py
+++ b/benchmarks/bench/tools/josh_cli_sync.py
@@ -35,7 +35,8 @@ def _git(repo: Path, args: str) -> str:
 
 
 def setup_cli_remote(
-    josh: Path, work: Path, upstream_url: str, filter_spec: str, remote: str = "upstream"
+    josh: str | Path, work: Path, upstream_url: str, filter_spec: str,
+    remote: str = "upstream",
 ) -> None:
     """Configure the josh remote for the upstream mirror in the work clone."""
     run(
@@ -45,7 +46,7 @@ def setup_cli_remote(
 
 
 def replay_pull_cli(
-    josh: Path, work: Path, upstream: Path, ev: dict, branch: str
+    josh: str | Path, work: Path, upstream: Path, ev: dict, branch: str
 ) -> tuple[float, str]:
     """Replay a pull with the josh CLI; return (elapsed, verification status).
 
@@ -82,7 +83,7 @@ def replay_pull_cli(
 
 
 def replay_push_cli(
-    josh: Path, work: Path, upstream: Path, ev: dict, branch: str
+    josh: str | Path, work: Path, upstream: Path, ev: dict, branch: str
 ) -> tuple[float, str]:
     """Replay a push with the josh CLI; return (elapsed, verification status)."""
     _git(upstream, f"update-ref refs/heads/{branch} {ev['base_rust_sha']}")


### PR DESCRIPTION
Add a cli-nodc variant to the rustc-josh-sync benchmark

Replay the CLI pass a second time with the global --no-distributed-cache
flag, so the cost of the DistributedCacheBackend (cache-ref population
and the remote cache fetch before filtering) is measured separately.
Bump the pinned JOSH_COMMIT to the commit introducing the flag.

Change: rustc-josh-sync-cli-nodc
Assisted-By: Claude Fable 5 (claude-fable-5)