### PR TITLE
Gate the :INDEX filter behind JOSH_EXPERIMENTAL_FEATURES

### DIFF
--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -368,11 +368,8 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     josh_core::update_refs(&transaction, updated_refs.clone());
 
     if let Some(searchstring) = args.get_one::<String>("search") {
-        let ifilterobj = filterobj.chain(josh_core::filter::parse(":SQUASH:INDEX")?);
-
         let commit = repo.revparse_single(&input_ref)?.peel_to_commit()?;
 
-        let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit.id())?;
         let tree = repo
             .find_commit(josh_core::filter_commit(
                 &transaction,
@@ -380,10 +377,27 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
                 commit.id(),
             )?)?
             .tree()?;
-        let index_tree = repo.find_commit(index_commit)?.tree()?;
 
         /* let start = std::time::Instant::now(); */
-        let candidates = josh_search::search_candidates(&repo, &index_tree, &tree, searchstring)?;
+        // The trigram index is experimental; without it every file is a candidate and
+        // search_matches does all the filtering, so results are identical, just slower.
+        let candidates = if josh_core::filter::experimental_features_enabled() {
+            let ifilterobj = filterobj.chain(josh_core::filter::parse(":SQUASH:INDEX")?);
+            let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit.id())?;
+            let index_tree = repo.find_commit(index_commit)?.tree()?;
+            josh_search::search_candidates(&repo, &index_tree, &tree, searchstring)?
+        } else {
+            let mut scan = vec![];
+            tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
+                if entry.kind() == Some(git2::ObjectType::Blob)
+                    && let Ok(name) = entry.name()
+                {
+                    scan.push(format!("{}{}", root, name));
+                }
+                0
+            })?;
+            scan
+        };
         let matches = josh_search::search_matches(&repo, &tree, searchstring, &candidates)?;
         /* let duration = start.elapsed(); */
 

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use anyhow::anyhow;
 use josh_filter::check_experimental_features_enabled;
+pub use josh_filter::experimental_features_enabled;
 
 use std::path::Path;
 use std::sync::LazyLock;

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -91,7 +91,10 @@ fn make_filter(args: &[&str]) -> anyhow::Result<Filter> {
         }
 
         ["PATHS"] => Ok(to_filter(Op::Paths)),
-        ["INDEX"] => Ok(to_filter(Op::Index)),
+        ["INDEX"] => {
+            check_experimental_features_enabled(":INDEX filter")?;
+            Ok(to_filter(Op::Index))
+        }
         ["INVERT"] => Ok(to_filter(Op::Invert)),
         ["FOLD"] => Ok(to_filter(Op::Fold)),
         ["hook", arg] => Ok(f.hook(arg)),

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -430,19 +430,34 @@ impl Revision {
 
     fn search(&self, string: String, context: &Context) -> FieldResult<Option<Vec<SearchResult>>> {
         let transaction = context.transaction.lock().unwrap();
-        let ifilterobj = filter::parse(":SQUASH:INDEX")?;
         let tree = transaction.repo().find_commit(self.commit_id)?.tree()?;
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
-        let index_tree = filter::apply(&transaction, ifilterobj, x.clone())?;
 
         /* let start = std::time::Instant::now(); */
-        let candidates = josh_search::search_candidates(
-            transaction.repo(),
-            index_tree.tree(),
-            x.tree(),
-            &string,
-        )?;
+        // The trigram index is experimental; without it every file is a candidate and
+        // search_matches does all the filtering, so results are identical, just slower.
+        let candidates = if filter::experimental_features_enabled() {
+            let ifilterobj = filter::parse(":SQUASH:INDEX")?;
+            let index_tree = filter::apply(&transaction, ifilterobj, x.clone())?;
+            josh_search::search_candidates(
+                transaction.repo(),
+                index_tree.tree(),
+                x.tree(),
+                &string,
+            )?
+        } else {
+            let mut scan = vec![];
+            x.tree().walk(git2::TreeWalkMode::PreOrder, |root, entry| {
+                if entry.kind() == Some(git2::ObjectType::Blob)
+                    && let Ok(name) = entry.name()
+                {
+                    scan.push(format!("{}{}", root, name));
+                }
+                0
+            })?;
+            scan
+        };
         let results =
             josh_search::search_matches(transaction.repo(), x.tree(), &string, &candidates)?;
         /* let duration = start.elapsed(); */

--- a/tests/filter/filter_id.t
+++ b/tests/filter/filter_id.t
@@ -651,8 +651,10 @@ Test :PATHS
   
   1 directory, 1 file
 
-Test :INDEX
-  $ FILTER_HASH=$(josh-filter -i ':INDEX')
+Test :INDEX (the filter is experimental; parsing it needs the opt-in)
+  $ josh-filter -i ':INDEX' 2>&1 | head -1
+  ERROR: :INDEX filter requires JOSH_EXPERIMENTAL_FEATURES=1
+  $ FILTER_HASH=$(JOSH_EXPERIMENTAL_FEATURES=1 josh-filter -i ':INDEX')
   $ josh-filter -p ${FILTER_HASH}
   :INDEX
   $ git read-tree --reset -u ${FILTER_HASH}


### PR DESCRIPTION
Gate the :INDEX filter behind JOSH_EXPERIMENTAL_FEATURES

The trigram index format is still evolving (cache version bumps ahead
in this series change it several times), so parsing :INDEX now
requires the experimental opt-in, like link, embed and export.

Search keeps working either way: the GraphQL search field and
josh-filter --search consult the index only when experimental
features are enabled, and otherwise fall back to a full tree scan --
every file becomes a candidate and search_matches does all the
filtering, so results are identical, just slower. The :INDEX section
of filter_id.t opts in explicitly; the experimental test suite
already runs with the feature enabled.

Change: index-filter-experimental

Assisted-By: Claude (claude-fable-5)