### PR TITLE
Add a rev(...) builder to Filter

### DIFF
--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -1,5 +1,5 @@
 use crate::check_experimental_features_enabled;
-use crate::op::{InsertContent, LazyRef, Op, Regex};
+use crate::op::{InsertContent, LazyRef, Op, Regex, RevMatch};
 use crate::opt;
 use crate::persist::{self, Node, to_filter, to_op};
 use std::sync::LazyLock;
@@ -84,6 +84,18 @@ impl Filter {
     /// would otherwise change across revisions
     pub fn pin(self, other: Filter) -> Filter {
         self.chain(to_filter(Op::Pin(other)))
+    }
+
+    /// Chain a `:rev(...)` filter. Each `(match, tip, then)` arm applies `then` to a commit whose
+    /// relationship to `tip` satisfies `match` (e.g. `AncestorInclusive` is `<=tip`); the first
+    /// matching arm wins and a commit matching none passes through unchanged. Tips are resolved
+    /// oids (`RevMatch::Default` ignores its tip); construct `Op::Rev` directly for lazy refs.
+    pub fn rev(self, arms: Vec<(RevMatch, git2::Oid, Filter)>) -> Filter {
+        self.chain(to_filter(Op::Rev(
+            arms.into_iter()
+                .map(|(m, tip, then)| (m, LazyRef::Resolved(tip), then))
+                .collect(),
+        )))
     }
 
     /// Create a no-op filter that passes everything through unchanged


### PR DESCRIPTION
Add a rev(...) builder to Filter

Constructing a :rev(...) filter programmatically meant hand-building
Op::Rev(vec![(RevMatch::_, LazyRef::Resolved(oid), _)]) through to_filter -- exposing the LazyRef
and Op internals that every other filter kind hides behind a builder. Add Filter::rev(arms), each
arm a (RevMatch, tip oid, subfilter), in the style of pin/select/subdir; it wraps the tips in
LazyRef::Resolved and chains the Op::Rev.

Change: filter-rev-builder
Assisted-By: Claude Opus 4.8 (claude-opus-4-8)