### PR TITLE
Add josh-gix-ext with a StagingOdb generalizing the persist.rs gix pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -815,7 +815,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1265,7 +1265,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1402,7 +1402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2860,7 +2860,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2914,7 +2914,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3107,6 +3107,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "josh-filter",
+ "josh-gix-ext",
  "josh-memodb",
  "josh-search",
  "josh-starlark",
@@ -3173,6 +3174,7 @@ dependencies = [
  "gix-object",
  "indoc",
  "itertools 0.14.0",
+ "josh-gix-ext",
  "josh-memodb",
  "pest",
  "pest_derive",
@@ -3281,6 +3283,16 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tracing",
+]
+
+[[package]]
+name = "josh-gix-ext"
+version = "26.7.28"
+dependencies = [
+ "anyhow",
+ "git2",
+ "gix-hash",
+ "gix-object",
 ]
 
 [[package]]
@@ -3861,7 +3873,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4806,7 +4818,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4863,7 +4875,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5270,7 +5282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5490,7 +5502,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6275,7 +6287,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "josh-memodb",
     "josh-cli",
     "josh-filter",
+    "josh-gix-ext",
     "josh-graphql",
     "josh-link",
     "josh-proxy",
@@ -87,6 +88,7 @@ graphql_client_codegen = { version = "^0.16.0" }
 
 axum-cgi = { path = "axum-cgi", version = "26.7.28" }
 josh-filter = { path = "josh-filter", version = "26.7.28" }
+josh-gix-ext = { path = "josh-gix-ext", version = "26.7.28" }
 josh-changes = { path = "josh-changes", version = "26.7.28" }
 josh-core = { path = "josh-core", version = "26.7.28" }
 josh-memodb = { path = "josh-memodb", version = "26.7.28" }
@@ -184,6 +186,7 @@ version = "0.4"
 [patch.crates-io]
 axum-cgi = { path = "axum-cgi" }
 josh-filter = { path = "josh-filter" }
+josh-gix-ext = { path = "josh-gix-ext" }
 josh-changes = { path = "josh-changes" }
 josh-core = { path = "josh-core" }
 josh-memodb = { path = "josh-memodb" }

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -82,6 +82,7 @@ tracing.workspace = true
 toml.workspace = true
 
 josh-filter.workspace = true
+josh-gix-ext.workspace = true
 josh-memodb.workspace = true
 josh-search.workspace = true
 josh-starlark.workspace = true

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -23,6 +23,8 @@ pub mod link;
 pub mod submodules;
 pub mod trailers;
 
+pub use josh_gix_ext as objects;
+
 #[derive(
     Clone, Hash, PartialEq, Eq, Copy, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize,
 )]

--- a/josh-filter/Cargo.toml
+++ b/josh-filter/Cargo.toml
@@ -19,6 +19,7 @@ itertools = "0.14.0"
 anyhow.workspace = true
 git2.workspace = true
 josh-memodb.workspace = true
+josh-gix-ext.workspace = true
 gix-object.workspace = true
 gix-hash.workspace = true
 regex.workspace = true

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, anyhow};
-use gix_object::WriteTo;
 use gix_object::bstr::BString;
 use std::collections::HashMap;
 use std::sync::{LazyLock, OnceLock};
@@ -92,8 +91,7 @@ fn push_tree_entries(
 }
 
 struct InMemoryBuilder<'a> {
-    // Map from hash to (kind, raw bytes)
-    pending_writes: HashMap<gix_hash::ObjectId, (gix_object::Kind, Vec<u8>)>,
+    staging: josh_gix_ext::StagingOdb<'a>,
     /// Present when building for persistence (`as_tree`): used to resolve the object kind of
     /// `InsertContent::Oid` so the object can be referenced as a tree entry with the correct
     /// mode. Absent when computing `Filter::id`, which must stay repository-independent.
