### PR TITLE
Ignore trigram cache hits for indexes missing from the odb

### DIFF
--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -474,7 +474,14 @@ impl Transaction {
     }
 
     pub fn get_trigram_index(&self, tree: git2::Oid) -> Option<git2::Oid> {
-        TRIGRAM_INDEX_MAP.read().unwrap().get(&tree).cloned()
+        let oid = TRIGRAM_INDEX_MAP.read().unwrap().get(&tree).cloned()?;
+        // Only report an index as cached if it still exists in the object database: index
+        // trees not anchored by a ref (all per-subtree ones) are pruned by gc/repack, and
+        // a dangling hit must rebuild instead of erroring.
+        if self.repo.odb().ok()?.exists(oid) {
+            return Some(oid);
+        }
+        None
     }
 
     pub fn insert_populate(&self, tree: (git2::Oid, git2::Oid), result: git2::Oid) {

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -528,7 +528,14 @@ impl Transaction {
     }
 
     pub fn get_trigram_index(&self, tree: git2::Oid) -> Option<git2::Oid> {
-        TRIGRAM_INDEX_MAP.read().unwrap().get(&tree).cloned()
+        let oid = TRIGRAM_INDEX_MAP.read().unwrap().get(&tree).cloned()?;
+        // Only report an index as cached if it still exists in the object database: index
+        // trees not anchored by a ref (all per-subtree ones) are pruned by gc/repack, and
+        // a dangling hit must rebuild instead of erroring.
+        if self.repo.odb().ok()?.exists(oid) {
+            return Some(oid);
+        }
+        None
     }
 
     pub fn insert_populate(&self, tree: (git2::Oid, git2::Oid), result: git2::Oid) {


### PR DESCRIPTION
Ignore trigram cache hits for indexes missing from the odb

The trigram sled memo stores tree -> index oids, but per-subtree index
trees are not anchored by any ref, so gc or repack -ad prunes them and
the memo entry dangles; a later index build or search then failed with
"object not found". Honor a cached entry only if the object still
exists, the same policy the commit cache already applies: a dangling
hit becomes a miss and the subtree reindexes on demand.

Observed in practice on a git/git test repository after a repack: a
whole-history search errored before this change, and with it completed
correctly while transparently rebuilding the pruned subtree indexes
(1:57 for the healing sweep, 33s once healed).

Change: trigram-cache-existence-check

Assisted-By: Claude (claude-fable-5)