### PR TITLE
Memoize search across commits with a transaction-held cache

### DIFF
--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -385,7 +385,13 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             let ifilterobj = filterobj.chain(josh_core::filter::parse(":SQUASH:INDEX")?);
             let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit.id())?;
             let index_tree = repo.find_commit(index_commit)?.tree()?;
-            josh_search::search_candidates(&repo, &index_tree, &tree, searchstring)?
+            josh_search::search_candidates(
+                &repo,
+                &mut transaction.search_cache(),
+                &index_tree,
+                &tree,
+                searchstring,
+            )?
         } else {
             let mut scan = vec![];
             tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
@@ -398,7 +404,13 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             })?;
             scan
         };
-        let matches = josh_search::search_matches(&repo, &tree, searchstring, &candidates)?;
+        let matches = josh_search::search_matches(
+            &repo,
+            &mut transaction.search_cache(),
+            &tree,
+            searchstring,
+            &candidates,
+        )?;
         /* let duration = start.elapsed(); */
 
         for r in matches {

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -360,7 +360,13 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             let ifilterobj = filterobj.chain(josh_core::filter::parse(":SQUASH:INDEX")?);
             let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit)?;
             let index_tree = josh_core::objects::CommitData::read(odb, index_commit)?.tree_id()?;
-            josh_search::search_candidates(odb, index_tree, tree, searchstring)?
+            josh_search::search_candidates(
+                odb,
+                &mut transaction.search_cache(),
+                index_tree,
+                tree,
+                searchstring,
+            )?
         } else {
             let mut scan = vec![];
             josh_core::objects::walk_tree_preorder(odb, tree, &mut |parent, entry| {
@@ -375,7 +381,13 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             })?;
             scan
         };
-        let matches = josh_search::search_matches(odb, tree, searchstring, &candidates)?;
+        let matches = josh_search::search_matches(
+            odb,
+            &mut transaction.search_cache(),
+            tree,
+            searchstring,
+            &candidates,
+        )?;
 
         for r in matches {
             for l in r.1 {

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -261,6 +261,10 @@ pub struct Transaction {
     /// commits reuses the merge work of earlier commits. Its own cell because `trigram_index`
     /// borrows it for the entire call while also borrowing other caches through `t2`.
     trigram_indexer: std::cell::RefCell<josh_search::Indexer>,
+    /// josh-search search memoization, kept for the whole transaction so searching many
+    /// commits (e.g. one GraphQL query over `history { search }`) reuses candidate walks of
+    /// shared subtrees and verifies each distinct blob once.
+    search_cache: std::cell::RefCell<josh_search::SearchCache>,
     /// The primary repository view for object and ref reads. Held in its thread-safe form:
     /// a transaction crosses threads (josh-graphql requires `Send`) while a `gix::Repository`
     /// holds `Rc` snapshots of packed-refs and shallow state and does not.
@@ -374,6 +378,7 @@ impl Transaction {
                 nesting_level: 0,
             }),
             trigram_indexer: Default::default(),
+            search_cache: Default::default(),
             gix_repo,
             mem_odb,
             odb,
@@ -1461,6 +1466,12 @@ impl Transaction {
     /// alongside the [`IndexCache`] from [`Transaction::trigram_index_cache`].
     pub fn trigram_indexer(&self) -> std::cell::RefMut<'_, josh_search::Indexer> {
         self.trigram_indexer.borrow_mut()
+    }
+
+    /// The transaction-lifetime josh-search search memoization, for passing to
+    /// `josh_search::search_candidates` / `search_matches`.
+    pub fn search_cache(&self) -> std::cell::RefMut<'_, josh_search::SearchCache> {
+        self.search_cache.borrow_mut()
     }
 }
 

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -149,6 +149,10 @@ pub struct Transaction {
     /// it stays borrowed across a whole `trigram_index` call, which reads other caches through
     /// `t2`.
     trigram_indexer: std::cell::RefCell<josh_search::Indexer>,
+    /// josh-search search memoization, kept for the whole transaction so searching many
+    /// commits (e.g. one GraphQL query over `history { search }`) reuses candidate walks of
+    /// shared subtrees and verifies each distinct blob once.
+    search_cache: std::cell::RefCell<josh_search::SearchCache>,
     repo: git2::Repository,
     /// Per-transaction in-memory object store, flushed to a packfile when the transaction drops, at
     /// an explicit boundary, or mid-transaction when it exceeds its size limit. Never shared with
@@ -220,6 +224,7 @@ impl Transaction {
                 nesting_level: 0,
             }),
             trigram_indexer: Default::default(),
+            search_cache: Default::default(),
             repo,
             mem_odb,
             mem_odb_limit,
@@ -653,6 +658,12 @@ impl Transaction {
     /// `josh_search::trigram_index` alongside the transaction itself (the [`IndexCache`]).
     pub fn trigram_indexer(&self) -> std::cell::RefMut<'_, josh_search::Indexer> {
         self.trigram_indexer.borrow_mut()
+    }
+
+    /// The transaction-lifetime josh-search search memoization, for passing to
+    /// `josh_search::search_candidates` / `search_matches`.
+    pub fn search_cache(&self) -> std::cell::RefMut<'_, josh_search::SearchCache> {
+        self.search_cache.borrow_mut()
     }
 }
 

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -436,6 +436,7 @@ impl Revision {
             let index_tree = filter::apply(&transaction, ifilterobj, x.clone())?;
             josh_search::search_candidates(
                 transaction.repo(),
+                &mut transaction.search_cache(),
                 index_tree.tree(),
                 x.tree(),
                 &string,
@@ -452,8 +453,13 @@ impl Revision {
             })?;
             scan
         };
