### PR TITLE
Support :SQUASH entries in :rev filters

### DIFF
--- a/josh-core/src/cache/mod.rs
+++ b/josh-core/src/cache/mod.rs
@@ -7,7 +7,7 @@ mod transaction;
 
 /// Schema version for on-disk cache structures. Bump when the layout of the
 /// sled trees or distributed cache refs changes incompatibly.
-pub const CACHE_VERSION: u64 = 31;
+pub const CACHE_VERSION: u64 = 32;
 
 pub use backend::{CacheBackend, HistoryGraphHint};
 pub use distributed::DistributedCacheBackend;

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2162,6 +2162,52 @@ fn per_rev_filter(
 
     let filtered_parent_ids: Vec<_> = normal_parents.into_iter().chain(splice_parents).collect();
 
+    if let Op::Squash(None) = to_op(commit_filter.peel()) {
+        // `:SQUASH` as a per-commit filter squashes the commit away, mapping it
+        // to the surviving filtered parent with the largest sequence number.
+        // Ancestors have strictly smaller sequence numbers, so a parent that
+        // has all others as ancestors always wins and nothing gets
+        // disconnected; a fixed parent position would instead strand lineages
+        // that only join through other parents (subtree sync merges carry the
+        // newer subtree tip as their second parent).
+        let mut target = None;
+        for id in filtered_parent_ids
+            .iter()
+            .filter(|x| **x != git2::Oid::zero())
+        {
+            let seq = cache::compute_sequence_number(transaction, *id)?;
+            if target.map(|(top, _)| seq > top).unwrap_or(true) {
+                target = Some((seq, *id));
+            }
+        }
+        // Squashing a merge is only lossless when the chosen parent has every
+        // other surviving parent in its ancestry; incomparable parents mean
+        // two preserved lineages join only inside the squashed region and one
+        // of them would silently become unreachable. Fail instead.
+        if let Some((_, target_id)) = target {
+            for id in filtered_parent_ids
+                .iter()
+                .filter(|x| **x != git2::Oid::zero() && **x != target_id)
+            {
+                if !transaction.repo().graph_descendant_of(target_id, *id)? {
+                    return Err(anyhow!(
+                        "cannot squash {}: its filtered parents {} and {} do not descend \
+                         from one another. `:SQUASH` can only preserve a single lineage",
+                        commit.id(),
+                        target_id,
+                        id
+                    ));
+                }
+            }
+        }
+        return Ok(Some(history::drop_commit(
+            commit,
+            target.map(|(_, id)| id).into_iter().collect(),
+            transaction,
+            filter,
+        )?));
+    }
+
     let mut tree_data = apply(transaction, commit_filter, Rewrite::from_commit(commit)?)?;
 
     if let Some((pin_subtract, pin_overlay)) = pin_details {

--- a/tests/cli/cache.t
+++ b/tests/cli/cache.t
@@ -50,13 +50,13 @@ Build the distributed cache (applies the filter to already-fetched refs)
 Verify local cache refs were created
 
   $ git for-each-ref --format='%(refname)' 'refs/josh/cache/'
-  refs/josh/cache/31/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+  refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d
 
 Push the distributed cache and filtered ref to the backing remote
 
   $ josh cache push
   To file://${TESTTMP}/remote/libs
-   * [new reference]   refs/josh/cache/31/0/bf567e0faf634a663d6cef48145a035e1974ab1d -> refs/josh/cache/31/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+   * [new reference]   refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d -> refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d
   
   To file://${TESTTMP}/remote/libs
    * [new reference]   refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master -> refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master
@@ -89,7 +89,7 @@ Fetch the distributed cache and filtered objects from the remote
 
   $ josh cache fetch
   From file://${TESTTMP}/remote/libs
-   * [new ref]         refs/josh/cache/31/0/bf567e0faf634a663d6cef48145a035e1974ab1d -> refs/josh/cache/31/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+   * [new ref]         refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d -> refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d
   
   From file://${TESTTMP}/remote/libs
    * [new ref]         refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master -> refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master
@@ -99,7 +99,7 @@ Fetch the distributed cache and filtered objects from the remote
 Verify cache refs are now present locally
 
   $ git for-each-ref --format='%(refname)' 'refs/josh/cache/'
-  refs/josh/cache/31/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+  refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d
 
   $ cd ${TESTTMP}
 

--- a/tests/filter/rev_squash.t
+++ b/tests/filter/rev_squash.t
@@ -1,0 +1,106 @@
+A `:SQUASH` entry in a `:rev()` filter squashes the commits it matches out of
+the filtered history: none of them may appear in the output. Each one is mapped
+to the surviving filtered parent with the largest sequence number (or to zero
+when nothing survives). In particular, the whole squashed region between an
+identity-preserved subtree lineage and the first commit after the cutoff must
+collapse away, even when the boundary merges are reachable only through second
+parents of further merges (the rollup/bors style indirection used in
+rust-lang/rust), and the commits after the cutoff must attach directly to the
+subtree lineage.
+
+  $ git init -q 1>/dev/null
+
+Main branch with a file outside the subtree
+  $ echo rust > rustfile
+  $ git add .
+  $ git commit -m "m1" 1>/dev/null
+
+Standalone subtree lineage as an orphan branch
+  $ git checkout -q --orphan sub
+  $ git rm -q -rf .
+  $ echo subcontent > subfile
+  $ git add .
+  $ git commit -m "s1" 1>/dev/null
+  $ export SUBTREE_TIP=$(git rev-parse HEAD)
+
+Subtree merge on a side branch (subtree files moved under subtree/)
+  $ git checkout -q master
+  $ git checkout -qb syncbr
+  $ git merge sub --allow-unrelated-histories --no-commit 1>/dev/null
+  Automatic merge went well; stopped before committing as requested
+  $ mkdir subtree
+  $ git mv subfile subtree/
+  $ git commit -m "sync merge" 1>/dev/null
+
+The sync merge lands on master through two levels of merge indirection
+  $ git checkout -q master
+  $ git checkout -qb rollup
+  $ git merge --no-ff syncbr -m "rollup merge" 1>/dev/null
+  $ git checkout -q master
+  $ git merge --no-ff rollup -m "bors merge" 1>/dev/null
+  $ export R=$(git rev-parse HEAD)
+
+A change after the elision cutoff
+  $ echo post > subtree/post
+  $ git add .
+  $ git commit -m "post cutoff change" 1>/dev/null
+
+  $ export FILTER=":~(history=\"keep-trivial-merges,no-splice\")[:rev(<=$SUBTREE_TIP:prefix=subtree,<=$R:SQUASH)]:/subtree"
+
+The filtered history is the identity-preserved subtree lineage with the
+post-cutoff commit attached directly to it; the elided region leaves no trace
+  $ josh-filter -s "$FILTER" refs/heads/master --update refs/heads/filtered
+  ddbbceeab0f8a545c505cccb24ae71b76cdc4f67
+  [2] :/subtree
+  [2] :~(
+      history="keep-trivial-merges,no-splice"
+  )[
+      :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=75a11dcdd41d68e57d9d9f07862bd284a99da6f0:SQUASH)
+  ]
+  [8] reachable_roots
+  [8] sequence_number
+
+  $ git log --graph --pretty=%s refs/heads/filtered
+  * post cutoff change
+  * s1
+
+The subtree commit is preserved with its original id and is the direct parent
+of the post-cutoff commit
+  $ test $(git rev-parse refs/heads/filtered~1) = $SUBTREE_TIP && echo preserved
+  preserved
+
+  $ git ls-tree --name-only -r refs/heads/filtered
+  post
+  subfile
+
+Squashing away a merge that is the only join between two preserved lineages
+would disconnect one of them: the filter fails loudly instead
+  $ git checkout -q --orphan sub2
+  $ git rm -q -rf .
+  $ echo other > otherfile
+  $ git add .
+  $ git commit -m "c1" 1>/dev/null
+  $ export SUB2_TIP=$(git rev-parse HEAD)
+  $ git checkout -q master
+  $ git merge sub2 --allow-unrelated-histories --no-commit 2>/dev/null 1>/dev/null
+  $ mkdir subtree2
+  $ git mv otherfile subtree2/
+  $ git commit -m "second sync merge" 1>/dev/null
+  $ export R2=$(git rev-parse HEAD)
+
+  $ josh-filter -s ":~(history=\"keep-trivial-merges,no-splice\")[:rev(<=$SUBTREE_TIP:prefix=subtree,<=$SUB2_TIP:prefix=subtree2,<=$R2:SQUASH)]" refs/heads/master --update refs/heads/broken
+  [2] :/subtree
+  [2] :~(
+      history="keep-trivial-merges,no-splice"
+  )[
+      :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=64eeef227e94b848388854ea5e8b86a043c7ac12:prefix=subtree2,<=e18fef9705f6a52d6fc63f8b98aa25a45f8866b7:SQUASH)
+  ]
+  [2] :~(
+      history="keep-trivial-merges,no-splice"
+  )[
+      :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=75a11dcdd41d68e57d9d9f07862bd284a99da6f0:SQUASH)
+  ]
+  [11] reachable_roots
+  [11] sequence_number
+  ERROR: cannot squash e18fef9705f6a52d6fc63f8b98aa25a45f8866b7: its filtered parents 8d43373df2033c39f110dd8066eb4a78e9d4866d and 308067b73b0fa23ba642aa27603e6b6b4a63dbf4 do not descend from one another. `:SQUASH` can only preserve a single lineage
+  [1]

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -125,7 +125,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/authentication.t
+++ b/tests/proxy/authentication.t
@@ -125,7 +125,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/caching.t
+++ b/tests/proxy/caching.t
@@ -52,7 +52,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf
@@ -162,7 +162,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_absent_head.t
+++ b/tests/proxy/clone_absent_head.t
@@ -86,7 +86,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_all.t
+++ b/tests/proxy/clone_all.t
@@ -54,7 +54,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_invalid_url.t
+++ b/tests/proxy/clone_invalid_url.t
@@ -31,7 +31,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -75,7 +75,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_sha.t
+++ b/tests/proxy/clone_sha.t
@@ -94,7 +94,7 @@ Check (2) and (3) but with a branch ref
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -88,7 +88,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -86,7 +86,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_subtree_no_master.t
+++ b/tests/proxy/clone_subtree_no_master.t
@@ -79,7 +79,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -118,7 +118,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/empty_commit.t
+++ b/tests/proxy/empty_commit.t
@@ -84,7 +84,7 @@ should still be included.
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/get_version.t
+++ b/tests/proxy/get_version.t
@@ -8,7 +8,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -302,7 +302,7 @@ Flushed credential cache
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -60,7 +60,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -341,7 +341,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/no_proxy.t
+++ b/tests/proxy/no_proxy.t
@@ -36,7 +36,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/no_proxy_lfs.t
+++ b/tests/proxy/no_proxy_lfs.t
@@ -51,7 +51,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_graphql.t
+++ b/tests/proxy/push_graphql.t
@@ -70,7 +70,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -115,7 +115,7 @@ Check the branch again
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_new_orphan_branch.t
+++ b/tests/proxy/push_new_orphan_branch.t
@@ -126,7 +126,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -57,7 +57,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -88,7 +88,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_review_already_in.t
+++ b/tests/proxy/push_review_already_in.t
@@ -49,7 +49,7 @@ test for that.
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_review_nop_behind.t
+++ b/tests/proxy/push_review_nop_behind.t
@@ -56,7 +56,7 @@ This is a regression test for that problem.
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -86,7 +86,7 @@ Flushed credential cache
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -43,7 +43,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -168,7 +168,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_stacked_gerrit.t
+++ b/tests/proxy/push_stacked_gerrit.t
@@ -110,7 +110,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_stacked_split.t
+++ b/tests/proxy/push_stacked_split.t
@@ -86,7 +86,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -151,7 +151,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -49,7 +49,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -91,7 +91,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -119,7 +119,7 @@ Put a double slash in the URL to see that it also works
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/unrelated_leak.t
+++ b/tests/proxy/unrelated_leak.t
@@ -134,7 +134,7 @@ Flushed credential cache
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -226,7 +226,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -443,7 +443,7 @@ Note that ws/d/ is now present in the ws
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -103,7 +103,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -197,7 +197,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -246,7 +246,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -185,7 +185,7 @@ Flushed credential cache
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -442,7 +442,7 @@ Note that ws/d/ is now present in the ws
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -250,7 +250,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -305,7 +305,7 @@ Note that ws/d/ is now present in the ws
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -89,7 +89,7 @@ file was created
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -126,7 +126,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -232,7 +232,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 31
+  |       `-- 32
   |           `-- sled
   |               |-- blobs
   |               |-- conf


