### PR TITLE
Refuse non-fast-forward reverse updates without --force

### DIFF
--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -1,6 +1,6 @@
 #![warn(unused_extern_crates)]
 
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use std::fs::read_to_string;
 use std::io::Write;
 
@@ -125,6 +125,11 @@ fn make_app() -> clap::Command {
         .arg(
             clap::Arg::new("check-roundtrip").action(clap::ArgAction::SetTrue).long("check-roundtrip").help(
                 "If --reverse is also set, check if applying the filter to the result of the reverse filter gives back the input",
+            ),
+        )
+        .arg(
+            clap::Arg::new("force").action(clap::ArgAction::SetTrue).long("force").help(
+                "Allow --reverse to move the input reference to a non-fast-forward result, discarding commits made on it since the filtered reference was created",
             ),
         )
         .arg(
@@ -416,6 +421,20 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             None,
         ) {
             Ok(rewritten) => {
+                // Concurrent commits on the input reference that are not
+                // represented in the pushed filtered state would be silently
+                // discarded by the ref update: require fast-forward like git.
+                if rewritten != unfiltered_old
+                    && !repo.graph_descendant_of(rewritten, unfiltered_old)?
+                    && !args.get_flag("force")
+                {
+                    return Err(anyhow!(
+                        "refusing non-fast-forward update of {} -- it contains commits that \
+                         the reverse apply would discard. Re-apply the filter and rebase the \
+                         filtered changes onto the result, or pass --force",
+                        input_ref
+                    ));
+                }
                 repo.reference(&input_ref, rewritten, true, "unapply_filter")?;
                 rewritten
             }

--- a/tests/filter/reverse_non_ff.t
+++ b/tests/filter/reverse_non_ff.t
@@ -1,0 +1,78 @@
+A reverse apply rebuilds the input reference from the pushed filtered state.
+If the input reference gained commits since the filtered reference was created
+(a concurrent commit landing between pull and push), those commits are not
+represented in the pushed state and the rebuilt input would discard them:
+refuse the update like a non-fast-forward git push, unless --force is given.
+
+  $ git init -q 1>/dev/null
+
+  $ mkdir sub
+  $ echo a > sub/file1
+  $ echo r > rustfile
+  $ git add .
+  $ git commit -m "initial" 1>/dev/null
+
+  $ josh-filter -s :/sub refs/heads/master --update refs/heads/filtered
+  5886bbc38681f63608dc7bb09044b2f46f092eae
+  [1] :/sub
+  [1] reachable_roots
+  [1] sequence_number
+
+Work on the filtered side
+  $ git checkout -q -b work refs/heads/filtered
+  $ echo b > file2
+  $ git add .
+  $ git commit -m "filtered side work" 1>/dev/null
+  $ git update-ref refs/heads/filtered HEAD
+
+Meanwhile a concurrent commit lands on master
+  $ git checkout -q master
+  $ echo c > sub/file3
+  $ git add .
+  $ git commit -m "concurrent master work" 1>/dev/null
+  $ export RACED_MASTER=$(git rev-parse master)
+
+Pushing without re-pulling first is refused
+  $ josh-filter -s :/sub refs/heads/master --update refs/heads/filtered --reverse
+  [2] :/sub
+  [2] reachable_roots
+  [2] sequence_number
+  ERROR: refusing non-fast-forward update of refs/heads/master -- it contains commits that the reverse apply would discard. Re-apply the filter and rebase the filtered changes onto the result, or pass --force
+  [1]
+
+  $ test $(git rev-parse master) = $RACED_MASTER && echo master-untouched
+  master-untouched
+
+With --force the update happens and the concurrent commit is discarded
+  $ josh-filter -s :/sub refs/heads/master --update refs/heads/filtered --reverse --force
+  cae93bf6a6f602f2777c66ce12a76065b21d30f9
+  [2] :/sub
+  [2] reachable_roots
+  [2] sequence_number
+
+  $ git log --graph --pretty=%s refs/heads/master
+  * filtered side work
+  * initial
+
+After a proper pull (re-filter) the same push fast-forwards cleanly
+  $ git update-ref refs/heads/master $RACED_MASTER
+  $ josh-filter -s :/sub refs/heads/master --update refs/heads/filtered2
+  6436bdb983b15392190096cc9dd832af2ae017ed
+  [2] :/sub
+  [2] reachable_roots
+  [2] sequence_number
+  $ git checkout -q -b work2 refs/heads/filtered2
+  $ echo d > file4
+  $ git add .
+  $ git commit -m "rebased filtered work" 1>/dev/null
+  $ git update-ref refs/heads/filtered2 HEAD
+  $ josh-filter -s :/sub refs/heads/master --update refs/heads/filtered2 --reverse
+  0b1cb14b07f000ffbed470ae7abc3c698ebb7781
+  [2] :/sub
+  [2] reachable_roots
+  [2] sequence_number
+
+  $ git log --graph --pretty=%s refs/heads/master
+  * rebased filtered work
+  * concurrent master work
+  * initial

--- a/tests/filter/subtree_prefix.t
+++ b/tests/filter/subtree_prefix.t
@@ -256,7 +256,7 @@ taken back into the main history.
   $ git checkout master
   Switched to branch 'master'
 
-  $ josh-filter -s $FILTER refs/heads/master --update refs/heads/subtree --reverse
+  $ josh-filter -s $FILTER refs/heads/master --update refs/heads/subtree --reverse --force
   b0a4107ddd6054442a8eaac89a2af0ab375607eb
   [11] :/subtree
   [11] :~(

--- a/tests/filter/subtree_prefix_legacy.t
+++ b/tests/filter/subtree_prefix_legacy.t
@@ -278,7 +278,7 @@ taken back into the main history.
   $ git checkout master
   Switched to branch 'master'
 
-  $ josh-filter -s $FILTER refs/heads/master --update refs/heads/subtree --reverse
+  $ josh-filter -s $FILTER refs/heads/master --update refs/heads/subtree --reverse --force
   f814033dd0148da19a3199cd3cb2d21464ce85a3
   [13] :~(
       history="keep-trivial-merges"


### PR DESCRIPTION
Refuse non-fast-forward reverse updates without --force

A reverse apply rebuilds the input reference from the pushed filtered
state and force-updated it unconditionally. Commits that landed on the
input reference after the filtered reference was created (a concurrent
commit between pull and push) are not represented in that state and were
silently discarded.

Require the rebuilt input to be a fast-forward of the current one, like
a git push, and add --force to override for deliberate history rewrites
such as amending already-pushed commits.

Change: reverse-non-ff-guard
Assisted-By: anthropic/claude-fable-5