### PR TITLE
Walk glob patterns component-wise with subtree pruning

### DIFF
--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -21,7 +21,10 @@ static REF_CACHE: LazyLock<RwLock<HashMap<git2::Oid, HashMap<git2::Oid, git2::Oi
 static POPULATE_MAP: LazyLock<RwLock<HashMap<(git2::Oid, git2::Oid), git2::Oid>>> =
     LazyLock::new(Default::default);
 
-static GLOB_MAP: LazyLock<RwLock<HashMap<(git2::Oid, git2::Oid), git2::Oid>>> =
+// Keyed by (input tree, pattern key, NFA state mask). The state mask makes entries independent
+// of the path a subtree was reached through; the legacy full-path fallback folds its root path
+// into a synthetic pattern key and uses mask 0.
+static GLOB_MAP: LazyLock<RwLock<HashMap<(git2::Oid, git2::Oid, u64), git2::Oid>>> =
     LazyLock::new(Default::default);
 
 /// Clear the process-global in-memory caches shared across all transactions.
@@ -433,11 +436,11 @@ impl Transaction {
         POPULATE_MAP.read().unwrap().get(&tree).cloned()
     }
 
-    pub fn insert_glob(&self, tree: (git2::Oid, git2::Oid), result: git2::Oid) {
+    pub fn insert_glob(&self, tree: (git2::Oid, git2::Oid, u64), result: git2::Oid) {
         GLOB_MAP.write().unwrap().entry(tree).or_insert(result);
     }
 
-    pub fn get_glob(&self, tree: (git2::Oid, git2::Oid)) -> Option<git2::Oid> {
+    pub fn get_glob(&self, tree: (git2::Oid, git2::Oid, u64)) -> Option<git2::Oid> {
         GLOB_MAP.read().unwrap().get(&tree).cloned()
     }
 

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1362,20 +1362,29 @@ pub fn apply<'a>(
             Ok(x.with_tree(t))
         }
 
-        Op::Pattern(glob) => {
-            let options = glob::MatchOptions {
-                case_sensitive: true,
-                require_literal_separator: true,
-                require_literal_leading_dot: true,
-            };
+        Op::Pattern(cp) => {
             let input = x.tree().id();
-            let t = tree::remove_pred(
-                transaction,
-                &mut String::new(),
-                input,
-                &|path, isblob| isblob && glob.matches_with(path, options),
-                peel_filter(filter).id(),
-            )?;
+            let key = peel_filter(filter).id();
+            let t = if cp.fallback {
+                // More components than the NFA state mask can hold: match full paths.
+                tree::remove_pred(
+                    transaction,
+                    &mut String::new(),
+                    input,
+                    &|path, isblob| {
+                        isblob && cp.full.matches_with(path, tree::PATTERN_MATCH_OPTIONS)
+                    },
+                    key,
+                )?
+            } else {
+                tree::remove_pattern(
+                    transaction,
+                    input,
+                    cp,
+                    key,
+                    tree::CompiledPattern::initial_state(),
+                )?
+            };
             Ok(if t == input {
                 x
             } else {

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -106,6 +106,10 @@ fn git_tree_entry_cmp(a: &[u8], a_is_tree: bool, b: &[u8], b_is_tree: bool) -> s
 /// Rebuild `input` keeping only blob entries accepted by `pred`. `path` is a reusable buffer
 /// holding the slash-separated path of the tree currently being visited; it is restored to its
 /// incoming length before returning. Gitlink (submodule) entries are always dropped.
+///
+/// The predicate sees full paths, so the result of a subtree depends on where it sits, not only
+/// on its oid. The cache key therefore folds the current root path into a synthetic oid (the
+/// insert_invert idiom): identical subtrees at different paths get distinct entries.
 pub fn remove_pred(
     transaction: &cache::Transaction,
     path: &mut String,
@@ -113,7 +117,11 @@ pub fn remove_pred(
     pred: &dyn Fn(&str, bool) -> bool,
     key: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    if let Some(cached) = transaction.get_glob((input, key)) {
+    let root_key = git2::Oid::hash_object(
+        git2::ObjectType::Blob,
+        format!("glob-fallback:{:?}:{}", key, path).as_bytes(),
+    )?;
+    if let Some(cached) = transaction.get_glob((input, root_key, 0)) {
         return Ok(cached);
     }
 
@@ -197,7 +205,157 @@ pub fn remove_pred(
         debug_assert_eq!(builder.write()?, input);
         input
     };
-    transaction.insert_glob((input, key), result);
+    transaction.insert_glob((input, root_key, 0), result);
+    Ok(result)
+}
+
+pub use josh_filter::pattern::{CompiledPattern, PATTERN_MATCH_OPTIONS, PatternComponent};
+
+/// Component-wise NFA walk for `Op::Pattern`: rebuild `input` keeping exactly the blobs whose
+/// full path matches the pattern, without ever materializing full paths. `state` is a bitmask of
+/// active component positions (bit `p` set = components `0..p` already consumed by ancestor
+/// directories). Subtrees whose next state is empty cannot contain any match and are pruned
+/// without recursion.
+///
+/// Results are cached by `(input, key, closed state)` -- `key` identifies the pattern (the
+/// peeled Pattern filter's id): the closed state fully determines match behavior below a
+/// subtree independent of the path taken to reach it, so identical subtrees reached in the same
+/// state share one entry, while identical subtrees in different states (e.g. inside vs outside
+/// a literal prefix) stay separate.
+pub fn remove_pattern(
+    transaction: &cache::Transaction,
+    input: git2::Oid,
+    cp: &CompiledPattern,
+    key: git2::Oid,
+    state: u64,
+) -> anyhow::Result<git2::Oid> {
+    let state = cp.closure(state);
+    if let Some(cached) = transaction.get_glob((input, key, state)) {
+        return Ok(cached);
+    }
+
+    let k = cp.components.len();
+    // Whether any active position can accept a blob at this level: a non-`**` final component, or
+    // a `**` with only `**`s after it (which matches any non-dot suffix of components).
+    let mut accepts_blobs = false;
+    {
+        let mut bits = state;
+        while bits != 0 {
+            let p = bits.trailing_zeros() as usize;
+            bits &= bits - 1;
+            accepts_blobs |= match cp.components[p] {
+                PatternComponent::Glob(_) => p == k - 1,
+                PatternComponent::Star2 => cp.suffix_all_star[p],
+            };
+        }
+    }
+
+    let repo = transaction.repo();
+    let tree = repo.find_tree(input)?;
+    let mut builder = repo.treebuilder(None)?;
+    let empty = empty_id();
+    let mut changed = false;
+    // See remove_pred: non-canonical input trees must not take the unchanged fast path.
+    let mut prev: Option<(git2::TreeEntry, bool)> = None;
+
+    for entry in tree.iter() {
+        let name = entry.name().ok_or_else(|| anyhow!("INVALID_FILENAME"))?;
+
+        let is_tree = entry.kind() == Some(git2::ObjectType::Tree);
+        if let Some((prev_entry, prev_is_tree)) = &prev {
+            let prev_name = prev_entry.name_bytes();
+            if prev_name == name.as_bytes()
+                || git_tree_entry_cmp(prev_name, *prev_is_tree, name.as_bytes(), is_tree)
+                    != std::cmp::Ordering::Less
+            {
+                changed = true;
+            }
+        }
+
+        match entry.kind() {
+            Some(git2::ObjectType::Blob) => {
+                let mut keep = false;
+                if accepts_blobs {
+                    let mut bits = state;
+                    while bits != 0 && !keep {
+                        let p = bits.trailing_zeros() as usize;
+                        bits &= bits - 1;
+                        keep = match &cp.components[p] {
+                            PatternComponent::Glob(g) => {
+                                p == k - 1 && g.matches_with(name, PATTERN_MATCH_OPTIONS)
+                            }
+                            PatternComponent::Star2 => {
+                                cp.suffix_all_star[p] && !name.starts_with('.')
+                            }
+                        };
+                    }
+                }
+                if keep {
+                    // See remove_pred for why legacy filemodes and rejected names count as
+                    // changed.
+                    if entry.filemode_raw() != entry.filemode() {
+                        changed = true;
+                    }
+                    if builder.insert(name, entry.id(), entry.filemode()).is_err() {
+                        changed = true;
+                    }
+                } else {
+                    changed = true;
+                }
+            }
+            Some(git2::ObjectType::Tree) => {
+                // Successor state: a matching non-final glob component advances to `p + 1`; a
+                // `**` also stays at `p` for any non-dot name (its zero-width advance is part of
+                // the closure).
+                let mut next = 0u64;
+                let mut bits = state;
+                while bits != 0 {
+                    let p = bits.trailing_zeros() as usize;
+                    bits &= bits - 1;
+                    match &cp.components[p] {
+                        PatternComponent::Glob(g) => {
+                            if p + 1 < k && g.matches_with(name, PATTERN_MATCH_OPTIONS) {
+                                next |= 1 << (p + 1);
+                            }
+                        }
+                        PatternComponent::Star2 => {
+                            if !name.starts_with('.') {
+                                next |= 1 << p;
+                            }
+                        }
+                    }
+                }
+                // An empty successor state can match nothing below this subtree: prune it
+                // entirely, identical to the full walk producing an empty result that is then
+                // omitted.
+                let s = if next == 0 {
+                    empty
+                } else {
+                    remove_pattern(transaction, entry.id(), cp, key, next)?
+                };
+                if s != entry.id() || s == empty || entry.filemode_raw() != 0o0040000 {
+                    changed = true;
+                }
+                if s != empty && builder.insert(name, s, 0o0040000).is_err() {
+                    changed = true;
+                }
+            }
+            // Gitlinks (and any other kinds) are dropped, as in remove_pred.
+            _ => {
+                changed = true;
+            }
+        }
+        prev = Some((entry, is_tree));
+    }
+
+    // See remove_pred: an untouched entry set reproduces `input` bit-identically.
+    let result = if changed {
+        builder.write()?
+    } else {
+        debug_assert_eq!(builder.write()?, input);
+        input
+    };
+    transaction.insert_glob((input, key, state), result);
     Ok(result)
 }
 
@@ -886,6 +1044,235 @@ mod tests {
         let key = git2::Oid::from_str("7777777777777777777777777777777777777777").unwrap();
         let out = remove_pred(&t, &mut String::new(), input, &|_, isblob| isblob, key).unwrap();
         assert_eq!(out, expected, "duplicate entries must be deduplicated");
+    }
+
+    // Build a tree whose blob contents depend only on the entry NAME (not the full path), so
+    // directories with identical children get identical subtree oids -- the precondition for
+    // exercising the path-aliasing scenario.
+    fn make_named_tree(repo: &git2::Repository, paths: &[String]) -> git2::Oid {
+        let mut b = git2::build::TreeUpdateBuilder::new();
+        for p in paths {
+            let name = p.rsplit('/').next().unwrap();
+            let oid = repo.blob(name.as_bytes()).unwrap();
+            b.upsert(p.as_str(), oid, git2::FileMode::Blob);
+        }
+        let base = repo.treebuilder(None).unwrap().write().unwrap();
+        b.create_updated(repo, &repo.find_tree(base).unwrap())
+            .unwrap()
+    }
+
+    // Ground truth for a pattern filter: enumerate every blob path of `input` and keep exactly
+    // those the glob crate matches on the FULL path (with the Op::Pattern MatchOptions), rebuilt
+    // with a TreeUpdateBuilder (which drops empty dirs). Deliberately NOT remove_pred: the old
+    // full-path walk had an order-dependent cache-aliasing bug for identical subtrees at
+    // different paths, which the duplicated-subtree case below exercises.
+    fn ground_truth_tree(repo: &git2::Repository, input: git2::Oid, pattern: &str) -> git2::Oid {
+        let glob = glob::Pattern::new(pattern).unwrap();
+        let tree = repo.find_tree(input).unwrap();
+        let mut kept = vec![];
+        tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
+            if entry.kind() == Some(git2::ObjectType::Blob) {
+                let path = format!("{}{}", root, entry.name().unwrap());
+                if glob.matches_path_with(Path::new(&path), PATTERN_MATCH_OPTIONS) {
+                    kept.push((path, entry.id()));
+                }
+            }
+            git2::TreeWalkResult::Ok
+        })
+        .unwrap();
+        let mut b = git2::build::TreeUpdateBuilder::new();
+        for (path, oid) in &kept {
+            b.upsert(path.as_str(), *oid, git2::FileMode::Blob);
+        }
+        let base = repo.treebuilder(None).unwrap().write().unwrap();
+        b.create_updated(repo, &repo.find_tree(base).unwrap())
+            .unwrap()
+    }
+
+    // Property-style equivalence of the component-wise NFA walk against full-path glob matching:
+    // a deterministic pseudo-random tree with dotfiles (blobs and subtrees) at multiple depths,
+    // >= 5 levels of nesting, varied extensions, and two IDENTICAL subtrees at different paths
+    // ("a/x" and "c/x") whose files a path-sensitive pattern must treat differently -- the
+    // scenario the old (oid, filter)-keyed cache got wrong depending on walk order.
+    #[test]
+    fn remove_pattern_matches_full_path_glob() {
+        use rand::prelude::*;
+
+        let td = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(td.path()).unwrap();
+
+        let mut paths: Vec<String> = [
+            // Two identical subtrees at different paths; "a/*/b" and "a/**/b" keep only the "a/"
+            // side.
+            "a/x/b",
+            "a/x/c.rs",
+            "c/x/b",
+            "c/x/c.rs",
+            // Dotfiles at multiple depths: blobs and whole dot-led subtrees.
+            ".hidden",
+            ".hiddendir/inner.rs",
+            "d/.hidden",
+            "d/.hiddendir/deep/x.rs",
+            "dir_02/sub/.hidden",
+            // Deep nesting.
+            "dir_01/l1/l2/l3/l4/l5/deep.rs",
+            "top.rs",
+            "top.txt",
+        ]
+        .map(String::from)
+        .to_vec();
+
+        // Randomized bulk of the tree, deterministic via a fixed seed. Directory names avoid
+        // "a"/"c" so the identical-subtree pair above stays identical.
+        let mut rng = StdRng::seed_from_u64(42);
+        let dirs = ["dir_00", "dir_01", "dir_02", ".dotdir", "sub", "nested"];
+        let stems = ["file", "lib", "main", "x", ".hidden", "mod"];
+        let exts = ["rs", "txt", "c"];
+        for _ in 0..150 {
+            let depth = rng.random_range(1..=6);
+            let mut p = String::new();
+            for _ in 0..depth - 1 {
+                p.push_str(dirs[rng.random_range(0..dirs.len())]);
+                p.push('/');
+            }
+            let stem = stems[rng.random_range(0..stems.len())];
+            let ext = exts[rng.random_range(0..exts.len())];
+            p.push_str(&format!("{stem}_{}.{ext}", rng.random_range(0..8)));
+            paths.push(p);
+        }
+        // Drop paths that collide with another path as a directory prefix (a TreeUpdateBuilder
+        // cannot hold "x" as both blob and dir), keeping the first occurrence.
+        paths.sort();
+        paths.dedup();
+        let paths: Vec<String> = paths
+            .iter()
+            .enumerate()
+            .filter(|(i, p)| {
+                !paths.iter().enumerate().any(|(j, q)| {
+                    *i != j && (q.starts_with(&format!("{p}/")) || p.starts_with(&format!("{q}/")))
+                })
+            })
+            .map(|(_, p)| p.clone())
+            .collect();
+
+        let input = make_named_tree(&repo, &paths);
+
+        let tree = repo.find_tree(input).unwrap();
+        assert_eq!(
+            tree.get_path(Path::new("a/x")).unwrap().id(),
+            tree.get_path(Path::new("c/x")).unwrap().id(),
+            "a/x and c/x must be identical subtrees for the aliasing case to be exercised"
+        );
+
+        let t = open_transaction(&td);
+        for pattern in [
+            "**/*.rs",
+            "*.rs",
+            "a/*/b",
+            "a/**/b",
+            "dir_0?/**",
+            "**/.hidden",
+            "**",
+            "a/x/*.rs",
+            "sub/**",
+            "a/**/",
+            "**/",
+            "[a-d]*/**/*.rs",
+            "dir_01/l1/**/l4/*/deep.rs",
+            // A '/' inside a bracket class is a class member (which can never match under
+            // require_literal_separator), not a separator: the token-based split keeps these
+            // on the NFA walk.
+            "a[/]b",
+            "dir_0[!/]/**",
+            "a/**/**/x*.rs",
+        ] {
+            // Isolate the cases from each other (and from other tests in this process).
+            cache::clear_global_caches();
+
+            let key = git2::Oid::hash_object(git2::ObjectType::Blob, pattern.as_bytes()).unwrap();
+            let cp = CompiledPattern::compile(pattern).unwrap();
+            assert!(!cp.fallback, "`{pattern}` must not need the fallback");
+            let got =
+                remove_pattern(&t, input, &cp, key, CompiledPattern::initial_state()).unwrap();
+            let want = ground_truth_tree(t.repo(), input, pattern);
+            assert_eq!(
+                got, want,
+                "`{pattern}` diverged from full-path glob matching"
+            );
+        }
+    }
+
+    // Only patterns with more than 63 components (the u64 state mask limit) take the fallback;
+    // the token-based component split handles every other pattern exactly. The fallback itself
+    // must produce ground-truth results with per-root cache keys.
+    #[test]
+    fn compiled_pattern_fallback_cases() {
+        let key = git2::Oid::from_str("1234567890123456789012345678901234567890").unwrap();
+
+        // A '/' inside a bracket class never splits: it is inside the class token, not a
+        // `Char('/')` token, so these stay on the NFA walk.
+        assert!(!CompiledPattern::compile("a[/]b").unwrap().fallback);
+        assert!(!CompiledPattern::compile("a[!/]b").unwrap().fallback);
+        // A ']' in first member position is a literal member, not the closing bracket.
+        assert!(!CompiledPattern::compile("a[]]b").unwrap().fallback);
+        assert!(!CompiledPattern::compile("a[!]]b").unwrap().fallback);
+        // 64 components exceed the u64 state mask limit; 63 still fit.
+        let components_64 = format!("{}a", "a/".repeat(63));
+        let components_63 = format!("{}a", "a/".repeat(62));
+        assert!(CompiledPattern::compile(&components_64).unwrap().fallback);
+        assert!(!CompiledPattern::compile(&components_63).unwrap().fallback);
+        // Whole-pattern compile errors stay bit-identical.
+        assert!(CompiledPattern::compile("a**").is_err());
+
+        // The fallback walk must still match full paths correctly for a fallback pattern.
+        let td = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(td.path()).unwrap();
+        let paths: Vec<String> = ["a/f.txt", "b/f.txt"].map(String::from).to_vec();
+        let input = make_named_tree(&repo, &paths);
+        let t = open_transaction(&td);
+        let cp = CompiledPattern::compile(&components_64).unwrap();
+        let out = remove_pred(
+            &t,
+            &mut String::new(),
+            input,
+            &|path, isblob| isblob && cp.full.matches_with(path, PATTERN_MATCH_OPTIONS),
+            key,
+        )
+        .unwrap();
+        assert_eq!(
+            out,
+            empty_id(),
+            "a 64-component pattern matches nothing here"
+        );
+    }
+
+    // The remove_pred fallback keys its cache by (subtree, pattern, root path), so identical
+    // subtrees at different paths must not alias even in the legacy walk.
+    #[test]
+    fn remove_pred_does_not_alias_identical_subtrees() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(td.path()).unwrap();
+        let paths: Vec<String> = ["a/f.txt", "b/f.txt"].map(String::from).to_vec();
+        let input = make_named_tree(&repo, &paths);
+        let tree = repo.find_tree(input).unwrap();
+        assert_eq!(
+            tree.get_path(Path::new("a")).unwrap().id(),
+            tree.get_path(Path::new("b")).unwrap().id()
+        );
+
+        let t = open_transaction(&td);
+        let pattern = glob::Pattern::new("a/*.txt").unwrap();
+        let key = git2::Oid::from_str("abcdef1234567890123456789012345678901234").unwrap();
+        let out = remove_pred(
+            &t,
+            &mut String::new(),
+            input,
+            &|path, isblob| isblob && pattern.matches_with(path, PATTERN_MATCH_OPTIONS),
+            key,
+        )
+        .unwrap();
+        let want = ground_truth_tree(t.repo(), input, "a/*.txt");
+        assert_eq!(out, want, "b/f.txt must not be kept via the a/ cache entry");
     }
 
     // Removing a whole subdirectory must report every file under it as removed. This exercises

--- a/josh-filter/src/lib.rs
+++ b/josh-filter/src/lib.rs
@@ -2,6 +2,7 @@ pub mod filter;
 pub mod flang;
 pub mod op;
 pub mod opt;
+pub mod pattern;
 pub mod persist;
 
 pub use filter::{Filter, compose};

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -34,35 +34,6 @@ impl std::hash::Hash for Regex {
     }
 }
 
-/// Newtype around `glob::Pattern` adding structural `PartialEq`/`Eq`/`Hash` (by pattern
-/// string, like [`Regex`]) so `Op` can derive them for use as an interning key. The glob is
-/// compiled at construction -- use [`Op::pattern`] -- so applying a `Pattern` op never
-/// recompiles it, and `as_str()` recovers the source pattern verbatim (which is why
-/// `Op::Pattern` carries no separate string). Derefs to the compiled glob.
-#[derive(Clone, Debug)]
-pub struct PatternGlob(pub glob::Pattern);
-
-impl std::ops::Deref for PatternGlob {
-    type Target = glob::Pattern;
-    fn deref(&self) -> &glob::Pattern {
-        &self.0
-    }
-}
-
-impl PartialEq for PatternGlob {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.as_str() == other.0.as_str()
-    }
-}
-
-impl Eq for PatternGlob {}
-
-impl std::hash::Hash for PatternGlob {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.as_str().hash(state);
-    }
-}
-
 impl std::fmt::Display for LinkMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -176,7 +147,7 @@ pub enum Op {
     ObjectDeref(std::path::PathBuf),
     ObjectRef(std::path::PathBuf),
 
-    Pattern(PatternGlob),
+    Pattern(crate::pattern::CompiledPattern),
     Message(String, Regex),
 
     Unapply(LazyRef, Filter),
@@ -195,6 +166,8 @@ impl Op {
     /// Construct a `Pattern` op, compiling its glob. A bad glob therefore errors where the
     /// pattern enters the system (parse, deserialization) instead of on first apply.
     pub fn pattern(pattern: &str) -> anyhow::Result<Op> {
-        Ok(Op::Pattern(PatternGlob(glob::Pattern::new(pattern)?)))
+        Ok(Op::Pattern(crate::pattern::CompiledPattern::compile(
+            pattern,
+        )?))
     }
 }

--- a/josh-filter/src/pattern.rs
+++ b/josh-filter/src/pattern.rs
@@ -1,0 +1,154 @@
+use glob::PatternToken;
+
+/// The MatchOptions of the `Op::Pattern` arm: full-path glob matching with literal separators
+/// and literal leading dots. Also exactly the options under which the component-wise walk of
+/// `tree::remove_pattern` is equivalent to a full-path match.
+pub const PATTERN_MATCH_OPTIONS: glob::MatchOptions = glob::MatchOptions {
+    case_sensitive: true,
+    require_literal_separator: true,
+    require_literal_leading_dot: true,
+};
+
+/// One '/'-separated component of a glob pattern.
+#[derive(Clone)]
+pub enum PatternComponent {
+    /// A component that is exactly `**`: matches zero or more non-dot-leading path components.
+    Star2,
+    /// Any other component, matched against single entry names.
+    Glob(glob::Pattern),
+}
+
+/// The payload of `Op::Pattern`: a glob compiled at construction -- use `Op::pattern` -- for
+/// the component-wise NFA walk of `tree::remove_pattern`. `PartialEq`/`Eq`/`Hash` are the
+/// source pattern string (recovered verbatim by `as_str`), so `Op` can derive them for use as
+/// an interning key.
+///
+/// Splitting at '/' is sound because the glob crate rejects any `**` that is not a full path
+/// component, and under `require_literal_separator` a '/' in the path can only ever be matched
+/// by a literal '/' in the pattern -- so a full-path match factorizes into per-component
+/// matches. Matching a single component with `matches_with` starts with
+/// `follows_separator = true`, which applies the `require_literal_leading_dot` rule at the name
+/// start exactly as the full-path match does after a '/'.
+#[derive(Clone)]
+pub struct CompiledPattern {
+    /// The whole pattern, compiled as one glob. Used by the legacy full-path fallback.
+    pub full: glob::Pattern,
+    pub components: Vec<PatternComponent>,
+    /// `suffix_all_star[p]`: components `p..` are all `Star2`, so a blob accepted at position `p`
+    /// needs no further components.
+    pub suffix_all_star: Vec<bool>,
+    /// More than 63 components (the u64 state mask limit): use the legacy full-path walk
+    /// instead of the NFA walk.
+    pub fallback: bool,
+}
+
+impl PartialEq for CompiledPattern {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for CompiledPattern {}
+
+impl std::hash::Hash for CompiledPattern {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl std::fmt::Debug for CompiledPattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CompiledPattern({:?})", self.as_str())
+    }
+}
+
+/// Split a compiled pattern into path components. This is exact by construction: in the parsed
+/// token stream a '/' inside a bracket class is a class member, never a `Char('/')` token, so
+/// components are simply the runs between `Char('/')` tokens. A bracket class listing '/' (or a
+/// range spanning it) needs no special case either: under `require_literal_separator` a class
+/// can never match a separator, in the full-path walk and the per-component walk alike.
+///
+/// `AnyRecursiveSequence` also ends its component: the parser guarantees `**` is a full path
+/// component and consumes the separator that follows it, so no `Char('/')` split ever comes
+/// after one. Consecutive `**` components are already collapsed into a single token upstream.
+fn split_pattern_components(full: &glob::Pattern) -> Vec<Vec<PatternToken>> {
+    let mut parts: Vec<Vec<PatternToken>> = vec![vec![]];
+    for token in full.tokens() {
+        match token {
+            PatternToken::Char('/') => parts.push(vec![]),
+            PatternToken::AnyRecursiveSequence => {
+                debug_assert!(parts.last().unwrap().is_empty());
+                parts.last_mut().unwrap().push(token.clone());
+                parts.push(vec![]);
+            }
+            t => parts.last_mut().unwrap().push(t.clone()),
+        }
+    }
+    // Drop the empty component opened after a trailing `**`: the parser consumed any separator
+    // that followed it, so the pattern ends with the `**` component itself.
+    if parts.len() >= 2
+        && parts.last().unwrap().is_empty()
+        && parts[parts.len() - 2] == [PatternToken::AnyRecursiveSequence]
+    {
+        parts.pop();
+    }
+    parts
+}
+
+impl CompiledPattern {
+    pub fn compile(pattern: &str) -> Result<Self, glob::PatternError> {
+        // Compile the whole pattern first so error behavior is bit-identical to the full-path
+        // implementation (this also rejects any `**` that is not a full path component, which is
+        // what makes the '/'-split below sound).
+        let full = glob::Pattern::new(pattern)?;
+        let components: Vec<PatternComponent> = split_pattern_components(&full)
+            .into_iter()
+            .map(|tokens| {
+                if tokens == [PatternToken::AnyRecursiveSequence] {
+                    PatternComponent::Star2
+                } else {
+                    PatternComponent::Glob(glob::Pattern::from_tokens(tokens))
+                }
+            })
+            .collect();
+        // NFA states are u64 bitmasks of component positions.
+        let fallback = components.len() > 63;
+        let k = components.len();
+        let mut suffix_all_star = vec![false; k];
+        for p in (0..k).rev() {
+            suffix_all_star[p] = matches!(components[p], PatternComponent::Star2)
+                && (p + 1 == k || suffix_all_star[p + 1]);
+        }
+        Ok(CompiledPattern {
+            full,
+            components,
+            suffix_all_star,
+            fallback,
+        })
+    }
+
+    /// The source pattern string, verbatim.
+    pub fn as_str(&self) -> &str {
+        self.full.as_str()
+    }
+
+    /// Epsilon closure of a state mask: a `**` at position `p` can match zero components, so
+    /// position `p + 1` is active whenever `p` is. A single ascending pass reaches the fixpoint
+    /// because additions only propagate upward. Position `k` is never stored: with the pattern
+    /// exhausted, nothing deeper can match under `require_literal_separator` (blob acceptance at
+    /// the last component is handled directly in the walk).
+    pub fn closure(&self, mut state: u64) -> u64 {
+        let k = self.components.len();
+        for p in 0..k.saturating_sub(1) {
+            if state & (1 << p) != 0 && matches!(self.components[p], PatternComponent::Star2) {
+                state |= 1 << (p + 1);
+            }
+        }
+        state
+    }
+
+    /// Initial state: component 0 active (plus its closure, taken by `remove_pattern`).
+    pub fn initial_state() -> u64 {
+        1
+    }
+}

--- a/tests/filter/pattern_glob_aliasing.t
+++ b/tests/filter/pattern_glob_aliasing.t
@@ -1,0 +1,32 @@
+Two directories with identical contents have the same subtree oid. A pattern filter matches full
+paths, so the filtered result of such a subtree depends on where it sits: the glob cache must not
+serve the result computed for "a/" when walking "b/". Prior to the state-keyed glob cache, the
+entry for the shared oid aliased across paths and "b/f.txt" was wrongly kept, depending on walk
+order within the process.
+
+  $ export TESTTMP=${PWD}
+
+  $ cd ${TESTTMP}
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir a b
+  $ echo same > a/f.txt
+  $ echo same > b/f.txt
+  $ git add .
+  $ git commit -m "add identical files" 1> /dev/null
+
+The subtrees of a/ and b/ are identical:
+
+  $ test "$(git rev-parse HEAD:a)" = "$(git rev-parse HEAD:b)"
+
+  $ josh-filter -s "::a/*.txt" master --update refs/heads/filtered
+  ac628907bfee2d475634285db2fd0909ac42d7d6
+  [1] ::a/*.txt
+  [1] reachable_roots
+  [1] sequence_number
+
+Only a/f.txt may survive; b/f.txt must not leak in via the shared subtree oid:
+
+  $ git ls-tree -r --name-only refs/heads/filtered
+  a/f.txt

--- a/tests/filter/pattern_glob_dotfiles.t
+++ b/tests/filter/pattern_glob_dotfiles.t
@@ -1,0 +1,40 @@
+Pattern filters run the glob crate with require_literal_leading_dot: `*` and `**` never match a
+path component that starts with '.', at any depth. Literal dot-led components in the pattern are
+unaffected and match normally.
+
+  $ export TESTTMP=${PWD}
+
+  $ cd ${TESTTMP}
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir -p d .d .github/workflows
+  $ echo hidden_root > .hidden.rs
+  $ echo hidden_sub > d/.hidden.rs
+  $ echo in_dot_dir > .d/x.rs
+  $ echo visible > d/visible.rs
+  $ echo ci > .github/workflows/ci.yml
+  $ git add .
+  $ git commit -m "add files" 1> /dev/null
+
+`::**/*.rs` must exclude dot-led components at every depth: the dot-led blobs `.hidden.rs` and
+`d/.hidden.rs`, and everything under the dot-led directory `.d/`:
+
+  $ josh-filter -s "::**/*.rs" master --update refs/heads/rs
+  84780ae93f90c8dfc053fe624e808af7c2187e0b
+  [1] ::**/*.rs
+  [1] reachable_roots
+  [1] sequence_number
+  $ git ls-tree -r --name-only refs/heads/rs
+  d/visible.rs
+
+A literal dot-led pattern component matches dot-led names; only wildcards refuse them:
+
+  $ josh-filter -s "::.github/**/*.yml" master --update refs/heads/yml
+  6a611b6b95846206de1f7323da3f88217d6c9984
+  [1] ::**/*.rs
+  [1] ::.github/**/*.yml
+  [1] reachable_roots
+  [1] sequence_number
+  $ git ls-tree -r --name-only refs/heads/yml
+  .github/workflows/ci.yml

--- a/vendor/rust-lang/glob/src/lib.rs
+++ b/vendor/rust-lang/glob/src/lib.rs
@@ -577,19 +577,29 @@ impl FromStr for Pattern {
     }
 }
 
+/// A token of a compiled glob pattern; the output of the glob parser.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-enum PatternToken {
+pub enum PatternToken {
+    /// A literal character, matched verbatim.
     Char(char),
+    /// `?`: any single character.
     AnyChar,
+    /// `*`: any sequence of characters, possibly empty.
     AnySequence,
+    /// `**` as a full path component: any sequence of path components.
     AnyRecursiveSequence,
+    /// `[...]`: any character matching one of the given specifiers.
     AnyWithin(Vec<CharSpecifier>),
+    /// `[!...]`: any character matching none of the given specifiers.
     AnyExcept(Vec<CharSpecifier>),
 }
 
+/// A member of a bracket class: a single character or an inclusive range.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-enum CharSpecifier {
+pub enum CharSpecifier {
+    /// A single character, e.g. `a` in `[abc]`.
     SingleChar(char),
+    /// An inclusive character range, e.g. `a-z` in `[a-z0-9]`.
     CharRange(char, char),
 }
 
@@ -795,6 +805,32 @@ impl Pattern {
     /// Access the original glob pattern.
     pub fn as_str(&self) -> &str {
         &self.original
+    }
+
+    /// Access the parsed token stream of this pattern.
+    ///
+    /// This is the exact output of the glob parser: literal characters are
+    /// `Char` tokens, bracket classes are `AnyWithin`/`AnyExcept`, and `**`
+    /// is `AnyRecursiveSequence`. In particular, a `/` inside a bracket class
+    /// never appears as a `Char('/')` token, so splitting a pattern into
+    /// path components is a matter of splitting this slice at `Char('/')`.
+    pub fn tokens(&self) -> &[PatternToken] {
+        &self.tokens
+    }
+
+    /// Construct a pattern directly from a token stream, e.g. a sub-slice of
+    /// another pattern's `tokens()`. The pattern has no original string form:
+    /// `as_str` returns `""`; matching is unaffected, as it only ever
+    /// consults the tokens.
+    pub fn from_tokens(tokens: Vec<PatternToken>) -> Self {
+        let is_recursive = tokens.contains(&AnyRecursiveSequence);
+        let has_metachars = tokens.iter().any(|t| !matches!(t, Char(_)));
+        Self {
+            original: String::new(),
+            tokens,
+            is_recursive,
+            has_metachars,
+        }
     }
 
     fn matches_from(


### PR DESCRIPTION
Walk glob patterns component-wise with subtree pruning

Op::Pattern previously matched every blob's full path against the whole glob via
tree::remove_pred, recursing into every subtree regardless of whether the pattern could still
match anything below it. Replace that walk with tree::remove_pattern: the pattern is split into
'/'-separated components, each component is compiled once, and the walk advances an NFA state
bitmask of active component positions per tree level. Subtrees where no position can match
anything below are pruned without recursion, and a trailing all-'**' suffix short-circuits
per-entry matching to a dotfile check, preserving require_literal_leading_dot semantics.

The component split works on the glob parser's own token stream instead of re-scanning the
pattern string: the vendored glob crate is patched to expose its parser output (PatternToken
and CharSpecifier become public, plus a Pattern::tokens() accessor and a Pattern::from_tokens()
constructor that compiles a component from a token sub-slice). That makes the split exact by
construction -- a '/' inside a bracket class lives inside the class token and never appears as
a Char('/') separator, and '**' arrives pre-validated as its own path component -- so bracket
classes containing '/' need no fallback: under require_literal_separator a class can never
match a separator, in the full-path walk and the per-component walk alike.

The glob result cache key gains the state mask -- (input tree, pattern key, state) -- so cached
subtree results stay independent of the path they were reached through. Patterns with more than
63 components (the u64 mask limit) fall back to the legacy full-path walk under a synthetic
root-keyed cache entry at state 0. The compiled form is the new
josh_filter::pattern::CompiledPattern, replacing the plain compiled glob as the Op::Pattern
payload (still built at op construction, with Eq/Hash on the source string); the tree walk
stays in tree.rs and takes the cache key as a parameter. A differential unit test compares
remove_pattern against reference full-path glob matching over randomized trees with dotfiles
and collisions, and new prysk tests cover dotfile and path-aliasing behavior.

Criterion, vs the previous commit: deephistory_glob prefix -61%, literal -65%, recursive -9%;
widetree_glob prefix -89% (9x), sparse -25%, recursive -19%; no case regressed.

Change: pattern-nfa-walk
Assisted-By: anthropic/claude-fable-5