### PR TITLE
Add experimental :inline_submodules filter

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -933,6 +933,81 @@ pub fn apply_to_commit2(
                 .transpose();
             }
         }
+        Op::InlineSubmodules => {
+            check_experimental_features_enabled("inline_submodules filter")?;
+
+            let normal_parents = commit
+                .parent_ids()
+                .map(|p| transaction.get(filter, p))
+                .collect::<anyhow::Result<Option<Vec<gix_hash::ObjectId>>>>()?;
+            let normal_parents = some_or!(normal_parents, { return Ok(None) });
+
+            let current_submodules =
+                extract_submodule_commits(transaction, &odb, commit.tree_id()?)?;
+
+            let first_parent_submodules = if let Some(parent) = commit.parent_ids().next() {
+                let parent_tree =
+                    git::read_tree_id(&odb, parent).unwrap_or_else(|_| tree::empty_id());
+                extract_submodule_commits(transaction, &odb, parent_tree)?
+            } else {
+                std::collections::BTreeMap::new()
+            };
+
+            // Only added or updated submodules contribute history parents.
+            let changed_submodules: Vec<(
+                std::path::PathBuf,
+                gix_hash::ObjectId,
+                gix_hash::ObjectId,
+            )> = current_submodules
+                .iter()
+                .filter_map(|(path, (new_oid, _))| {
+                    let old_oid = first_parent_submodules
+                        .get(path)
+                        .map(|(oid, _)| *oid)
+                        .unwrap_or(gix_hash::ObjectId::null(gix_hash::Kind::Sha1));
+                    if old_oid != *new_oid {
+                        Some((path.clone(), old_oid, *new_oid))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            let original_target = normal_parents
+                .first()
+                .copied()
+                .unwrap_or(gix_hash::ObjectId::null(gix_hash::Kind::Sha1));
+
+            let mut extra_parents: Vec<gix_hash::ObjectId> = Vec::new();
+            for (path, old_oid, new_oid) in changed_submodules {
+                let path_filter = to_filter(Op::Subdir(path));
+                let unapplied = history::unapply_filter(
+                    transaction,
+                    path_filter,
+                    original_target,
+                    old_oid,
+                    new_oid,
+                    history::OrphansMode::Keep,
+                    None,
+                )?;
+                if unapplied != gix_hash::ObjectId::null(gix_hash::Kind::Sha1) {
+                    extra_parents.push(unapplied);
+                }
+            }
+
+            let filtered_tree = apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?;
+            let filtered_parent_ids: Vec<gix_hash::ObjectId> =
+                normal_parents.into_iter().chain(extra_parents).collect();
+
+            return Some(history::create_filtered_commit(
+                &commit,
+                filtered_parent_ids,
+                filtered_tree,
+                transaction,
+                filter,
+            ))
+            .transpose();
+        }
         Op::Workspace(ws_path) => {
             // The get_* helpers return a bare Filter and would fold an unreadable tree to
             // Op::Empty, so bad input must error here; every probe below shares the read.
@@ -1376,6 +1451,40 @@ fn apply_impl(
                 }
                 _ => return Err(anyhow!("unknown adapter {:?}", adapter)),
             }
+
+            Ok(x.with_tree(result_tree))
+        }
+        Op::InlineSubmodules => {
+            check_experimental_features_enabled("inline_submodules filter")?;
+
+            let mut result_tree = x.tree_id();
+            let submodule_commits = extract_submodule_commits(transaction, odb, result_tree)?;
+
+            for (submodule_path, (commit_oid, _meta)) in submodule_commits {
+                let submodule_tree = git::read_tree_id(odb, commit_oid)?;
+
+                // Remove the gitlink before overlaying a tree at the same path.
+                result_tree = tree::insert_oid(
+                    odb,
+                    result_tree,
+                    &submodule_path,
+                    gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
+                    0o0160000,
+                )?;
+
+                let path_filter = to_filter(Op::Subdir(submodule_path.clone()));
+                result_tree =
+                    filter::unapply(transaction, path_filter, submodule_tree, result_tree, None)?;
+            }
+
+            // Drop .gitmodules after replacing every submodule with plain content.
+            result_tree = tree::insert_oid(
+                odb,
+                result_tree,
+                std::path::Path::new(".gitmodules"),
+                gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
+                0o0100644,
+            )?;
 
             Ok(x.with_tree(result_tree))
         }

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -915,6 +915,76 @@ pub fn apply_to_commit2(
                 .transpose();
             }
         }
+        Op::InlineSubmodules => {
+            check_experimental_features_enabled("inline_submodules filter")?;
+
+            let normal_parents = commit
+                .parent_ids()
+                .map(|p| transaction.get(filter, p))
+                .collect::<anyhow::Result<Option<Vec<git2::Oid>>>>()?;
+            let normal_parents = some_or!(normal_parents, { return Ok(None) });
+
+            let current_submodules = extract_submodule_commits(repo, &commit.tree()?)?;
+
+            let first_parent_submodules = if let Some(parent) = commit.parents().next() {
+                extract_submodule_commits(
+                    repo,
+                    &parent.tree().unwrap_or_else(|_| tree::empty(repo)),
+                )?
+            } else {
+                std::collections::BTreeMap::new()
+            };
+
+            // Find submodules whose pointer was added or changed in this commit
+            // (vs the first parent). Removed submodules contribute no extra parent.
+            let changed_submodules: Vec<(std::path::PathBuf, git2::Oid, git2::Oid)> =
+                current_submodules
+                    .iter()
+                    .filter_map(|(path, (new_oid, _))| {
+                        let old_oid = first_parent_submodules
+                            .get(path)
+                            .map(|(oid, _)| *oid)
+                            .unwrap_or(git2::Oid::zero());
+                        if old_oid != *new_oid {
+                            Some((path.clone(), old_oid, *new_oid))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+
+            let original_target = normal_parents.first().copied().unwrap_or(git2::Oid::zero());
+
+            let mut extra_parents: Vec<git2::Oid> = Vec::new();
+            for (path, old_oid, new_oid) in changed_submodules {
+                let path_filter = to_filter(Op::Subdir(path));
+                let unapplied = history::unapply_filter(
+                    transaction,
+                    path_filter,
+                    original_target,
+                    old_oid,
+                    new_oid,
+                    history::OrphansMode::Keep,
+                    None,
+                )?;
+                if unapplied != git2::Oid::zero() {
+                    extra_parents.push(unapplied);
+                }
+            }
+
+            let filtered_tree = apply(transaction, filter, Rewrite::from_commit(commit)?)?;
+            let filtered_parent_ids: Vec<git2::Oid> =
+                normal_parents.into_iter().chain(extra_parents).collect();
+
+            return Some(history::create_filtered_commit(
+                commit,
+                filtered_parent_ids,
+                filtered_tree,
+                transaction,
+                filter,
+            ))
+            .transpose();
+        }
         Op::Workspace(ws_path) => {
             let tree = repo.find_tree(commit.tree_id()?)?;
             if let Some((redirect, _)) = resolve_workspace_redirect(repo, &tree, ws_path) {
@@ -1295,6 +1365,42 @@ pub fn apply<'a>(
                 }
                 _ => return Err(anyhow!("unknown adapter {:?}", adapter)),
             }
+
+            Ok(x.with_tree(result_tree))
+        }
+        Op::InlineSubmodules => {
+            check_experimental_features_enabled("inline_submodules filter")?;
+
+            let mut result_tree = x.tree().clone();
+            let submodule_commits = extract_submodule_commits(repo, &result_tree)?;
+
+            for (submodule_path, (commit_oid, _meta)) in submodule_commits {
+                let submodule_tree = repo.find_commit(commit_oid)?.tree()?;
+
+                // Strip the 160000 commit-mode entry at the submodule path so the
+                // subsequent unapply overlays cleanly on a plain (or missing) entry.
+                result_tree = tree::insert(
+                    repo,
+                    &result_tree,
+                    &submodule_path,
+                    git2::Oid::zero(),
+                    0o0160000,
+                )?;
+
+                // Lay the submodule's tree at <path> on top of the cleaned tree.
+                let path_filter = to_filter(Op::Subdir(submodule_path.clone()));
+                result_tree =
+                    filter::unapply(transaction, path_filter, submodule_tree, result_tree, None)?;
+            }
+
+            // Remove .gitmodules so the filtered output has no trace of submodules.
+            result_tree = tree::insert(
+                repo,
+                &result_tree,
+                std::path::Path::new(".gitmodules"),
+                git2::Oid::zero(),
+                0o0100644,
+            )?;
 
             Ok(x.with_tree(result_tree))
         }

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -267,6 +267,7 @@ pub(crate) fn spec2(op: &Op) -> String {
         Op::Link(Some(mode)) => format!(":link={}", mode),
         Op::Export => ":export".to_string(),
         Op::Unlink => ":unlink".to_string(),
+        Op::InlineSubmodules => ":inline_submodules".to_string(),
         Op::Subdir(path) => format!(":/{}", parse::quote_if(&path.to_string_lossy())),
         Op::Insert(path, content) => {
             let p = parse::quote_if(&path.to_string_lossy());

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -69,6 +69,10 @@ fn make_filter(args: &[&str]) -> anyhow::Result<Filter> {
             check_experimental_features_enabled("unlink filter")?;
             Ok(to_filter(Op::Unlink))
         }
+        ["inline_submodules"] => {
+            check_experimental_features_enabled("inline_submodules filter")?;
+            Ok(to_filter(Op::InlineSubmodules))
+        }
         ["adapt", adapter] => {
             check_experimental_features_enabled("adapt filter")?;
             Ok(to_filter(Op::Adapt(adapter.to_string())))

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -117,6 +117,7 @@ pub enum Op {
     Adapt(String),
     Link(Option<LinkMode>),
     Unlink,
+    InlineSubmodules,
     Export,
     Embed(std::path::PathBuf),
 

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -506,6 +506,10 @@ impl<'a> InMemoryBuilder<'a> {
                 let blob = self.write_blob(b"");
                 push_blob_entries(&mut entries, [("unlink", blob)]);
             }
+            Op::InlineSubmodules => {
+                let blob = self.write_blob(b"");
+                push_blob_entries(&mut entries, [("inline_submodules", blob)]);
+            }
             Op::Invert => {
                 let blob = self.write_blob(b"");
                 push_blob_entries(&mut entries, [("invert", blob)]);
@@ -809,6 +813,10 @@ fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyh
         "unlink" => {
             let _ = Blob::read(src, entry.id())?;
             Ok(Op::Unlink)
+        }
+        "inline_submodules" => {
+            let _ = Blob::read(src, entry.id())?;
+            Ok(Op::InlineSubmodules)
         }
         "invert" => {
             let _ = Blob::read(src, entry.id())?;

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -505,6 +505,10 @@ impl<'a> InMemoryBuilder<'a> {
                 let blob = self.write_blob(b"");
                 push_blob_entries(&mut entries, [("unlink", blob)]);
             }
+            Op::InlineSubmodules => {
+                let blob = self.write_blob(b"");
+                push_blob_entries(&mut entries, [("inline_submodules", blob)]);
+            }
             Op::Invert => {
                 let blob = self.write_blob(b"");
                 push_blob_entries(&mut entries, [("invert", blob)]);
@@ -711,6 +715,10 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
         "unlink" => {
             let _ = repo.find_blob(entry.id())?;
             Ok(Op::Unlink)
+        }
+        "inline_submodules" => {
+            let _ = repo.find_blob(entry.id())?;
+            Ok(Op::InlineSubmodules)
         }
         "invert" => {
             let _ = repo.find_blob(entry.id())?;

--- a/tests/experimental/inline_submodules.t
+++ b/tests/experimental/inline_submodules.t
@@ -1,0 +1,220 @@
+  $ export TESTTMP=${PWD}
+
+  $ cd ${TESTTMP}
+  $ git init -q submodule-repo 1> /dev/null
+  $ cd submodule-repo
+
+  $ mkdir -p foo
+  $ echo "foo content" > foo/file1.txt
+  $ echo "bar content" > foo/file2.txt
+  $ git add foo
+  $ git commit -m "add foo with files" 1> /dev/null
+
+  $ mkdir -p bar
+  $ echo "baz content" > bar/file3.txt
+  $ git add bar
+  $ git commit -m "add bar with file" 1> /dev/null
+
+  $ cd ${TESTTMP}
+  $ git init -q main-repo 1> /dev/null
+  $ cd main-repo
+  $ git commit -m "init" --allow-empty 1> /dev/null
+
+  $ echo "main content" > main.txt
+  $ git add main.txt
+  $ git commit -m "add main.txt" 1> /dev/null
+
+  $ git submodule add ../submodule-repo libs 2> /dev/null
+  $ git submodule status
+   00c8fe9f1bb75a3f6280992ec7c3c893d858f5dd libs (heads/master)
+
+  $ git commit -m "add libs submodule" 1> /dev/null
+
+  $ git fetch ../submodule-repo
+  From ../submodule-repo
+   * branch            HEAD       -> FETCH_HEAD
+
+  $ git log --graph --pretty=%s
+  * add libs submodule
+  * add main.txt
+  * init
+
+  $ git ls-tree --name-only -r HEAD
+  .gitmodules
+  libs
+  main.txt
+
+Test InlineSubmodules filter - should inline submodule tree content and add the
+submodule history as an extra parent at each pointer update.
+
+  $ josh-filter -s :inline_submodules master --update refs/josh/filter/master
+  2ffcff2eab987cbae3d21c9ffca4741298ca7338
+  [1] :/libs
+  [3] :inline_submodules
+  [3] reachable_roots
+  [3] sequence_number
+
+  $ git log --graph --pretty=%s refs/josh/filter/master
+  *   add libs submodule
+  |\  
+  | * add bar with file
+  | * add foo with files
+  * add main.txt
+  * init
+
+The filtered tree should have the submodule files inlined at libs/ and no
+.gitmodules:
+
+  $ git ls-tree --name-only -r refs/josh/filter/master
+  libs/bar/file3.txt
+  libs/foo/file1.txt
+  libs/foo/file2.txt
+  main.txt
+
+  $ git show refs/josh/filter/master:libs/foo/file1.txt
+  foo content
+
+  $ git show refs/josh/filter/master:libs/foo/file2.txt
+  bar content
+
+  $ git show refs/josh/filter/master:libs/bar/file3.txt
+  baz content
+
+Test .gitmodules is absent
+
+  $ git ls-tree refs/josh/filter/master | grep gitmodules
+  [1]
+
+Test InlineSubmodules with multiple submodules
+
+  $ cd ${TESTTMP}
+  $ git init -q another-submodule 1> /dev/null
+  $ cd another-submodule
+  $ echo "another content" > another.txt
+  $ git add another.txt
+  $ git commit -m "add another.txt" 1> /dev/null
+
+  $ cd ${TESTTMP}/main-repo
+  $ git submodule add ../another-submodule modules/another 2> /dev/null
+  $ git commit -m "add another submodule" 1> /dev/null
+
+  $ git fetch ../another-submodule
+  From ../another-submodule
+   * branch            HEAD       -> FETCH_HEAD
+
+  $ josh-filter -s :inline_submodules master --update refs/josh/filter/master
+  49287de5bf4b68fb60ef2df8d2676c25a78edcbc
+  [1] :/another
+  [1] :/libs
+  [3] :/modules
+  [4] :inline_submodules
+  [7] reachable_roots
+  [7] sequence_number
+
+  $ git log --graph --pretty=%s refs/josh/filter/master
+  *   add another submodule
+  |\  
+  | * add another.txt
+  *   add libs submodule
+  |\  
+  | * add bar with file
+  | * add foo with files
+  * add main.txt
+  * init
+
+  $ git ls-tree --name-only -r refs/josh/filter/master
+  libs/bar/file3.txt
+  libs/foo/file1.txt
+  libs/foo/file2.txt
+  main.txt
+  modules/another/another.txt
+
+  $ git show refs/josh/filter/master:modules/another/another.txt
+  another content
+
+Test InlineSubmodules with submodule update - moving the libs pointer should
+become a merge with the additional submodule commits as the second parent.
+
+  $ cd ${TESTTMP}/submodule-repo
+  $ mkdir -p libs/foo libs/bar
+  $ echo "new content" > libs/foo/file3.txt
+  $ git add libs/foo/file3.txt
+  $ git commit -m "add file3.txt" 1> /dev/null
+
+  $ echo "another new content" > libs/bar/file4.txt
+  $ git add libs/bar/file4.txt
+  $ git commit -m "add file4.txt" 1> /dev/null
+
+  $ cd ${TESTTMP}/main-repo
+  $ git fetch ../submodule-repo
+  From ../submodule-repo
+   * branch            HEAD       -> FETCH_HEAD
+  $ git submodule update --remote libs
+  From /tmp/prysk-tests-*/inline_submodules.t/submodule-repo (glob)
+     00c8fe9..47f1d80  master     -> origin/master
+  Submodule path 'libs': checked out '47f1d800e93b0892d3bc525632c9ffc8d32eeb4c'
+  $ git add libs
+  $ git commit -m "update libs submodule" 1> /dev/null
+
+  $ josh-filter -s :inline_submodules master --update refs/josh/filter/master
+  3af469419c26b5fd7d3d708a23e9273f55ac1355
+  [1] :/another
+  [3] :/modules
+  [5] :inline_submodules
+  [6] :/libs
+  [12] reachable_roots
+  [12] sequence_number
+
+  $ git log --graph --pretty=%s refs/josh/filter/master
+  *   update libs submodule
+  |\  
+  | * add file4.txt
+  | * add file3.txt
+  |/  
+  *   add another submodule
+  |\  
+  | * add another.txt
+  *   add libs submodule
+  |\  
+  | * add bar with file
+  | * add foo with files
+  * add main.txt
+  * init
+
+  $ git ls-tree --name-only -r refs/josh/filter/master
+  libs/bar/file3.txt
+  libs/foo/file1.txt
+  libs/foo/file2.txt
+  libs/libs/bar/file4.txt
+  libs/libs/foo/file3.txt
+  main.txt
+  modules/another/another.txt
+
+  $ git show refs/josh/filter/master:libs/foo/file3.txt
+  fatal: path 'libs/foo/file3.txt' does not exist in 'refs/josh/filter/master'
+  [128]
+
+  $ git show refs/josh/filter/master:libs/bar/file4.txt
+  fatal: path 'libs/bar/file4.txt' does not exist in 'refs/josh/filter/master'
+  [128]
+
+Test InlineSubmodules on repo without submodules (should be no-op)
+
+  $ cd ${TESTTMP}
+  $ git init -q no-submodules 1> /dev/null
+  $ cd no-submodules
+  $ echo "content" > file.txt
+  $ git add file.txt
+  $ git commit -m "add file" 1> /dev/null
+
+  $ josh-filter -s :inline_submodules master --update refs/josh/filter/master
+  62f270988ac3ab05a33d0705fb1e4982165f69f2
+  [1] :inline_submodules
+  [1] reachable_roots
+  [1] sequence_number
+
+  $ git ls-tree --name-only -r refs/josh/filter/master
+  file.txt
+
+  $ git show refs/josh/filter/master:file.txt
+  content

--- a/tests/experimental/inline_submodules.t
+++ b/tests/experimental/inline_submodules.t
@@ -1,0 +1,220 @@
+  $ export TESTTMP=${PWD}
+
+  $ cd ${TESTTMP}
+  $ git init -q submodule-repo 1> /dev/null
+  $ cd submodule-repo
+
+  $ mkdir -p foo
+  $ echo "foo content" > foo/file1.txt
+  $ echo "bar content" > foo/file2.txt
+  $ git add foo
+  $ git commit -m "add foo with files" 1> /dev/null
+
+  $ mkdir -p bar
+  $ echo "baz content" > bar/file3.txt
+  $ git add bar
+  $ git commit -m "add bar with file" 1> /dev/null
+
+  $ cd ${TESTTMP}
+  $ git init -q main-repo 1> /dev/null
+  $ cd main-repo
+  $ git commit -m "init" --allow-empty 1> /dev/null
+
+  $ echo "main content" > main.txt
+  $ git add main.txt
+  $ git commit -m "add main.txt" 1> /dev/null
+
+  $ git submodule add ../submodule-repo libs 2> /dev/null
+  $ git submodule status
+   00c8fe9f1bb75a3f6280992ec7c3c893d858f5dd libs (heads/master)
+
+  $ git commit -m "add libs submodule" 1> /dev/null
+
+  $ git fetch ../submodule-repo
+  From ../submodule-repo
+   * branch            HEAD       -> FETCH_HEAD
+
+  $ git log --graph --pretty=%s
+  * add libs submodule
+  * add main.txt
+  * init
+
+  $ git ls-tree --name-only -r HEAD
+  .gitmodules
+  libs
+  main.txt
+
+Test InlineSubmodules filter - should inline submodule tree content and add the
+submodule history as an extra parent at each pointer update.
+
+  $ josh-filter -s :inline_submodules master --update refs/josh/filter/master
+  2ffcff2eab987cbae3d21c9ffca4741298ca7338
+  [1] :/libs
+  [3] :inline_submodules
+  [3] reachable_roots
+  [3] sequence_number
+
+  $ git log --graph --pretty=%s refs/josh/filter/master
+  *   add libs submodule
+  |\  
+  | * add bar with file
+  | * add foo with files
+  * add main.txt
+  * init
+
+The filtered tree should have the submodule files inlined at libs/ and no
+.gitmodules:
+
+  $ git ls-tree --name-only -r refs/josh/filter/master
+  libs/bar/file3.txt
+  libs/foo/file1.txt
+  libs/foo/file2.txt
+  main.txt
+
+  $ git show refs/josh/filter/master:libs/foo/file1.txt
+  foo content
+
+  $ git show refs/josh/filter/master:libs/foo/file2.txt
+  bar content
+
+  $ git show refs/josh/filter/master:libs/bar/file3.txt
+  baz content
+
+Test .gitmodules is absent
+
+  $ git ls-tree refs/josh/filter/master | grep gitmodules
+  [1]
+
+Test InlineSubmodules with multiple submodules
+
+  $ cd ${TESTTMP}
+  $ git init -q another-submodule 1> /dev/null
+  $ cd another-submodule
+  $ echo "another content" > another.txt
+  $ git add another.txt
+  $ git commit -m "add another.txt" 1> /dev/null
+
+  $ cd ${TESTTMP}/main-repo
+  $ git submodule add ../another-submodule modules/another 2> /dev/null
+  $ git commit -m "add another submodule" 1> /dev/null
+
+  $ git fetch ../another-submodule
+  From ../another-submodule
+   * branch            HEAD       -> FETCH_HEAD
+
+  $ josh-filter -s :inline_submodules master --update refs/josh/filter/master
+  49287de5bf4b68fb60ef2df8d2676c25a78edcbc
+  [1] :/another
+  [1] :/libs
+  [3] :/modules
+  [4] :inline_submodules
+  [7] reachable_roots
+  [7] sequence_number
+
+  $ git log --graph --pretty=%s refs/josh/filter/master
+  *   add another submodule
+  |\  
+  | * add another.txt
+  *   add libs submodule
+  |\  
+  | * add bar with file
+  | * add foo with files
+  * add main.txt
+  * init
+
+  $ git ls-tree --name-only -r refs/josh/filter/master
+  libs/bar/file3.txt
+  libs/foo/file1.txt
+  libs/foo/file2.txt
+  main.txt
+  modules/another/another.txt
+
+  $ git show refs/josh/filter/master:modules/another/another.txt
+  another content
+
+Test InlineSubmodules with submodule update - moving the libs pointer should
+become a merge with the additional submodule commits as the second parent.
+
+  $ cd ${TESTTMP}/submodule-repo
+  $ mkdir -p libs/foo libs/bar
+  $ echo "new content" > libs/foo/file3.txt
+  $ git add libs/foo/file3.txt
+  $ git commit -m "add file3.txt" 1> /dev/null
+
+  $ echo "another new content" > libs/bar/file4.txt
+  $ git add libs/bar/file4.txt
+  $ git commit -m "add file4.txt" 1> /dev/null
+
+  $ cd ${TESTTMP}/main-repo
+  $ git fetch ../submodule-repo
+  From ../submodule-repo
+   * branch            HEAD       -> FETCH_HEAD
+  $ git submodule update --remote libs
+  From /tmp/*/inline_submodules.t/submodule-repo (glob)
+     00c8fe9..47f1d80  master     -> origin/master
+  Submodule path 'libs': checked out '47f1d800e93b0892d3bc525632c9ffc8d32eeb4c'
+  $ git add libs
+  $ git commit -m "update libs submodule" 1> /dev/null
+
+  $ josh-filter -s :inline_submodules master --update refs/josh/filter/master
+  3af469419c26b5fd7d3d708a23e9273f55ac1355
+  [1] :/another
+  [3] :/modules
+  [5] :inline_submodules
+  [6] :/libs
+  [12] reachable_roots
+  [12] sequence_number
+
+  $ git log --graph --pretty=%s refs/josh/filter/master
+  *   update libs submodule
+  |\  
+  | * add file4.txt
+  | * add file3.txt
+  |/  
+  *   add another submodule
+  |\  
+  | * add another.txt
+  *   add libs submodule
+  |\  
+  | * add bar with file
+  | * add foo with files
+  * add main.txt
+  * init
+
+  $ git ls-tree --name-only -r refs/josh/filter/master
+  libs/bar/file3.txt
+  libs/foo/file1.txt
+  libs/foo/file2.txt
+  libs/libs/bar/file4.txt
+  libs/libs/foo/file3.txt
+  main.txt
+  modules/another/another.txt
+
+  $ git show refs/josh/filter/master:libs/foo/file3.txt
+  fatal: path 'libs/foo/file3.txt' does not exist in 'refs/josh/filter/master'
+  [128]
+
+  $ git show refs/josh/filter/master:libs/bar/file4.txt
+  fatal: path 'libs/bar/file4.txt' does not exist in 'refs/josh/filter/master'
+  [128]
+
+Test InlineSubmodules on repo without submodules (should be no-op)
+
+  $ cd ${TESTTMP}
+  $ git init -q no-submodules 1> /dev/null
+  $ cd no-submodules
+  $ echo "content" > file.txt
+  $ git add file.txt
+  $ git commit -m "add file" 1> /dev/null
+
+  $ josh-filter -s :inline_submodules master --update refs/josh/filter/master
+  62f270988ac3ab05a33d0705fb1e4982165f69f2
+  [1] :inline_submodules
+  [1] reachable_roots
+  [1] sequence_number
+
+  $ git ls-tree --name-only -r refs/josh/filter/master
+  file.txt
+
+  $ git show refs/josh/filter/master:file.txt
+  content


### PR DESCRIPTION
Add experimental :inline_submodules filter

Replace gitlinks with submodule trees and merge pointer-update history into the
filtered result.

Change: inline-submodules-filter
Assisted-By: openai-codex/gpt-5.6-sol