### PR TITLE
Read parent ids without loading parent commits in apply_to_commit2

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -722,8 +722,8 @@ pub fn apply_to_commit2(
             check_experimental_features_enabled("export filter")?;
             let filtered_parent_ids = {
                 commit
-                    .parents()
-                    .map(|x| transaction.get(filter, x.id()))
+                    .parent_ids()
+                    .map(|x| transaction.get(filter, x))
                     .collect::<anyhow::Result<Option<_>>>()?
             };
 
@@ -778,8 +778,8 @@ pub fn apply_to_commit2(
 
             let filtered_parent_ids = {
                 commit
-                    .parents()
-                    .map(|x| transaction.get(filter, x.id()))
+                    .parent_ids()
+                    .map(|x| transaction.get(filter, x))
                     .collect::<anyhow::Result<Option<_>>>()?
             };
 
@@ -983,8 +983,8 @@ pub fn apply_to_commit2(
         }
         Op::Fold => {
             let filtered_parent_ids = commit
-                .parents()
-                .map(|x| transaction.get(filter, x.id()))
+                .parent_ids()
+                .map(|x| transaction.get(filter, x))
                 .collect::<anyhow::Result<Option<Vec<_>>>>()?;
 
             let filtered_parent_ids = some_or!(filtered_parent_ids, { return Ok(None) });
@@ -1080,8 +1080,8 @@ pub fn apply_to_commit2(
 
     let filtered_parent_ids = {
         commit
-            .parents()
-            .map(|x| transaction.get(filter, x.id()))
+            .parent_ids()
+            .map(|x| transaction.get(filter, x))
             .collect::<anyhow::Result<Option<_>>>()?
     };
 

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -266,10 +266,10 @@ Flushed credential cache
       |   `-- pack
       |       |-- pack-6094f48eea5b3933a6584a6925dac03cf644f01e.idx
       |       |-- pack-6094f48eea5b3933a6584a6925dac03cf644f01e.pack
+      |       |-- pack-7118fd5d4e16516ded4435a0e2ebddbde19ded1b.idx
+      |       |-- pack-7118fd5d4e16516ded4435a0e2ebddbde19ded1b.pack
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
-      |       |-- pack-90b662d3c4386bdd60eaa36cc1699fa799a7dd30.idx
-      |       |-- pack-90b662d3c4386bdd60eaa36cc1699fa799a7dd30.pack
       |       |-- pack-9f918747f4ae3e54ccf603a1e77dd40c584aa821.idx
       |       `-- pack-9f918747f4ae3e54ccf603a1e77dd40c584aa821.pack
       `-- refs

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -348,8 +348,6 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-4ee5410a0d07448774a9d777901482c58c903f84.idx
-      |       |-- pack-4ee5410a0d07448774a9d777901482c58c903f84.pack
       |       |-- pack-61cee1ce849190d88cdfb51f8fd8aea0bcfd8e63.idx
       |       |-- pack-61cee1ce849190d88cdfb51f8fd8aea0bcfd8e63.pack
       |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.idx
@@ -361,6 +359,6 @@
           |-- namespaces
           `-- tags
   
-  67 directories, 64 files
+  67 directories, 62 files
 
 $ cat ${TESTTMP}/josh-proxy.out


### PR DESCRIPTION
Read parent ids without loading parent commits in apply_to_commit2

commit.parents() loads each parent commit through libgit2's object cache; the filtered-parent
sites that only need the parent oid (Op::Export, Op::Unlink, Op::Fold, and the general
fallthrough) now use commit.parent_ids(), which reads the oids straight out of the already-parsed
commit.

The saving is invisible with libgit2's object cache on -- the redundant parse is a cache hit
(-0.3%, within noise). But that cache masks the real cost: with it disabled, filtering a deep
history is 1.85-2.4x slower overall, and this change is -9.4% to -11.4% on
deephistory_subdir_sparse (p<0.05, all sizes). The cache is a process-global behind a lock that
is contended under concurrent josh-proxy load, so this removes real work from the hot path.

The dropped loads are visible in the proxy tests that assert exact pack listings of the
overlay object store: the staging-odb flush now packs fewer redundant objects, removing one
pack in workspace_tags.t and changing a pack hash in workspace_invalid_trailing_slash.t.
Update the expected listings to the new output, which is stable across repeated runs.

Change: apply-parent-ids-no-load
Assisted-By: Claude Opus 4.8 (claude-opus-4-8)
Assisted-By: Claude Fable 5 (claude-fable-5)