### PR TITLE
Only distribute a chain over a compose when the suffix commutes

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2628,6 +2628,22 @@ mod tests {
             ins("x", "y"),
         ])));
 
+        // Chain[Compose[Subdir(d1), Subdir(d2)], Exclude(File(s2/f0, s1/f0))]. `File` reads its
+        // source (`s1/f0`, present only under d1) from the *composed* tree, so distributing the
+        // trailing `Exclude(File)` into each branch changes the result: sequentially the merged
+        // tree contains `s1/f0`, so `File` recreates `s2/f0` and `Exclude` drops it; distributed,
+        // the d2 branch has no `s1/f0`, so nothing is excluded and `s2/f0` survives.
+        cases.push(to_filter(Op::Chain(vec![
+            to_filter(Op::Compose(vec![
+                to_filter(Op::Subdir(std::path::PathBuf::from("d1"))),
+                to_filter(Op::Subdir(std::path::PathBuf::from("d2"))),
+            ])),
+            to_filter(Op::Exclude(to_filter(Op::File(
+                std::path::PathBuf::from("s2/f0"),
+                std::path::PathBuf::from("s1/f0"),
+            )))),
+        ])));
+
         for sub in cases {
             // Both `optimize` and `minimize` run the rules under test, so exercise both.
             for (name, optimized) in [

--- a/josh-filter/src/opt/flatten.rs
+++ b/josh-filter/src/opt/flatten.rs
@@ -1,4 +1,5 @@
 use super::invert::invert;
+use super::structure::distributes_over_compose;
 use super::{FLATTENED, FLATTENED_FULL};
 use crate::filter::Filter;
 use crate::op::Op;
@@ -65,7 +66,15 @@ fn flatten_impl(filter: Filter, full: bool) -> Filter {
                         .iter()
                         .enumerate()
                         .all(|(j, f)| j == i || invert(*f).is_ok());
-                    if !others_invertible {
+                    // Pulling an element that sits *after* the Compose into each branch is only
+                    // valid if it commutes with `tree::compose`. Elements before the Compose
+                    // always do (`A:(compose C) == compose over c of (A:c)`), but a suffix element
+                    // like `Exclude(File(..))` reads paths that may only meet in the composed tree,
+                    // so distributing it changes the result. Leave the Chain intact in that case.
+                    let suffix_distributes = flattened[i + 1..]
+                        .iter()
+                        .all(|f| distributes_over_compose(*f));
+                    if !others_invertible || !suffix_distributes {
                         break;
                     }
                     // Distributing a trailing Compose with a non-empty prefix is often futile: it

--- a/josh-filter/src/opt/structure.rs
+++ b/josh-filter/src/opt/structure.rs
@@ -127,6 +127,24 @@ pub(super) fn resurrects_from_empty(filter: Filter) -> bool {
     }
 }
 
+/// Whether `filter` commutes with `tree::compose`, i.e. `filter(compose(t0, t1, ..)) ==
+/// compose(filter(t0), filter(t1), ..)`. This is the condition for pulling a chain element that
+/// sits *after* a `Compose` into each of the compose's branches (see `flatten`). Only pure path
+/// relocation/selection ops distribute: `Prefix`/`Subdir` (and `Nop`/`Empty`), plus `Chain`/
+/// `Compose` built from them. Ops whose result at one path depends on another path -- `Exclude`,
+/// `Select`, `Subtract`, `File` -- do not, since the paths they read may be split across branches
+/// and only meet in the composed tree. The whitelist is deliberately conservative: anything not
+/// listed is assumed not to distribute, which only ever suppresses the optimization.
+pub(super) fn distributes_over_compose(filter: Filter) -> bool {
+    match to_op_ref(filter) {
+        Op::Nop | Op::Empty | Op::Prefix(_) | Op::Subdir(_) => true,
+        Op::Chain(filters) | Op::Compose(filters) => {
+            filters.iter().all(|f| distributes_over_compose(*f))
+        }
+        _ => false,
+    }
+}
+
 pub(super) fn common_post(filters: &Vec<Filter>) -> Option<(Filter, Vec<Filter>)> {
     let mut rest = vec![];
     let mut common_post: Option<Filter> = None;


### PR DESCRIPTION
Only distribute a chain over a compose when the suffix commutes

`flatten` distributes `A:(compose C):B` into `compose over c of (A:c:B)`,
duplicating the other chain elements into every branch. It guarded this only
with an invertibility check, which exists for a downstream reason and does not
imply the rewrite is semantics-preserving. Pulling a *suffix* element (one
after the Compose) into each branch is valid only if it commutes with
`tree::compose`; an element such as `Exclude(File(dst, src))` reads a source
path that may exist only in the composed tree, not in an individual branch, so
distribution changes the result. Prefix elements always commute, and the
`ultrawide_pin` path distributes a trailing Compose (empty suffix), so both
keep working.

Add `distributes_over_compose` (a conservative whitelist of `Prefix`/`Subdir`/
`Nop`/`Empty` and chains/composes thereof) and require every suffix element to
satisfy it before distributing. Add a raw-AST regression case to
`subtract_optimizer_apply_oracle`.

Change: flatten-distribute-suffix-guard
Assisted-By: Claude Opus 4.8