### PR TITLE
Increase ultrawide_pin benchmark workload 5x

### DIFF
--- a/josh-core/benches/ultrawide_pin.rs
+++ b/josh-core/benches/ultrawide_pin.rs
@@ -4,7 +4,11 @@ use rand::prelude::*;
 use std::cell::RefCell;
 use std::ops::DerefMut;
 
-const N_FILES: usize = if cfg!(debug_assertions) { 50 } else { 500 };
+const N_FILES: usize = if cfg!(debug_assertions) {
+    50 * 5
+} else {
+    500 * 5
+};
 
 const N_COMMITS: usize = if cfg!(debug_assertions) { 5 } else { 10 };
 

--- a/josh-core/benches/ultrawide_pin.rs
+++ b/josh-core/benches/ultrawide_pin.rs
@@ -6,7 +6,11 @@ use std::cell::RefCell;
 use std::ops::DerefMut;
 use std::str::FromStr;
 
-const N_FILES: usize = if cfg!(debug_assertions) { 50 } else { 500 };
+const N_FILES: usize = if cfg!(debug_assertions) {
+    50 * 5
+} else {
+    500 * 5
+};
 
 const N_COMMITS: usize = if cfg!(debug_assertions) { 5 } else { 10 };
 


### PR DESCRIPTION
Increase ultrawide_pin benchmark workload 5x

Local experiment; do not merge.

Change: ultrawide-pin-bench-5x
Assisted-By: openai-codex/gpt-5.6-sol