@@ -105,16 +103,8 @@ struct InMemoryBuilder<'a> {
 
 impl<'a> InMemoryBuilder<'a> {
     fn new(repo: Option<&'a git2::Repository>) -> Self {
-        // Add an empty blob because we use a shortcut for them below
-        // in write_blob
-        let mut pending_writes = HashMap::new();
-        pending_writes.insert(
-            gix_hash::ObjectId::empty_blob(gix_hash::Kind::Sha1),
-            (gix_object::Kind::Blob, Vec::new()),
-        );
-
         Self {
-            pending_writes,
+            staging: josh_gix_ext::StagingOdb::new(),
             repo,
             persist_ids: HashMap::new(),
         }
@@ -130,26 +120,16 @@ impl<'a> InMemoryBuilder<'a> {
     }
 
     fn write_blob(&mut self, data: &[u8]) -> gix_hash::ObjectId {
-        if data.is_empty() {
-            return gix_hash::ObjectId::empty_blob(gix_hash::Kind::Sha1);
-        }
-
-        let hash = gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Blob, data)
-            .expect("failed to compute hash");
-        self.pending_writes
-            .insert(hash, (gix_object::Kind::Blob, data.to_vec()));
-        hash
+        self.staging.write_blob(data)
     }
 
+    /// Persisted filter trees sort by plain filename bytes -- NOT canonical git tree order (which
+    /// treats tree entry names as if they had a trailing '/'). The two differ when one name is a
+    /// strict prefix of another; this order is part of the persisted filter format and must stay
+    /// as is for filter ids to remain stable.
     fn write_tree(&mut self, mut tree: gix_object::Tree) -> gix_hash::ObjectId {
         tree.entries.sort_by(|a, b| a.filename.cmp(&b.filename));
-        let mut buffer = Vec::with_capacity(tree.size() as usize);
-        tree.write_to(&mut buffer).expect("failed to write tree");
-        let hash = gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Tree, &buffer)
-            .expect("failed to compute hash");
-        self.pending_writes
-            .insert(hash, (gix_object::Kind::Tree, buffer));
-        hash
+        self.staging.write_tree(&tree)
     }
 
     fn build_str_params(&mut self, params: &[&str]) -> gix_hash::ObjectId {
@@ -669,23 +649,7 @@ pub fn as_tree(repo: &git2::Repository, filter: Filter) -> anyhow::Result<git2::
     let root_oid = builder.build_persist(&odb, filter)?;
     let root_oid = git2::Oid::from_bytes(root_oid.as_bytes())?;
 
-    // Write all pending objects to the git2 repository
-    for (oid, (kind, data)) in builder.pending_writes {
-        let oid = git2::Oid::from_bytes(oid.as_bytes())?;
-
-        // On some platforms, .exists() is cheaper in terms of i/o
-        // than .write(), because .write() updates file access time
-        // in loose object backend
-        if !odb.exists(oid) {
-            let git2_type = match kind {
-                gix_object::Kind::Tree => git2::ObjectType::Tree,
-                gix_object::Kind::Blob => git2::ObjectType::Blob,
-                gix_object::Kind::Commit => git2::ObjectType::Commit,
-                gix_object::Kind::Tag => git2::ObjectType::Tag,
-            };
-            odb.write(git2_type, &data)?;
-        }
-    }
+    builder.staging.flush(&odb)?;
 
     // Now the tree should really be in the ODB
     Ok(root_oid)

--- a/josh-gix-ext/Cargo.toml
+++ b/josh-gix-ext/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "josh-gix-ext"
+version = "26.7.28"
+repository = "https://github.com/josh-project/josh"
+authors = ["Josh Project authors <contact@josh-project.dev>"]
+license-file = "../LICENSE"
+description = "Gitoxide interop and extension utilities for josh"
+keywords = ["git", "gitoxide", "odb"]
+readme = "../README.md"
+edition = "2024"
+
+[dependencies]
+anyhow.workspace = true
+git2.workspace = true
+gix-hash.workspace = true
+gix-object.workspace = true

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -1,0 +1,214 @@
+//! In-memory object staging over a single object database.
+//!
+//! This is the transition vehicle for the incremental git2 -> gix port: all gix-object compute
+//! (tree construction, commit parsing and serialization, hashing) works against this adapter,
+//! which stages written objects in memory and reads through to the one repository object
+//! database. At no point does a second repository handle perform I/O -- the lesson from the
+//! reverted side-by-side gitoxide integration (cd6dc206) is that gix is used for pure in-memory
+//! compute while a single ODB owns all I/O.
+//!
+//! Objects are staged as raw `(kind, bytes)` pairs keyed by their content hash, computed with
+//! [`gix_object::compute_hash`] -- no repository access, no zlib, no filesystem. [`flush`] batch
+//! writes the staged objects to the repository ODB at an explicit boundary, skipping objects that
+//! already exist (on some platforms `exists()` is cheaper in terms of I/O than `write()`, because
+//! `write()` updates the file access time in the loose object backend).
+//!
+//! The adapter implements [`gix_object::Find`] (and friends), so gix readers -- `TreeRef`
+//! parsing, `CommitRefIter`, the tree editor, the topo walk -- see staged-but-unflushed objects
+//! and disk objects through one interface.
+//!
+//! [`flush`]: StagingOdb::flush
+
+use std::collections::HashMap;
+
+use gix_object::WriteTo;
+
+/// Map the kind of a raw object between the two libraries. Infallible: both enums cover exactly
+/// the four git object kinds.
+pub fn git2_kind(kind: gix_object::Kind) -> git2::ObjectType {
+    match kind {
+        gix_object::Kind::Tree => git2::ObjectType::Tree,
+        gix_object::Kind::Blob => git2::ObjectType::Blob,
+        gix_object::Kind::Commit => git2::ObjectType::Commit,
+        gix_object::Kind::Tag => git2::ObjectType::Tag,
+    }
+}
+
+/// See [`git2_kind`]. Fails only for `Any`/`Ref`, which are not object kinds.
+pub fn gix_kind(kind: git2::ObjectType) -> Option<gix_object::Kind> {
+    match kind {
+        git2::ObjectType::Tree => Some(gix_object::Kind::Tree),
+        git2::ObjectType::Blob => Some(gix_object::Kind::Blob),
+        git2::ObjectType::Commit => Some(gix_object::Kind::Commit),
+        git2::ObjectType::Tag => Some(gix_object::Kind::Tag),
+        _ => None,
+    }
+}
+
+/// Zero-cost oid conversion: both libraries use the same 20-byte binary representation.
+pub fn gix_oid(oid: git2::Oid) -> gix_hash::ObjectId {
+    gix_hash::ObjectId::from_bytes_or_panic(oid.as_bytes())
+}
+
+/// See [`gix_oid`].
+pub fn git2_oid(oid: &gix_hash::oid) -> git2::Oid {
+    git2::Oid::from_bytes(oid.as_bytes()).expect("oid sizes match")
+}
+
+/// An in-memory staging store over an optional read-through object database.
+///
+/// Writes stage objects in a hash map; reads (via the [`gix_object::Find`] family) consult the
+/// staged objects first and fall back to the repository ODB when one is attached. Constructed
+/// without an ODB it is a pure store for computing content hashes repository-independently (the
+/// `Filter::id` use case, which must not touch a repository at all).
+pub struct StagingOdb<'a> {
+    /// Staged objects by content hash: `(kind, raw bytes)`, not yet written to the repository.
+    pending: HashMap<gix_hash::ObjectId, (gix_object::Kind, Vec<u8>)>,
+    /// Read-through target, when reads are needed.
+    odb: Option<git2::Odb<'a>>,
+}
+
+impl<'a> StagingOdb<'a> {
+    /// A pure in-memory store without read-through: reads only see staged objects.
+    pub fn new() -> Self {
+        // Pre-seed the empty blob because `write_blob` short-cuts hashing for empty content;
+        // seeding keeps the shortcut consistent with flushing (the object is written if missing).
+        let mut pending = HashMap::new();
+        pending.insert(
+            gix_hash::ObjectId::empty_blob(gix_hash::Kind::Sha1),
+            (gix_object::Kind::Blob, Vec::new()),
+        );
+        Self { pending, odb: None }
+    }
+
+    /// A staging store reading through to `odb` for objects that are not staged.
+    pub fn with_odb(odb: git2::Odb<'a>) -> Self {
+        Self {
+            odb: Some(odb),
+            ..Self::new()
+        }
+    }
+
+    /// Stage a raw object that is already serialized. Returns its content hash.
+    pub fn write_raw(&mut self, kind: gix_object::Kind, data: Vec<u8>) -> gix_hash::ObjectId {
+        let hash = gix_object::compute_hash(gix_hash::Kind::Sha1, kind, &data)
+            .expect("failed to compute hash");
+        self.pending.insert(hash, (kind, data));
+        hash
+    }
+
+    /// Stage a blob. Empty blobs short-cut to the well-known empty-blob oid.
+    pub fn write_blob(&mut self, data: &[u8]) -> gix_hash::ObjectId {
+        if data.is_empty() {
+            return gix_hash::ObjectId::empty_blob(gix_hash::Kind::Sha1);
+        }
+        self.write_raw(gix_object::Kind::Blob, data.to_vec())
+    }
+
+    /// Serialize and stage a tree. Entries are written in the order given -- ordering is the
+    /// caller's responsibility, because the two orders in use differ: real git trees require
+    /// canonical git entry order ([`gix_object::tree::Entry`]'s `Ord`), while persisted filter
+    /// trees historically sort by plain filename bytes and must keep hashing identically.
+    pub fn write_tree(&mut self, tree: &gix_object::Tree) -> gix_hash::ObjectId {
+        let mut buffer = Vec::with_capacity(tree.size() as usize);
+        tree.write_to(&mut buffer).expect("failed to write tree");
+        self.write_raw(gix_object::Kind::Tree, buffer)
+    }
+
+    /// Serialize and stage a commit.
+    pub fn write_commit(&mut self, commit: &gix_object::Commit) -> gix_hash::ObjectId {
+        let mut buffer = Vec::with_capacity(commit.size() as usize);
+        commit
+            .write_to(&mut buffer)
+            .expect("failed to write commit");
+        self.write_raw(gix_object::Kind::Commit, buffer)
+    }
+
+    /// Write every staged object to `odb`, emptying the staging map. Objects the ODB already
+    /// has are skipped (see module docs).
+    pub fn flush(&mut self, odb: &git2::Odb) -> anyhow::Result<()> {
+        for (oid, (kind, data)) in self.pending.drain() {
+            let oid = git2_oid(&oid);
+            if !odb.exists(oid) {
+                odb.write(git2_kind(kind), &data)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for StagingOdb<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl gix_object::Find for StagingOdb<'_> {
+    fn try_find<'b>(
+        &self,
+        id: &gix_hash::oid,
+        buffer: &'b mut Vec<u8>,
+    ) -> Result<Option<gix_object::Data<'b>>, gix_object::find::Error> {
+        if let Some((kind, data)) = self.pending.get(id) {
+            buffer.clear();
+            buffer.extend_from_slice(data);
+            return Ok(Some(gix_object::Data {
+                kind: *kind,
+                data: buffer,
+            }));
+        }
+        let Some(odb) = &self.odb else {
+            return Ok(None);
+        };
+        let obj = match odb.read(git2_oid(id)) {
+            Ok(obj) => obj,
+            Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
+            Err(e) => return Err(Box::new(e)),
+        };
+        let Some(kind) = gix_kind(obj.kind()) else {
+            return Ok(None);
+        };
+        buffer.clear();
+        buffer.extend_from_slice(obj.data());
+        Ok(Some(gix_object::Data { kind, data: buffer }))
+    }
+}
+
+impl gix_object::FindHeader for StagingOdb<'_> {
+    fn try_header(
+        &self,
+        id: &gix_hash::oid,
+    ) -> Result<Option<gix_object::Header>, gix_object::find::Error> {
+        if let Some((kind, data)) = self.pending.get(id) {
+            return Ok(Some(gix_object::Header {
+                kind: *kind,
+                size: data.len() as u64,
+            }));
+        }
+        let Some(odb) = &self.odb else {
+            return Ok(None);
+        };
+        let (size, kind) = match odb.read_header(git2_oid(id)) {
+            Ok(h) => h,
+            Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
+            Err(e) => return Err(Box::new(e)),
+        };
+        let Some(kind) = gix_kind(kind) else {
+            return Ok(None);
+        };
+        Ok(Some(gix_object::Header {
+            kind,
+            size: size as u64,
+        }))
+    }
+}
+
+impl gix_object::Exists for StagingOdb<'_> {
+    fn exists(&self, id: &gix_hash::oid) -> bool {
+        self.pending.contains_key(id)
+            || self
+                .odb
+                .as_ref()
+                .is_some_and(|odb| odb.exists(git2_oid(id)))
+    }
+}


### PR DESCRIPTION
Add josh-gix-ext with a StagingOdb generalizing the persist.rs gix pattern

Introduce a new crate for gitoxide interop and extension utilities:
zero-cost git2<->gix oid and kind conversions and a StagingOdb -- an
in-memory object store that computes content hashes with
gix_object::compute_hash (no repository access, no zlib), implements
the gix_object::Find/FindHeader/Exists traits with read-through to a
git2 odb, and batch-writes staged objects with an exists() check.

This is the transition vehicle for the incremental git2->gix port:
gix-object compute (tree construction, commit parsing, hashing) plugs
into this adapter while a single ODB keeps owning all I/O -- the
side-by-side approach reverted in cd6dc206 is explicitly avoided. A
dedicated crate keeps it out of josh-filter (which only consumes it
for filter persistence) and gives the port's future shared machinery
(commit helpers, pack writing) a home below every other josh crate.

persist.rs is refactored onto the adapter; its plain-filename tree
sort (part of the persisted filter format, distinct from canonical
git tree order) stays at the persist layer. Filter ids and persisted
trees hash identically to before.

josh-core re-exports the crate as josh_core::objects.

Change: gix-objects-adapter
Assisted-By: Claude Fable 5 (claude-fable-5)