### PR TITLE
Add write-flush and ref-update criterion benches

### DIFF
--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -41,6 +41,14 @@ harness = false
 name = "widetree_glob"
 harness = false
 
+[[bench]]
+name = "deephistory_prefix_flush"
+harness = false
+
+[[bench]]
+name = "refs_filter_update"
+harness = false
+
 [dependencies]
 backtrace = "0.3.76"
 bitvec = "1.0.1"

--- a/josh-core/benches/deephistory_prefix_flush.rs
+++ b/josh-core/benches/deephistory_prefix_flush.rs
@@ -1,0 +1,276 @@
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use josh_core::filter::Filter;
+use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::{build_index, random_string};
+use rand::prelude::*;
+use std::path::{Path, PathBuf};
+
+// This bench measures the object *write* path: unlike `:/<subdir>` (which only selects existing
+// subtrees, so the filtered output reuses existing tree objects), a `:prefix=<path>` filter writes
+// fresh objects for every filtered commit -- one new tree per prefix component plus the rewritten
+// commit itself. All of those writes land in the per-transaction in-memory object store
+// (josh-memodb) and are packed to disk by its background flusher, so this bench covers both the
+// per-object write cost and the overflow-pack/boundary-drain cost that the other benches only
+// exercise incidentally. The mem-odb size limit is set artificially low (see `MEM_ODB_LIMIT`) so
+// mid-transaction overflow packs actually trigger at bench scale, and the timed section ends with
+// an explicit boundary flush so pack durability is inside the measurement.
+
+// Number of history commits generated on top of the root commit for each case. Kept small in debug
+// builds so `cargo test`/`--test` runs stay fast.
+const HISTORY_SIZES: &[usize] = if cfg!(debug_assertions) {
+    &[10, 100]
+} else {
+    &[100, 1_000]
+};
+
+// A fixed, modest tree shared as the root of every case, same shape as `deephistory_subdir`: this
+// bench varies history length, not tree width.
+const TREE_FILES: usize = 200;
+const N_DIRS: usize = 10;
+
+// Fraction of the tree's files each commit changes ("churns"). Churn makes every commit's root tree
+// unique, so the prefix filter writes distinct trees for every commit instead of hitting the odb
+// dedup path.
+const CHURN_FRACTION: f64 = 0.1;
+const CHURN_CONTENT_LEN: usize = 10;
+
+// The prefix the benchmarked filter applies. Three components deep, so every filtered commit writes
+// three fresh tree objects plus the commit object.
+const PREFIX: &str = "a/b/c";
+
+// In-memory object store size limit for the benchmarked transactions. Low enough that the writes of
+// the larger cases exceed it several times over, forcing the mid-transaction overflow packs this
+// bench exists to measure; high enough that the smallest case still fits (giving one boundary-drain
+// data point without overflow packs).
+const MEM_ODB_LIMIT: usize = 64 * 1024;
+
+/// Expected oid of the cached bench repo's aggregate index commit. This is the cache validity key:
+/// changing any build parameter above changes a case head, which changes the index commit oid,
+/// which then fails the strict check in `provision_repo` and reports the new value to paste here.
+/// Filled in by running the bench once after a build change. Debug builds use reduced
+/// HISTORY_SIZES, so they have their own expected oid and their own provision-cache name (below)
+/// -- otherwise `cargo test --benches` and `cargo bench` would fight over the same cache entry.
+const EXPECTED_HEAD: &str = if cfg!(debug_assertions) {
+    "d4c3f665871dd8f4413cae2aa55a73f4d86d8ccc"
+} else {
+    "85136c91e53cddde412086e85d25a33d05931ff0"
+};
+
+/// Provision-cache name, split per profile to match the per-profile EXPECTED_HEAD.
+const CACHE_NAME: &str = if cfg!(debug_assertions) {
+    "deephistory_prefix_flush_debug"
+} else {
+    "deephistory_prefix_flush"
+};
+
+/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME` so the built
+/// history is reproducible. Without it the signature uses the wall clock, every run produces
+/// different head oids, and `EXPECTED_HEAD` can never be stable. The value itself is arbitrary.
+const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
+
+/// One history length and the head of its generated history.
+struct SizeCase {
+    n_commits: usize,
+    head: git2::Oid,
+}
+
+struct PrefixFlushBench {
+    // Keeps the on-disk repository (and its tempdir) alive for the duration of the benchmark.
+    _repo: josh_test_support::provision_repo::ProvisionedRepo,
+    // A fresh transaction is opened from this for every iteration.
+    context: josh_core::cache::TransactionContext,
+    cases: Vec<SizeCase>,
+    // The filter under benchmark: a single `:prefix=<PREFIX>`.
+    filter: Filter,
+}
+
+impl PrefixFlushBench {
+    fn setup() -> anyhow::Result<Self> {
+        let _setup = tracing::info_span!(target: "bench", "setup").entered();
+
+        // Pin commit timestamps before building so the head oids are reproducible and
+        // `EXPECTED_HEAD` stays valid across runs. Must run before the cache-miss path invokes the
+        // build callback. SAFETY: setup runs single-threaded, before any benchmark iteration.
+        unsafe {
+            std::env::set_var("JOSH_COMMIT_TIME", JOSH_BENCH_COMMIT_TIME);
+        }
+
+        // Build (or reuse from cache) the bare repo holding every history-length case. On a cache
+        // miss the callback builds all cases, tags each tip with a `refs/heads/case_<n_commits>`
+        // ref, and returns an aggregate index commit whose oid is the content-addressed cache
+        // stamp checked against `EXPECTED_HEAD`.
+        let provisioned = josh_test_support::provision_repo::provision_repo(
+            CACHE_NAME,
+            &git2::Oid::from_str(EXPECTED_HEAD).expect("EXPECTED_HEAD must be a valid oid"),
+            |repo| {
+                let mut heads = vec![];
+                for &n_commits in HISTORY_SIZES {
+                    let head = tracing::info_span!(target: "bench", "build_case", n_commits)
+                        .in_scope(|| build_case(repo, n_commits))?;
+                    heads.push(head);
+                }
+                build_index(repo, &josh_commit_signature()?, &heads)
+            },
+        )?;
+
+        // Recover each case head from its ref. This runs identically whether the repo was freshly
+        // built or copied from cache.
+        let mut cases = vec![];
+        {
+            let repo = &provisioned.repo;
+            for &n_commits in HISTORY_SIZES {
+                let head = repo.refname_to_id(&format!("refs/heads/case_{n_commits}"))?;
+                cases.push(SizeCase { n_commits, head });
+            }
+        }
+
+        let filter = Filter::new().prefix(PREFIX);
+
+        josh_core::cache::sled_load(provisioned.path())?;
+        let cache = std::sync::Arc::new(
+            josh_core::cache::CacheStack::new()
+                .with_backend(josh_core::cache::SledCacheBackend::default()),
+        );
+        let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache)
+            .with_mem_odb_limit(MEM_ODB_LIMIT);
+
+        // Correctness gate (untimed): confirm the prefix filter nests the raw head tree under
+        // `PREFIX`, so we never silently measure a filter that drops everything or is a no-op. Run
+        // through a throwaway transaction on the smallest case (the check is history-length
+        // independent), then reset caches so nothing here warms the timed runs.
+        {
+            let transaction = context.open()?;
+            let case = cases.first().expect("at least one case");
+            let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
+            let repo = transaction.repo();
+            let nested_tree = repo
+                .find_commit(filtered)?
+                .tree()?
+                .get_path(Path::new(PREFIX))?
+                .id();
+            let raw_tree = repo.find_commit(case.head)?.tree_id();
+            anyhow::ensure!(
+                nested_tree == raw_tree,
+                "prefix filter did not nest the tree under `{PREFIX}` -- benchmark would measure \
+                 the wrong thing"
+            );
+        }
+        josh_core::reset_caches()?;
+
+        Ok(Self {
+            _repo: provisioned,
+            context,
+            cases,
+            filter,
+        })
+    }
+}
+
+/// Build a root commit whose tree holds `TREE_FILES` files spread across `N_DIRS` top-level
+/// directories, then generate an `n_commits` history that churns ~`CHURN_FRACTION` of the files per
+/// commit. The tip is tagged with `refs/heads/case_<n_commits>` so the head is recoverable after
+/// the repo round-trips through the cache.
+fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<git2::Oid> {
+    use rand::RngExt;
+
+    let mut builder = git2::build::TreeUpdateBuilder::new();
+    let mut all_paths = vec![];
+    for i in 0..TREE_FILES {
+        let path = PathBuf::from(format!("dir_{:02}", i % N_DIRS)).join(format!("file_{i:04}"));
+        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        builder.upsert(&path, oid, git2::FileMode::Blob);
+        all_paths.push(path);
+    }
+
+    let baseline = repo.find_tree(repo.treebuilder(None)?.write()?)?;
+    let root_tree = repo.find_tree(builder.create_updated(repo, &baseline)?)?;
+
+    let sig = josh_commit_signature()?;
+    // No ref update yet -- the tip ref is set once the history is complete.
+    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+
+    // Deterministic history: each commit churns a fresh random ~CHURN_FRACTION of the files.
+    let mut rng = StdRng::seed_from_u64(1);
+    for i in 0..n_commits {
+        let parent = repo.find_commit(head)?;
+        let tree = parent.tree()?;
+        let mut builder = git2::build::TreeUpdateBuilder::new();
+
+        let churned = all_paths
+            .iter()
+            .filter(|_| rng.random_bool(CHURN_FRACTION))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for path in &churned {
+            let content = random_string(&mut rng, CHURN_CONTENT_LEN);
+            let blob = repo.blob(content.as_bytes())?;
+            builder.upsert(path, blob, git2::FileMode::Blob);
+        }
+
+        let new_tree = repo.find_tree(builder.create_updated(repo, &tree)?)?;
+        head = repo.commit(
+            None,
+            &sig,
+            &sig,
+            &format!("commit {i}"),
+            &new_tree,
+            &[&parent],
+        )?;
+    }
+
+    // Tag the tip so `setup` can find this case's head on the cache-hit path, where the build
+    // callback never runs. Also keeps the whole history reachable, so provision_repo's `git prune`
+    // retains it.
+    repo.reference(
+        &format!("refs/heads/case_{n_commits}"),
+        head,
+        true,
+        "bench case tip",
+    )?;
+
+    Ok(head)
+}
+
+fn deephistory_prefix_flush(c: &mut Criterion) {
+    josh_test_support::init_tracing("bench=trace");
+
+    let bench = PrefixFlushBench::setup().expect("set up benchmark");
+
+    let mut group = c.benchmark_group("deephistory_prefix_flush");
+    // The largest case costs seconds per iteration, so keep Criterion at its minimum sample count
+    // to bound the total wall-clock of a run.
+    group.sample_size(10);
+    for case in &bench.cases {
+        group.throughput(Throughput::Elements(case.n_commits as u64));
+        group.bench_function(BenchmarkId::from_parameter(case.n_commits), |b| {
+            b.iter_batched(
+                // Per-iteration setup (untimed): start from a cold cache and a fresh transaction so
+                // every run does the full filtering and object-write work instead of hitting
+                // memoized results. The written objects themselves persist in the repo across
+                // iterations, but the write path buffers and packs them again regardless, so the
+                // measured work is stable.
+                || {
+                    josh_core::reset_caches().expect("reset caches");
+                    let transaction = bench.context.open().expect("open transaction");
+                    let iter_span = tracing::info_span!(target: "bench", "iter").entered();
+                    (transaction, iter_span)
+                },
+                // Timed: filter the case head (writing prefix trees and commits into the mem odb,
+                // with overflow packs once MEM_ODB_LIMIT is exceeded), then drain the store so pack
+                // durability is part of the measurement.
+                |(transaction, iter_span)| {
+                    josh_core::filter_commit(&transaction, bench.filter, case.head)
+                        .expect("filter commit");
+                    transaction.flush_mem_odb().expect("flush mem odb");
+                    (transaction, iter_span)
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, deephistory_prefix_flush);
+criterion_main!(benches);

--- a/josh-core/benches/refs_filter_update.rs
+++ b/josh-core/benches/refs_filter_update.rs
@@ -1,0 +1,300 @@
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use josh_core::filter::Filter;
+use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::{build_index, random_string};
+use rand::prelude::*;
+use std::path::{Path, PathBuf};
+
+// This bench measures the *reference* surface: enumerating refs by glob, resolving each to an oid,
+// looking up the (cache-hot) filtered result per ref, and force-writing the filtered refs back. The
+// scaling parameter is the number of refs, and the filter caches are deliberately warmed during
+// setup and never reset, so the measured loop is dominated by ref enumeration, resolution and
+// updates rather than by filtering work -- the proxy's steady state when serving a repo whose
+// filter results are already cached. The filtering benches cover the cold path; this one exists so
+// the ref backend (enumeration, loose/packed lookup, ref writes) has its own regression gate.
+
+// Number of change refs (each pointing to a distinct commit of a churned history) per case. Kept
+// small in debug builds so `cargo test`/`--test` runs stay fast.
+const REF_COUNTS: &[usize] = if cfg!(debug_assertions) {
+    &[10]
+} else {
+    &[100, 1_000]
+};
+
+// A fixed, modest tree shared as the root of every case, same shape as `deephistory_subdir`.
+const TREE_FILES: usize = 200;
+const N_DIRS: usize = 10;
+
+// The directory the benchmarked filter selects; churn keeps touching it so per-ref filter results
+// stay distinct and non-trivial.
+const SUBDIR: &str = "dir_00";
+
+// Fraction of the tree's files each commit changes ("churns").
+const CHURN_FRACTION: f64 = 0.1;
+const CHURN_CONTENT_LEN: usize = 10;
+
+/// Expected oid of the cached bench repo's aggregate index commit. This is the cache validity key:
+/// changing any build parameter above changes a case head, which changes the index commit oid,
+/// which then fails the strict check in `provision_repo` and reports the new value to paste here.
+/// Filled in by running the bench once after a build change. Debug builds use reduced REF_COUNTS,
+/// so they have their own expected oid and their own provision-cache name (below) -- otherwise
+/// `cargo test --benches` and `cargo bench` would fight over the same cache entry.
+const EXPECTED_HEAD: &str = if cfg!(debug_assertions) {
+    "63a90b791bb6ac771f445f4f085001eae6362a1e"
+} else {
+    "85136c91e53cddde412086e85d25a33d05931ff0"
+};
+
+/// Provision-cache name, split per profile to match the per-profile EXPECTED_HEAD.
+const CACHE_NAME: &str = if cfg!(debug_assertions) {
+    "refs_filter_update_debug"
+} else {
+    "refs_filter_update"
+};
+
+/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME` so the built
+/// history is reproducible. Without it the signature uses the wall clock, every run produces
+/// different head oids, and `EXPECTED_HEAD` can never be stable. The value itself is arbitrary.
+const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
+
+/// One ref-count case and the head of its generated history.
+struct SizeCase {
+    n_refs: usize,
+    head: git2::Oid,
+}
+
+struct RefsBench {
+    // Keeps the on-disk repository (and its tempdir) alive for the duration of the benchmark.
+    _repo: josh_test_support::provision_repo::ProvisionedRepo,
+    // A fresh transaction is opened from this for every iteration.
+    context: josh_core::cache::TransactionContext,
+    cases: Vec<SizeCase>,
+    // The filter under benchmark: a single `:/<SUBDIR>` subdir selection.
+    filter: Filter,
+}
+
+impl RefsBench {
+    fn setup() -> anyhow::Result<Self> {
+        let _setup = tracing::info_span!(target: "bench", "setup").entered();
+
+        // Pin commit timestamps before building so the head oids are reproducible and
+        // `EXPECTED_HEAD` stays valid across runs. Must run before the cache-miss path invokes the
+        // build callback. SAFETY: setup runs single-threaded, before any benchmark iteration.
+        unsafe {
+            std::env::set_var("JOSH_COMMIT_TIME", JOSH_BENCH_COMMIT_TIME);
+        }
+
+        // Build (or reuse from cache) the bare repo holding every case. On a cache miss the
+        // callback builds all cases -- a churned linear history per case, one
+        // `refs/heads/case_<n>/change_<i>` ref per commit plus a `refs/heads/case_<n>_tip` ref --
+        // and returns an aggregate index commit whose oid is the content-addressed cache stamp
+        // checked against `EXPECTED_HEAD`.
+        let provisioned = josh_test_support::provision_repo::provision_repo(
+            CACHE_NAME,
+            &git2::Oid::from_str(EXPECTED_HEAD).expect("EXPECTED_HEAD must be a valid oid"),
+            |repo| {
+                let mut heads = vec![];
+                for &n_refs in REF_COUNTS {
+                    let head = tracing::info_span!(target: "bench", "build_case", n_refs)
+                        .in_scope(|| build_case(repo, n_refs))?;
+                    heads.push(head);
+                }
+                build_index(repo, &josh_commit_signature()?, &heads)
+            },
+        )?;
+
+        // Recover each case head from its tip ref. This runs identically whether the repo was
+        // freshly built or copied from cache.
+        let mut cases = vec![];
+        {
+            let repo = &provisioned.repo;
+            for &n_refs in REF_COUNTS {
+                let head = repo.refname_to_id(&format!("refs/heads/case_{n_refs}_tip"))?;
+                cases.push(SizeCase { n_refs, head });
+            }
+        }
+
+        let filter = Filter::new().subdir(SUBDIR);
+
+        josh_core::cache::sled_load(provisioned.path())?;
+        let cache = std::sync::Arc::new(
+            josh_core::cache::CacheStack::new()
+                .with_backend(josh_core::cache::SledCacheBackend::default()),
+        );
+        let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
+
+        // Correctness gate (untimed): confirm the subdir filter selects exactly the SUBDIR subtree
+        // of a case head, so we never silently measure a filter that drops everything or is a
+        // no-op.
+        {
+            let transaction = context.open()?;
+            let case = cases.first().expect("at least one case");
+            let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
+            let repo = transaction.repo();
+            let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
+            let raw_subdir_tree = repo
+                .find_commit(case.head)?
+                .tree()?
+                .get_path(Path::new(SUBDIR))?
+                .id();
+            anyhow::ensure!(
+                filtered_tree == raw_subdir_tree,
+                "subdir filter did not select `{SUBDIR}` -- benchmark would measure the wrong thing"
+            );
+        }
+
+        // Warm the filter caches for every case: filtering each head walks and memoizes its whole
+        // ancestry, so every per-ref lookup in the timed loop is a cache hit. Deliberately NOT
+        // followed by `reset_caches` -- warm caches are the point (see module comment).
+        {
+            let transaction = context.open()?;
+            for case in &cases {
+                josh_core::filter_commit(&transaction, filter, case.head)?;
+            }
+        }
+
+        Ok(Self {
+            _repo: provisioned,
+            context,
+            cases,
+            filter,
+        })
+    }
+}
+
+/// Build a root commit whose tree holds `TREE_FILES` files spread across `N_DIRS` top-level
+/// directories, then generate `n_refs` churn commits, pointing `refs/heads/case_<n>/change_<i>` at
+/// each. The tip additionally gets `refs/heads/case_<n>_tip` so the head is recoverable after
+/// the repo round-trips through the cache.
+fn build_case(repo: &git2::Repository, n_refs: usize) -> anyhow::Result<git2::Oid> {
+    use rand::RngExt;
+
+    let mut builder = git2::build::TreeUpdateBuilder::new();
+    let mut all_paths = vec![];
+    for i in 0..TREE_FILES {
+        let path = PathBuf::from(format!("dir_{:02}", i % N_DIRS)).join(format!("file_{i:04}"));
+        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        builder.upsert(&path, oid, git2::FileMode::Blob);
+        all_paths.push(path);
+    }
+
+    let baseline = repo.find_tree(repo.treebuilder(None)?.write()?)?;
+    let root_tree = repo.find_tree(builder.create_updated(repo, &baseline)?)?;
+
+    let sig = josh_commit_signature()?;
+    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+
+    // Deterministic history: each commit churns a fresh random ~CHURN_FRACTION of the files and
+    // gets its own change ref, so every ref resolves to a distinct commit.
+    let mut rng = StdRng::seed_from_u64(1);
+    for i in 0..n_refs {
+        let parent = repo.find_commit(head)?;
+        let tree = parent.tree()?;
+        let mut builder = git2::build::TreeUpdateBuilder::new();
+
+        let churned = all_paths
+            .iter()
+            .filter(|_| rng.random_bool(CHURN_FRACTION))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for path in &churned {
+            let content = random_string(&mut rng, CHURN_CONTENT_LEN);
+            let blob = repo.blob(content.as_bytes())?;
+            builder.upsert(path, blob, git2::FileMode::Blob);
+        }
+
+        let new_tree = repo.find_tree(builder.create_updated(repo, &tree)?)?;
+        head = repo.commit(
+            None,
+            &sig,
+            &sig,
+            &format!("commit {i}"),
+            &new_tree,
+            &[&parent],
+        )?;
+        repo.reference(
+            &format!("refs/heads/case_{n_refs}/change_{i:04}"),
+            head,
+            true,
+            "bench change ref",
+        )?;
+    }
+
+    // Tip ref so `setup` can find this case's head on the cache-hit path, where the build callback
+    // never runs. Named `_tip` (not `case_<n>`) because `refs/heads/case_<n>/change_*` makes
+    // `case_<n>` a ref *directory*, and a ref cannot shadow a directory.
+    repo.reference(
+        &format!("refs/heads/case_{n_refs}_tip"),
+        head,
+        true,
+        "bench case tip",
+    )?;
+
+    Ok(head)
+}
+
+fn refs_filter_update(c: &mut Criterion) {
+    josh_test_support::init_tracing("bench=trace");
+
+    let bench = RefsBench::setup().expect("set up benchmark");
+
+    let mut group = c.benchmark_group("refs_filter_update");
+    group.sample_size(10);
+    for case in &bench.cases {
+        let glob = format!("refs/heads/case_{}/change_*", case.n_refs);
+        group.throughput(Throughput::Elements(case.n_refs as u64));
+        group.bench_function(BenchmarkId::from_parameter(case.n_refs), |b| {
+            b.iter_batched(
+                // Per-iteration setup (untimed): a fresh transaction only. Caches stay warm across
+                // iterations by design (see module comment).
+                || {
+                    let transaction = bench.context.open().expect("open transaction");
+                    let iter_span = tracing::info_span!(target: "bench", "iter").entered();
+                    (transaction, iter_span)
+                },
+                // Timed: enumerate the change refs, resolve each to its oid, look up the filtered
+                // commit per ref (cache-hot), and force-write every filtered ref under
+                // `refs/josh/bench/`. This is the proxy's fetch steady state.
+                |(transaction, iter_span)| {
+                    let mut refs = vec![];
+                    for r in transaction
+                        .repo()
+                        .references_glob(&glob)
+                        .expect("iterate refs")
+                    {
+                        let r = r.expect("read ref");
+                        let name = r.name().expect("utf-8 ref name").to_string();
+                        let oid = r.target().expect("direct ref");
+                        refs.push((name, oid));
+                    }
+                    assert_eq!(
+                        refs.len(),
+                        case.n_refs,
+                        "ref enumeration must see every ref"
+                    );
+
+                    let (updated, errors) =
+                        josh_core::filter_refs(&transaction, bench.filter, &refs);
+                    assert!(errors.is_empty(), "no ref may fail to filter");
+
+                    let updated = updated
+                        .into_iter()
+                        .map(|(name, oid)| {
+                            let renamed = name.replacen("refs/heads/", "refs/josh/bench/", 1);
+                            (renamed, oid)
+                        })
+                        .collect::<Vec<_>>();
+                    josh_core::update_refs(&transaction, updated);
+
+                    (transaction, iter_span)
+                },
+                BatchSize::PerIteration,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, refs_filter_update);
+criterion_main!(benches);


### PR DESCRIPTION
Add write-flush and ref-update criterion benches

The incremental git2->gix port needs regression gates for two surfaces
the existing benches only exercise incidentally: the object write path
(mem-odb buffering, overflow packs, boundary drain) and the reference
surface (glob enumeration, per-ref resolution, force-updates).

deephistory_prefix_flush filters a churned history through :prefix=a/b/c
so every filtered commit writes fresh trees, with an artificially low
mem-odb size limit so the store overflows into background packs inside
the timed section, which ends with an explicit boundary flush.

refs_filter_update enumerates refs/heads/case_<n>/change_* refs,
filters each with caches deliberately kept warm (so filtering cost
stays out of the measurement) and force-writes the filtered refs under
refs/josh/bench/.

Change: gix-port-bench-gap
Assisted-By: Claude Fable 5 (claude-fable-5)