### PR TITLE
Define the inverse of :SQUASH as :/ (nop)

### DIFF
--- a/josh-filter/src/opt/invert.rs
+++ b/josh-filter/src/opt/invert.rs
@@ -13,6 +13,9 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
         let result = match to_op_ref(filter) {
             Op::Nop => Some(Op::Nop),
             Op::Message(..) => Some(Op::Nop),
+            // `:SQUASH` only rewrites history; at tree level it is identity,
+            // so content pushed through it maps back unchanged.
+            Op::Squash(None) => Some(Op::Nop),
             Op::Prune => Some(Op::Prune),
             Op::Export => Some(Op::Export),
             Op::Empty => Some(Op::Empty),

--- a/tests/filter/rev_squash.t
+++ b/tests/filter/rev_squash.t
@@ -73,6 +73,47 @@ of the post-cutoff commit
   post
   subfile
 
+A branch rooted at the identity-preserved tip itself can be merged and pushed:
+the unapply base for that tip may be a squashed original, whose `:SQUASH`
+resolution must reverse like a fall-through commit
+  $ git checkout -q -b tipbranch $SUBTREE_TIP
+  $ echo note > tip-note.md
+  $ git add .
+  $ git commit -m "tip branch work" 1>/dev/null
+  $ git checkout -q -b fwork refs/heads/filtered
+  $ git merge --no-ff tipbranch -m "merge tip branch" 1>/dev/null
+  $ git update-ref refs/heads/filtered HEAD
+  $ josh-filter -s "$FILTER" refs/heads/master --update refs/heads/filtered --reverse --check-roundtrip
+  502c4f2c20e968f20dc97f4bb54b6a1598f690fd
+  [4] :/subtree
+  [4] :~(
+      history="keep-trivial-merges,no-splice"
+  )[
+      :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=75a11dcdd41d68e57d9d9f07862bd284a99da6f0:SQUASH)
+  ]
+  [15] reachable_roots
+  [15] sequence_number
+
+  $ git ls-tree --name-only -r refs/heads/master
+  rustfile
+  subtree/post
+  subtree/subfile
+  subtree/tip-note.md
+  $ git log --graph --pretty=%s refs/heads/master
+  *   merge tip branch
+  |\  
+  | * tip branch work
+  * | post cutoff change
+  |/  
+  *   bors merge
+  |\  
+  | * rollup merge
+  |/| 
+  | * sync merge
+  |/| 
+  | * s1
+  * m1
+
 Squashing away a merge that is the only join between two preserved lineages
 would disconnect one of them: the filter fails loudly instead
   $ git checkout -q --orphan sub2
@@ -89,18 +130,18 @@ would disconnect one of them: the filter fails loudly instead
   $ export R2=$(git rev-parse HEAD)
 
   $ josh-filter -s ":~(history=\"keep-trivial-merges,no-splice\")[:rev(<=$SUBTREE_TIP:prefix=subtree,<=$SUB2_TIP:prefix=subtree2,<=$R2:SQUASH)]" refs/heads/master --update refs/heads/broken
-  [2] :/subtree
   [2] :~(
       history="keep-trivial-merges,no-splice"
   )[
-      :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=64eeef227e94b848388854ea5e8b86a043c7ac12:prefix=subtree2,<=e18fef9705f6a52d6fc63f8b98aa25a45f8866b7:SQUASH)
+      :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=64eeef227e94b848388854ea5e8b86a043c7ac12:prefix=subtree2,<=2019cb20591f675b8600a09209e884ccaaf8d1cd:SQUASH)
   ]
-  [2] :~(
+  [4] :/subtree
+  [4] :~(
       history="keep-trivial-merges,no-splice"
   )[
       :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=75a11dcdd41d68e57d9d9f07862bd284a99da6f0:SQUASH)
   ]
-  [11] reachable_roots
-  [11] sequence_number
-  ERROR: cannot squash e18fef9705f6a52d6fc63f8b98aa25a45f8866b7: its filtered parents 8d43373df2033c39f110dd8066eb4a78e9d4866d and 308067b73b0fa23ba642aa27603e6b6b4a63dbf4 do not descend from one another. `:SQUASH` can only preserve a single lineage
+  [18] reachable_roots
+  [18] sequence_number
+  ERROR: cannot squash 2019cb20591f675b8600a09209e884ccaaf8d1cd: its filtered parents 8d43373df2033c39f110dd8066eb4a78e9d4866d and 308067b73b0fa23ba642aa27603e6b6b4a63dbf4 do not descend from one another. `:SQUASH` can only preserve a single lineage
   [1]

--- a/tests/filter/squash_push.t
+++ b/tests/filter/squash_push.t
@@ -1,0 +1,55 @@
+A plain `:SQUASH` view presents the entire history as a single squashed
+commit. Since `:SQUASH` is identity at tree level, commits made on top of the
+view unapply onto the original history with their content unchanged; the
+re-filtered view is the squash of the new tip.
+
+  $ git init -q 1>/dev/null
+
+  $ echo a > file1
+  $ git add .
+  $ git commit -m "one" 1>/dev/null
+  $ echo b > file2
+  $ git add .
+  $ git commit -m "two" 1>/dev/null
+
+  $ josh-filter -s :SQUASH refs/heads/master --update refs/heads/filtered
+  ef7dc63d9aeb1f69b5537e8fd7ab9682a03084d7
+
+  $ git log --graph --pretty=%s refs/heads/filtered
+  * two
+
+  $ git ls-tree --name-only -r refs/heads/filtered
+  file1
+  file2
+
+A commit on top of the squashed view pushes back onto the original history
+  $ git checkout -q -b work refs/heads/filtered
+  $ echo c > file3
+  $ git add .
+  $ git commit -m "add file3" 1>/dev/null
+  $ git update-ref refs/heads/filtered HEAD
+
+  $ josh-filter -s :SQUASH refs/heads/master --update refs/heads/filtered --reverse
+  e947255d78b17600bb2b9036e5c86104cdf639ee
+
+  $ git log --graph --pretty=%s refs/heads/master
+  * add file3
+  * two
+  * one
+
+  $ git ls-tree --name-only -r refs/heads/master
+  file1
+  file2
+  file3
+
+Re-filtering squashes the updated history back into a single commit
+  $ josh-filter -s :SQUASH refs/heads/master --update refs/heads/refiltered
+  8fe1090d633aa8413a2f04e20c0c11efe6dfc332
+
+  $ git log --graph --pretty=%s refs/heads/refiltered
+  * add file3
+
+  $ git ls-tree --name-only -r refs/heads/refiltered
+  file1
+  file2
+  file3


### PR DESCRIPTION
Define the inverse of :SQUASH as :/ (nop)

`:SQUASH` only rewrites history; at tree level it is identity, so
content maps back through it unchanged. Without an inverse, any reverse
apply that resolved a commit to `:SQUASH` failed with "no invert
Squash(None)". That made pushes into `:rev(...:SQUASH)` filtered repos
fail whenever the unapply base found for a filtered parent was a
squashed original -- many squashed originals share one filtered commit
as their image, so for commits at the boundary of the squashed region
it usually is. Example: pushing a merge of a branch rooted at the
cutoff tip of a subtree migration filter.

This also makes filters containing `:SQUASH` reversible in general,
so pushing through squashed views is possible.

Change: rev-squash-unapply
Assisted-By: anthropic/claude-fable-5