### PR TITLE
Drop the SQUASH detour from search index resolution

### DIFF
--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -382,9 +382,16 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         // The trigram index is experimental; without it every file is a candidate and
         // search_matches does all the filtering, so results are identical, just slower.
         let candidates = if josh_core::filter::experimental_features_enabled() {
-            let ifilterobj = filterobj.chain(josh_core::filter::parse(":SQUASH:INDEX")?);
-            let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit.id())?;
-            let index_tree = repo.find_commit(index_commit)?.tree()?;
+            // Index just the tip tree: no history walk needed for a one-shot search, and the
+            // per-tree memoization shares everything with any other indexing of the same
+            // trees.
+            let index_tree = josh_core::filter::apply(
+                &transaction,
+                josh_core::filter::parse(":INDEX")?,
+                josh_core::filter::Rewrite::from_tree(tree.clone()),
+            )?
+            .tree()
+            .clone();
             josh_search::search_candidates(
                 &repo,
                 &mut transaction.search_cache(),

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -357,9 +357,15 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         // The trigram index is experimental; without it every file is a candidate and
         // search_matches does all the filtering, so results are identical, just slower.
         let candidates = if josh_core::filter::experimental_features_enabled() {
-            let ifilterobj = filterobj.chain(josh_core::filter::parse(":SQUASH:INDEX")?);
-            let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit)?;
-            let index_tree = josh_core::objects::CommitData::read(odb, index_commit)?.tree_id()?;
+            // Index just the tip tree: no history walk needed for a one-shot search, and the
+            // per-tree memoization shares everything with any other indexing of the same
+            // trees.
+            let index_tree = josh_core::filter::apply(
+                &transaction,
+                josh_core::filter::parse(":INDEX")?,
+                josh_core::filter::Rewrite::from_tree(tree),
+            )?
+            .tree_id();
             josh_search::search_candidates(
                 odb,
                 &mut transaction.search_cache(),

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -424,15 +424,20 @@ impl Revision {
 
     fn search(&self, string: String, context: &Context) -> FieldResult<Option<Vec<SearchResult>>> {
         let transaction = context.transaction.lock().unwrap();
-        let tree = transaction.repo().find_commit(self.commit_id)?.tree()?;
-
-        let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
+        // Resolve the filtered tree through the commit-level cache (persistent, and already
+        // warm in a history+search query: the history resolver just filtered this commit).
+        let commit = transaction.repo().find_commit(self.commit_id)?;
+        let filtered_id = filter::apply_to_commit(self.filter, &commit, &transaction)?;
+        if filtered_id == git2::Oid::zero() {
+            return Ok(Some(vec![]));
+        }
+        let x = Rewrite::from_tree(transaction.repo().find_commit(filtered_id)?.tree()?);
 
         /* let start = std::time::Instant::now(); */
         // The trigram index is experimental; without it every file is a candidate and
         // search_matches does all the filtering, so results are identical, just slower.
         let candidates = if filter::experimental_features_enabled() {
-            let ifilterobj = filter::parse(":SQUASH:INDEX")?;
+            let ifilterobj = filter::parse(":INDEX")?;
             let index_tree = filter::apply(&transaction, ifilterobj, x.clone())?;
             josh_search::search_candidates(
                 transaction.repo(),

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -443,14 +443,18 @@ impl Revision {
     fn search(&self, string: String, context: &Context) -> FieldResult<Option<Vec<SearchResult>>> {
         let transaction = context.transaction.lock().unwrap();
         let odb = transaction.odb();
-        let tree = CommitData::read(odb, self.commit_id)?.tree_id()?;
-
-        let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
+        // Resolve the filtered tree through the commit-level cache (persistent, and already
+        // warm in a history+search query: the history resolver just filtered this commit).
+        let filtered_id = filter::apply_to_commit(self.filter, self.commit_id, &transaction)?;
+        if filtered_id == gix_hash::ObjectId::null(gix_hash::Kind::Sha1) {
+            return Ok(Some(vec![]));
+        }
+        let x = Rewrite::from_tree(CommitData::read(odb, filtered_id)?.tree_id()?);
 
         // The trigram index is experimental; without it every file is a candidate and
         // search_matches does all the filtering, so results are identical, just slower.
         let candidates = if filter::experimental_features_enabled() {
-            let ifilterobj = filter::parse(":SQUASH:INDEX")?;
+            let ifilterobj = filter::parse(":INDEX")?;
             let index_tree = filter::apply(&transaction, ifilterobj, x.clone())?;
             josh_search::search_candidates(
                 odb,


### PR DESCRIPTION
Drop the SQUASH detour from search index resolution

Both search entry points chained :SQUASH:INDEX, but neither needs the
squash. At tree level, where the GraphQL resolver applied it, SQUASH is the
identity. The CLI used it at history level to avoid indexing every commit
for a one-shot tip search; indexing the tip tree through a tree-level :INDEX
apply does the same with no history walk, and stays fast on repeat through
Op::Index's own persistent cache.

The GraphQL resolver now also resolves the filtered tree through
apply_to_commit: that cache is persistent, a history+search query has the
filtered commit in the transaction's map already, and a commit the filter
drops entirely now yields an empty result instead of searching an empty
tree.

Change: trigram-search-no-squash
Assisted-By: anthropic/claude-fable-5