### PR TITLE
Keep orphan history connected when pushing without a base

### DIFF
--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -89,14 +89,19 @@ fn find_unapply_base(
     // Filtered OID to compare against
     filtered: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    if contained_in == git2::Oid::zero() {
-        tracing::info!("contained in zero",);
-        return Ok(git2::Oid::zero());
-    }
-
+    // Consult the running map first: during an unapply walk we insert every
+    // freshly created commit here, so a later commit can find its parent even
+    // when there is no `contained_in` hint (e.g. a no-base push of an orphan
+    // history). Checking this before the zero guard is what keeps such a push
+    // connected instead of collapsing into a single parentless commit.
     if let Some(original) = filtered_to_original.get(&filtered) {
         tracing::info!("Found in filtered_to_original",);
         return Ok(*original);
+    }
+
+    if contained_in == git2::Oid::zero() {
+        tracing::info!("contained in zero",);
+        return Ok(git2::Oid::zero());
     }
 
     let contained_in_commit = transaction.repo().find_commit(contained_in)?;

--- a/tests/cli/push_vendor_orphan.t
+++ b/tests/cli/push_vendor_orphan.t
@@ -1,0 +1,105 @@
+Vendor a standalone repo into a subdirectory of a central repo *without*
+`--base`, keeping the vendored history as a disconnected (orphan) branch.
+
+This is the workflow from issue #2205: the pushed branch should carry the
+full vendored history (one commit per original commit, not a single squash)
+and must NOT be reparented onto central's history — it stays unconnected so
+it can be merged into the main branch separately.
+
+Contrast with tests/cli/push_vendor.t, which uses `--base=master` to make the
+vendored history descend from central master.
+
+Setup
+
+  $ export TESTTMP=${PWD}
+
+Central repo (bare) with pre-existing history under app/
+
+  $ git init -q --bare central
+  $ git init -q central-seed
+  $ cd central-seed
+  $ mkdir -p app
+  $ echo "central app v1" > app/main.txt
+  $ git add app
+  $ git commit -q -m "central: add app/main.txt"
+  $ echo "central app v2" >> app/main.txt
+  $ git add app
+  $ git commit -q -m "central: extend app/main.txt"
+  $ git remote add origin ${TESTTMP}/central
+  $ git push -q origin master
+  $ cd ${TESTTMP}
+
+Standalone vendor repo with its own unrelated history (three commits).
+
+  $ git init -q vendored
+  $ cd vendored
+  $ echo "lib v1" > lib.txt
+  $ git add lib.txt
+  $ git commit -q -m "vendor: initial lib"
+  $ echo "lib v2" >> lib.txt
+  $ git add lib.txt
+  $ git commit -q -m "vendor: extend lib"
+  $ echo "lib v3" >> lib.txt
+  $ git add lib.txt
+  $ git commit -q -m "vendor: extend lib again"
+
+Add central as a josh remote mounting our tree at `libs/vendored`.
+
+  $ josh remote add central ${TESTTMP}/central :/libs/vendored
+  Added remote 'central' with filter ':/libs/vendored'
+
+Push the vendor history into central as a new branch, WITHOUT `--base`.
+
+  $ josh push central HEAD:refs/heads/vendored-in
+  Pushing * to central/refs/heads/vendored-in (glob)
+  To file://${TESTTMP}/central
+   * [new branch]      * -> vendored-in (glob)
+  
+  Pushed 1 ref(s) to central
+
+
+All three vendor commits must be present — not collapsed into one.
+
+  $ git --git-dir=${TESTTMP}/central log --oneline vendored-in
+  * vendor: extend lib again (glob)
+  * vendor: extend lib (glob)
+  * vendor: initial lib (glob)
+
+The branch must be an orphan: central `master` is NOT an ancestor of it,
+and the oldest commit has no parents.
+
+  $ git --git-dir=${TESTTMP}/central merge-base --is-ancestor master vendored-in && echo connected || echo unconnected
+  unconnected
+  $ git --git-dir=${TESTTMP}/central rev-list --max-parents=0 vendored-in | wc -l | tr -d ' '
+  1
+
+The tree carries only the mounted vendored content (no central `app/`).
+
+  $ git --git-dir=${TESTTMP}/central ls-tree -r --name-only vendored-in
+  libs/vendored/lib.txt
+  $ git --git-dir=${TESTTMP}/central show vendored-in:libs/vendored/lib.txt
+  lib v1
+  lib v2
+  lib v3
+
+Round-trip: filtering the pushed branch back through `:/libs/vendored`
+reproduces the original vendor commits exactly — same OIDs, lossless.
+
+  $ josh fetch --remote central
+  From file://${TESTTMP}/central
+   * [new branch]      master      -> refs/josh/remotes/central/master
+   * [new branch]      vendored-in -> refs/josh/remotes/central/vendored-in
+  
+  From file://${TESTTMP}/vendored
+   * [new branch]      vendored-in -> central/vendored-in
+  
+  Fetched from remote: central
+
+
+
+  $ test "$(git rev-parse central/vendored-in)" = "$(git rev-parse master)" && echo tip-equal
+  tip-equal
+  $ git log --format='%s' central/vendored-in
+  vendor: extend lib again
+  vendor: extend lib
+  vendor: initial lib


### PR DESCRIPTION
Keep orphan history connected when pushing without a base

find_unapply_base returned early when there is no containing commit
(contained_in is zero), so a no-base push of a disconnected history --
vendoring a standalone repo into a subdirectory, issue #2205 -- never
consulted the filtered_to_original map that the unapply walk fills with
every freshly created commit. Each pushed commit then failed to find
its just-created parent and the whole history collapsed into a single
parentless commit.

Consulting the map before the zero guard keeps such a push connected,
one commit per original, while still leaving the branch an orphan
(unconnected to the target's existing history). Covered by the new
push_vendor_orphan.t, the no-base counterpart of push_vendor.t.

Change: unapply-base-orphan-map

Assisted-By: Claude (claude-fable-5)