### PR TITLE
Port subtract, intersect and overlay to gix-object with a tree cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3146,7 +3146,6 @@ dependencies = [
  "pest_derive",
  "rand 0.10.1",
  "regex",
- "rustc-hash",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -61,7 +61,6 @@ pest = "2.8.6"
 pest_derive = "2.8.6"
 strfmt = "0.2.4"
 sled = "0.34.7"
-rustc-hash = "2.1.2"
 smallvec = "1.15.1"
 
 anyhow.workspace = true

--- a/josh-core/src/cache/mod.rs
+++ b/josh-core/src/cache/mod.rs
@@ -4,6 +4,7 @@ mod history_graph;
 pub mod sled;
 pub mod stack;
 mod transaction;
+mod tree_cache;
 
 /// Schema version for on-disk cache structures. Bump when the layout of the
 /// sled trees or distributed cache refs changes incompatibly.
@@ -18,3 +19,4 @@ pub use history_graph::{
 pub use sled::{SledCacheBackend, sled_clear, sled_load, sled_open_josh_trees, sled_print_stats};
 pub use stack::CacheStack;
 pub use transaction::*;
+pub use tree_cache::TreeBytes;

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -2,6 +2,7 @@ use super::backend::HistoryGraphHint;
 use super::history_graph::compute_history_hint;
 use super::sled::sled_open_josh_trees;
 use super::stack::CacheStack;
+use super::tree_cache::{TreeBytes, TreeCache};
 use anyhow::anyhow;
 
 use std::collections::HashMap;
@@ -113,6 +114,7 @@ struct Transaction2 {
     downstack_deps_map: HashMap<git2::Oid, std::collections::HashSet<crate::filter::DownstackDep>>,
     merge_trees_map: HashMap<(git2::Oid, git2::Oid, git2::Oid), git2::Oid>,
     last_written_commit: Option<(git2::Oid, git2::Oid)>,
+    tree_cache: TreeCache,
 
     cache: std::sync::Arc<CacheStack>,
     path_tree: sled::Tree,
@@ -192,6 +194,7 @@ impl Transaction {
                 downstack_deps_map: HashMap::new(),
                 merge_trees_map: HashMap::new(),
                 last_written_commit: None,
+                tree_cache: Default::default(),
                 cache,
                 path_tree,
                 invert_tree,
@@ -223,6 +226,30 @@ impl Transaction {
 
     pub fn repo(&self) -> &git2::Repository {
         &self.repo
+    }
+
+    /// Read the raw bytes of the tree `oid` through the per-transaction [`TreeCache`]
+    /// (see there for the promotion and eviction policy). `Ok(None)` means the object exists
+    /// but is not a tree; a missing object is an error, like a plain odb read.
+    pub fn read_tree_bytes<'a>(
+        &self,
+        odb: &'a git2::Odb,
+        oid: git2::Oid,
+    ) -> anyhow::Result<Option<TreeBytes<'a>>> {
+        if let Some(bytes) = self.t2.borrow().tree_cache.get(oid) {
+            return Ok(Some(TreeBytes::Cached(bytes)));
+        }
+        let obj = odb.read(oid)?;
+        if obj.kind() != git2::ObjectType::Tree {
+            return Ok(None);
+        }
+        let mut t2 = self.t2.borrow_mut();
+        if t2.tree_cache.should_promote(oid) {
+            let bytes: std::sync::Arc<[u8]> = obj.data().into();
+            t2.tree_cache.insert(oid, bytes.clone());
+            return Ok(Some(TreeBytes::Cached(bytes)));
+        }
+        Ok(Some(TreeBytes::Odb(obj)))
     }
 
     // TODO: remove and rework proxy git launch path to use spawn_git

--- a/josh-core/src/cache/tree_cache.rs
+++ b/josh-core/src/cache/tree_cache.rs
@@ -1,0 +1,106 @@
+use josh_memodb::PassthroughHasher;
+use std::hash::BuildHasherDefault;
+
+/// Raw bytes of a tree object, either straight from the odb (first read, zero-copy) or from the
+/// per-transaction tree cache (repeated reads). Derefs to the byte slice either way.
+pub enum TreeBytes<'a> {
+    Odb(git2::OdbObject<'a>),
+    Cached(std::sync::Arc<[u8]>),
+}
+
+impl std::ops::Deref for TreeBytes<'_> {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        match self {
+            TreeBytes::Odb(obj) => obj.data(),
+            TreeBytes::Cached(bytes) => bytes,
+        }
+    }
+}
+
+/// Cache key routing the oid digest into [`PassthroughHasher`]'s single-`write` path:
+/// `git2::Oid`'s own `Hash` impl hashes its bytes as a slice, whose `write_usize` length
+/// prefix the hasher rejects.
+#[derive(PartialEq, Eq)]
+struct OidKey(git2::Oid);
+
+impl std::hash::Hash for OidKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(self.0.as_bytes());
+    }
+}
+
+type OidMap<V> = std::collections::HashMap<OidKey, V, BuildHasherDefault<PassthroughHasher>>;
+type OidSet = std::collections::HashSet<OidKey, BuildHasherDefault<PassthroughHasher>>;
+
+/// Per-transaction cache of raw tree bytes, standing in for the parsed-object cache libgit2
+/// kept behind `find_tree` (which the gix-object tree ops no longer go through). See
+/// [`super::Transaction::read_tree_bytes`] for the read path.
+///
+/// Policy: a tree is only copied into the cache on its second read
+/// ([`should_promote`](Self::should_promote)), so once-read trees cost nothing extra; trees are
+/// content-addressed so cached entries never go stale; the cache is dropped wholesale when it
+/// outgrows [`LIMIT`](Self::LIMIT).
+#[derive(Default)]
+pub(crate) struct TreeCache {
+    map: OidMap<std::sync::Arc<[u8]>>,
+    bytes: usize,
+    seen: OidSet,
+}
+
+impl TreeCache {
+    const LIMIT: usize = 64 * 1024 * 1024;
+
+    pub(crate) fn get(&self, oid: git2::Oid) -> Option<std::sync::Arc<[u8]>> {
+        self.map.get(&OidKey(oid)).cloned()
+    }
+
+    /// Whether `oid` is being read for the second time and should be copied into the cache
+    /// now; the first read is only recorded, so it can hand out the odb buffer zero-copy.
+    pub(crate) fn should_promote(&mut self, oid: git2::Oid) -> bool {
+        !self.seen.insert(OidKey(oid))
+    }
+
+    pub(crate) fn insert(&mut self, oid: git2::Oid, bytes: std::sync::Arc<[u8]>) {
+        if self.bytes > Self::LIMIT {
+            self.map.clear();
+            self.bytes = 0;
+        }
+        self.bytes += bytes.len();
+        self.map.insert(OidKey(oid), bytes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn oid(n: u8) -> git2::Oid {
+        git2::Oid::from_bytes(&[n; 20]).unwrap()
+    }
+
+    // The first read is only recorded; the second read promotes, and only then does the cache
+    // hold the bytes.
+    #[test]
+    fn promotes_on_second_read_only() {
+        let mut cache = TreeCache::default();
+        assert!(!cache.should_promote(oid(1)));
+        assert!(cache.get(oid(1)).is_none());
+        assert!(cache.should_promote(oid(1)));
+        cache.insert(oid(1), b"tree bytes"[..].into());
+        assert_eq!(&*cache.get(oid(1)).unwrap(), b"tree bytes");
+    }
+
+    // Growing past the budget drops the whole cache before the next insert, which itself
+    // stays cached.
+    #[test]
+    fn clears_wholesale_over_limit() {
+        let mut cache = TreeCache::default();
+        cache.insert(oid(1), b"x"[..].into());
+        cache.bytes = TreeCache::LIMIT + 1;
+        cache.insert(oid(2), b"y"[..].into());
+        assert!(cache.get(oid(1)).is_none());
+        assert_eq!(&*cache.get(oid(2)).unwrap(), b"y");
+        assert_eq!(cache.bytes, 1);
+    }
+}

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -202,6 +202,36 @@ impl TreeRebuild {
     }
 }
 
+/// Clone a parsed tree's entries for use as the starting set of a rebuild, replicating what
+/// seeding a libgit2 treebuilder from a tree did: entry names and raw modes are taken over
+/// unvalidated and unnormalized, but duplicate names collapse to the last occurrence (the
+/// treebuilder was a name-keyed map). [`TreeRebuild::keep`] owns that dedup and the
+/// order-violation detection arming it; `keep` is usable standalone here because seeded
+/// rebuilds always write via `write_tree_now` and never consult the `changed` flag it also
+/// maintains.
+fn seed_entries(tree: &gix_object::TreeRef) -> Vec<gix_object::tree::Entry> {
+    let mut rebuild = TreeRebuild::new(tree.entries.len());
+    for entry in &tree.entries {
+        rebuild.keep((*entry).into());
+    }
+    rebuild.out
+}
+
+/// Look up an entry by name irrespective of its kind, like libgit2's `git_tree_entry_byname`.
+/// Canonical order sorts a blob before a same-named tree, so the blob probe comes first.
+fn lookup_entry<'a>(
+    tree: &gix_object::TreeRef<'a>,
+    name: &gix_object::bstr::BStr,
+) -> Option<gix_object::tree::EntryRef<'a>> {
+    tree.bisect_entry(name, false)
+        .or_else(|| tree.bisect_entry(name, true))
+}
+
+/// The [`gix_object::tree::EntryMode`] for a libgit2-normalized mode value.
+fn entry_mode(norm: u16) -> gix_object::tree::EntryMode {
+    gix_object::tree::EntryMode::try_from(norm as u32).expect("normalized modes are valid")
+}
+
 /// Rebuild `input` keeping only blob entries accepted by `pred`. `path` is a reusable buffer
 /// holding the slash-separated path of the tree currently being visited; it is restored to its
 /// incoming length before returning. Gitlink (submodule) entries are always dropped.
