### PR TITLE
Keep chains with a trailing generative op from collapsing to empty

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2606,25 +2606,49 @@ mod tests {
             to_filter(Op::Subdir(std::path::PathBuf::from("ws"))),
         )));
 
+        // A generative Insert ignores its input, so a chain that becomes empty before it must not
+        // collapse to `Empty`. These filters have to be built as raw ASTs: `parse` optimizes, which
+        // would apply (and previously mis-apply) the very rule under test.
+        let ins = |p: &str, c: &str| {
+            to_filter(Op::Insert(
+                std::path::PathBuf::from(p),
+                InsertContent::Inline(c.to_string()),
+            ))
+        };
+        // Chain[Empty, Insert] -- the interior emptiness comes from an explicit `Empty`.
+        cases.push(to_filter(Op::Chain(vec![
+            to_filter(Op::Empty),
+            ins("x", "y"),
+        ])));
+        // Chain[Prefix(p), Subdir(q), Insert] -- the interior emptiness comes from the
+        // prefix/subdir-mismatch rule (`:prefix=p:/q` is always empty).
+        cases.push(to_filter(Op::Chain(vec![
+            to_filter(Op::Prefix(std::path::PathBuf::from("p"))),
+            to_filter(Op::Subdir(std::path::PathBuf::from("q"))),
+            ins("x", "y"),
+        ])));
+
         for sub in cases {
-            let optimized = opt::optimize(sub);
-            match (apply_tree(sub), apply_tree(optimized)) {
-                (Ok(g), Ok(o)) => {
-                    assert_eq!(
-                        g, o,
-                        "optimizer changed result for {sub:?} -> {optimized:?}"
-                    )
+            // Both `optimize` and `minimize` run the rules under test, so exercise both.
+            for (name, optimized) in [
+                ("optimize", opt::optimize(sub)),
+                ("minimize", opt::minimize(sub)),
+            ] {
+                match (apply_tree(sub), apply_tree(optimized)) {
+                    (Ok(g), Ok(o)) => {
+                        assert_eq!(g, o, "{name} changed result for {sub:?} -> {optimized:?}")
+                    }
+                    (Err(ge), _) => panic!("ground-truth apply failed for {sub:?}: {ge}"),
+                    (_, Err(oe)) => {
+                        panic!("{name} apply failed for {sub:?} -> {optimized:?}: {oe}")
+                    }
                 }
-                (Err(ge), _) => panic!("ground-truth apply failed for {sub:?}: {ge}"),
-                (_, Err(oe)) => {
-                    panic!("optimized apply failed for {sub:?} -> {optimized:?}: {oe}")
+                if invert(sub).is_ok() {
+                    assert!(
+                        invert(optimized).is_ok(),
+                        "{name} broke invertibility of {sub:?} -> {optimized:?}"
+                    );
                 }
-            }
-            if invert(sub).is_ok() {
-                assert!(
-                    invert(optimized).is_ok(),
-                    "optimize broke invertibility of {sub:?} -> {optimized:?}"
-                );
             }
         }
     }

--- a/josh-filter/src/opt/step.rs
+++ b/josh-filter/src/opt/step.rs
@@ -1,5 +1,5 @@
 use super::prefix_sort::prefix_sort;
-use super::structure::{common_post, common_pre, group, last_chain};
+use super::structure::{common_post, common_pre, group, last_chain, resurrects_from_empty};
 use super::{FilterSet, OPTIMIZED};
 use crate::filter::Filter;
 use crate::op::Op;
@@ -129,16 +129,23 @@ pub(super) fn step(filter: Filter) -> Filter {
                 }
             }
 
-            // If any filter is Op::Empty the whole chain results in Op::Empty
-            if filters.contains(&to_filter(Op::Empty)) {
-                return to_filter(Op::Empty);
-            }
-
             // Remove Nop filters
             let nop_filter = to_filter(Op::Nop);
             flattened.retain(|f| *f != nop_filter);
             if flattened.is_empty() {
                 return to_filter(Op::Nop);
+            }
+
+            // If a filter is Op::Empty the tree becomes empty at that point, so the whole chain
+            // is Op::Empty -- unless a later element resurrects content from an empty tree
+            // (a generative Insert/TreeId ignores its input), in which case we must keep the chain.
+            if let Some(pos) = flattened.iter().position(|f| *f == to_filter(Op::Empty)) {
+                if !flattened[pos + 1..]
+                    .iter()
+                    .any(|f| resurrects_from_empty(*f))
+                {
+                    return to_filter(Op::Empty);
+                }
             }
 
             // Optimize adjacent Prefix/Subdir pairs
@@ -156,8 +163,13 @@ pub(super) fn step(filter: Filter) -> Filter {
                             if a != b && a.components().count() == b.components().count() =>
                         {
                             // :prefix=a:/b will always result in an empty tree since the
-                            // output of :prefix=a does not have a subtree "b"
-                            return to_filter(Op::Empty);
+                            // output of :prefix=a does not have a subtree "b". As above, this
+                            // only collapses the whole chain when nothing after the pair can
+                            // resurrect content from the resulting empty tree.
+                            if !flattened[i + 2..].iter().any(|f| resurrects_from_empty(*f)) {
+                                return to_filter(Op::Empty);
+                            }
+                            // A generative op follows: fall through and keep the chain intact.
                         }
                         _ => {}
                     }

--- a/josh-filter/src/opt/structure.rs
+++ b/josh-filter/src/opt/structure.rs
@@ -107,6 +107,26 @@ fn is_generative(filter: Filter) -> bool {
     matches!(to_op_ref(filter), Op::Insert(..) | Op::TreeId(..))
 }
 
+/// Whether applying `filter` to an *empty* tree can produce a *non-empty* tree.
+///
+/// Only the generative ops (`Insert`, `TreeId`) fabricate content from nothing; every other
+/// tree op maps empty to empty (`File` uses a zero oid as a delete sentinel, and path/content
+/// ops have nothing to act on). Generative entries also survive `tree::compose`, so a generative
+/// op nested inside `Chain`/`Compose`/the kept side of `Subtract` still resurrects. `Exclude`,
+/// `Select` and `Pin` always yield empty on an empty input regardless of their operand, so they
+/// (and every other op) are treated as non-resurrecting. Unknown ops default to `false`, which is
+/// sound for the verified op set and only ever makes callers less aggressive.
+pub(super) fn resurrects_from_empty(filter: Filter) -> bool {
+    match to_op_ref(filter) {
+        Op::Insert(..) | Op::TreeId(..) => true,
+        Op::Chain(filters) | Op::Compose(filters) => {
+            filters.iter().any(|f| resurrects_from_empty(*f))
+        }
+        Op::Subtract(a, _) => resurrects_from_empty(*a),
+        _ => false,
+    }
+}
+
 pub(super) fn common_post(filters: &Vec<Filter>) -> Option<(Filter, Vec<Filter>)> {
     let mut rest = vec![];
     let mut common_post: Option<Filter> = None;


### PR DESCRIPTION
Keep chains with a trailing generative op from collapsing to empty

The `Op::Chain` optimizer collapsed a whole chain to `Op::Empty` whenever the
tree became empty at some interior point: either an explicit `Op::Empty`
element, or the prefix/subdir-mismatch rule (`:prefix=a:/b` is always empty).
Both assumed emptiness propagates to the end of the chain, but the generative
ops `Insert` and `TreeId` ignore their input and fabricate content from an
empty tree, so e.g. `:empty:$x="y"` really yields `{x:"y"}` yet optimized to
`:empty`. `apply` (the ground-truth interpreter) and the optimized filter then
disagreed.

Add `resurrects_from_empty` (a sibling of the existing `is_generative`) and
only collapse a chain to `Op::Empty` when no element after the emptying point
can resurrect content from an empty tree. The predicate recurses through
`Chain`/`Compose`/the kept side of `Subtract` (generative entries survive
`tree::compose`) and stops at `Exclude`/`Select`/`Pin`, which always map empty
to empty.

Extend the `subtract_optimizer_apply_oracle` test with raw-AST cases for both
collapse sites, and run every case through `minimize` as well as `optimize`.

Change: chain-empty-generative-guard
Assisted-By: Claude Opus 4.8