### PR TITLE
Read parent ids via the raw-ODB helper for the remaining parent-only loads

### DIFF
--- a/josh-core/src/cache/history_graph.rs
+++ b/josh-core/src/cache/history_graph.rs
@@ -134,7 +134,7 @@ fn ensure_hint_cached(
         return Err(anyhow!("ensure_hint_cached: input does not exist"));
     }
 
-    let parent_ids = read_parent_ids(transaction.repo(), input)?;
+    let parent_ids = crate::git::read_parent_ids(transaction.repo(), input)?;
 
     // Fast path: every parent already has both pieces cached.
     let parents_hint: Option<Vec<(u64, git2::Oid)>> = parent_ids
@@ -171,14 +171,15 @@ fn ensure_hint_cached(
 
     for c in walk {
         let oid = c?;
-        let parents_hint: Vec<(u64, git2::Oid)> = read_parent_ids(transaction.repo(), oid)?
-            .into_iter()
-            .map(|p| {
-                try_read_cached_hint(transaction, p)?
-                    .map(|(seq, _, blob)| (seq, blob))
-                    .ok_or_else(|| anyhow!("parent {} hint missing during walk for {}", p, oid))
-            })
-            .collect::<anyhow::Result<Vec<_>>>()?;
+        let parents_hint: Vec<(u64, git2::Oid)> =
+            crate::git::read_parent_ids(transaction.repo(), oid)?
+                .into_iter()
+                .map(|p| {
+                    try_read_cached_hint(transaction, p)?
+                        .map(|(seq, _, blob)| (seq, blob))
+                        .ok_or_else(|| anyhow!("parent {} hint missing during walk for {}", p, oid))
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
         let hint = derive_from_parents(transaction.repo(), oid, &parents_hint)?;
         store_hint(transaction, oid, hint)?;
     }
@@ -256,19 +257,6 @@ fn store_hint(
     )?;
     transaction.insert(crate::filter::reachable_roots(), input, roots_blob, true)?;
     Ok(())
-}
-
-/// Reads a commit's parent OIDs directly from the raw ODB bytes, parsing only
-/// the parent lines via `gix_object::CommitRefIter`. This avoids the libgit2
-/// commit parse cache entirely, since the walk only ever needs the parent ids.
-fn read_parent_ids(repo: &git2::Repository, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
-    let odb = repo.odb()?;
-    let odb_commit = odb.read(oid)?;
-    debug_assert_eq!(odb_commit.kind(), git2::ObjectType::Commit);
-    gix_object::CommitRefIter::from_bytes(odb_commit.data())
-        .parent_ids()
-        .map(|p| Ok(git2::Oid::from_bytes(p.as_bytes())?))
-        .collect()
 }
 
 fn write_roots_blob(repo: &git2::Repository, roots: &[git2::Oid]) -> anyhow::Result<git2::Oid> {

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1947,7 +1947,7 @@ pub fn is_ancestor_of(
             let mut todo = vec![tip];
             let mut ancestors = std::collections::HashSet::from_iter(todo.iter().copied());
             while let Some(commit) = todo.pop() {
-                for parent in transaction.repo().find_commit(commit)?.parent_ids() {
+                for parent in crate::git::read_parent_ids(transaction.repo(), commit)? {
                     if ancestors.insert(parent) {
                         // Newly inserted! Also handle its parents.
                         todo.push(parent);

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -205,3 +205,16 @@ pub fn spawn_git_command(
         }
     }
 }
+
+/// Read a commit's parent OIDs directly from the raw ODB bytes, parsing only the parent lines via
+/// `gix_object::CommitRefIter`. This avoids libgit2's commit parse cache (a lock-guarded global
+/// that also decodes author/committer/message) whenever a caller only needs the parent ids.
+pub fn read_parent_ids(repo: &git2::Repository, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
+    let odb = repo.odb()?;
+    let odb_commit = odb.read(oid)?;
+    debug_assert_eq!(odb_commit.kind(), git2::ObjectType::Commit);
+    gix_object::CommitRefIter::from_bytes(odb_commit.data())
+        .parent_ids()
+        .map(|p| Ok(git2::Oid::from_bytes(p.as_bytes())?))
+        .collect()
+}

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -192,14 +192,10 @@ impl Revision {
     fn parents(&self, context: &Context) -> FieldResult<Vec<Revision>> {
         let transaction = context.transaction.lock().unwrap();
         let commit = transaction.repo().find_commit(self.commit_id)?;
-        let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
-            self.filter,
-            &commit,
-            &transaction,
-        )?)?;
+        let filter_commit_id = filter::apply_to_commit(self.filter, &commit, &transaction)?;
 
-        let parents = filter_commit
-            .parent_ids()
+        let parents = josh_core::git::read_parent_ids(transaction.repo(), filter_commit_id)?
+            .into_iter()
             .map(|id| Revision {
                 filter: self.filter,
                 commit_id: history::find_original(
@@ -252,10 +248,8 @@ impl Revision {
 
                 if orig != git2::Oid::zero() {
                     ids[i] = orig;
-                    contained_in = transaction
-                        .repo()
-                        .find_commit(ids[i])?
-                        .parent_ids()
+                    contained_in = josh_core::git::read_parent_ids(transaction.repo(), ids[i])?
+                        .into_iter()
                         .next()
                         .unwrap_or(ids[i]);
                 } else {


### PR DESCRIPTION
Read parent ids via the raw-ODB helper for the remaining parent-only loads

read_parent_ids -- a commit read that parses only the parent lines and skips libgit2's
lock-guarded commit parse cache -- was private to the history-graph walk. Promote it to
josh_core::git and route the other sites that loaded a whole commit only to read its parent ids
through it:

- filter::is_ancestor_of walked the ancestors of a tip with a find_commit per commit purely for
  parent_ids(), fully parsing (and populating the parse cache with) every ancestor.
- graphql Revision::parents and ::history read parent ids of the filtered commit and while
  walking history.

No behavior change: read_parent_ids returns the same parent ids find_commit would, and every
converted site passes a known commit oid. The deephistory / history-graph benches are unaffected
(the helper body only moved); the converted paths are not covered by a criterion bench
(is_ancestor_of needs a :rev filter), but the reduction mirrors the already-measured
history-graph change. Full josh compose run suite passes.

Change: gix-parent-ids-everywhere
Assisted-By: Claude Opus 4.8 (claude-opus-4-8)