### PR DESCRIPTION
Support :SQUASH entries in :rev filters

A `:SQUASH` entry in `:rev()` squashes the matched commits out of the
filtered history: each one is mapped to the surviving filtered parent
with the largest sequence number, or dropped entirely when nothing
survives. Ancestors have strictly smaller sequence numbers, so a parent
that has all others as ancestors always wins and nothing gets
disconnected. When no such parent exists -- two preserved lineages
joining only inside the squashed region -- squashing would silently
make one of them unreachable, so the filter fails instead, naming the
offending commit and the incomparable parents.

This enables migrating git-subtree based repositories to josh-sync
without duplicating history: with

  :~(history="keep-trivial-merges,no-splice")[:rev(<=TIP:prefix=DIR,<=R:SQUASH)]:/DIR

the subtree lineage up to TIP is reproduced identity-preserved while the
remaining history up to R is squashed away, so the filtered history
shares the subtree repo ancestry and the initial pull adds only the
commits after R. Verified against rust-lang/rust: the filtered history
is the full rustc_codegen_cranelift lineage plus only the commits after
the cutoff, and all currently deployed josh-sync subtree filters produce
bit-identical output.

Bump CACHE_VERSION: `:SQUASH` inside `:rev` previously resolved to a
tree-level no-op, so cached mappings from older versions are stale.

Change: rev-squash-entries
Assisted-By: anthropic/claude-fable-5