### PR TITLE
Symlink skills folder for claude code

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@ e2e-tests/_remote*
 docs/_build
 .cargo_home
 .idea
-.claude
+.claude/*
+!.claude/skills
 .josh
 .agents/work
 **/.DS_Store


### PR DESCRIPTION
Symlink skills folder for claude code

Anthropic stubbornly refuses to use the general .agents convention,
similar as with requiring `claude.md` file -- i guess as a means of
advetising the use of their product.

Symlink the "generic" skills folder so that claude code can see it.

Change: symlink-skills
Change-Id: I5803d05645a8ccc04ce4826effb2d76717d7029c