-        let results =
-            josh_search::search_matches(transaction.repo(), x.tree(), &string, &candidates)?;
+        let results = josh_search::search_matches(
+            transaction.repo(),
+            &mut transaction.search_cache(),
+            x.tree(),
+            &string,
+            &candidates,
+        )?;
         /* let duration = start.elapsed(); */
 
         let mut r = vec![];

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -452,7 +452,13 @@ impl Revision {
         let candidates = if filter::experimental_features_enabled() {
             let ifilterobj = filter::parse(":SQUASH:INDEX")?;
             let index_tree = filter::apply(&transaction, ifilterobj, x.clone())?;
-            josh_search::search_candidates(odb, index_tree.tree_id(), x.tree_id(), &string)?
+            josh_search::search_candidates(
+                odb,
+                &mut transaction.search_cache(),
+                index_tree.tree_id(),
+                x.tree_id(),
+                &string,
+            )?
         } else {
             let mut scan = vec![];
             objects::walk_tree_preorder(odb, x.tree_id(), &mut |parent, entry| {
@@ -467,7 +473,13 @@ impl Revision {
             })?;
             scan
         };
-        let results = josh_search::search_matches(odb, x.tree_id(), &string, &candidates)?;
+        let results = josh_search::search_matches(
+            odb,
+            &mut transaction.search_cache(),
+            x.tree_id(),
+            &string,
+            &candidates,
+        )?;
 
         let mut r = vec![];
         for m in results {

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -314,12 +314,13 @@ fn recover_chain(
 /// the index tree, then exact matching over the source tree.
 fn search(
     src: &dyn josh_search::Objects,
+    cache: &mut josh_search::SearchCache,
     index_tree: gix_hash::ObjectId,
     source_tree: gix_hash::ObjectId,
     needle: &str,
 ) -> anyhow::Result<(Vec<String>, Vec<(String, Vec<(usize, String)>)>)> {
-    let candidates = josh_search::search_candidates(src, index_tree, source_tree, needle)?;
-    let matches = josh_search::search_matches(src, source_tree, needle, &candidates)?;
+    let candidates = josh_search::search_candidates(src, cache, index_tree, source_tree, needle)?;
+    let matches = josh_search::search_matches(src, cache, source_tree, needle, &candidates)?;
     Ok((candidates, matches))
 }
 
@@ -390,7 +391,9 @@ impl TrigramBench {
             // degenerated and the search numbers would be meaningless. (The bound is kept at
             // the pre-rework value of 5; the exact index should always produce exactly 1.)
             let rare_path = path_for(n_files / 2).to_string_lossy().into_owned();
-            let (candidates, matches) = search(odb, index_tree_oid, tip_tree, NEEDLE_RARE)?;
+            let mut scache = josh_search::SearchCache::default();
+            let (candidates, matches) =
+                search(odb, &mut scache, index_tree_oid, tip_tree, NEEDLE_RARE)?;
             anyhow::ensure!(
                 matches.len() == 1 && matches[0].0 == rare_path,
                 "rare needle not found in exactly its planted file {rare_path}: {matches:?}"
@@ -403,13 +406,13 @@ impl TrigramBench {
 
             // Gate: the common needle is found in every planted file, the absent one nowhere.
             let common_count = n_files.div_ceil(COMMON_EVERY);
-            let (_, matches) = search(odb, index_tree_oid, tip_tree, NEEDLE_COMMON)?;
+            let (_, matches) = search(odb, &mut scache, index_tree_oid, tip_tree, NEEDLE_COMMON)?;
             anyhow::ensure!(
                 matches.len() == common_count,
                 "common needle found in {} files, expected {common_count}",
                 matches.len()
             );
-            let (_, matches) = search(odb, index_tree_oid, tip_tree, NEEDLE_ABSENT)?;
+            let (_, matches) = search(odb, &mut scache, index_tree_oid, tip_tree, NEEDLE_ABSENT)?;
             anyhow::ensure!(
                 matches.is_empty(),
                 "absent needle found in {} files",
@@ -589,8 +592,13 @@ fn trigram_benches(c: &mut Criterion) {
                         .tree_id()
                         .expect("read tip tree");
 
+                    // A fresh cache per iteration: this group measures the uncached
+                    // single-commit search.
+                    let mut scache = josh_search::SearchCache::default();
+
                     runner.run(|| {
-                        search(odb, case.index_tree_oid, source_tree, needle).expect("search")
+                        search(odb, &mut scache, case.index_tree_oid, source_tree, needle)
+                            .expect("search")
                     });
                 });
             });
@@ -616,12 +624,16 @@ fn trigram_benches(c: &mut Criterion) {
                     josh_core::reset_caches().expect("reset caches");
                     let transaction = bench.context.open().expect("open transaction");
                     let odb = transaction.odb();
+                    // One cache for the whole chain, matching how josh keeps one per
+                    // transaction (a GraphQL history+search query runs in one transaction).
+                    let mut scache = josh_search::SearchCache::default();
 
                     runner.run(|| {
                         let mut hits = 0;
                         for (tree_oid, index_oid) in &case.chain_indexes {
                             let (_, matches) =
-                                search(odb, *index_oid, *tree_oid, needle).expect("search");
+                                search(odb, &mut scache, *index_oid, *tree_oid, needle)
+                                    .expect("search");
                             hits += matches.len();
                         }
                         hits

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -279,12 +279,13 @@ fn recover_chain(repo: &git2::Repository, n_files: usize) -> anyhow::Result<Vec<
 /// the index tree, then exact matching over the source tree.
 fn search(
     repo: &git2::Repository,
+    cache: &mut josh_search::SearchCache,
     index_tree: &git2::Tree,
     source_tree: &git2::Tree,
     needle: &str,
 ) -> anyhow::Result<(Vec<String>, Vec<(String, Vec<(usize, String)>)>)> {
-    let candidates = josh_search::search_candidates(repo, index_tree, source_tree, needle)?;
-    let matches = josh_search::search_matches(repo, source_tree, needle, &candidates)?;
+    let candidates = josh_search::search_candidates(repo, cache, index_tree, source_tree, needle)?;
+    let matches = josh_search::search_matches(repo, cache, source_tree, needle, &candidates)?;
     Ok((candidates, matches))
 }
 
@@ -354,7 +355,9 @@ impl TrigramBench {
             // degenerated and the search numbers would be meaningless. (The bound is kept at
             // the pre-rework value of 5; the exact index should always produce exactly 1.)
             let rare_path = path_for(n_files / 2).to_string_lossy().into_owned();
-            let (candidates, matches) = search(repo, &index_tree, &tip_tree, NEEDLE_RARE)?;
+            let mut scache = josh_search::SearchCache::default();
+            let (candidates, matches) =
+                search(repo, &mut scache, &index_tree, &tip_tree, NEEDLE_RARE)?;
             anyhow::ensure!(
                 matches.len() == 1 && matches[0].0 == rare_path,
                 "rare needle not found in exactly its planted file {rare_path}: {matches:?}"
@@ -367,13 +370,13 @@ impl TrigramBench {
 
             // Gate: the common needle is found in every planted file, the absent one nowhere.
             let common_count = n_files.div_ceil(COMMON_EVERY);
-            let (_, matches) = search(repo, &index_tree, &tip_tree, NEEDLE_COMMON)?;
+            let (_, matches) = search(repo, &mut scache, &index_tree, &tip_tree, NEEDLE_COMMON)?;
             anyhow::ensure!(
                 matches.len() == common_count,
                 "common needle found in {} files, expected {common_count}",
                 matches.len()
             );
-            let (_, matches) = search(repo, &index_tree, &tip_tree, NEEDLE_ABSENT)?;
+            let (_, matches) = search(repo, &mut scache, &index_tree, &tip_tree, NEEDLE_ABSENT)?;
             anyhow::ensure!(
                 matches.is_empty(),
                 "absent needle found in {} files",
@@ -536,7 +539,14 @@ fn trigram_benches(c: &mut Criterion) {
                         .tree()
                         .expect("tip tree");
 
-                    runner.run(|| search(repo, &index_tree, &source_tree, needle).expect("search"));
+                    // A fresh cache per iteration: this group measures the uncached
+                    // single-commit search.
+                    let mut scache = josh_search::SearchCache::default();
+
+                    runner.run(|| {
+                        search(repo, &mut scache, &index_tree, &source_tree, needle)
+                            .expect("search")
+                    });
                 });
             });
         }
@@ -561,6 +571,9 @@ fn trigram_benches(c: &mut Criterion) {
                     josh_core::reset_caches().expect("reset caches");
                     let transaction = bench.context.open().expect("open transaction");
                     let repo = transaction.repo();
+                    // One cache for the whole chain, matching how josh keeps one per
+                    // transaction (a GraphQL history+search query runs in one transaction).
+                    let mut scache = josh_search::SearchCache::default();
 
                     runner.run(|| {
                         let mut hits = 0;
@@ -568,7 +581,7 @@ fn trigram_benches(c: &mut Criterion) {
                             let source = repo.find_tree(*tree_oid).expect("find source tree");
                             let index = repo.find_tree(*index_oid).expect("find index tree");
                             let (_, matches) =
-                                search(repo, &index, &source, needle).expect("search");
+                                search(repo, &mut scache, &index, &source, needle).expect("search");
                             hits += matches.len();
                         }
                         hits

--- a/josh-search/src/lib.rs
+++ b/josh-search/src/lib.rs
@@ -653,57 +653,87 @@ pub fn trigram_index<'a>(
     Ok(repo.find_tree(to_git2(index))?)
 }
 
+/// Search memoization, meant to be kept alive for many [`search_candidates`] /
+/// [`search_matches`] calls (josh keeps one per transaction). Everything is keyed by content
+/// — object ids and the query string — so entries are valid for any commit of the repository:
+/// searching a history reuses the candidate walks of every shared subtree and verifies every
+/// distinct blob once, no matter how many commits it appears in.
+#[derive(Default)]
+pub struct SearchCache {
+    /// (query, index tree, source tree) -> sorted candidate paths.
+    candidates: HashMap<(String, git2::Oid, git2::Oid), std::sync::Arc<Vec<String>>>,
+    /// (mirror roots (normalized), source tree) -> relative candidate paths of the walk.
+    walks: HashMap<(Vec<git2::Oid>, git2::Oid), std::sync::Arc<Vec<String>>>,
+    /// source tree -> all file paths under it (relative).
+    all_paths: HashMap<git2::Oid, std::sync::Arc<Vec<String>>>,
+    /// (query, blob) -> matching (line number, line) pairs.
+    blob_matches: HashMap<(String, git2::Oid), std::sync::Arc<Vec<(usize, String)>>>,
+}
+
 /// Exact candidate files for `searchstring`: files containing every trigram of the query.
 ///
 /// Queries shorter than three bytes (or without any valid-UTF-8 window) have no trigrams; every
 /// file of `source_tree` is a candidate then, and [`search_matches`] does the filtering.
 pub fn search_candidates(
     repo: &git2::Repository,
+    cache: &mut SearchCache,
     index_tree: &git2::Tree,
     source_tree: &git2::Tree,
     searchstring: &str,
 ) -> anyhow::Result<Vec<String>> {
+    let key = (searchstring.to_owned(), index_tree.id(), source_tree.id());
+    if let Some(hit) = cache.candidates.get(&key) {
+        return Ok((**hit).clone());
+    }
+
     let trigrams = distinct_trigrams(searchstring);
 
-    let mut results = vec![];
-    if trigrams.is_empty() {
-        collect_paths(repo, source_tree.id(), "", &mut results)?;
-        return Ok(results);
-    }
-
-    let mut roots = vec![];
-    for t in &trigrams {
-        let path = format!("{:02x}/{:02x}/{:02x}", t[0], t[1], t[2]);
-        match index_tree.get_path(std::path::Path::new(&path)) {
-            Ok(entry) => roots.push(entry.id()),
-            // A trigram absent from the index cannot occur in any file.
-            Err(_) => return Ok(vec![]),
+    let results = if trigrams.is_empty() {
+        (*all_paths(repo, cache, source_tree.id())?).clone()
+    } else {
+        let mut roots = vec![];
+        let mut absent = false;
+        for t in &trigrams {
+            let path = format!("{:02x}/{:02x}/{:02x}", t[0], t[1], t[2]);
+            match index_tree.get_path(std::path::Path::new(&path)) {
+                Ok(entry) => roots.push(entry.id()),
+                // A trigram absent from the index cannot occur in any file.
+                Err(_) => {
+                    absent = true;
+                    break;
+                }
+            }
         }
-    }
-    roots.sort();
-    roots.dedup();
+        if absent {
+            vec![]
+        } else {
+            roots.sort();
+            roots.dedup();
 
-    // Cap the intersection width: any subset of trigrams yields a superset of candidates, and
-    // search_matches verifies exactly anyway. Keep the mirrors with the fewest entries — they
-    // constrain the most.
-    const MAX_INTERSECT: usize = 16;
-    if roots.len() > MAX_INTERSECT {
-        let mut sized = roots
-            .iter()
-            .map(|&oid| anyhow::Ok((repo.find_tree(oid)?.len(), oid)))
-            .collect::<Result<Vec<_>, _>>()?;
-        sized.sort();
-        roots = sized
-            .into_iter()
-            .take(MAX_INTERSECT)
-            .map(|(_, oid)| oid)
-            .collect();
-    }
+            // Cap the intersection width: any subset of trigrams yields a superset of
+            // candidates, and search_matches verifies exactly anyway. Keep the mirrors with
+            // the fewest entries — they constrain the most.
+            const MAX_INTERSECT: usize = 16;
+            if roots.len() > MAX_INTERSECT {
+                let mut sized = roots
+                    .iter()
+                    .map(|&oid| anyhow::Ok((repo.find_tree(oid)?.len(), oid)))
+                    .collect::<Result<Vec<_>, _>>()?;
+                sized.sort();
+                roots = sized
+                    .into_iter()
+                    .take(MAX_INTERSECT)
+                    .map(|(_, oid)| oid)
+                    .collect();
+            }
 
-    intersect_walk(repo, &roots, source_tree, "", &mut results)?;
-    // The walk visits mirror entries in bucket (hash) order; report candidates in path order.
-    results.sort();
-    results.dedup();
+            (*walk(repo, cache, roots, source_tree)?).clone()
+        }
+    };
+
+    cache
+        .candidates
+        .insert(key, std::sync::Arc::new(results.clone()));
     Ok(results)
 }
 
@@ -719,21 +749,26 @@ fn buckets_of<'tree>(
     map
 }
 
-/// Emit every candidate file path present in ALL of the mirror trees `roots`. Mirror entries
-/// are named by bucket; `source` provides the bucket -> entries mapping per level. A blob
-/// entry expands to every bucket member (each file directly, each directory — coarse leaf —
-/// to all files under it); a tree entry recurses into every large-directory member.
-fn intersect_walk(
+/// The candidate file paths (relative to `source`) present in ALL of the mirror trees
+/// `roots`, memoized on the normalized root set and the source tree. Mirror entries are named
+/// by bucket; `source` provides the bucket -> entries mapping per level. A blob entry expands
+/// to every bucket member (each file directly, each directory — coarse leaf — to all files
+/// under it); a tree entry recurses into every large-directory member. Because results are
+/// relative and keyed by content, walks are shared across commits and across trigrams
+/// wherever the subtrees agree.
+fn walk(
     repo: &git2::Repository,
-    roots: &[git2::Oid],
+    cache: &mut SearchCache,
+    mut roots: Vec<git2::Oid>,
     source: &git2::Tree,
-    prefix: &str,
-    out: &mut Vec<String>,
-) -> anyhow::Result<()> {
-    // Content addressing fast path: identical mirrors (trigrams with the same file set)
-    // intersect to themselves.
-    if roots.iter().all(|oid| *oid == roots[0]) {
-        return collect_mirror_paths(repo, roots[0], source, prefix, out);
+) -> anyhow::Result<std::sync::Arc<Vec<String>>> {
+    // The intersection is a set operation: normalize the key. Identical mirrors (trigrams
+    // with the same file set) intersect to themselves, so duplicates collapse.
+    roots.sort();
+    roots.dedup();
+    let key = (roots.clone(), source.id());
+    if let Some(hit) = cache.walks.get(&key) {
+        return Ok(hit.clone());
     }
 
     let trees = roots
@@ -746,14 +781,19 @@ fn intersect_walk(
         .expect("roots is never empty");
     let buckets = buckets_of(source);
 
+    let mut out = vec![];
     'entry: for entry in smallest.iter() {
         let bucket = entry.name()?;
 
         let mut child_roots = Vec::with_capacity(trees.len());
-        for tree in &trees {
-            match tree.get_name(bucket) {
-                Some(other) if other.kind() == entry.kind() => child_roots.push(other.id()),
-                _ => continue 'entry,
+        if trees.len() == 1 {
+            child_roots.push(entry.id());
+        } else {
+            for tree in &trees {
+                match tree.get_name(bucket) {
+                    Some(other) if other.kind() == entry.kind() => child_roots.push(other.id()),
+                    _ => continue 'entry,
+                }
             }
         }
 
@@ -768,90 +808,61 @@ fn intersect_walk(
                     }
                     let name = member.name()?;
                     let source_child = repo.find_tree(member.id())?;
-                    let path = join_path(prefix, name);
-                    intersect_walk(repo, &child_roots, &source_child, &path, out)?;
+                    let sub = walk(repo, cache, child_roots.clone(), &source_child)?;
+                    out.extend(sub.iter().map(|p| join_path(name, p)));
                 }
             }
-            Some(git2::ObjectType::Blob) => emit_leaf(repo, members, prefix, out)?,
-            _ => {}
-        }
-    }
-    Ok(())
-}
-
-/// Emit the candidates of one mirror blob leaf resolved to its bucket `members`: each file
-/// member directly, each directory member (a coarse leaf) expanded to all files under it.
-fn emit_leaf(
-    repo: &git2::Repository,
-    members: &[git2::TreeEntry],
-    prefix: &str,
-    out: &mut Vec<String>,
-) -> anyhow::Result<()> {
-    for member in members {
-        let name = member.name()?;
-        let path = join_path(prefix, name);
-        match member.kind() {
-            Some(git2::ObjectType::Blob) => out.push(path),
-            Some(git2::ObjectType::Tree) => collect_paths(repo, member.id(), &path, out)?,
-            _ => {}
-        }
-    }
-    Ok(())
-}
-
-/// Emit every candidate of the single mirror `oid`, following `source` for bucket resolution
-/// and coarse expansion.
-fn collect_mirror_paths(
-    repo: &git2::Repository,
-    oid: git2::Oid,
-    source: &git2::Tree,
-    prefix: &str,
-    out: &mut Vec<String>,
-) -> anyhow::Result<()> {
-    let tree = repo.find_tree(oid)?;
-    let buckets = buckets_of(source);
-    for entry in tree.iter() {
-        let bucket = entry.name()?;
-        let Some(members) = buckets.get(bucket) else {
-            continue;
-        };
-        match entry.kind() {
-            Some(git2::ObjectType::Tree) => {
+            Some(git2::ObjectType::Blob) => {
                 for member in members {
-                    if member.kind() != Some(git2::ObjectType::Tree) {
-                        continue;
-                    }
                     let name = member.name()?;
-                    let source_child = repo.find_tree(member.id())?;
-                    let path = join_path(prefix, name);
-                    collect_mirror_paths(repo, entry.id(), &source_child, &path, out)?;
+                    match member.kind() {
+                        Some(git2::ObjectType::Blob) => out.push(name.to_owned()),
+                        Some(git2::ObjectType::Tree) => {
+                            let sub = all_paths(repo, cache, member.id())?;
+                            out.extend(sub.iter().map(|p| join_path(name, p)));
+                        }
+                        _ => {}
+                    }
                 }
             }
-            Some(git2::ObjectType::Blob) => emit_leaf(repo, members, prefix, out)?,
             _ => {}
         }
     }
-    Ok(())
+
+    // Mirror iteration follows bucket (hash) order; keep results in path order.
+    out.sort();
+    out.dedup();
+    let out = std::sync::Arc::new(out);
+    cache.walks.insert(key, out.clone());
+    Ok(out)
 }
 
-/// Emit every blob path under `oid` (a tree), prefixed with `prefix`.
-fn collect_paths(
+/// All file paths under the tree `oid` (relative), memoized per tree: the expansion of coarse
+/// leaves and the fallback for queries without trigrams.
+fn all_paths(
     repo: &git2::Repository,
+    cache: &mut SearchCache,
     oid: git2::Oid,
-    prefix: &str,
-    out: &mut Vec<String>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<std::sync::Arc<Vec<String>>> {
+    if let Some(hit) = cache.all_paths.get(&oid) {
+        return Ok(hit.clone());
+    }
     let tree = repo.find_tree(oid)?;
+    let mut out = vec![];
     for entry in tree.iter() {
         let name = entry.name()?;
-        let path = join_path(prefix, name);
         match entry.kind() {
-            Some(git2::ObjectType::Tree) => collect_paths(repo, entry.id(), &path, out)?,
-            Some(git2::ObjectType::Blob) => out.push(path),
+            Some(git2::ObjectType::Tree) => {
+                let sub = all_paths(repo, cache, entry.id())?;
+                out.extend(sub.iter().map(|p| join_path(name, p)));
+            }
+            Some(git2::ObjectType::Blob) => out.push(name.to_owned()),
             _ => {}
         }
     }
-    Ok(())
+    let out = std::sync::Arc::new(out);
+    cache.all_paths.insert(oid, out.clone());
+    Ok(out)
 }
 
 fn join_path(prefix: &str, name: &str) -> String {
@@ -864,40 +875,49 @@ fn join_path(prefix: &str, name: &str) -> String {
 
 type SearchMatchesResult = Vec<(String, Vec<(usize, String)>)>;
 
+/// Verify `candidates` against the query, byte-exact. Per-blob results are memoized on
+/// (query, blob oid): a blob's matching lines do not depend on the commit or path it appears
+/// under, so verifying a history costs one scan per distinct blob.
 pub fn search_matches(
     repo: &git2::Repository,
+    cache: &mut SearchCache,
     tree: &git2::Tree,
     searchstring: &str,
-    candidates: &Vec<String>,
+    candidates: &[String],
 ) -> anyhow::Result<SearchMatchesResult> {
     let mut results = vec![];
 
     for c in candidates {
-        let b = get_blob_path(repo, tree, std::path::Path::new(&c));
-
-        let mut bresults = vec![];
-
-        for (linenr, l) in b.lines().enumerate() {
-            if l.contains(searchstring) {
-                bresults.push((linenr + 1, l.to_owned()));
+        let Ok(entry) = tree.get_path(std::path::Path::new(&c)) else {
+            continue;
+        };
+        let key = (searchstring.to_owned(), entry.id());
+        let bresults = if let Some(hit) = cache.blob_matches.get(&key) {
+            hit.clone()
+        } else {
+            let b = blob_content(repo, entry.id());
+            let mut lines = vec![];
+            for (linenr, l) in b.lines().enumerate() {
+                if l.contains(searchstring) {
+                    lines.push((linenr + 1, l.to_owned()));
+                }
             }
-        }
+            let lines = std::sync::Arc::new(lines);
+            cache.blob_matches.insert(key, lines.clone());
+            lines
+        };
 
         if !bresults.is_empty() {
-            results.push((c.to_owned(), bresults));
+            results.push((c.to_owned(), (*bresults).clone()));
         }
     }
 
     Ok(results)
 }
 
-/// Like [`get_blob`], but for a (possibly nested) path instead of a root entry name.
-fn get_blob_path(repo: &git2::Repository, tree: &git2::Tree, path: &std::path::Path) -> String {
-    let Ok(entry) = tree.get_path(path) else {
-        return "".to_owned();
-    };
-
-    let Ok(blob) = repo.find_blob(entry.id()) else {
+/// Like [`get_blob`], but by oid: "" if the object is not a blob, binary or not UTF-8.
+fn blob_content(repo: &git2::Repository, oid: git2::Oid) -> String {
+    let Ok(blob) = repo.find_blob(oid) else {
         return "".to_owned();
     };
 
@@ -998,6 +1018,8 @@ mod tests {
             "03111ef5ca624b955d799a80181c1bf0c2099fcd"
         );
 
+        let mut sc = SearchCache::default();
+
         // "Tes" folds to "tes", which lives at 74/65/73 in the hex spine. sub1 is a small
         // directory, so the mirror records it as one coarse blob leaf under its bucket name.
         let leaf = index
@@ -1009,23 +1031,23 @@ mod tests {
         assert_eq!(leaf.kind(), Some(git2::ObjectType::Blob));
 
         // Coarse hits expand to every file under the directory; verification is exact.
-        let candidates = search_candidates(&repo, &index, &tree, "document").unwrap();
+        let candidates = search_candidates(&repo, &mut sc, &index, &tree, "document").unwrap();
         assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
-        let matches = search_matches(&repo, &tree, "document", &candidates).unwrap();
+        let matches = search_matches(&repo, &mut sc, &tree, "document", &candidates).unwrap();
         assert_eq!(matches.len(), 2);
 
         // Trigrams are case-folded, so candidates are a case-insensitive superset ("Test" in
         // file1 makes sub1 a candidate for "test") while match verification stays byte-exact.
-        let candidates = search_candidates(&repo, &index, &tree, "test").unwrap();
+        let candidates = search_candidates(&repo, &mut sc, &index, &tree, "test").unwrap();
         assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
-        let matches = search_matches(&repo, &tree, "test", &candidates).unwrap();
+        let matches = search_matches(&repo, &mut sc, &tree, "test", &candidates).unwrap();
         assert!(matches.is_empty());
 
-        let candidates = search_candidates(&repo, &index, &tree, "missingword").unwrap();
+        let candidates = search_candidates(&repo, &mut sc, &index, &tree, "missingword").unwrap();
         assert!(candidates.is_empty());
 
         // Short query: every file is a candidate.
-        let candidates = search_candidates(&repo, &index, &tree, "e").unwrap();
+        let candidates = search_candidates(&repo, &mut sc, &index, &tree, "e").unwrap();
         assert_eq!(candidates.len(), 3);
 
         // Indexing is deterministic and memoization-independent: a cold rebuild of the same
@@ -1074,10 +1096,11 @@ mod tests {
 
         // The bucket is a superset: both members are candidates for a needle in one of them;
         // verification is exact.
-        let candidates = search_candidates(&repo, &index, &tree, "needleword").unwrap();
+        let mut sc = SearchCache::default();
+        let candidates = search_candidates(&repo, &mut sc, &index, &tree, "needleword").unwrap();
         assert!(candidates.contains(&"big/target_file".to_owned()));
         assert!(candidates.contains(&format!("big/{}", collider)));
-        let matches = search_matches(&repo, &tree, "needleword", &candidates).unwrap();
+        let matches = search_matches(&repo, &mut sc, &tree, "needleword", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "big/target_file");
     }
@@ -1123,18 +1146,20 @@ mod tests {
             .unwrap();
         assert_eq!(leaf.kind(), Some(git2::ObjectType::Blob));
 
+        let mut sc = SearchCache::default();
+
         // Fine candidates stay per-file (modulo bucket collisions) and matches exact.
-        let candidates = search_candidates(&repo, &index, &tree, "uniqueword07").unwrap();
+        let candidates = search_candidates(&repo, &mut sc, &index, &tree, "uniqueword07").unwrap();
         assert!(candidates.contains(&"big/file_07".to_owned()));
-        let matches = search_matches(&repo, &tree, "uniqueword07", &candidates).unwrap();
+        let matches = search_matches(&repo, &mut sc, &tree, "uniqueword07", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "big/file_07");
 
         // A coarse hit makes every file under the directory a candidate; verification is
         // exact.
-        let candidates = search_candidates(&repo, &index, &tree, "needleinsmall").unwrap();
+        let candidates = search_candidates(&repo, &mut sc, &index, &tree, "needleinsmall").unwrap();
         assert_eq!(candidates, vec!["small/a", "small/b"]);
-        let matches = search_matches(&repo, &tree, "needleinsmall", &candidates).unwrap();
+        let matches = search_matches(&repo, &mut sc, &tree, "needleinsmall", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "small/a");
 
@@ -1161,7 +1186,7 @@ mod tests {
                 ("sub2/mod", "alpha beta gamma"),
             ],
         );
-        trigram_index(&repo, &cache, &mut indexer, tree_a).unwrap();
+        let index_a = trigram_index(&repo, &cache, &mut indexer, tree_a.clone()).unwrap();
 
         // One file modified, one removed (its unique trigrams must vanish from the spine), one
         // added in a fresh directory.
@@ -1186,12 +1211,33 @@ mod tests {
             trigram_index(&repo, &cold, &mut Indexer::default(), tree_b.clone()).unwrap();
         assert_eq!(index_b.id(), index_b_cold.id());
 
-        // And the incremental index searches correctly.
-        let hits = search_candidates(&repo, &index_b, &tree_b, "delta").unwrap();
-        assert_eq!(hits, vec!["sub2/mod"]);
-        let hits = search_candidates(&repo, &index_b, &tree_b, "zebra").unwrap();
+        // And the incremental index searches correctly — through a cache warmed on commit A,
+        // like one GraphQL history+search query warms it: memo entries are content-keyed, so
+        // cross-commit reuse must not leak commit A's results into commit B's.
+        let mut sc = SearchCache::default();
+        let hits = search_candidates(&repo, &mut sc, &index_a, &tree_a, "delta").unwrap();
         assert!(hits.is_empty());
-        let hits = search_candidates(&repo, &index_b, &tree_b, "addition").unwrap();
+        let hits = search_candidates(&repo, &mut sc, &index_a, &tree_a, "zebra").unwrap();
+        let matches = search_matches(&repo, &mut sc, &tree_a, "zebra", &hits).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].0, "sub1/gone");
+
+        let hits = search_candidates(&repo, &mut sc, &index_b, &tree_b, "delta").unwrap();
+        assert_eq!(hits, vec!["sub2/mod"]);
+        let hits = search_candidates(&repo, &mut sc, &index_b, &tree_b, "zebra").unwrap();
+        assert!(hits.is_empty());
+        let hits = search_candidates(&repo, &mut sc, &index_b, &tree_b, "addition").unwrap();
         assert_eq!(hits, vec!["sub3/new"]);
+
+        // Warm-cache results equal fresh-cache results.
+        let fresh = search_candidates(
+            &repo,
+            &mut SearchCache::default(),
+            &index_b,
+            &tree_b,
+            "delta",
+        )
+        .unwrap();
+        assert_eq!(fresh, vec!["sub2/mod"]);
     }
 }

--- a/josh-search/src/lib.rs
+++ b/josh-search/src/lib.rs
@@ -632,57 +632,88 @@ pub fn trigram_index(
     Ok(index)
 }
 
+/// Search memoization, meant to be kept alive for many [`search_candidates`] /
+/// [`search_matches`] calls (josh keeps one per transaction). Everything is keyed by content
+/// — object ids and the query string — so entries are valid for any commit of the repository:
+/// searching a history reuses the candidate walks of every shared subtree and verifies every
+/// distinct blob once, no matter how many commits it appears in.
+#[derive(Default)]
+pub struct SearchCache {
+    /// (query, index tree, source tree) -> sorted candidate paths.
+    candidates:
+        HashMap<(String, gix_hash::ObjectId, gix_hash::ObjectId), std::sync::Arc<Vec<String>>>,
+    /// (mirror roots (normalized), source tree) -> relative candidate paths of the walk.
+    walks: HashMap<(Vec<gix_hash::ObjectId>, gix_hash::ObjectId), std::sync::Arc<Vec<String>>>,
+    /// source tree -> all file paths under it (relative).
+    all_paths: HashMap<gix_hash::ObjectId, std::sync::Arc<Vec<String>>>,
+    /// (query, blob) -> matching (line number, line) pairs.
+    blob_matches: HashMap<(String, gix_hash::ObjectId), std::sync::Arc<Vec<(usize, String)>>>,
+}
+
 /// The candidate files for `searchstring`: those containing every trigram of the query.
 ///
 /// Queries shorter than three characters have no trigrams; every file of `source_tree` is a
 /// candidate then, and [`search_matches`] does the filtering.
 pub fn search_candidates(
     src: &dyn Objects,
+    cache: &mut SearchCache,
     index_tree: gix_hash::ObjectId,
     source_tree: gix_hash::ObjectId,
     searchstring: &str,
 ) -> anyhow::Result<Vec<String>> {
+    let key = (searchstring.to_owned(), index_tree, source_tree);
+    if let Some(hit) = cache.candidates.get(&key) {
+        return Ok((**hit).clone());
+    }
+
     let trigrams = distinct_trigrams(searchstring);
 
-    let mut results = vec![];
-    if trigrams.is_empty() {
-        collect_paths(src, source_tree, "", &mut results)?;
-        return Ok(results);
-    }
-
-    let mut roots = vec![];
-    for t in &trigrams {
-        let path = format!("{:02x}/{:02x}/{:02x}", t[0], t[1], t[2]);
-        match path_entry(src, index_tree, std::path::Path::new(&path))? {
-            Some(oid) => roots.push(oid),
-            // A trigram absent from the index cannot occur in any file.
-            None => return Ok(vec![]),
+    let results = if trigrams.is_empty() {
+        (*all_paths(src, cache, source_tree)?).clone()
+    } else {
+        let mut roots = vec![];
+        let mut absent = false;
+        for t in &trigrams {
+            let path = format!("{:02x}/{:02x}/{:02x}", t[0], t[1], t[2]);
+            match path_entry(src, index_tree, std::path::Path::new(&path))? {
+                Some(oid) => roots.push(oid),
+                // A trigram absent from the index cannot occur in any file.
+                None => {
+                    absent = true;
+                    break;
+                }
+            }
         }
-    }
-    roots.sort();
-    roots.dedup();
+        if absent {
+            vec![]
+        } else {
+            roots.sort();
+            roots.dedup();
 
-    // Cap the intersection width: any subset of trigrams yields a superset of candidates, and
-    // search_matches verifies exactly anyway. Keep the mirrors with the fewest entries — they
-    // constrain the most.
-    const MAX_INTERSECT: usize = 16;
-    if roots.len() > MAX_INTERSECT {
-        let mut sized = roots
-            .iter()
-            .map(|&oid| anyhow::Ok((read_tree_entries(src, oid)?.len(), oid)))
-            .collect::<Result<Vec<_>, _>>()?;
-        sized.sort();
-        roots = sized
-            .into_iter()
-            .take(MAX_INTERSECT)
-            .map(|(_, oid)| oid)
-            .collect();
-    }
+            // Cap the intersection width: any subset of trigrams yields a superset of
+            // candidates, and search_matches verifies exactly anyway. Keep the mirrors with
+            // the fewest entries — they constrain the most.
+            const MAX_INTERSECT: usize = 16;
+            if roots.len() > MAX_INTERSECT {
+                let mut sized = roots
+                    .iter()
+                    .map(|&oid| anyhow::Ok((read_tree_entries(src, oid)?.len(), oid)))
+                    .collect::<Result<Vec<_>, _>>()?;
+                sized.sort();
+                roots = sized
+                    .into_iter()
+                    .take(MAX_INTERSECT)
+                    .map(|(_, oid)| oid)
+                    .collect();
+            }
 
-    intersect_walk(src, &roots, source_tree, "", &mut results)?;
-    // The walk visits mirror entries in bucket (hash) order; report candidates in path order.
-    results.sort();
-    results.dedup();
+            (*walk(src, cache, roots, source_tree)?).clone()
+        }
+    };
+
+    cache
+        .candidates
+        .insert(key, std::sync::Arc::new(results.clone()));
     Ok(results)
 }
 
@@ -698,21 +729,26 @@ fn buckets_of(
     map
 }
 
-/// Emit every candidate file path present in ALL of the mirror trees `roots`. Mirror entries
-/// are named by bucket; `source` provides the bucket -> entries mapping per level. A blob
-/// entry expands to every bucket member (each file directly, each directory — coarse leaf —
-/// to all files under it); a tree entry recurses into every large-directory member.
-fn intersect_walk(
+/// The candidate file paths (relative to `source`) present in ALL of the mirror trees
+/// `roots`, memoized on the normalized root set and the source tree. Mirror entries are named
+/// by bucket; `source` provides the bucket -> entries mapping per level. A blob entry expands
+/// to every bucket member (each file directly, each directory — coarse leaf — to all files
+/// under it); a tree entry recurses into every large-directory member. Because results are
+/// relative and keyed by content, walks are shared across commits and across trigrams
+/// wherever the subtrees agree.
+fn walk(
     src: &dyn Objects,
-    roots: &[gix_hash::ObjectId],
+    cache: &mut SearchCache,
+    mut roots: Vec<gix_hash::ObjectId>,
     source: gix_hash::ObjectId,
-    prefix: &str,
-    out: &mut Vec<String>,
-) -> anyhow::Result<()> {
-    // Content addressing fast path: identical mirrors (trigrams with the same file set)
-    // intersect to themselves.
-    if roots.iter().all(|oid| *oid == roots[0]) {
-        return collect_mirror_paths(src, roots[0], source, prefix, out);
+) -> anyhow::Result<std::sync::Arc<Vec<String>>> {
+    // The intersection is a set operation: normalize the key. Identical mirrors (trigrams
+    // with the same file set) intersect to themselves, so duplicates collapse.
+    roots.sort();
+    roots.dedup();
+    let key = (roots.clone(), source);
+    if let Some(hit) = cache.walks.get(&key) {
+        return Ok(hit.clone());
     }
 
     let trees = roots
@@ -726,16 +762,21 @@ fn intersect_walk(
     let source_entries = read_tree_entries(src, source)?;
     let buckets = buckets_of(&source_entries);
 
+    let mut out = vec![];
     'entry: for entry in smallest {
         let bucket = std::str::from_utf8(&entry.filename)?;
 
         let mut child_roots = Vec::with_capacity(trees.len());
-        for tree in &trees {
-            match tree.iter().find(|e| e.filename == entry.filename) {
-                Some(other) if other.mode.is_tree() == entry.mode.is_tree() => {
-                    child_roots.push(other.oid.to_owned())
+        if trees.len() == 1 {
+            child_roots.push(entry.oid.to_owned());
+        } else {
+            for tree in &trees {
+                match tree.iter().find(|e| e.filename == entry.filename) {
+                    Some(other) if other.mode.is_tree() == entry.mode.is_tree() => {
+                        child_roots.push(other.oid.to_owned())
+                    }
+                    _ => continue 'entry,
                 }
-                _ => continue 'entry,
             }
         }
 
@@ -748,66 +789,28 @@ fn intersect_walk(
                     continue;
                 }
                 let name = std::str::from_utf8(&member.filename)?;
-                let path = join_path(prefix, name);
-                intersect_walk(src, &child_roots, member.oid.to_owned(), &path, out)?;
+                let sub = walk(src, cache, child_roots.clone(), member.oid.to_owned())?;
+                out.extend(sub.iter().map(|p| join_path(name, p)));
             }
         } else if !entry.mode.is_commit() {
-            emit_leaf(src, members, prefix, out)?;
-        }
-    }
-    Ok(())
-}
-
-/// Emit the candidates of one mirror blob leaf resolved to its bucket `members`: each file
-/// member directly, each directory member (a coarse leaf) expanded to all files under it.
-fn emit_leaf(
-    src: &dyn Objects,
-    members: &[&gix_object::tree::Entry],
-    prefix: &str,
-    out: &mut Vec<String>,
-) -> anyhow::Result<()> {
-    for member in members {
-        let name = std::str::from_utf8(&member.filename)?;
-        let path = join_path(prefix, name);
-        if member.mode.is_tree() {
-            collect_paths(src, member.oid.to_owned(), &path, out)?;
-        } else if !member.mode.is_commit() {
-            out.push(path);
-        }
-    }
-    Ok(())
-}
-
-/// Emit every candidate of the single mirror `oid`, following `source` for bucket resolution
-/// and coarse expansion.
-fn collect_mirror_paths(
-    src: &dyn Objects,
-    oid: gix_hash::ObjectId,
-    source: gix_hash::ObjectId,
-    prefix: &str,
-    out: &mut Vec<String>,
-) -> anyhow::Result<()> {
-    let source_entries = read_tree_entries(src, source)?;
-    let buckets = buckets_of(&source_entries);
-    for entry in read_tree_entries(src, oid)? {
-        let bucket = std::str::from_utf8(&entry.filename)?;
-        let Some(members) = buckets.get(bucket) else {
-            continue;
-        };
-        if entry.mode.is_tree() {
             for member in members {
-                if !member.mode.is_tree() {
-                    continue;
-                }
                 let name = std::str::from_utf8(&member.filename)?;
-                let path = join_path(prefix, name);
-                collect_mirror_paths(src, entry.oid.to_owned(), member.oid.to_owned(), &path, out)?;
+                if member.mode.is_tree() {
+                    let sub = all_paths(src, cache, member.oid.to_owned())?;
+                    out.extend(sub.iter().map(|p| join_path(name, p)));
+                } else if !member.mode.is_commit() {
+                    out.push(name.to_owned());
+                }
             }
-        } else if !entry.mode.is_commit() {
-            emit_leaf(src, members, prefix, out)?;
         }
     }
-    Ok(())
+
+    // Mirror iteration follows bucket (hash) order; keep results in path order.
+    out.sort();
+    out.dedup();
+    let out = std::sync::Arc::new(out);
+    cache.walks.insert(key, out.clone());
+    Ok(out)
 }
 
 /// The entries of the tree `oid`, owned so several trees can be walked side by side.
@@ -830,34 +833,29 @@ fn read_tree_entries(
     )
 }
 
-/// Emit every blob path under `oid` (a tree), prefixed with `prefix`.
-fn collect_paths(
+/// All file paths under the tree `oid` (relative), memoized per tree: the expansion of coarse
+/// leaves and the fallback for queries without trigrams.
+fn all_paths(
     src: &dyn Objects,
+    cache: &mut SearchCache,
     oid: gix_hash::ObjectId,
-    prefix: &str,
-    out: &mut Vec<String>,
-) -> anyhow::Result<()> {
-    let mut buffer = Vec::new();
-    let Some(data) = src
-        .try_find(&oid, &mut buffer)
-        .map_err(|e| anyhow::anyhow!("read tree {}: {}", oid, e))?
-    else {
-        return Ok(());
-    };
-    if data.kind != gix_object::Kind::Tree {
-        return Ok(());
+) -> anyhow::Result<std::sync::Arc<Vec<String>>> {
+    if let Some(hit) = cache.all_paths.get(&oid) {
+        return Ok(hit.clone());
     }
-    let tree = gix_object::TreeRef::from_bytes(&buffer, gix_hash::Kind::Sha1)?.into_owned();
-    for entry in tree.entries {
+    let mut out = vec![];
+    for entry in read_tree_entries(src, oid)? {
         let name = std::str::from_utf8(&entry.filename)?;
-        let path = join_path(prefix, name);
         if entry.mode.is_tree() {
-            collect_paths(src, entry.oid.to_owned(), &path, out)?;
+            let sub = all_paths(src, cache, entry.oid.to_owned())?;
+            out.extend(sub.iter().map(|p| join_path(name, p)));
         } else if !entry.mode.is_commit() {
-            out.push(path);
+            out.push(name.to_owned());
         }
     }
-    Ok(())
+    let out = std::sync::Arc::new(out);
+    cache.all_paths.insert(oid, out.clone());
+    Ok(out)
 }
 
 fn join_path(prefix: &str, name: &str) -> String {
@@ -870,39 +868,44 @@ fn join_path(prefix: &str, name: &str) -> String {
 
 type SearchMatchesResult = Vec<(String, Vec<(usize, String)>)>;
 
+/// Verify `candidates` against the query, byte-exact. Per-blob results are memoized on
+/// (query, blob oid): a blob's matching lines do not depend on the commit or path it appears
+/// under, so verifying a history costs one scan per distinct blob.
 pub fn search_matches(
     src: &dyn Objects,
+    cache: &mut SearchCache,
     tree: gix_hash::ObjectId,
     searchstring: &str,
-    candidates: &Vec<String>,
+    candidates: &[String],
 ) -> anyhow::Result<SearchMatchesResult> {
     let mut results = vec![];
 
     for c in candidates {
-        let b = get_blob_path(src, tree, std::path::Path::new(&c));
-
-        let mut bresults = vec![];
-
-        for (linenr, l) in b.lines().enumerate() {
-            if l.contains(searchstring) {
-                bresults.push((linenr + 1, l.to_owned()));
+        let Some(blob) = path_entry(src, tree, std::path::Path::new(&c))? else {
+            continue;
+        };
+        let key = (searchstring.to_owned(), blob);
+        let bresults = if let Some(hit) = cache.blob_matches.get(&key) {
+            hit.clone()
+        } else {
+            let b = read_blob_text(src, blob);
+            let mut lines = vec![];
+            for (linenr, l) in b.lines().enumerate() {
+                if l.contains(searchstring) {
+                    lines.push((linenr + 1, l.to_owned()));
+                }
             }
-        }
+            let lines = std::sync::Arc::new(lines);
+            cache.blob_matches.insert(key, lines.clone());
+            lines
+        };
 
         if !bresults.is_empty() {
-            results.push((c.to_owned(), bresults));
+            results.push((c.to_owned(), (*bresults).clone()));
         }
     }
 
     Ok(results)
-}
-
-/// Like [`read_blob_text`], but for a path inside `tree`.
-fn get_blob_path(src: &dyn Objects, tree: gix_hash::ObjectId, path: &std::path::Path) -> String {
-    match path_entry(src, tree, path) {
-        Ok(Some(oid)) => read_blob_text(src, oid),
-        _ => "".to_owned(),
-    }
 }
 
 /// The oid at `path` inside `tree`, or `None` when any component is missing or not a tree.
@@ -1031,6 +1034,8 @@ mod tests {
             "03111ef5ca624b955d799a80181c1bf0c2099fcd"
         );
 
+        let mut sc = SearchCache::default();
+
         // "Tes" folds to "tes", which lives at 74/65/73 in the hex spine. sub1 is a small
         // directory, so the mirror records it as one coarse blob leaf under its bucket name.
         let leaf = path_entry(
@@ -1049,23 +1054,26 @@ mod tests {
         );
 
         // Coarse hits expand to every file under the directory; verification is exact.
-        let candidates = search_candidates(objects(&repo), index, tree, "document").unwrap();
+        let candidates =
+            search_candidates(objects(&repo), &mut sc, index, tree, "document").unwrap();
         assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
-        let matches = search_matches(objects(&repo), tree, "document", &candidates).unwrap();
+        let matches =
+            search_matches(objects(&repo), &mut sc, tree, "document", &candidates).unwrap();
         assert_eq!(matches.len(), 2);
 
         // Trigrams are case-folded, so candidates are a case-insensitive superset ("Test" in
         // file1 makes sub1 a candidate for "test") while match verification stays byte-exact.
-        let candidates = search_candidates(objects(&repo), index, tree, "test").unwrap();
+        let candidates = search_candidates(objects(&repo), &mut sc, index, tree, "test").unwrap();
         assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
-        let matches = search_matches(objects(&repo), tree, "test", &candidates).unwrap();
+        let matches = search_matches(objects(&repo), &mut sc, tree, "test", &candidates).unwrap();
         assert!(matches.is_empty());
 
-        let candidates = search_candidates(objects(&repo), index, tree, "missingword").unwrap();
+        let candidates =
+            search_candidates(objects(&repo), &mut sc, index, tree, "missingword").unwrap();
         assert!(candidates.is_empty());
 
         // Short query: every file is a candidate.
-        let candidates = search_candidates(objects(&repo), index, tree, "e").unwrap();
+        let candidates = search_candidates(objects(&repo), &mut sc, index, tree, "e").unwrap();
         assert_eq!(candidates.len(), 3);
 
         // Indexing is deterministic and memoization-independent.
@@ -1112,10 +1120,13 @@ mod tests {
 
         // The bucket is a superset: both members are candidates for a needle in one of them;
         // verification is exact.
-        let candidates = search_candidates(objects(&repo), index, tree, "needleword").unwrap();
+        let mut sc = SearchCache::default();
+        let candidates =
+            search_candidates(objects(&repo), &mut sc, index, tree, "needleword").unwrap();
         assert!(candidates.contains(&"big/target_file".to_owned()));
         assert!(candidates.contains(&format!("big/{}", collider)));
-        let matches = search_matches(objects(&repo), tree, "needleword", &candidates).unwrap();
+        let matches =
+            search_matches(objects(&repo), &mut sc, tree, "needleword", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "big/target_file");
     }
@@ -1178,18 +1189,24 @@ mod tests {
             gix_object::Kind::Blob
         );
 
+        let mut sc = SearchCache::default();
+
         // Fine candidates stay per-file (modulo bucket collisions) and matches exact.
-        let candidates = search_candidates(objects(&repo), index, tree, "uniqueword07").unwrap();
+        let candidates =
+            search_candidates(objects(&repo), &mut sc, index, tree, "uniqueword07").unwrap();
         assert!(candidates.contains(&"big/file_07".to_owned()));
-        let matches = search_matches(objects(&repo), tree, "uniqueword07", &candidates).unwrap();
+        let matches =
+            search_matches(objects(&repo), &mut sc, tree, "uniqueword07", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "big/file_07");
 
         // A coarse hit makes every file under the directory a candidate; verification is
         // exact.
-        let candidates = search_candidates(objects(&repo), index, tree, "needleinsmall").unwrap();
+        let candidates =
+            search_candidates(objects(&repo), &mut sc, index, tree, "needleinsmall").unwrap();
         assert_eq!(candidates, vec!["small/a", "small/b"]);
-        let matches = search_matches(objects(&repo), tree, "needleinsmall", &candidates).unwrap();
+        let matches =
+            search_matches(objects(&repo), &mut sc, tree, "needleinsmall", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "small/a");
 
@@ -1216,7 +1233,7 @@ mod tests {
                 ("sub2/mod", "alpha beta gamma"),
             ],
         );
-        trigram_index(objects(&repo), &cache, &mut indexer, tree_a).unwrap();
+        let index_a = trigram_index(objects(&repo), &cache, &mut indexer, tree_a).unwrap();
 
         // One file modified, one removed (its unique trigrams must vanish from the spine), one
         // added in a fresh directory.
@@ -1241,12 +1258,33 @@ mod tests {
             trigram_index(objects(&repo), &cold, &mut Indexer::default(), tree_b).unwrap();
         assert_eq!(index_b, index_b_cold);
 
-        // The incremental index searches correctly.
-        let hits = search_candidates(objects(&repo), index_b, tree_b, "delta").unwrap();
-        assert_eq!(hits, vec!["sub2/mod"]);
-        let hits = search_candidates(objects(&repo), index_b, tree_b, "zebra").unwrap();
+        // The incremental index searches correctly — through a cache warmed on commit A,
+        // like one GraphQL history+search query warms it: memo entries are content-keyed, so
+        // cross-commit reuse must not leak commit A's results into commit B's.
+        let mut sc = SearchCache::default();
+        let hits = search_candidates(objects(&repo), &mut sc, index_a, tree_a, "delta").unwrap();
         assert!(hits.is_empty());
-        let hits = search_candidates(objects(&repo), index_b, tree_b, "addition").unwrap();
+        let hits = search_candidates(objects(&repo), &mut sc, index_a, tree_a, "zebra").unwrap();
+        let matches = search_matches(objects(&repo), &mut sc, tree_a, "zebra", &hits).unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].0, "sub1/gone");
+
+        let hits = search_candidates(objects(&repo), &mut sc, index_b, tree_b, "delta").unwrap();
+        assert_eq!(hits, vec!["sub2/mod"]);
+        let hits = search_candidates(objects(&repo), &mut sc, index_b, tree_b, "zebra").unwrap();
+        assert!(hits.is_empty());
+        let hits = search_candidates(objects(&repo), &mut sc, index_b, tree_b, "addition").unwrap();
         assert_eq!(hits, vec!["sub3/new"]);
+
+        // Warm-cache results equal fresh-cache results.
+        let fresh = search_candidates(
+            objects(&repo),
+            &mut SearchCache::default(),
+            index_b,
+            tree_b,
+            "delta",
+        )
+        .unwrap();
+        assert_eq!(fresh, vec!["sub2/mod"]);
     }
 }


### PR DESCRIPTION
Memoize search across commits with a transaction-held cache

Searching many commits of a history -- one GraphQL query iterating
history { search } does exactly that -- repeated almost all of its work,
although consecutive commits share nearly every subtree.

search_candidates and search_matches now take a SearchCache memoizing
purely on content: candidate lists, the mirror-intersection walks (kept
relative, so position-independent), the all-files expansion, and per-blob
match verification. The Transaction owns one, so the GraphQL search field
benefits without API changes there.

On the josh repository, one query searching all 2240 commits with identical
output: a rare identifier 1.69s -> 0.95s, a common word 40.3s -> 3.7s.

Change: trigram-search-cache
Assisted-By: anthropic/claude-fable-5