### PR TITLE
Carry blob ids through search and merge mirror entries

### DIFF
--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -31,6 +31,14 @@ fn make_app() -> clap::Command {
     let app = clap::Command::new("josh-filter");
 
     let app = { app.arg(clap::Arg::new("search").long("search")) };
+    let app = {
+        app.arg(
+            clap::Arg::new("search-history")
+                .long("search-history")
+                .action(clap::ArgAction::SetTrue)
+                .help("With --search: search every commit of the filtered first-parent history"),
+        )
+    };
 
     app
         .arg(
@@ -337,6 +345,52 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     josh_core::update_refs(&transaction, updated_refs.clone());
 
     if let Some(searchstring) = args.get_one::<String>("search") {
+        if args.get_flag("search-history") {
+            if !josh_core::filter::experimental_features_enabled() {
+                anyhow::bail!("--search-history requires JOSH_EXPERIMENTAL_FEATURES=1");
+            }
+            // Search every reachable commit of the filtered history (like `git log -S`, the
+            // whole graph, not just first-parent). Walking the filtered graph directly gives
+            // exactly the trees being searched — no mapping back and forth between original
+            // and filtered commits.
+            let commit = transaction
+                .rev_parse(&input_ref)?
+                .ok_or_else(|| anyhow!("no such revision: {}", input_ref))?;
+            let filtered_id = josh_core::filter_commit(&transaction, filterobj, commit)?;
+            let ifilterobj = josh_core::filter::parse(":INDEX")?;
+            let odb = transaction.odb();
+
+            let mut walk = josh_core::objects::RevWalk::new(odb);
+            walk.push(filtered_id)?;
+            for id in walk.into_topo_vec(|_| false)? {
+                let tree = josh_core::objects::CommitData::read(odb, id)?.tree_id()?;
+                let index_tree = josh_core::filter::apply(
+                    &transaction,
+                    ifilterobj,
+                    josh_core::filter::Rewrite::from_tree(tree),
+                )?
+                .tree_id();
+                let candidates = josh_search::search_candidates(
+                    odb,
+                    &mut transaction.search_cache(),
+                    index_tree,
+                    tree,
+                    searchstring,
+                )?;
+                let matches = josh_search::search_matches(
+                    odb,
+                    &mut transaction.search_cache(),
+                    searchstring,
+                    &candidates,
+                )?;
+                for r in matches {
+                    for l in r.1 {
+                        println!("{}:{}:{}: {}", id, r.0, l.0, l.1);
+                    }
+                }
+            }
+            return Ok(0);
+        }
         let commit = transaction
             .rev_parse(&input_ref)?
             .ok_or_else(|| anyhow!("no such revision: {}", input_ref))?;
@@ -375,7 +429,10 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
                     && let Ok(name) = std::str::from_utf8(entry.filename)
                 {
                     let separator = if parent.is_empty() { "" } else { "/" };
-                    scan.push(format!("{}{}{}", parent, separator, name));
+                    scan.push((
+                        format!("{}{}{}", parent, separator, name),
+                        entry.oid.to_owned(),
+                    ));
                 }
                 Ok(())
             })?;
@@ -384,7 +441,6 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         let matches = josh_search::search_matches(
             odb,
             &mut transaction.search_cache(),
-            tree,
             searchstring,
             &candidates,
         )?;

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -25,6 +25,14 @@ fn make_app() -> clap::Command {
     let app = clap::Command::new("josh-filter");
 
     let app = { app.arg(clap::Arg::new("search").long("search")) };
+    let app = {
+        app.arg(
+            clap::Arg::new("search-history")
+                .long("search-history")
+                .action(clap::ArgAction::SetTrue)
+                .help("With --search: search every commit of the filtered first-parent history"),
+        )
+    };
 
     app
         .arg(
@@ -368,6 +376,53 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     josh_core::update_refs(&transaction, updated_refs.clone());
 
     if let Some(searchstring) = args.get_one::<String>("search") {
+        if args.get_flag("search-history") {
+            if !josh_core::filter::experimental_features_enabled() {
+                anyhow::bail!("--search-history requires JOSH_EXPERIMENTAL_FEATURES=1");
+            }
+            // Search every reachable commit of the filtered history (like `git log -S`, the
+            // whole graph, not just first-parent). Walking the filtered graph directly gives
+            // exactly the trees being searched — no mapping back and forth between original
+            // and filtered commits.
+            let commit = repo.revparse_single(&input_ref)?.peel_to_commit()?;
+            let filtered_id = josh_core::filter_commit(&transaction, filterobj, commit.id())?;
+            let ifilterobj = josh_core::filter::parse(":INDEX")?;
+
+            let mut walk = repo.revwalk()?;
+            walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+            walk.push(filtered_id)?;
+            for id in walk {
+                let id = id?;
+                let tree = repo.find_commit(id)?.tree()?;
+                let index_tree = josh_core::filter::apply(
+                    &transaction,
+                    ifilterobj,
+                    josh_core::filter::Rewrite::from_tree(tree.clone()),
+                )?
+                .tree()
+                .clone();
+                let candidates = josh_search::search_candidates(
+                    &repo,
+                    &mut transaction.search_cache(),
+                    &index_tree,
+                    &tree,
+                    searchstring,
+                )?;
+                let matches = josh_search::search_matches(
+                    &repo,
+                    &mut transaction.search_cache(),
+                    searchstring,
+                    &candidates,
+                )?;
+                for r in matches {
+                    for l in r.1 {
+                        println!("{}:{}:{}: {}", id, r.0, l.0, l.1);
+                    }
+                }
+            }
+            return Ok(0);
+        }
+
         let commit = repo.revparse_single(&input_ref)?.peel_to_commit()?;
 
         let tree = repo
@@ -405,7 +460,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
                 if entry.kind() == Some(git2::ObjectType::Blob)
                     && let Ok(name) = entry.name()
                 {
-                    scan.push(format!("{}{}", root, name));
+                    scan.push((format!("{}{}", root, name), entry.id()));
                 }
                 0
             })?;
@@ -414,7 +469,6 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         let matches = josh_search::search_matches(
             &repo,
             &mut transaction.search_cache(),
-            &tree,
             searchstring,
             &candidates,
         )?;

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -452,7 +452,7 @@ impl Revision {
                 if entry.kind() == Some(git2::ObjectType::Blob)
                     && let Ok(name) = entry.name()
                 {
-                    scan.push(format!("{}{}", root, name));
+                    scan.push((format!("{}{}", root, name), entry.id()));
                 }
                 0
             })?;
@@ -461,7 +461,6 @@ impl Revision {
         let results = josh_search::search_matches(
             transaction.repo(),
             &mut transaction.search_cache(),
-            x.tree(),
             &string,
             &candidates,
         )?;

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -471,7 +471,10 @@ impl Revision {
                     && let Ok(name) = std::str::from_utf8(entry.filename)
                 {
                     let separator = if parent.is_empty() { "" } else { "/" };
-                    scan.push(format!("{}{}{}", parent, separator, name));
+                    scan.push((
+                        format!("{}{}{}", parent, separator, name),
+                        entry.oid.to_owned(),
+                    ));
                 }
                 Ok(())
             })?;
@@ -480,7 +483,6 @@ impl Revision {
         let results = josh_search::search_matches(
             odb,
             &mut transaction.search_cache(),
-            x.tree_id(),
             &string,
             &candidates,
         )?;

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -283,9 +283,12 @@ fn search(
     index_tree: &git2::Tree,
     source_tree: &git2::Tree,
     needle: &str,
-) -> anyhow::Result<(Vec<String>, Vec<(String, Vec<(usize, String)>)>)> {
+) -> anyhow::Result<(
+    Vec<(String, git2::Oid)>,
+    Vec<(String, Vec<(usize, String)>)>,
+)> {
     let candidates = josh_search::search_candidates(repo, cache, index_tree, source_tree, needle)?;
-    let matches = josh_search::search_matches(repo, cache, source_tree, needle, &candidates)?;
+    let matches = josh_search::search_matches(repo, cache, needle, &candidates)?;
     Ok((candidates, matches))
 }
 

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -318,9 +318,12 @@ fn search(
     index_tree: gix_hash::ObjectId,
     source_tree: gix_hash::ObjectId,
     needle: &str,
-) -> anyhow::Result<(Vec<String>, Vec<(String, Vec<(usize, String)>)>)> {
+) -> anyhow::Result<(
+    Vec<(String, gix_hash::ObjectId)>,
+    Vec<(String, Vec<(usize, String)>)>,
+)> {
     let candidates = josh_search::search_candidates(src, cache, index_tree, source_tree, needle)?;
-    let matches = josh_search::search_matches(src, cache, source_tree, needle, &candidates)?;
+    let matches = josh_search::search_matches(src, cache, needle, &candidates)?;
     Ok((candidates, matches))
 }
 

--- a/josh-search/src/lib.rs
+++ b/josh-search/src/lib.rs
@@ -118,12 +118,38 @@ fn hex_name(b: u8) -> BString {
 /// go (a dense scheme like positions would rename neighbours on every insertion), while
 /// cutting entry names to two bytes and capping mirror fan-out at 256. Colliding names share
 /// a bucket, which then means "some member contains the trigram".
-fn bucket_name(name: &[u8]) -> String {
+fn bucket_byte(name: &[u8]) -> u8 {
     let mut h: u32 = 0x811c9dc5;
     for &b in name {
         h = (h ^ b as u32).wrapping_mul(0x01000193);
     }
-    format!("{:02x}", (h ^ (h >> 8) ^ (h >> 16) ^ (h >> 24)) & 0xff)
+    (h ^ (h >> 8) ^ (h >> 16) ^ (h >> 24)) as u8
+}
+
+fn bucket_name(name: &[u8]) -> String {
+    format!("{:02x}", bucket_byte(name))
+}
+
+/// A byte as two lowercase hex chars — the fixed-width entry-name form used by both the spine
+/// and the mirror bucket levels.
+fn hex_pair(b: u8) -> [u8; 2] {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    [HEX[(b >> 4) as usize], HEX[(b & 15) as usize]]
+}
+
+/// Parse a mirror entry name (two lowercase hex chars) back into its bucket byte.
+fn parse_bucket(name: &[u8]) -> Option<u8> {
+    fn hex_val(b: u8) -> Option<u8> {
+        match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 10),
+            _ => None,
+        }
+    }
+    match name {
+        [hi, lo] => Some(hex_val(*hi)? * 16 + hex_val(*lo)?),
+        _ => None,
+    }
 }
 
 /// A source directory's indexable entries with their mirror bucket names: blobs and trees in
@@ -639,13 +665,22 @@ pub fn trigram_index(
 /// distinct blob once, no matter how many commits it appears in.
 #[derive(Default)]
 pub struct SearchCache {
-    /// (query, index tree, source tree) -> sorted candidate paths.
-    candidates:
-        HashMap<(String, gix_hash::ObjectId, gix_hash::ObjectId), std::sync::Arc<Vec<String>>>,
-    /// (mirror roots (normalized), source tree) -> relative candidate paths of the walk.
-    walks: HashMap<(Vec<gix_hash::ObjectId>, gix_hash::ObjectId), std::sync::Arc<Vec<String>>>,
-    /// source tree -> all file paths under it (relative).
-    all_paths: HashMap<gix_hash::ObjectId, std::sync::Arc<Vec<String>>>,
+    /// (query, index tree, source tree) -> sorted candidate (path, blob) pairs.
+    candidates: HashMap<
+        (String, gix_hash::ObjectId, gix_hash::ObjectId),
+        std::sync::Arc<Vec<(String, gix_hash::ObjectId)>>,
+    >,
+    /// (mirror roots (normalized), source tree) -> relative candidate (path, blob) pairs.
+    walks: HashMap<
+        (Vec<gix_hash::ObjectId>, gix_hash::ObjectId),
+        std::sync::Arc<Vec<(String, gix_hash::ObjectId)>>,
+    >,
+    /// Mirror tree oid -> its entries in compact parsed form. Mirrors are shared heavily
+    /// across commits and trigrams, and parsing each distinct mirror once avoids repeated
+    /// object decoding.
+    mirrors: HashMap<gix_hash::ObjectId, std::sync::Arc<Vec<MirrorEntry>>>,
+    /// source tree -> all (relative path, blob) pairs under it.
+    all_paths: HashMap<gix_hash::ObjectId, std::sync::Arc<Vec<(String, gix_hash::ObjectId)>>>,
     /// (query, blob) -> matching (line number, line) pairs.
     blob_matches: HashMap<(String, gix_hash::ObjectId), std::sync::Arc<Vec<(usize, String)>>>,
 }
@@ -660,7 +695,7 @@ pub fn search_candidates(
     index_tree: gix_hash::ObjectId,
     source_tree: gix_hash::ObjectId,
     searchstring: &str,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<Vec<(String, gix_hash::ObjectId)>> {
     let key = (searchstring.to_owned(), index_tree, source_tree);
     if let Some(hit) = cache.candidates.get(&key) {
         return Ok((**hit).clone());
@@ -671,18 +706,25 @@ pub fn search_candidates(
     let results = if trigrams.is_empty() {
         (*all_paths(src, cache, source_tree)?).clone()
     } else {
+        // Resolve each trigram's three spine levels through the parsed-mirror cache (spine
+        // names are the same fixed-width hex as bucket names): each distinct spine node is
+        // parsed once per process instead of once per lookup.
         let mut roots = vec![];
         let mut absent = false;
-        for t in &trigrams {
-            let path = format!("{:02x}/{:02x}/{:02x}", t[0], t[1], t[2]);
-            match path_entry(src, index_tree, std::path::Path::new(&path))? {
-                Some(oid) => roots.push(oid),
-                // A trigram absent from the index cannot occur in any file.
-                None => {
-                    absent = true;
-                    break;
+        'trigram: for t in &trigrams {
+            let mut node = index_tree;
+            for b in t {
+                let entries = mirror_entries(src, cache, node)?;
+                match entries.binary_search_by_key(&hex_pair(*b), |e| e.name) {
+                    Ok(i) => node = entries[i].oid,
+                    // A trigram absent from the index cannot occur in any file.
+                    Err(_) => {
+                        absent = true;
+                        break 'trigram;
+                    }
                 }
             }
+            roots.push(node);
         }
         if absent {
             vec![]
@@ -697,7 +739,7 @@ pub fn search_candidates(
             if roots.len() > MAX_INTERSECT {
                 let mut sized = roots
                     .iter()
-                    .map(|&oid| anyhow::Ok((read_tree_entries(src, oid)?.len(), oid)))
+                    .map(|&oid| anyhow::Ok((mirror_entries(src, cache, oid)?.len(), oid)))
                     .collect::<Result<Vec<_>, _>>()?;
                 sized.sort();
                 roots = sized
@@ -717,31 +759,55 @@ pub fn search_candidates(
     Ok(results)
 }
 
-/// The bucket -> source entries mapping of one directory level. Colliding names share a
-/// bucket, so a mirror entry can resolve to several source entries.
-fn buckets_of(
-    source_entries: &[gix_object::tree::Entry],
-) -> HashMap<String, Vec<&gix_object::tree::Entry>> {
-    let mut map: HashMap<String, Vec<&gix_object::tree::Entry>> = HashMap::new();
-    for (bucket, entry) in bucketed_entries(source_entries) {
-        map.entry(bucket).or_default().push(entry);
+/// One mirror tree entry in compact parsed form: the fixed-width bucket name, the child oid,
+/// and whether it is a subtree (versus a coarse or file leaf).
+struct MirrorEntry {
+    name: [u8; 2],
+    oid: gix_hash::ObjectId,
+    tree: bool,
+}
+
+/// The entries of the mirror tree `oid`, parsed once per process and memoized.
+fn mirror_entries(
+    src: &dyn Objects,
+    cache: &mut SearchCache,
+    oid: gix_hash::ObjectId,
+) -> anyhow::Result<std::sync::Arc<Vec<MirrorEntry>>> {
+    if let Some(hit) = cache.mirrors.get(&oid) {
+        return Ok(hit.clone());
     }
-    map
+    let mut entries = vec![];
+    for entry in read_tree_entries(src, oid)? {
+        if let [a, b] = entry.filename.as_slice() {
+            entries.push(MirrorEntry {
+                name: [*a, *b],
+                oid: entry.oid.to_owned(),
+                tree: entry.mode.is_tree(),
+            });
+        }
+    }
+    let entries = std::sync::Arc::new(entries);
+    cache.mirrors.insert(oid, entries.clone());
+    Ok(entries)
 }
 
 /// The candidate file paths (relative to `source`) present in ALL of the mirror trees
-/// `roots`, memoized on the normalized root set and the source tree. Mirror entries are named
-/// by bucket; `source` provides the bucket -> entries mapping per level. A blob entry expands
-/// to every bucket member (each file directly, each directory — coarse leaf — to all files
-/// under it); a tree entry recurses into every large-directory member. Because results are
-/// relative and keyed by content, walks are shared across commits and across trigrams
-/// wherever the subtrees agree.
+/// `roots`. Mirror entries are named by bucket; `source` provides the bucket -> entries
+/// mapping per level. A blob entry expands to every bucket member (each file directly, each
+/// directory — a coarse leaf — to all files under it); a tree entry recurses into every
+/// large-directory member. Results are relative and keyed by content, so a walk is reused
+/// across commits and trigrams wherever the subtrees agree.
+///
+/// The intersection is a k-way merge over the mirrors' entry lists: bucket names are fixed
+/// width, so git's canonical entry order is plain byte order and one linear pass replaces
+/// per-bucket lookups. This loop runs once per commit of a history sweep, so its constant
+/// factor matters.
 fn walk(
     src: &dyn Objects,
     cache: &mut SearchCache,
     mut roots: Vec<gix_hash::ObjectId>,
     source: gix_hash::ObjectId,
-) -> anyhow::Result<std::sync::Arc<Vec<String>>> {
+) -> anyhow::Result<std::sync::Arc<Vec<(String, gix_hash::ObjectId)>>> {
     // The intersection is a set operation: normalize the key. Identical mirrors (trigrams
     // with the same file set) intersect to themselves, so duplicates collapse.
     roots.sort();
@@ -751,57 +817,83 @@ fn walk(
         return Ok(hit.clone());
     }
 
-    let trees = roots
+    let entry_lists = roots
         .iter()
-        .map(|oid| read_tree_entries(src, *oid))
+        .map(|oid| mirror_entries(src, cache, *oid))
         .collect::<anyhow::Result<Vec<_>>>()?;
-    let smallest = trees
-        .iter()
-        .min_by_key(|t| t.len())
-        .expect("roots is never empty");
+
+    // Source entries by bucket byte; a flat table instead of a hash map keyed by name.
     let source_entries = read_tree_entries(src, source)?;
-    let buckets = buckets_of(&source_entries);
+    let mut by_bucket: Vec<Vec<&gix_object::tree::Entry>> = (0..256).map(|_| Vec::new()).collect();
+    for entry in &source_entries {
+        if !entry.mode.is_commit() {
+            by_bucket[bucket_byte(&entry.filename) as usize].push(entry);
+        }
+    }
 
+    let k = entry_lists.len();
+    let mut idx = vec![0usize; k];
     let mut out = vec![];
-    'entry: for entry in smallest {
-        let bucket = std::str::from_utf8(&entry.filename)?;
+    'merge: loop {
+        // The largest bucket name under the cursors; every list must reach it for the bucket
+        // to be in the intersection.
+        let mut max: [u8; 2] = match entry_lists[0].get(idx[0]) {
+            Some(e) => e.name,
+            None => break,
+        };
+        for i in 1..k {
+            match entry_lists[i].get(idx[i]) {
+                Some(e) if e.name > max => max = e.name,
+                Some(_) => {}
+                None => break 'merge,
+            }
+        }
+        let mut all_equal = true;
+        for i in 0..k {
+            while entry_lists[i].get(idx[i]).is_some_and(|e| e.name < max) {
+                idx[i] += 1;
+            }
+            match entry_lists[i].get(idx[i]) {
+                Some(e) if e.name == max => {}
+                Some(_) => all_equal = false,
+                None => break 'merge,
+            }
+        }
+        if !all_equal {
+            continue;
+        }
 
-        let mut child_roots = Vec::with_capacity(trees.len());
-        if trees.len() == 1 {
-            child_roots.push(entry.oid.to_owned());
-        } else {
-            for tree in &trees {
-                match tree.iter().find(|e| e.filename == entry.filename) {
-                    Some(other) if other.mode.is_tree() == entry.mode.is_tree() => {
-                        child_roots.push(other.oid.to_owned())
+        let is_tree = entry_lists[0][idx[0]].tree;
+        let kinds_match = (1..k).all(|i| entry_lists[i][idx[i]].tree == is_tree);
+        if kinds_match {
+            let members = parse_bucket(&max)
+                .map(|b| &by_bucket[b as usize][..])
+                .unwrap_or(&[]);
+            if is_tree {
+                let child_roots: Vec<gix_hash::ObjectId> =
+                    (0..k).map(|i| entry_lists[i][idx[i]].oid).collect();
+                for member in members {
+                    if !member.mode.is_tree() {
+                        continue;
                     }
-                    _ => continue 'entry,
+                    let name = std::str::from_utf8(&member.filename)?;
+                    let sub = walk(src, cache, child_roots.clone(), member.oid.to_owned())?;
+                    out.extend(sub.iter().map(|(p, b)| (join_path(name, p), *b)));
+                }
+            } else {
+                for member in members {
+                    let name = std::str::from_utf8(&member.filename)?;
+                    if member.mode.is_tree() {
+                        let sub = all_paths(src, cache, member.oid.to_owned())?;
+                        out.extend(sub.iter().map(|(p, b)| (join_path(name, p), *b)));
+                    } else if !member.mode.is_commit() {
+                        out.push((name.to_owned(), member.oid.to_owned()));
+                    }
                 }
             }
         }
-
-        let Some(members) = buckets.get(bucket) else {
-            continue;
-        };
-        if entry.mode.is_tree() {
-            for member in members {
-                if !member.mode.is_tree() {
-                    continue;
-                }
-                let name = std::str::from_utf8(&member.filename)?;
-                let sub = walk(src, cache, child_roots.clone(), member.oid.to_owned())?;
-                out.extend(sub.iter().map(|p| join_path(name, p)));
-            }
-        } else if !entry.mode.is_commit() {
-            for member in members {
-                let name = std::str::from_utf8(&member.filename)?;
-                if member.mode.is_tree() {
-                    let sub = all_paths(src, cache, member.oid.to_owned())?;
-                    out.extend(sub.iter().map(|p| join_path(name, p)));
-                } else if !member.mode.is_commit() {
-                    out.push(name.to_owned());
-                }
-            }
+        for i in 0..k {
+            idx[i] += 1;
         }
     }
 
@@ -833,13 +925,13 @@ fn read_tree_entries(
     )
 }
 
-/// All file paths under the tree `oid` (relative), memoized per tree: the expansion of coarse
-/// leaves and the fallback for queries without trigrams.
+/// All (relative path, blob) pairs under the tree `oid`, memoized per tree: the expansion of
+/// coarse leaves and the fallback for queries without trigrams.
 fn all_paths(
     src: &dyn Objects,
     cache: &mut SearchCache,
     oid: gix_hash::ObjectId,
-) -> anyhow::Result<std::sync::Arc<Vec<String>>> {
+) -> anyhow::Result<std::sync::Arc<Vec<(String, gix_hash::ObjectId)>>> {
     if let Some(hit) = cache.all_paths.get(&oid) {
         return Ok(hit.clone());
     }
@@ -848,9 +940,9 @@ fn all_paths(
         let name = std::str::from_utf8(&entry.filename)?;
         if entry.mode.is_tree() {
             let sub = all_paths(src, cache, entry.oid.to_owned())?;
-            out.extend(sub.iter().map(|p| join_path(name, p)));
+            out.extend(sub.iter().map(|(p, b)| (join_path(name, p), *b)));
         } else if !entry.mode.is_commit() {
-            out.push(name.to_owned());
+            out.push((name.to_owned(), entry.oid.to_owned()));
         }
     }
     let out = std::sync::Arc::new(out);
@@ -870,25 +962,22 @@ type SearchMatchesResult = Vec<(String, Vec<(usize, String)>)>;
 
 /// Verify `candidates` against the query, byte-exact. Per-blob results are memoized on
 /// (query, blob oid): a blob's matching lines do not depend on the commit or path it appears
-/// under, so verifying a history costs one scan per distinct blob.
+/// under, so verifying a history costs one scan per distinct blob. Candidates carry their
+/// blob oids from candidate selection, so no path resolution happens here.
 pub fn search_matches(
     src: &dyn Objects,
     cache: &mut SearchCache,
-    tree: gix_hash::ObjectId,
     searchstring: &str,
-    candidates: &[String],
+    candidates: &[(String, gix_hash::ObjectId)],
 ) -> anyhow::Result<SearchMatchesResult> {
     let mut results = vec![];
 
-    for c in candidates {
-        let Some(blob) = path_entry(src, tree, std::path::Path::new(&c))? else {
-            continue;
-        };
-        let key = (searchstring.to_owned(), blob);
+    for (c, blob) in candidates {
+        let key = (searchstring.to_owned(), *blob);
         let bresults = if let Some(hit) = cache.blob_matches.get(&key) {
             hit.clone()
         } else {
-            let b = read_blob_text(src, blob);
+            let b = read_blob_text(src, *blob);
             let mut lines = vec![];
             for (linenr, l) in b.lines().enumerate() {
                 if l.contains(searchstring) {
@@ -909,6 +998,9 @@ pub fn search_matches(
 }
 
 /// The oid at `path` inside `tree`, or `None` when any component is missing or not a tree.
+/// Production code resolves spine and mirror levels through [`mirror_entries`]; this remains
+/// as the tests' direct way to probe index paths.
+#[cfg(test)]
 fn path_entry(
     src: &dyn Objects,
     tree: gix_hash::ObjectId,
@@ -1056,16 +1148,17 @@ mod tests {
         // Coarse hits expand to every file under the directory; verification is exact.
         let candidates =
             search_candidates(objects(&repo), &mut sc, index, tree, "document").unwrap();
-        assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
-        let matches =
-            search_matches(objects(&repo), &mut sc, tree, "document", &candidates).unwrap();
+        let paths: Vec<&str> = candidates.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(paths, vec!["sub1/file1", "sub1/file2"]);
+        let matches = search_matches(objects(&repo), &mut sc, "document", &candidates).unwrap();
         assert_eq!(matches.len(), 2);
 
         // Trigrams are case-folded, so candidates are a case-insensitive superset ("Test" in
         // file1 makes sub1 a candidate for "test") while match verification stays byte-exact.
         let candidates = search_candidates(objects(&repo), &mut sc, index, tree, "test").unwrap();
-        assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
-        let matches = search_matches(objects(&repo), &mut sc, tree, "test", &candidates).unwrap();
+        let paths: Vec<&str> = candidates.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(paths, vec!["sub1/file1", "sub1/file2"]);
+        let matches = search_matches(objects(&repo), &mut sc, "test", &candidates).unwrap();
         assert!(matches.is_empty());
 
         let candidates =
@@ -1123,10 +1216,10 @@ mod tests {
         let mut sc = SearchCache::default();
         let candidates =
             search_candidates(objects(&repo), &mut sc, index, tree, "needleword").unwrap();
-        assert!(candidates.contains(&"big/target_file".to_owned()));
-        assert!(candidates.contains(&format!("big/{}", collider)));
-        let matches =
-            search_matches(objects(&repo), &mut sc, tree, "needleword", &candidates).unwrap();
+        let paths: Vec<&str> = candidates.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(paths.contains(&"big/target_file"));
+        assert!(paths.contains(&format!("big/{}", collider).as_str()));
+        let matches = search_matches(objects(&repo), &mut sc, "needleword", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "big/target_file");
     }
@@ -1194,9 +1287,8 @@ mod tests {
         // Fine candidates stay per-file (modulo bucket collisions) and matches exact.
         let candidates =
             search_candidates(objects(&repo), &mut sc, index, tree, "uniqueword07").unwrap();
-        assert!(candidates.contains(&"big/file_07".to_owned()));
-        let matches =
-            search_matches(objects(&repo), &mut sc, tree, "uniqueword07", &candidates).unwrap();
+        assert!(candidates.iter().any(|(p, _)| p == "big/file_07"));
+        let matches = search_matches(objects(&repo), &mut sc, "uniqueword07", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "big/file_07");
 
@@ -1204,9 +1296,10 @@ mod tests {
         // exact.
         let candidates =
             search_candidates(objects(&repo), &mut sc, index, tree, "needleinsmall").unwrap();
-        assert_eq!(candidates, vec!["small/a", "small/b"]);
+        let paths: Vec<&str> = candidates.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(paths, vec!["small/a", "small/b"]);
         let matches =
-            search_matches(objects(&repo), &mut sc, tree, "needleinsmall", &candidates).unwrap();
+            search_matches(objects(&repo), &mut sc, "needleinsmall", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "small/a");
 
@@ -1265,16 +1358,22 @@ mod tests {
         let hits = search_candidates(objects(&repo), &mut sc, index_a, tree_a, "delta").unwrap();
         assert!(hits.is_empty());
         let hits = search_candidates(objects(&repo), &mut sc, index_a, tree_a, "zebra").unwrap();
-        let matches = search_matches(objects(&repo), &mut sc, tree_a, "zebra", &hits).unwrap();
+        let matches = search_matches(objects(&repo), &mut sc, "zebra", &hits).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "sub1/gone");
 
         let hits = search_candidates(objects(&repo), &mut sc, index_b, tree_b, "delta").unwrap();
-        assert_eq!(hits, vec!["sub2/mod"]);
+        assert_eq!(
+            hits.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>(),
+            vec!["sub2/mod"]
+        );
         let hits = search_candidates(objects(&repo), &mut sc, index_b, tree_b, "zebra").unwrap();
         assert!(hits.is_empty());
         let hits = search_candidates(objects(&repo), &mut sc, index_b, tree_b, "addition").unwrap();
-        assert_eq!(hits, vec!["sub3/new"]);
+        assert_eq!(
+            hits.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>(),
+            vec!["sub3/new"]
+        );
 
         // Warm-cache results equal fresh-cache results.
         let fresh = search_candidates(
@@ -1285,6 +1384,9 @@ mod tests {
             "delta",
         )
         .unwrap();
-        assert_eq!(fresh, vec!["sub2/mod"]);
+        assert_eq!(
+            fresh.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>(),
+            vec!["sub2/mod"]
+        );
     }
 }

--- a/josh-search/src/lib.rs
+++ b/josh-search/src/lib.rs
@@ -134,12 +134,38 @@ fn hex_name(b: u8) -> BString {
 /// cutting entry names to two bytes and capping mirror fan-out at 256. Entries whose names
 /// collide share a bucket: the bucket means "some member contains the trigram", search
 /// expands to all members, and verification stays exact.
-fn bucket_name(name: &[u8]) -> String {
+fn bucket_byte(name: &[u8]) -> u8 {
     let mut h: u32 = 0x811c9dc5;
     for &b in name {
         h = (h ^ b as u32).wrapping_mul(0x01000193);
     }
-    format!("{:02x}", (h ^ (h >> 8) ^ (h >> 16) ^ (h >> 24)) & 0xff)
+    (h ^ (h >> 8) ^ (h >> 16) ^ (h >> 24)) as u8
+}
+
+fn bucket_name(name: &[u8]) -> String {
+    format!("{:02x}", bucket_byte(name))
+}
+
+/// A byte as two lowercase hex chars — the fixed-width entry-name form used by both the spine
+/// and the mirror bucket levels.
+fn hex_pair(b: u8) -> [u8; 2] {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    [HEX[(b >> 4) as usize], HEX[(b & 15) as usize]]
+}
+
+/// Parse a mirror entry name (two lowercase hex chars) back into its bucket byte.
+fn parse_bucket(name: &[u8]) -> Option<u8> {
+    fn hex_val(b: u8) -> Option<u8> {
+        match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 10),
+            _ => None,
+        }
+    }
+    match name {
+        [hi, lo] => Some(hex_val(*hi)? * 16 + hex_val(*lo)?),
+        _ => None,
+    }
 }
 
 /// A source directory's indexable entries with their mirror bucket names: blobs and trees in
@@ -660,12 +686,16 @@ pub fn trigram_index<'a>(
 /// distinct blob once, no matter how many commits it appears in.
 #[derive(Default)]
 pub struct SearchCache {
-    /// (query, index tree, source tree) -> sorted candidate paths.
-    candidates: HashMap<(String, git2::Oid, git2::Oid), std::sync::Arc<Vec<String>>>,
-    /// (mirror roots (normalized), source tree) -> relative candidate paths of the walk.
-    walks: HashMap<(Vec<git2::Oid>, git2::Oid), std::sync::Arc<Vec<String>>>,
-    /// source tree -> all file paths under it (relative).
-    all_paths: HashMap<git2::Oid, std::sync::Arc<Vec<String>>>,
+    /// (query, index tree, source tree) -> sorted candidate (path, blob) pairs.
+    candidates: HashMap<(String, git2::Oid, git2::Oid), std::sync::Arc<Vec<(String, git2::Oid)>>>,
+    /// (mirror roots (normalized), source tree) -> relative candidate (path, blob) pairs.
+    walks: HashMap<(Vec<git2::Oid>, git2::Oid), std::sync::Arc<Vec<(String, git2::Oid)>>>,
+    /// Mirror tree oid -> its entries in compact parsed form. Mirrors are shared heavily
+    /// across commits and trigrams, and libgit2 re-parses trees on every lookup — this cache
+    /// parses each distinct mirror once per process.
+    mirrors: HashMap<git2::Oid, std::sync::Arc<Vec<MirrorEntry>>>,
+    /// source tree -> all (relative path, blob) pairs under it.
+    all_paths: HashMap<git2::Oid, std::sync::Arc<Vec<(String, git2::Oid)>>>,
     /// (query, blob) -> matching (line number, line) pairs.
     blob_matches: HashMap<(String, git2::Oid), std::sync::Arc<Vec<(usize, String)>>>,
 }
@@ -680,7 +710,7 @@ pub fn search_candidates(
     index_tree: &git2::Tree,
     source_tree: &git2::Tree,
     searchstring: &str,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<Vec<(String, git2::Oid)>> {
     let key = (searchstring.to_owned(), index_tree.id(), source_tree.id());
     if let Some(hit) = cache.candidates.get(&key) {
         return Ok((**hit).clone());
@@ -691,18 +721,25 @@ pub fn search_candidates(
     let results = if trigrams.is_empty() {
         (*all_paths(repo, cache, source_tree.id())?).clone()
     } else {
+        // Resolve each trigram's three spine levels through the parsed-mirror cache (spine
+        // names are the same fixed-width hex as bucket names): each distinct spine node is
+        // parsed once per process instead of once per lookup.
         let mut roots = vec![];
         let mut absent = false;
-        for t in &trigrams {
-            let path = format!("{:02x}/{:02x}/{:02x}", t[0], t[1], t[2]);
-            match index_tree.get_path(std::path::Path::new(&path)) {
-                Ok(entry) => roots.push(entry.id()),
-                // A trigram absent from the index cannot occur in any file.
-                Err(_) => {
-                    absent = true;
-                    break;
+        'trigram: for t in &trigrams {
+            let mut node = index_tree.id();
+            for b in t {
+                let entries = mirror_entries(repo, cache, node)?;
+                match entries.binary_search_by_key(&hex_pair(*b), |e| e.name) {
+                    Ok(i) => node = entries[i].oid,
+                    // A trigram absent from the index cannot occur in any file.
+                    Err(_) => {
+                        absent = true;
+                        break 'trigram;
+                    }
                 }
             }
+            roots.push(node);
         }
         if absent {
             vec![]
@@ -717,7 +754,7 @@ pub fn search_candidates(
             if roots.len() > MAX_INTERSECT {
                 let mut sized = roots
                     .iter()
-                    .map(|&oid| anyhow::Ok((repo.find_tree(oid)?.len(), oid)))
+                    .map(|&oid| anyhow::Ok((mirror_entries(repo, cache, oid)?.len(), oid)))
                     .collect::<Result<Vec<_>, _>>()?;
                 sized.sort();
                 roots = sized
@@ -737,16 +774,38 @@ pub fn search_candidates(
     Ok(results)
 }
 
-/// The bucket -> source entries mapping of one directory level. Colliding names share a
-/// bucket, so a mirror entry can resolve to several source entries.
-fn buckets_of<'tree>(
-    source: &'tree git2::Tree<'_>,
-) -> HashMap<String, Vec<git2::TreeEntry<'tree>>> {
-    let mut map: HashMap<String, Vec<git2::TreeEntry>> = HashMap::new();
-    for (bucket, entry) in bucketed_entries(source) {
-        map.entry(bucket).or_default().push(entry);
+/// One mirror tree entry in compact parsed form: the fixed-width bucket name, the child oid,
+/// and whether it is a subtree (versus a coarse or file leaf).
+struct MirrorEntry {
+    name: [u8; 2],
+    oid: git2::Oid,
+    tree: bool,
+}
+
+/// The entries of the mirror tree `oid`, parsed once per process and memoized.
+fn mirror_entries(
+    repo: &git2::Repository,
+    cache: &mut SearchCache,
+    oid: git2::Oid,
+) -> anyhow::Result<std::sync::Arc<Vec<MirrorEntry>>> {
+    if let Some(hit) = cache.mirrors.get(&oid) {
+        return Ok(hit.clone());
     }
-    map
+    let tree = repo.find_tree(oid)?;
+    let mut entries = Vec::with_capacity(tree.len());
+    for entry in tree.iter() {
+        let name = entry.name_bytes();
+        if let [a, b] = name {
+            entries.push(MirrorEntry {
+                name: [*a, *b],
+                oid: entry.id(),
+                tree: entry.kind() == Some(git2::ObjectType::Tree),
+            });
+        }
+    }
+    let entries = std::sync::Arc::new(entries);
+    cache.mirrors.insert(oid, entries.clone());
+    Ok(entries)
 }
 
 /// The candidate file paths (relative to `source`) present in ALL of the mirror trees
@@ -756,12 +815,17 @@ fn buckets_of<'tree>(
 /// under it); a tree entry recurses into every large-directory member. Because results are
 /// relative and keyed by content, walks are shared across commits and across trigrams
 /// wherever the subtrees agree.
+///
+/// The intersection is a k-way merge over the mirrors' entry lists: bucket names are fixed
+/// width, so git's canonical entry order is plain byte order and one linear pass replaces
+/// per-bucket lookups — this loop runs once per commit of a history sweep, so its constant
+/// factor matters.
 fn walk(
     repo: &git2::Repository,
     cache: &mut SearchCache,
     mut roots: Vec<git2::Oid>,
     source: &git2::Tree,
-) -> anyhow::Result<std::sync::Arc<Vec<String>>> {
+) -> anyhow::Result<std::sync::Arc<Vec<(String, git2::Oid)>>> {
     // The intersection is a set operation: normalize the key. Identical mirrors (trigrams
     // with the same file set) intersect to themselves, so duplicates collapse.
     roots.sort();
@@ -771,37 +835,63 @@ fn walk(
         return Ok(hit.clone());
     }
 
-    let trees = roots
+    let entry_lists = roots
         .iter()
-        .map(|oid| repo.find_tree(*oid))
-        .collect::<Result<Vec<_>, _>>()?;
-    let smallest = trees
-        .iter()
-        .min_by_key(|t| t.len())
-        .expect("roots is never empty");
-    let buckets = buckets_of(source);
+        .map(|oid| mirror_entries(repo, cache, *oid))
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
+    // Source entries by bucket byte; a flat table instead of a hash map keyed by name.
+    let mut by_bucket: Vec<Vec<git2::TreeEntry>> = (0..256).map(|_| Vec::new()).collect();
+    for entry in source.iter() {
+        if matches!(
+            entry.kind(),
+            Some(git2::ObjectType::Blob) | Some(git2::ObjectType::Tree)
+        ) {
+            by_bucket[bucket_byte(entry.name_bytes()) as usize].push(entry);
+        }
+    }
+
+    let k = entry_lists.len();
+    let mut idx = vec![0usize; k];
     let mut out = vec![];
-    'entry: for entry in smallest.iter() {
-        let bucket = entry.name()?;
-
-        let mut child_roots = Vec::with_capacity(trees.len());
-        if trees.len() == 1 {
-            child_roots.push(entry.id());
-        } else {
-            for tree in &trees {
-                match tree.get_name(bucket) {
-                    Some(other) if other.kind() == entry.kind() => child_roots.push(other.id()),
-                    _ => continue 'entry,
-                }
+    'merge: loop {
+        // The largest bucket name under the cursors; every list must reach it for the bucket
+        // to be in the intersection.
+        let mut max: [u8; 2] = match entry_lists[0].get(idx[0]) {
+            Some(e) => e.name,
+            None => break,
+        };
+        for i in 1..k {
+            match entry_lists[i].get(idx[i]) {
+                Some(e) if e.name > max => max = e.name,
+                Some(_) => {}
+                None => break 'merge,
             }
         }
-
-        let Some(members) = buckets.get(bucket) else {
+        let mut all_equal = true;
+        for i in 0..k {
+            while entry_lists[i].get(idx[i]).is_some_and(|e| e.name < max) {
+                idx[i] += 1;
+            }
+            match entry_lists[i].get(idx[i]) {
+                Some(e) if e.name == max => {}
+                Some(_) => all_equal = false,
+                None => break 'merge,
+            }
+        }
+        if !all_equal {
             continue;
-        };
-        match entry.kind() {
-            Some(git2::ObjectType::Tree) => {
+        }
+
+        let is_tree = entry_lists[0][idx[0]].tree;
+        let kinds_match = (1..k).all(|i| entry_lists[i][idx[i]].tree == is_tree);
+        if kinds_match {
+            let members = parse_bucket(&max)
+                .map(|b| &by_bucket[b as usize][..])
+                .unwrap_or(&[]);
+            if is_tree {
+                let child_roots: Vec<git2::Oid> =
+                    (0..k).map(|i| entry_lists[i][idx[i]].oid).collect();
                 for member in members {
                     if member.kind() != Some(git2::ObjectType::Tree) {
                         continue;
@@ -809,23 +899,24 @@ fn walk(
                     let name = member.name()?;
                     let source_child = repo.find_tree(member.id())?;
                     let sub = walk(repo, cache, child_roots.clone(), &source_child)?;
-                    out.extend(sub.iter().map(|p| join_path(name, p)));
+                    out.extend(sub.iter().map(|(p, b)| (join_path(name, p), *b)));
                 }
-            }
-            Some(git2::ObjectType::Blob) => {
+            } else {
                 for member in members {
                     let name = member.name()?;
                     match member.kind() {
-                        Some(git2::ObjectType::Blob) => out.push(name.to_owned()),
+                        Some(git2::ObjectType::Blob) => out.push((name.to_owned(), member.id())),
                         Some(git2::ObjectType::Tree) => {
                             let sub = all_paths(repo, cache, member.id())?;
-                            out.extend(sub.iter().map(|p| join_path(name, p)));
+                            out.extend(sub.iter().map(|(p, b)| (join_path(name, p), *b)));
                         }
                         _ => {}
                     }
                 }
             }
-            _ => {}
+        }
+        for i in 0..k {
+            idx[i] += 1;
         }
     }
 
@@ -837,13 +928,13 @@ fn walk(
     Ok(out)
 }
 
-/// All file paths under the tree `oid` (relative), memoized per tree: the expansion of coarse
-/// leaves and the fallback for queries without trigrams.
+/// All (relative path, blob) pairs under the tree `oid`, memoized per tree: the expansion of
+/// coarse leaves and the fallback for queries without trigrams.
 fn all_paths(
     repo: &git2::Repository,
     cache: &mut SearchCache,
     oid: git2::Oid,
-) -> anyhow::Result<std::sync::Arc<Vec<String>>> {
+) -> anyhow::Result<std::sync::Arc<Vec<(String, git2::Oid)>>> {
     if let Some(hit) = cache.all_paths.get(&oid) {
         return Ok(hit.clone());
     }
@@ -854,9 +945,9 @@ fn all_paths(
         match entry.kind() {
             Some(git2::ObjectType::Tree) => {
                 let sub = all_paths(repo, cache, entry.id())?;
-                out.extend(sub.iter().map(|p| join_path(name, p)));
+                out.extend(sub.iter().map(|(p, b)| (join_path(name, p), *b)));
             }
-            Some(git2::ObjectType::Blob) => out.push(name.to_owned()),
+            Some(git2::ObjectType::Blob) => out.push((name.to_owned(), entry.id())),
             _ => {}
         }
     }
@@ -877,25 +968,22 @@ type SearchMatchesResult = Vec<(String, Vec<(usize, String)>)>;
 
 /// Verify `candidates` against the query, byte-exact. Per-blob results are memoized on
 /// (query, blob oid): a blob's matching lines do not depend on the commit or path it appears
-/// under, so verifying a history costs one scan per distinct blob.
+/// under, so verifying a history costs one scan per distinct blob. Candidates carry their
+/// blob oids from candidate selection, so no path resolution happens here.
 pub fn search_matches(
     repo: &git2::Repository,
     cache: &mut SearchCache,
-    tree: &git2::Tree,
     searchstring: &str,
-    candidates: &[String],
+    candidates: &[(String, git2::Oid)],
 ) -> anyhow::Result<SearchMatchesResult> {
     let mut results = vec![];
 
-    for c in candidates {
-        let Ok(entry) = tree.get_path(std::path::Path::new(&c)) else {
-            continue;
-        };
-        let key = (searchstring.to_owned(), entry.id());
+    for (c, blob) in candidates {
+        let key = (searchstring.to_owned(), *blob);
         let bresults = if let Some(hit) = cache.blob_matches.get(&key) {
             hit.clone()
         } else {
-            let b = blob_content(repo, entry.id());
+            let b = blob_content(repo, *blob);
             let mut lines = vec![];
             for (linenr, l) in b.lines().enumerate() {
                 if l.contains(searchstring) {
@@ -1032,15 +1120,17 @@ mod tests {
 
         // Coarse hits expand to every file under the directory; verification is exact.
         let candidates = search_candidates(&repo, &mut sc, &index, &tree, "document").unwrap();
-        assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
-        let matches = search_matches(&repo, &mut sc, &tree, "document", &candidates).unwrap();
+        let paths: Vec<&str> = candidates.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(paths, vec!["sub1/file1", "sub1/file2"]);
+        let matches = search_matches(&repo, &mut sc, "document", &candidates).unwrap();
         assert_eq!(matches.len(), 2);
 
         // Trigrams are case-folded, so candidates are a case-insensitive superset ("Test" in
         // file1 makes sub1 a candidate for "test") while match verification stays byte-exact.
         let candidates = search_candidates(&repo, &mut sc, &index, &tree, "test").unwrap();
-        assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
-        let matches = search_matches(&repo, &mut sc, &tree, "test", &candidates).unwrap();
+        let paths: Vec<&str> = candidates.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(paths, vec!["sub1/file1", "sub1/file2"]);
+        let matches = search_matches(&repo, &mut sc, "test", &candidates).unwrap();
         assert!(matches.is_empty());
 
         let candidates = search_candidates(&repo, &mut sc, &index, &tree, "missingword").unwrap();
@@ -1098,9 +1188,10 @@ mod tests {
         // verification is exact.
         let mut sc = SearchCache::default();
         let candidates = search_candidates(&repo, &mut sc, &index, &tree, "needleword").unwrap();
-        assert!(candidates.contains(&"big/target_file".to_owned()));
-        assert!(candidates.contains(&format!("big/{}", collider)));
-        let matches = search_matches(&repo, &mut sc, &tree, "needleword", &candidates).unwrap();
+        let paths: Vec<&str> = candidates.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(paths.contains(&"big/target_file"));
+        assert!(paths.contains(&format!("big/{}", collider).as_str()));
+        let matches = search_matches(&repo, &mut sc, "needleword", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "big/target_file");
     }
@@ -1150,16 +1241,17 @@ mod tests {
 
         // Fine candidates stay per-file (modulo bucket collisions) and matches exact.
         let candidates = search_candidates(&repo, &mut sc, &index, &tree, "uniqueword07").unwrap();
-        assert!(candidates.contains(&"big/file_07".to_owned()));
-        let matches = search_matches(&repo, &mut sc, &tree, "uniqueword07", &candidates).unwrap();
+        assert!(candidates.iter().any(|(p, _)| p == "big/file_07"));
+        let matches = search_matches(&repo, &mut sc, "uniqueword07", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "big/file_07");
 
         // A coarse hit makes every file under the directory a candidate; verification is
         // exact.
         let candidates = search_candidates(&repo, &mut sc, &index, &tree, "needleinsmall").unwrap();
-        assert_eq!(candidates, vec!["small/a", "small/b"]);
-        let matches = search_matches(&repo, &mut sc, &tree, "needleinsmall", &candidates).unwrap();
+        let paths: Vec<&str> = candidates.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(paths, vec!["small/a", "small/b"]);
+        let matches = search_matches(&repo, &mut sc, "needleinsmall", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "small/a");
 
@@ -1218,16 +1310,22 @@ mod tests {
         let hits = search_candidates(&repo, &mut sc, &index_a, &tree_a, "delta").unwrap();
         assert!(hits.is_empty());
         let hits = search_candidates(&repo, &mut sc, &index_a, &tree_a, "zebra").unwrap();
-        let matches = search_matches(&repo, &mut sc, &tree_a, "zebra", &hits).unwrap();
+        let matches = search_matches(&repo, &mut sc, "zebra", &hits).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "sub1/gone");
 
         let hits = search_candidates(&repo, &mut sc, &index_b, &tree_b, "delta").unwrap();
-        assert_eq!(hits, vec!["sub2/mod"]);
+        assert_eq!(
+            hits.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>(),
+            vec!["sub2/mod"]
+        );
         let hits = search_candidates(&repo, &mut sc, &index_b, &tree_b, "zebra").unwrap();
         assert!(hits.is_empty());
         let hits = search_candidates(&repo, &mut sc, &index_b, &tree_b, "addition").unwrap();
-        assert_eq!(hits, vec!["sub3/new"]);
+        assert_eq!(
+            hits.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>(),
+            vec!["sub3/new"]
+        );
 
         // Warm-cache results equal fresh-cache results.
         let fresh = search_candidates(
@@ -1238,6 +1336,9 @@ mod tests {
             "delta",
         )
         .unwrap();
-        assert_eq!(fresh, vec!["sub2/mod"]);
+        assert_eq!(
+            fresh.iter().map(|(p, _)| p.as_str()).collect::<Vec<_>>(),
+            vec!["sub2/mod"]
+        );
     }
 }


### PR DESCRIPTION
Carry blob ids through search and merge mirror entries

Profiling history-wide search on git/git found the time split across two
read paths.

search_matches resolved every candidate path with tree.get_path, so each
lookup re-parsed every tree along the path once per candidate -- 98% of a
sweep's CPU. Candidate selection already touches each candidate's source
entry, so candidates now carry their blob oid and verification is a pure
memo lookup.

The intersection walk looked up every bucket by name and rebuilt a hash map
of the source directory per level. Mirror entry names are fixed width, so
git's canonical order is byte order: the walk is now a k-way merge over
compact parsed entry lists, memoized per mirror oid, and spine resolution
goes through the same cache.

A new josh-filter --search-history flag searches every reachable commit of
the filtered history -- both a user feature and the honest way to measure.

On git/git with warm indexes, rare needle: all 81,726 reachable commits in
33s (0.41 ms per commit), where before this series the first-parent subset
alone took 29:46. Single-commit results are byte-identical throughout.

Change: trigram-search-hot-path
Assisted-By: anthropic/claude-fable-5