@@ -216,6 +246,20 @@ pub fn remove_pred(
     pred: &dyn Fn(&str, bool) -> bool,
     key: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
+    let odb = transaction.repo().odb()?;
+    remove_pred_inner(transaction, &odb, path, input, pred, key)
+}
+
+/// Recursive body of [`remove_pred`], with the odb handle created once at the entry point --
+/// creating one per recursion level costs an FFI round-trip per tree node.
+fn remove_pred_inner(
+    transaction: &cache::Transaction,
+    odb: &git2::Odb,
+    path: &mut String,
+    input: git2::Oid,
+    pred: &dyn Fn(&str, bool) -> bool,
+    key: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
     let root_key = git2::Oid::hash_object(
         git2::ObjectType::Blob,
         format!("glob-fallback:{:?}:{}", key, path).as_bytes(),
@@ -224,12 +268,10 @@ pub fn remove_pred(
         return Ok(cached);
     }
 
-    let odb = transaction.repo().odb()?;
-    let obj = odb.read(input)?;
-    if obj.kind() != git2::ObjectType::Tree {
-        return Err(anyhow!("remove_pred: {} is not a tree", input));
-    }
-    let tree = gix_object::TreeRef::from_bytes(obj.data())?;
+    let bytes = transaction
+        .read_tree_bytes(odb, input)?
+        .ok_or_else(|| anyhow!("remove_pred: {} is not a tree", input))?;
+    let tree = gix_object::TreeRef::from_bytes(&bytes)?;
     let mut rebuild = TreeRebuild::new(tree.entries.len());
     let empty = empty_id();
 
@@ -243,7 +285,14 @@ pub fn remove_pred(
 
         let raw_mode = entry.mode.value();
         if entry.mode.is_tree() {
-            let s = remove_pred(transaction, path, objects::git2_oid(entry.oid), pred, key)?;
+            let s = remove_pred_inner(
+                transaction,
+                odb,
+                path,
+                objects::git2_oid(entry.oid),
+                pred,
+                key,
+            )?;
             // `entry.mode` compares by the serialized form, so the fsck-invalid "040000"
             // spelling also counts as changed (libgit2 could not distinguish it).
             if s != objects::git2_oid(entry.oid)
@@ -296,7 +345,7 @@ pub fn remove_pred(
         path.truncate(base);
     }
 
-    let result = rebuild.finish(&odb, input)?;
+    let result = rebuild.finish(odb, input)?;
     transaction.insert_glob((input, root_key, 0), result);
     Ok(result)
 }
@@ -316,6 +365,19 @@ pub use josh_filter::pattern::{CompiledPattern, PATTERN_MATCH_OPTIONS, PatternCo
 /// a literal prefix) stay separate.
 pub fn remove_pattern(
     transaction: &cache::Transaction,
+    input: git2::Oid,
+    cp: &CompiledPattern,
+    key: git2::Oid,
+    state: u64,
+) -> anyhow::Result<git2::Oid> {
+    let odb = transaction.repo().odb()?;
+    remove_pattern_inner(transaction, &odb, input, cp, key, state)
+}
+
+/// Recursive body of [`remove_pattern`]; see [`remove_pred_inner`] for why the odb is hoisted.
+fn remove_pattern_inner(
+    transaction: &cache::Transaction,
+    odb: &git2::Odb,
     input: git2::Oid,
     cp: &CompiledPattern,
     key: git2::Oid,
@@ -342,12 +404,10 @@ pub fn remove_pattern(
         }
     }
 
-    let odb = transaction.repo().odb()?;
-    let obj = odb.read(input)?;
-    if obj.kind() != git2::ObjectType::Tree {
-        return Err(anyhow!("remove_pattern: {} is not a tree", input));
-    }
-    let tree = gix_object::TreeRef::from_bytes(obj.data())?;
+    let bytes = transaction
+        .read_tree_bytes(odb, input)?
+        .ok_or_else(|| anyhow!("remove_pattern: {} is not a tree", input))?;
+    let tree = gix_object::TreeRef::from_bytes(&bytes)?;
     let mut rebuild = TreeRebuild::new(tree.entries.len());
     let empty = empty_id();
 
@@ -383,7 +443,14 @@ pub fn remove_pattern(
             let s = if next == 0 {
                 empty
             } else {
-                remove_pattern(transaction, objects::git2_oid(entry.oid), cp, key, next)?
+                remove_pattern_inner(
+                    transaction,
+                    odb,
+                    objects::git2_oid(entry.oid),
+                    cp,
+                    key,
+                    next,
+                )?
             };
             if s != objects::git2_oid(entry.oid)
                 || s == empty
@@ -444,7 +511,7 @@ pub fn remove_pattern(
     }
 
     // See remove_pred: an untouched entry set reproduces `input` bit-identically.
-    let result = rebuild.finish(&odb, input)?;
+    let result = rebuild.finish(odb, input)?;
     transaction.insert_glob((input, key, state), result);
     Ok(result)
 }
@@ -454,7 +521,17 @@ pub fn subtract(
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let repo = transaction.repo();
+    let odb = transaction.repo().odb()?;
+    subtract_inner(transaction, &odb, input1, input2)
+}
+
+/// Recursive body of [`subtract`]; see [`remove_pred_inner`] for why the odb is hoisted.
+fn subtract_inner(
+    transaction: &cache::Transaction,
+    odb: &git2::Odb,
+    input1: git2::Oid,
+    input2: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
     if input1 == input2 {
         return Ok(empty_id());
     }
@@ -466,26 +543,46 @@ pub fn subtract(
         return Ok(cached);
     }
 
-    if let (Ok(tree1), Ok(tree2)) = (repo.find_tree(input1), repo.find_tree(input2)) {
+    let bytes1 = transaction.read_tree_bytes(odb, input1)?;
+    let bytes2 = transaction.read_tree_bytes(odb, input2)?;
+    if let (Some(bytes1), Some(bytes2)) = (bytes1, bytes2) {
         if input2 == empty_id() {
             return Ok(input1);
         }
+        let tree1 = gix_object::TreeRef::from_bytes(&bytes1)?;
+        let tree2 = gix_object::TreeRef::from_bytes(&bytes2)?;
         // Start from `tree1` and drop or replace each path that also appears in `tree2`.
-        let mut builder = repo.treebuilder(Some(&tree1))?;
-
-        for entry in tree2.iter() {
-            let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
-            if let Some(e) = tree1.get_name(name) {
-                let sub = subtract(transaction, e.id(), entry.id())?;
+        // Modifications are collected by name first and applied in one pass, mirroring the
+        // name-keyed libgit2 treebuilder: `None` removes the entry, `Some` replaces its oid with
+        // the subtraction result (a tree, hence the normalized tree mode). Names that libgit2's
+        // insert would have rejected silently keep their original entry.
+        let mut mods: std::collections::HashMap<&[u8], Option<git2::Oid>> =
+            std::collections::HashMap::new();
+        for entry in &tree2.entries {
+            if let Some(e1) = lookup_entry(&tree1, entry.filename) {
+                let sub = subtract_inner(
+                    transaction,
+                    odb,
+                    objects::git2_oid(e1.oid),
+                    objects::git2_oid(entry.oid),
+                )?;
                 if sub == empty_id() || sub == git2::Oid::zero() {
-                    builder.remove(name).ok();
-                } else {
-                    builder.insert(name, sub, e.filemode()).ok();
+                    mods.insert(&**entry.filename, None);
+                } else if objects::tree_entry_name_valid(entry.filename) {
+                    mods.insert(&**entry.filename, Some(sub));
                 }
             }
         }
 
-        let result = builder.write()?;
+        let mut out = seed_entries(&tree1);
+        out.retain(|e| mods.get(e.filename.as_slice()) != Some(&None));
+        for entry in &mut out {
+            if let Some(Some(sub)) = mods.get(entry.filename.as_slice()) {
+                entry.mode = gix_object::tree::EntryKind::Tree.into();
+                entry.oid = objects::gix_oid(*sub);
+            }
+        }
+        let result = objects::write_tree_now(odb, out)?;
 
         transaction.insert_subtract((input1, input2), result);
 
@@ -509,7 +606,17 @@ pub fn intersect(
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let repo = transaction.repo();
+    let odb = transaction.repo().odb()?;
+    intersect_inner(transaction, &odb, input1, input2)
+}
+
+/// Recursive body of [`intersect`]; see [`remove_pred_inner`] for why the odb is hoisted.
+fn intersect_inner(
+    transaction: &cache::Transaction,
+    odb: &git2::Odb,
+    input1: git2::Oid,
+    input2: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
     // Identical (sub)trees intersect to themselves; an empty side leaves nothing to keep.
     if input1 == input2 {
         return Ok(input1);
@@ -522,20 +629,35 @@ pub fn intersect(
         return Ok(cached);
     }
 
-    let result = if let (Ok(tree1), Ok(tree2)) = (repo.find_tree(input1), repo.find_tree(input2)) {
+    let bytes1 = transaction.read_tree_bytes(odb, input1)?;
+    let bytes2 = transaction.read_tree_bytes(odb, input2)?;
+    let result = if let (Some(bytes1), Some(bytes2)) = (bytes1, bytes2) {
+        let tree1 = gix_object::TreeRef::from_bytes(&bytes1)?;
+        let tree2 = gix_object::TreeRef::from_bytes(&bytes2)?;
         // Iterate the selector (`input2`), keeping each of its paths that also exists in `tree1`
-        // with `tree1`'s content; cost tracks the size of the selected set.
-        let mut builder = repo.treebuilder(None)?;
-        for entry in tree2.iter() {
-            let name = entry.name().ok_or_else(|| anyhow!("no name"))?;
-            if let Some(e1) = tree1.get_name(name) {
-                let child = intersect(transaction, e1.id(), entry.id())?;
-                if child != empty_id() && child != git2::Oid::zero() {
-                    builder.insert(name, child, e1.filemode()).ok();
+        // with `tree1`'s content and normalized mode; cost tracks the size of the selected set.
+        // Entries with invalid names are dropped silently (libgit2 insert-name parity).
+        let mut rebuild = TreeRebuild::new(0);
+        for entry in &tree2.entries {
+            if let Some(e1) = lookup_entry(&tree1, entry.filename) {
+                let child = intersect(
+                    transaction,
+                    objects::git2_oid(e1.oid),
+                    objects::git2_oid(entry.oid),
+                )?;
+                if child != empty_id()
+                    && child != git2::Oid::zero()
+                    && objects::tree_entry_name_valid(entry.filename)
+                {
+                    rebuild.keep(gix_object::tree::Entry {
+                        mode: entry_mode(objects::normalize_filemode(e1.mode.value())),
+                        filename: entry.filename.to_owned(),
+                        oid: objects::gix_oid(child),
+                    });
                 }
             }
         }
-        builder.write()?
+        objects::write_tree_now(odb, rebuild.out)?
     } else {
         // At least one side is a blob at this already-name-matched path, so the path exists in both;
         // keep `input1`'s content, matching the path-based semantics of the tree case.
@@ -687,10 +809,20 @@ pub fn overlay(
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
+    let odb = transaction.repo().odb()?;
+    overlay_inner(transaction, &odb, input1, input2)
+}
+
+/// Recursive body of [`overlay`]; see [`remove_pred_inner`] for why the odb is hoisted.
+fn overlay_inner(
+    transaction: &cache::Transaction,
+    odb: &git2::Odb,
+    input1: git2::Oid,
+    input2: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
     if let Some(cached) = transaction.get_overlay((input1, input2)) {
         return Ok(cached);
     }
-    let repo = transaction.repo();
     if input1 == input2 {
         return Ok(input1);
     }
@@ -701,25 +833,61 @@ pub fn overlay(
         return Ok(input1);
     }
 
-    if let (Ok(tree1), Ok(tree2)) = (repo.find_tree(input1), repo.find_tree(input2)) {
-        let mut builder = repo.treebuilder(Some(&tree1))?;
-
-        for entry in tree2.iter() {
-            let (id, mode) =
-                if let Some(e) = tree1.get_name(entry.name().ok_or_else(|| anyhow!("no name"))?) {
-                    (overlay(transaction, e.id(), entry.id())?, e.filemode())
-                } else {
-                    (entry.id(), entry.filemode())
-                };
-
-            builder.insert(
-                Path::new(entry.name().ok_or_else(|| anyhow!("no name"))?),
-                id,
-                mode,
-            )?;
+    let bytes1 = transaction.read_tree_bytes(odb, input1)?;
+    let bytes2 = transaction.read_tree_bytes(odb, input2)?;
+    if let (Some(bytes1), Some(bytes2)) = (bytes1, bytes2) {
+        let tree1 = gix_object::TreeRef::from_bytes(&bytes1)?;
+        let tree2 = gix_object::TreeRef::from_bytes(&bytes2)?;
+        // Start from `tree1` and insert every entry of `tree2`: recursively overlaid where the
+        // name exists in `tree1` (with `tree1` winning on blob collisions), taken over as-is
+        // otherwise. Every inserted entry gets the normalized mode, and -- unlike the other tree
+        // ops -- an invalid entry name is an error.
+        let mut mods: std::collections::HashMap<&[u8], (git2::Oid, gix_object::tree::EntryMode)> =
+            std::collections::HashMap::new();
+        // Name-keyed, so duplicate names in `tree2` collapse to the last occurrence; the
+        // canonical sort in write_tree_now restores order.
+        let mut new_entries: std::collections::HashMap<&[u8], gix_object::tree::Entry> =
+            std::collections::HashMap::new();
+        for entry in &tree2.entries {
+            if !objects::tree_entry_name_valid(entry.filename) {
+                return Err(anyhow!(
+                    "overlay: invalid entry name {:?}",
+                    entry.filename.to_owned()
+                ));
+            }
+            if let Some(e1) = lookup_entry(&tree1, entry.filename) {
+                let id = overlay_inner(
+                    transaction,
+                    odb,
+                    objects::git2_oid(e1.oid),
+                    objects::git2_oid(entry.oid),
+                )?;
+                mods.insert(
+                    &**entry.filename,
+                    (id, entry_mode(objects::normalize_filemode(e1.mode.value()))),
+                );
+            } else {
+                new_entries.insert(
+                    &**entry.filename,
+                    gix_object::tree::Entry {
+                        mode: entry_mode(objects::normalize_filemode(entry.mode.value())),
+                        filename: entry.filename.to_owned(),
+                        oid: entry.oid.to_owned(),
+                    },
+                );
+            }
         }
 
-        let rid = builder.write()?;
+        let mut out = seed_entries(&tree1);
+        for entry in &mut out {
+            if let Some((id, mode)) = mods.get(entry.filename.as_slice()) {
+                entry.oid = objects::gix_oid(*id);
+                entry.mode = *mode;
+            }
+        }
+        out.extend(new_entries.into_values());
+
+        let rid = objects::write_tree_now(odb, out)?;
 
         transaction.insert_overlay((input1, input2), rid);
         return Ok(rid);
@@ -1387,5 +1555,73 @@ mod tests {
             added,
             vec![("dir/file1".to_string(), 1), ("dir/file2".to_string(), 1)]
         );
+    }
+
+    // Subtract starts from tree1's entries the way the seeded treebuilder did: untouched entries
+    // keep their raw (even fsck-invalid legacy) modes, while matched paths are removed or
+    // replaced by the recursive subtraction result.
+    #[test]
+    fn subtract_preserves_untouched_raw_modes() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(td.path()).unwrap();
+
+        let blob = repo.blob(b"legacy").unwrap();
+        let sub_tree = make_tree(&repo, &["dir/a.txt", "dir/b.txt"]);
+        let dir = repo
+            .find_tree(sub_tree)
+            .unwrap()
+            .get_name("dir")
+            .unwrap()
+            .id();
+        let input1 = write_raw_tree(
+            &repo,
+            &[("40000", "dir", dir), ("100664", "legacy.rs", blob)],
+        );
+        let input2 = make_tree(&repo, &["dir/a.txt"]);
+
+        let t = open_transaction(&td);
+        let out = subtract(&t, input1, input2).unwrap();
+
+        let out_tree = t.repo().find_tree(out).unwrap();
+        assert_eq!(
+            out_tree.get_name("legacy.rs").unwrap().filemode_raw(),
+            0o100664,
+            "untouched entries must keep their raw mode, like the seeded treebuilder"
+        );
+        let out_dir = t
+            .repo()
+            .find_tree(out_tree.get_name("dir").unwrap().id())
+            .unwrap();
+        assert!(out_dir.get_name("a.txt").is_none(), "matched path removed");
+        assert!(out_dir.get_name("b.txt").is_some(), "unmatched path kept");
+    }
+
+    // Overlay resolves blob collisions in favor of input1 and takes over input2-only entries
+    // with normalized modes, while input1-only entries keep their raw modes (seeded rebuild).
+    #[test]
+    fn overlay_keeps_input1_on_collision() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(td.path()).unwrap();
+
+        let ours = repo.blob(b"ours").unwrap();
+        let theirs = repo.blob(b"theirs").unwrap();
+        let input1 = write_raw_tree(&repo, &[("100664", "shared.rs", ours)]);
+        let mut b = repo.treebuilder(None).unwrap();
+        b.insert("new.rs", theirs, 0o100644).unwrap();
+        b.insert("shared.rs", theirs, 0o100644).unwrap();
+        let input2 = b.write().unwrap();
+
+        let t = open_transaction(&td);
+        let out = overlay(&t, input1, input2).unwrap();
+
+        let out_tree = t.repo().find_tree(out).unwrap();
+        let shared = out_tree.get_name("shared.rs").unwrap();
+        assert_eq!(shared.id(), ours, "input1 wins blob collisions");
+        assert_eq!(
+            shared.filemode_raw(),
+            0o100644,
+            "collision entries are re-inserted with the normalized mode"
+        );
+        assert_eq!(out_tree.get_name("new.rs").unwrap().id(), theirs);
     }
 }


### PR DESCRIPTION
Port subtract, intersect and overlay to gix-object with a tree cache

The three name-merging tree ops now parse both inputs from raw odb
bytes with gix_object::TreeRef, look up names via two-probe bisection
(like git_tree_entry_byname), and rebuild entry vectors serialized by
gix, replacing the seeded libgit2 treebuilders. Seeded-rebuild parity
is kept: untouched entries preserve their raw (even fsck-invalid
legacy) modes byte-for-byte, replaced entries get normalized modes,
duplicate names collapse last-wins (seed_entries delegates to
TreeRebuild::keep, which owns that dedup), overlay errors on invalid
names while subtract/intersect drop them silently, and blob collisions
in overlay keep input1's content.

The odb handle is created once per public entry point instead of per
recursion level, and tree reads go through a new per-transaction
tree-bytes cache (Transaction::read_tree_bytes, with the state and
promotion policy in cache::tree_cache::TreeCache): content-addressed,
keyed via PassthroughHasher (the oid already is a hash, through a key
wrapper feeding it the digest bytes directly, replacing rustc-hash),
promoted on second access only -- the first read hands out the odb
buffer zero-copy -- and wholesale-cleared beyond a 64 MB budget. This
stands in for libgit2's parsed-object cache, whose loss otherwise
regressed workloads that re-read the same small trees many times
(ultrawide per-path composes).

Unlike the old find_tree-based code, which conflated "not a tree" with
"missing object", the merging ops now propagate odb read errors
instead of silently degrading to their blob-semantics branches; only
Ok(None) (the object exists but is not a tree) takes those.

ultrawide_pin_hook improves 1-33% across all cases (the 50k-file
per-path case by a third), deephistory_glob/widetree_glob keep their
5-17% wins with recursive patterns improving further, and the
remaining benches are unchanged on a quiet machine.

Change: gix-port-subtract-intersect-overlay
Assisted-By: Claude Fable 5 (claude-fable-5)