### PR TITLE
Compile Pattern globs when the op is constructed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,6 +3202,7 @@ dependencies = [
  "git2",
  "gix-hash",
  "gix-object",
+ "glob",
  "indoc",
  "itertools 0.14.0",
  "josh-gix-ext",

--- a/josh-core/benches/deephistory_glob.rs
+++ b/josh-core/benches/deephistory_glob.rs
@@ -173,7 +173,7 @@ impl GlobBench {
             }
 
             for pattern in [PATTERN_RECURSIVE, PATTERN_PREFIX, PATTERN_LITERAL] {
-                let filter = Filter::new().pattern(pattern);
+                let filter = Filter::new().pattern(pattern).expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
                 let got = repo.find_commit(filtered)?.tree_id();
                 let (want, kept) = expected_tree(repo, case.head, &glob_pred(pattern))?;
@@ -191,7 +191,7 @@ impl GlobBench {
             // result must be exactly one top-level entry, `PREFIX_DIR`, whose oid equals the raw
             // head's subtree oid ("original path preserved, subtree taken wholesale") -- the shape
             // an identity/subtree fast path must reproduce bit-identically.
-            let filter = Filter::new().pattern(PATTERN_PREFIX);
+            let filter = Filter::new().pattern(PATTERN_PREFIX).expect("valid glob");
             let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
             let got_tree = repo.find_commit(filtered)?.tree()?;
             anyhow::ensure!(
@@ -365,7 +365,9 @@ fn deephistory_glob(c: &mut Criterion) {
     let bench = GlobBench::setup().expect("set up benchmark");
 
     // Group 1: cold-cache history scaling of the broad recursive pattern.
-    let filter = Filter::new().pattern(PATTERN_RECURSIVE);
+    let filter = Filter::new()
+        .pattern(PATTERN_RECURSIVE)
+        .expect("valid glob");
     let mut group = c.benchmark_group("deephistory_glob_recursive");
     // The longest history costs seconds per iteration, so keep Criterion at its minimum sample
     // count to bound the total wall-clock of a run.
@@ -398,7 +400,7 @@ fn deephistory_glob(c: &mut Criterion) {
     group.finish();
 
     // Group 2: cold-cache history scaling of the prefix-prunable pattern.
-    let filter = Filter::new().pattern(PATTERN_PREFIX);
+    let filter = Filter::new().pattern(PATTERN_PREFIX).expect("valid glob");
     let mut group = c.benchmark_group("deephistory_glob_prefix");
     group.sample_size(10);
     for case in &bench.cases {
@@ -424,7 +426,7 @@ fn deephistory_glob(c: &mut Criterion) {
 
     // Group 3: cold-cache history scaling of the literal-prefix pattern (only the final component
     // globs).
-    let filter = Filter::new().pattern(PATTERN_LITERAL);
+    let filter = Filter::new().pattern(PATTERN_LITERAL).expect("valid glob");
     let mut group = c.benchmark_group("deephistory_glob_literal");
     group.sample_size(10);
     for case in &bench.cases {
@@ -462,7 +464,7 @@ fn deephistory_glob(c: &mut Criterion) {
         let case = bench.cases.first().expect("at least one case");
         let transaction = bench.context.open().expect("open transaction");
         for (i, &(_, pattern)) in patterns.iter().enumerate() {
-            let filter = Filter::new().pattern(pattern);
+            let filter = Filter::new().pattern(pattern).expect("valid glob");
             let probe = make_edit_commit(&bench.repo.repo, case.head, u64::MAX - i as u64)
                 .expect("probe commit");
             let filtered =
@@ -482,7 +484,7 @@ fn deephistory_glob(c: &mut Criterion) {
     // throughput: the metric is time per incremental commit, not per history commit.
     group.sample_size(20);
     for &(label, pattern) in patterns {
-        let filter = Filter::new().pattern(pattern);
+        let filter = Filter::new().pattern(pattern).expect("valid glob");
         for case in &bench.cases {
             // Group-level warmup (once per id, NOT reset afterwards): filter the whole case
             // history so the per-iteration work is only the new tip. The cold groups above reset

--- a/josh-core/benches/widetree_glob.rs
+++ b/josh-core/benches/widetree_glob.rs
@@ -143,7 +143,9 @@ impl GlobBench {
             for case in &cases {
                 // Recursive pattern: keeps exactly the `.rs` blobs everywhere (string predicate is
                 // exact -- see the no-dot-component invariant above).
-                let filter = Filter::new().pattern(PATTERN_RECURSIVE);
+                let filter = Filter::new()
+                    .pattern(PATTERN_RECURSIVE)
+                    .expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
                 let got = repo.find_commit(filtered)?.tree_id();
                 let (want, kept) = expected_tree(repo, case.head, &|p| p.ends_with(".rs"))?;
@@ -158,7 +160,7 @@ impl GlobBench {
                 // entry, `PREFIX_DIR`, whose oid equals the raw head's subtree oid. This pins down
                 // "original path preserved, subtree taken wholesale -- NOT lifted to the root"
                 // (valid only absent dot-components).
-                let filter = Filter::new().pattern(PATTERN_PREFIX);
+                let filter = Filter::new().pattern(PATTERN_PREFIX).expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
                 let got_tree = repo.find_commit(filtered)?.tree()?;
                 anyhow::ensure!(
@@ -176,7 +178,7 @@ impl GlobBench {
                 );
 
                 // Sparse pattern: keeps exactly the N_SPARSE planted `.toml` blobs.
-                let filter = Filter::new().pattern(PATTERN_SPARSE);
+                let filter = Filter::new().pattern(PATTERN_SPARSE).expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
                 let got = repo.find_commit(filtered)?.tree_id();
                 let (want, kept) = expected_tree(repo, case.head, &|p| p.ends_with(".toml"))?;
@@ -292,7 +294,7 @@ fn widetree_glob(c: &mut Criterion) {
     ];
 
     for &(group_name, pattern) in groups {
-        let filter = Filter::new().pattern(pattern);
+        let filter = Filter::new().pattern(pattern).expect("valid glob");
         let mut group = c.benchmark_group(group_name);
         // The widest tree costs seconds per iteration, so keep Criterion at its minimum sample
         // count to bound the total wall-clock of a run.

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -14,7 +14,7 @@ pub use josh_filter::flang::parse::{get_comments, parse};
 pub use josh_filter::opt;
 pub use josh_filter::opt::invert;
 pub use josh_filter::persist::{as_tree, from_tree};
-pub use josh_filter::persist::{peel_op, to_filter, to_op, to_ops};
+pub use josh_filter::persist::{peel_filter, peel_op, to_filter, to_op, to_ops};
 pub use josh_filter::{Filter, InsertContent, LazyRef, Op, RevMatch};
 pub use josh_filter::{as_file, pretty, spec};
 
@@ -1150,7 +1150,7 @@ fn get_link_roots<'a>(
     transaction: &'a cache::Transaction,
     tree: &'a git2::Tree<'a>,
 ) -> anyhow::Result<Vec<std::path::PathBuf>> {
-    let link_filter = to_filter(Op::Pattern("**/.link.josh".to_string()));
+    let link_filter = to_filter(Op::pattern("**/.link.josh")?);
     let link_tree = apply(transaction, link_filter, Rewrite::from_tree(tree.clone()))?;
 
     let mut roots = vec![];
@@ -1362,8 +1362,7 @@ pub fn apply<'a>(
             Ok(x.with_tree(t))
         }
 
-        Op::Pattern(pattern) => {
-            let pattern = glob::Pattern::new(pattern)?;
+        Op::Pattern(glob) => {
             let options = glob::MatchOptions {
                 case_sensitive: true,
                 require_literal_separator: true,
@@ -1373,8 +1372,8 @@ pub fn apply<'a>(
                 transaction,
                 "",
                 x.tree().id(),
-                &|path, isblob| isblob && (pattern.matches_path_with(path, options)),
-                to_filter(op.clone()).id(),
+                &|path, isblob| isblob && (glob.matches_path_with(path, options)),
+                peel_filter(filter).id(),
             )?))
         }
         Op::Insert(dest_path, content) => {

--- a/josh-filter/Cargo.toml
+++ b/josh-filter/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 edition = "2024"
 
 [dependencies]
+glob = "0.3.1"
 smallvec = "1.15.1"
 pest = "2.8.6"
 pest_derive = "2.8.6"

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -209,8 +209,8 @@ impl Filter {
 
     /// Chain a filter that matches files by glob pattern
     /// Only files matching the pattern are included in the result
-    pub fn pattern(self, p: impl Into<String>) -> Filter {
-        self.chain(to_filter(Op::Pattern(p.into())))
+    pub fn pattern(self, p: impl AsRef<str>) -> anyhow::Result<Filter> {
+        Ok(self.chain(to_filter(Op::pattern(p.as_ref())?)))
     }
 
     /// Chain a filter that loads a workspace filter from a `workspace.josh` file

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -288,7 +288,7 @@ pub(crate) fn spec2(op: &Op) -> String {
         }
         Op::Prune => ":prune=trivial-merge".to_string(),
         Op::Prefix(path) => format!(":prefix={}", parse::quote_if(&path.to_string_lossy())),
-        Op::Pattern(pattern) => format!("::{}", parse::quote_if(pattern)),
+        Op::Pattern(glob) => format!("::{}", parse::quote_if(glob.as_str())),
         Op::Embed(path) => {
             format!(":embed={}", parse::quote_if(&path.to_string_lossy()),)
         }

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -201,7 +201,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
                         arg
                     ));
                 }
-                Ok(f.pattern(arg))
+                f.pattern(arg)
             } else {
                 // File case - error if source contains * (patterns not supported in source)
                 if let Some(ref source_arg) = second_arg

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -34,6 +34,35 @@ impl std::hash::Hash for Regex {
     }
 }
 
+/// Newtype around `glob::Pattern` adding structural `PartialEq`/`Eq`/`Hash` (by pattern
+/// string, like [`Regex`]) so `Op` can derive them for use as an interning key. The glob is
+/// compiled at construction -- use [`Op::pattern`] -- so applying a `Pattern` op never
+/// recompiles it, and `as_str()` recovers the source pattern verbatim (which is why
+/// `Op::Pattern` carries no separate string). Derefs to the compiled glob.
+#[derive(Clone, Debug)]
+pub struct PatternGlob(pub glob::Pattern);
+
+impl std::ops::Deref for PatternGlob {
+    type Target = glob::Pattern;
+    fn deref(&self) -> &glob::Pattern {
+        &self.0
+    }
+}
+
+impl PartialEq for PatternGlob {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_str() == other.0.as_str()
+    }
+}
+
+impl Eq for PatternGlob {}
+
+impl std::hash::Hash for PatternGlob {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.as_str().hash(state);
+    }
+}
+
 impl std::fmt::Display for LinkMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -147,7 +176,7 @@ pub enum Op {
     ObjectDeref(std::path::PathBuf),
     ObjectRef(std::path::PathBuf),
 
-    Pattern(String),
+    Pattern(PatternGlob),
     Message(String, Regex),
 
     Unapply(LazyRef, Filter),
@@ -160,4 +189,12 @@ pub enum Op {
     Pin(Filter),
 
     Downstack(LazyRef),
+}
+
+impl Op {
+    /// Construct a `Pattern` op, compiling its glob. A bad glob therefore errors where the
+    /// pattern enters the system (parse, deserialization) instead of on first apply.
+    pub fn pattern(pattern: &str) -> anyhow::Result<Op> {
+        Ok(Op::Pattern(PatternGlob(glob::Pattern::new(pattern)?)))
+    }
 }

--- a/josh-filter/src/opt/invert.rs
+++ b/josh-filter/src/opt/invert.rs
@@ -25,7 +25,7 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
                 Some(Op::File(source_path.clone(), dest_path.clone()))
             }
             Op::Prefix(path) => Some(Op::Subdir(path.clone())),
-            Op::Pattern(pattern) => Some(Op::Pattern(pattern.clone())),
+            Op::Pattern(glob) => Some(Op::Pattern(glob.clone())),
             Op::RegexReplace(_) => Some(Op::Nop),
             Op::Pin(_) => Some(Op::Nop),
             // Insert and TreeId are generative: they fabricate tree entries and consume no

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -26,11 +26,16 @@ pub fn peel_op(filter: Filter) -> Op {
 }
 
 pub fn peel_op_ref(filter: Filter) -> &'static Op {
-    let op = to_op_ref(filter);
-    if let Op::Meta(_, f) = op {
-        peel_op_ref(*f)
+    to_op_ref(peel_filter(filter))
+}
+
+/// The filter stripped of `Meta` wrappers: the node whose op `peel_op_ref` returns. Its id is
+/// the meta-independent identity of the filter, e.g. the glob cache key of a `Pattern` op.
+pub fn peel_filter(filter: Filter) -> Filter {
+    if let Op::Meta(_, f) = to_op_ref(filter) {
+        peel_filter(*f)
     } else {
-        op
+        filter
     }
 }
 
@@ -443,8 +448,8 @@ impl<'a> InMemoryBuilder<'a> {
                 let params_tree = self.build_str_params(&[path.to_string_lossy().as_ref()]);
                 push_tree_entries(&mut entries, [("embed", params_tree)]);
             }
-            Op::Pattern(pattern) => {
-                let params_tree = self.build_str_params(&[pattern.as_ref()]);
+            Op::Pattern(glob) => {
+                let params_tree = self.build_str_params(&[glob.as_str()]);
                 push_tree_entries(&mut entries, [("pattern", params_tree)]);
             }
             Op::Workspace(path) => {
@@ -849,8 +854,7 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
                     .context("pattern: missing pattern")?
                     .id(),
             )?;
-            let pattern = std::str::from_utf8(pattern_blob.content())?.to_string();
-            Ok(Op::Pattern(pattern))
+            Op::pattern(std::str::from_utf8(pattern_blob.content())?)
         }
         "workspace" => {
             let inner = repo.find_tree(entry.id())?;

--- a/josh-starlark/src/filter.rs
+++ b/josh-starlark/src/filter.rs
@@ -88,7 +88,7 @@ fn filter_methods(builder: &mut MethodsBuilder) {
         this.starlark(path, *subfilter)
     }
     fn pattern(this: &StarlarkFilter, pattern: StringValue) -> anyhow::Result<StarlarkFilter> {
-        Ok(this.pattern(pattern))
+        this.pattern(pattern)
     }
     fn workspace(this: &StarlarkFilter, path: StringValue) -> anyhow::Result<StarlarkFilter> {
         Ok(this.workspace(path))
@@ -241,10 +241,10 @@ impl StarlarkFilter {
     }
 
     /// Pattern filter
-    pub fn pattern(&self, pattern: StringValue) -> StarlarkFilter {
-        StarlarkFilter {
-            filter: self.filter.pattern(pattern.as_str()),
-        }
+    pub fn pattern(&self, pattern: StringValue) -> anyhow::Result<StarlarkFilter> {
+        Ok(StarlarkFilter {
+            filter: self.filter.pattern(pattern.as_str())?,
+        })
     }
 
     /// Workspace filter


### PR DESCRIPTION
Compile Pattern globs when the op is constructed

The Op::Pattern arm recompiled its glob with glob::Pattern::new and re-interned a clone of the
op to compute its cache key on every apply. Op::Pattern now carries a PatternGlob -- a newtype
like Regex with Eq/Hash on the source pattern, which as_str() recovers verbatim, so the variant
needs no separate string field -- compiled once in the new Op::pattern constructor. Bad globs
error where the pattern enters the system (parse or filter deserialization) instead of on first
apply; Filter::pattern and its starlark binding become fallible, and the glob benches unwrap
the now-fallible construction. The cache key is the peeled filter's id -- new helper
peel_filter, with the id memoized on the interned node -- so applies do no interning or
hashing at all.

Filtered results are bit-identical; perf effect alone is minor (one glob compile and one intern
lookup saved per apply), measured only together with pattern-arm-alloc-fixes on top.

Change: pattern-glob-in-op
Assisted-By: Claude Fable 5 (claude-fable-5)