### PR TITLE
Pass object data around as slice-arcs instead of vecs

### DIFF
--- a/josh-memodb/src/mem_odb.rs
+++ b/josh-memodb/src/mem_odb.rs
@@ -20,7 +20,7 @@ use libgit2_sys as raw;
 
 use crate::odb_backend::{self, OdbBackend};
 
-type ObjectMap = BTreeMap<Oid, (raw::git_object_t, Box<[u8]>)>;
+type ObjectMap = BTreeMap<Oid, (raw::git_object_t, Arc<[u8]>)>;
 
 /// The buffered objects plus a running total of their data size, guarded by one lock so that an
 /// insert and the overflow check following it are observed atomically.
@@ -75,11 +75,19 @@ impl MemOdb {
 
     /// Buffer `oid` (a no-op for a content-addressed duplicate) and return whether the store has now
     /// exceeded its size limit, so the caller can flush.
-    fn insert(&self, oid: Oid, kind: raw::git_object_t, data: Box<[u8]>) -> bool {
+    fn insert(&self, oid: Oid, kind: raw::git_object_t, data: &[u8]) -> bool {
+        use std::collections::btree_map::Entry;
+
         let len = data.len();
         let mut inner = self.inner.lock().unwrap();
-        if inner.map.insert(oid, (kind, data)).is_none() {
-            inner.size += len;
+        match inner.map.entry(oid) {
+            // Vacant: copy the borrowed bytes into the store. Occupied is a content-addressed
+            // duplicate (a no-op), so the allocation is gated behind the existence check.
+            Entry::Vacant(entry) => {
+                entry.insert((kind, Arc::from(data)));
+                inner.size += len;
+            }
+            Entry::Occupied(_) => {}
         }
         self.limit.is_some_and(|limit| inner.size > limit)
     }
@@ -186,19 +194,19 @@ impl OdbBackend for MemBackend {
             .ok_or_else(not_found)
     }
 
-    fn read(&self, oid: Oid) -> Result<(Vec<u8>, ObjectType), git2::Error> {
+    fn read(&self, oid: Oid) -> Result<(Arc<[u8]>, ObjectType), git2::Error> {
         self.store
             .inner
             .lock()
             .unwrap()
             .map
             .get(&oid)
-            .map(|(kind, data)| (data.to_vec(), raw_to_kind(*kind)))
+            .map(|(kind, data)| (data.clone(), raw_to_kind(*kind)))
             .ok_or_else(not_found)
     }
 
-    fn write(&mut self, oid: Oid, data: Vec<u8>, kind: ObjectType) -> Result<(), git2::Error> {
-        let overflow = self.store.insert(oid, kind.raw(), data.into_boxed_slice());
+    fn write(&mut self, oid: Oid, data: &[u8], kind: ObjectType) -> Result<(), git2::Error> {
+        let overflow = self.store.insert(oid, kind.raw(), data);
         if overflow {
             self.store.enqueue_chunk();
         }

--- a/josh-memodb/src/odb_backend.rs
+++ b/josh-memodb/src/odb_backend.rs
@@ -21,6 +21,7 @@
 
 use std::ffi::{c_int, c_void};
 use std::ptr;
+use std::sync::Arc;
 
 use crate::odb_cache::{CacheObjectData, ObjectCache};
 use git2::{ErrorCode, ObjectType, Oid};
@@ -34,9 +35,9 @@ use libgit2_sys as raw;
 /// forwards to the on-disk delegate. Any other error code propagates and aborts the lookup.
 pub trait OdbBackend {
     fn read_header(&self, oid: Oid) -> Result<(usize, ObjectType), git2::Error>;
-    fn read(&self, oid: Oid) -> Result<(Vec<u8>, ObjectType), git2::Error>;
+    fn read(&self, oid: Oid) -> Result<(Arc<[u8]>, ObjectType), git2::Error>;
     /// A duplicate (content-addressed) `oid` may be treated as a no-op.
-    fn write(&mut self, oid: Oid, data: Vec<u8>, kind: ObjectType) -> Result<(), git2::Error>;
+    fn write(&mut self, oid: Oid, data: &[u8], kind: ObjectType) -> Result<(), git2::Error>;
     fn exists(&self, oid: Oid) -> bool;
     /// Resolve an abbreviated object id to its full [`Oid`], if this backend holds a unique match.
     fn exists_prefix(&self, oid: Oid, oid_len: usize) -> Option<Oid>;
@@ -97,18 +98,18 @@ impl RawOdbBackend {
                     if buf.is_null() {
                         return raw::GIT_ERROR;
                     }
-                    ptr::copy_nonoverlapping(data.as_ptr(), buf as *mut u8, len);
+                    ptr::copy_nonoverlapping(data.as_ref().as_ptr(), buf as *mut u8, len);
                     *data_p = buf;
                     *len_p = len;
                     *kind_p = kind_raw;
                 }
 
-                // `into_boxed_slice` is zero-copy here — `data` came from a clone,
-                // so its capacity equals its length.
-                debug_assert_eq!(data.capacity(), data.len());
+                // `data` is an `Arc<[u8]>` shared with the in-memory store, so moving it into the
+                // cache is a refcount bump — mem_odb and the cache back the same allocation.
                 wrapper
                     .cache
                     .store(unsafe { *oid }, kind_raw, CacheObjectData::Allocated(data));
+
                 raw::GIT_OK
             }
             Err(err) if is_not_found(&err) && !wrapper.delegate.is_null() => {
@@ -185,7 +186,7 @@ impl RawOdbBackend {
             Some(kind) => kind,
             None => return raw::GIT_ERROR,
         };
-        let data = unsafe { std::slice::from_raw_parts(data as *const u8, len) }.to_vec();
+        let data = unsafe { std::slice::from_raw_parts(data as *const u8, len) };
         match wrapper.obj.write(oid, data, kind) {
             Ok(()) => raw::GIT_OK,
             Err(err) => err.raw_code(),
@@ -418,7 +419,7 @@ mod tests {
 
     /// A minimal in-memory backend used to exercise the trampolines end-to-end through libgit2.
     struct MapBackend {
-        data: std::collections::HashMap<Oid, (Vec<u8>, ObjectType)>,
+        data: std::collections::HashMap<Oid, (Arc<[u8]>, ObjectType)>,
     }
 
     impl OdbBackend for MapBackend {
@@ -426,12 +427,17 @@ mod tests {
             self.read(oid).map(|(data, kind)| (data.len(), kind))
         }
 
-        fn read(&self, oid: Oid) -> Result<(Vec<u8>, ObjectType), git2::Error> {
-            self.data.get(&oid).cloned().ok_or_else(not_found)
+        fn read(&self, oid: Oid) -> Result<(Arc<[u8]>, ObjectType), git2::Error> {
+            self.data
+                .get(&oid)
+                .map(|(data, kind)| (data.clone(), *kind))
+                .ok_or_else(not_found)
         }
 
-        fn write(&mut self, oid: Oid, data: Vec<u8>, kind: ObjectType) -> Result<(), git2::Error> {
-            self.data.insert(oid, (data, kind));
+        fn write(&mut self, oid: Oid, data: &[u8], kind: ObjectType) -> Result<(), git2::Error> {
+            self.data
+                .entry(oid)
+                .or_insert_with(|| (Arc::from(data), kind));
             Ok(())
         }
 

--- a/josh-memodb/src/odb_cache.rs
+++ b/josh-memodb/src/odb_cache.rs
@@ -1,6 +1,7 @@
 use crate::PassthroughHasher;
 use libgit2_sys as raw;
 use std::hash::{BuildHasherDefault, Hasher};
+use std::sync::Arc;
 
 // In context of josh, most often per transaction
 const OBJECT_CACHE_SIZE: usize = 300 * 1024 * 1024;
@@ -34,7 +35,7 @@ impl std::hash::Hash for ObjectCacheKey {
 pub struct ObjectCache {
     data: lru::LruCache<
         ObjectCacheKey,
-        (raw::git_object_t, Box<[u8]>),
+        (raw::git_object_t, Arc<[u8]>),
         BuildHasherDefault<PassthroughHasher>,
     >,
     size: usize,
@@ -54,7 +55,7 @@ impl Default for ObjectCache {
 }
 
 pub enum CacheObjectData<'a> {
-    Allocated(Vec<u8>),
+    Allocated(Arc<[u8]>),
     Ref(&'a [u8]),
 }
 
@@ -84,8 +85,8 @@ impl ObjectCache {
             self.size += len + KEY_SIZE;
 
             let data = match data {
-                CacheObjectData::Allocated(data) => data.into_boxed_slice(),
-                CacheObjectData::Ref(data) => data.into(),
+                CacheObjectData::Allocated(data) => data,
+                CacheObjectData::Ref(data) => Arc::from(data),
             };
 
             (kind, data)


### PR DESCRIPTION
Pass object data around as slice-arcs instead of vecs

Git object data is immutable; it will not be modified or resized.
Therefore, it would not only work with a boxed slice, but can also work
with Arcs -- different places that use object data can just store arcs.

Change-Id: I05916d8278764d488804783d06747188a601574c