### PR TITLE
Support publishing josh changes from a fork

### DIFF
--- a/docs/src/guide/stacked-changes.md
+++ b/docs/src/guide/stacked-changes.md
@@ -174,6 +174,27 @@ This rebases your remaining local commits on top of the updated upstream state.
 pulling, the next `josh changes publish` will retarget and promote the next PR in the stack
 from draft to ready for review.
 
+## Publishing from a fork
+
+If you cannot push to the target repository, point Josh at your own fork as a separate
+push destination while still opening all pull requests against the target. Configure the
+fork when adding the remote:
+
+```shell
+josh clone https://github.com/UPSTREAM/repo :/ work --push-url https://github.com/ME/repo
+```
+
+(or `josh remote add <name> <upstream-url> <filter> --push-url <fork-url>` for an existing
+repository). `josh changes publish` then pushes the `@changes/…` refs to your fork, and
+opens each pull request against the upstream repository with a cross-fork head
+(`ME:@changes/…`).
+
+Because a pull request's base branch must live in the repository the PR targets, fork
+pull requests base on the upstream **default branch** rather than on an intermediate
+`@base/…` branch. A change that still depends on unmerged predecessors is opened as a
+**draft** — its diff temporarily includes those predecessors — and is promoted to ready
+automatically once they merge and you re-publish.
+
 ## Without forge integration
 
 `josh changes publish` works without [forge integration](../reference/forge.md). Josh still

--- a/docs/src/reference/forge.md
+++ b/docs/src/reference/forge.md
@@ -56,3 +56,24 @@ Once authenticated, `josh changes publish` will, in addition to pushing the git 
   once they target the default branch directly.
 
 See the [Stacked changes](../guide/stacked-changes.md) guide for a full walkthrough.
+
+### Publishing from a fork
+
+When you do not have push access to the target repository, configure a separate **push
+URL** (your fork) with `--push-url` on `josh remote add` (or `josh clone`):
+
+```shell
+josh clone https://github.com/UPSTREAM/repo :/ work --push-url https://github.com/ME/repo
+```
+
+Change branches are then pushed to your fork while the pull requests — including upstack
+drafts — are opened against the upstream repository with a cross-fork head
+(`ME:@changes/…`). The push URL is stored as a `push` meta key in the remote config file
+(`<git-common-dir>/josh/remotes/<name>.josh`), analogous to git's
+`remote.<name>.pushurl`.
+
+Because a GitHub pull request's base branch must live in the repository the PR is opened
+against, fork PRs always target the upstream **default branch**. A change that still
+depends on unmerged predecessors is opened as a **draft** (its diff temporarily includes
+those dependencies) and is automatically promoted to "ready for review" once they merge
+and you re-publish.

--- a/forges/josh-github-changes/src/lib.rs
+++ b/forges/josh-github-changes/src/lib.rs
@@ -73,41 +73,112 @@ pub fn collect_pr_infos(repo: &git2::Repository, to_push: &[josh_changes::PushRe
         .collect()
 }
 
+/// The base branch, draft state, and head ref chosen for a single PR.
+#[derive(Debug, PartialEq)]
+struct PrPlan {
+    base_branch: String,
+    draft: bool,
+    head_ref: String,
+}
+
+/// Decide how a change's PR should be targeted.
+///
+/// `default_branch` is the target repo's `(name, tip_oid)`, if known. `fork_owner`
+/// is set when the head branch lives in a fork, in which case the head is
+/// namespaced as `fork_owner:branch` and the PR must base on the target's
+/// default branch (a PR base cannot live in a fork). Returns `None` when a
+/// cross-fork PR is requested but the target default branch is unknown.
+fn plan_pr(
+    info: &PrInfo,
+    default_branch: Option<&(String, String)>,
+    fork_owner: Option<&str>,
+) -> Option<PrPlan> {
+    let head_ref = match fork_owner {
+        Some(fork_owner) => format!("{}:{}", fork_owner, info.head_branch),
+        None => info.head_branch.clone(),
+    };
+
+    // Fork-mode PRs can only base on a branch that exists in the target repo,
+    // so they always base on its default branch; the change is a draft while its
+    // base still lags the default branch tip (i.e. it depends on unmerged work).
+    if fork_owner.is_some() {
+        let (default_name, default_oid) = default_branch?;
+        return Some(PrPlan {
+            base_branch: default_name.clone(),
+            draft: info.base_oid.to_string() != *default_oid,
+            head_ref,
+        });
+    }
+
+    // Same-repo PRs may base on the synthetic `@base/…` branch pushed alongside.
+    let base_branch = match default_branch {
+        Some((default_name, default_oid)) if info.base_oid.to_string() == *default_oid => {
+            default_name.clone()
+        }
+        _ => info.base_branch.clone(),
+    };
+    let draft = match default_branch {
+        Some((default_name, _)) => base_branch != *default_name,
+        None => base_branch == info.base_branch,
+    };
+    Some(PrPlan {
+        base_branch,
+        draft,
+        head_ref,
+    })
+}
+
+/// Create or update GitHub PRs for a set of changes.
+///
+/// `url` is the PR target (upstream). When `fork_url` is `Some`, the change
+/// branches live in that fork and PRs are opened with a cross-fork head
+/// (`fork_owner:branch`). Because a PR's base branch must live in the target
+/// repo, fork-mode PRs always base on the target's default branch; a change
+/// whose base is not yet the default branch tip (i.e. it still depends on
+/// unmerged changes) is opened as a draft.
 pub async fn create_or_update_prs(
     connection: &GithubApiConnection,
     url: &str,
+    fork_url: Option<&str>,
     pr_infos: &[PrInfo],
     dry_run: bool,
 ) -> anyhow::Result<()> {
     let (owner, repo_name) = crate::repo::parse_owner_repo(url)?;
 
+    let fork = fork_url.map(crate::repo::parse_owner_repo).transpose()?;
+    let fork_owner = fork.as_ref().map(|(o, _)| o.as_str());
+
     let repository_id = connection.get_repo_id(&owner, &repo_name).await?;
     let default_branch = connection.get_default_branch(&owner, &repo_name).await?;
 
     for info in pr_infos {
-        let effective_base_branch = match &default_branch {
-            Some((default_name, default_oid)) if info.base_oid.to_string() == *default_oid => {
-                default_name.as_str()
+        let plan = match plan_pr(info, default_branch.as_ref(), fork_owner) {
+            Some(plan) => plan,
+            None => {
+                eprintln!(
+                    "Skipping PR for {}: target default branch is unknown, \
+                     cannot open a cross-fork PR",
+                    info.head_branch
+                );
+                continue;
             }
-            _ => info.base_branch.as_str(),
         };
-        let desired_draft = match &default_branch {
-            Some((default_name, _)) => effective_base_branch != default_name.as_str(),
-            None => effective_base_branch == info.base_branch.as_str(),
-        };
+        let effective_base_branch = plan.base_branch.as_str();
+        let desired_draft = plan.draft;
+        let head_ref_for_create = plan.head_ref;
 
         if dry_run {
             match connection
-                .find_pull_request_by_head(&owner, &repo_name, &info.head_branch)
+                .find_pull_request_by_head(&owner, &repo_name, &info.head_branch, fork_owner)
                 .await
             {
                 Ok(Some((_, number, is_draft))) => eprintln!(
                     "Would update PR #{}: {} → {} (draft: {} → {})",
-                    number, info.head_branch, effective_base_branch, is_draft, desired_draft
+                    number, head_ref_for_create, effective_base_branch, is_draft, desired_draft
                 ),
                 Ok(None) => eprintln!(
                     "Would create PR: {} → {} (draft: {})",
-                    info.head_branch, effective_base_branch, desired_draft
+                    head_ref_for_create, effective_base_branch, desired_draft
                 ),
                 Err(e) => eprintln!("Failed to look up PR for {}: {}", info.head_branch, e),
             }
@@ -115,7 +186,7 @@ pub async fn create_or_update_prs(
         }
 
         match connection
-            .find_pull_request_by_head(&owner, &repo_name, &info.head_branch)
+            .find_pull_request_by_head(&owner, &repo_name, &info.head_branch, fork_owner)
             .await
         {
             Ok(Some((pr_id, number, is_draft))) => {
@@ -166,7 +237,7 @@ pub async fn create_or_update_prs(
                     .create_pull_request(
                         &repository_id,
                         effective_base_branch,
-                        &info.head_branch,
+                        &head_ref_for_create,
                         &info.title,
                         &info.body,
                         desired_draft,
@@ -279,7 +350,7 @@ pub async fn sync_change_comments(
     };
 
     let pr = match connection
-        .find_pull_request_by_head(owner, repo_name, head_ref)
+        .find_pull_request_by_head(owner, repo_name, head_ref, None)
         .await?
     {
         Some((_node_id, number, _draft)) => {
@@ -489,4 +560,68 @@ pub async fn post_local_votes(
     josh_changes::cleanup_posted_outbox_votes(repo, change_id, remote_scope)?;
 
     Ok(posted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TIP: &str = "1111111111111111111111111111111111111111";
+    const OTHER: &str = "2222222222222222222222222222222222222222";
+
+    fn pr_info(base_oid: &str) -> PrInfo {
+        PrInfo {
+            head_branch: "@changes/main/a@b.com/feature".to_string(),
+            base_branch: "@base/main/a@b.com/feature".to_string(),
+            base_oid: git2::Oid::from_str(base_oid).unwrap(),
+            title: "t".to_string(),
+            body: "b".to_string(),
+        }
+    }
+
+    fn default_branch() -> (String, String) {
+        ("main".to_string(), TIP.to_string())
+    }
+
+    #[test]
+    fn fork_change_on_default_is_ready_against_default() {
+        let info = pr_info(TIP);
+        let plan = plan_pr(&info, Some(&default_branch()), Some("forkowner")).unwrap();
+        assert_eq!(plan.base_branch, "main");
+        assert!(!plan.draft);
+        assert_eq!(plan.head_ref, "forkowner:@changes/main/a@b.com/feature");
+    }
+
+    #[test]
+    fn fork_dependent_change_is_draft_against_default() {
+        let info = pr_info(OTHER);
+        let plan = plan_pr(&info, Some(&default_branch()), Some("forkowner")).unwrap();
+        assert_eq!(plan.base_branch, "main");
+        assert!(plan.draft);
+        assert_eq!(plan.head_ref, "forkowner:@changes/main/a@b.com/feature");
+    }
+
+    #[test]
+    fn fork_without_known_default_is_skipped() {
+        let info = pr_info(TIP);
+        assert_eq!(plan_pr(&info, None, Some("forkowner")), None);
+    }
+
+    #[test]
+    fn same_repo_bottom_change_bases_on_default() {
+        let info = pr_info(TIP);
+        let plan = plan_pr(&info, Some(&default_branch()), None).unwrap();
+        assert_eq!(plan.base_branch, "main");
+        assert!(!plan.draft);
+        assert_eq!(plan.head_ref, "@changes/main/a@b.com/feature");
+    }
+
+    #[test]
+    fn same_repo_stacked_change_bases_on_synthetic_branch_as_draft() {
+        let info = pr_info(OTHER);
+        let plan = plan_pr(&info, Some(&default_branch()), None).unwrap();
+        assert_eq!(plan.base_branch, "@base/main/a@b.com/feature");
+        assert!(plan.draft);
+        assert_eq!(plan.head_ref, "@changes/main/a@b.com/feature");
+    }
 }

--- a/forges/josh-github-codegen-graphql/src/get_pr_by_head.graphql
+++ b/forges/josh-github-codegen-graphql/src/get_pr_by_head.graphql
@@ -1,10 +1,15 @@
 query GetPrByHead($owner: String!, $name: String!, $headRefName: String!) {
   repository(owner: $owner, name: $name) {
-    pullRequests(first: 1, headRefName: $headRefName, states: [OPEN]) {
+    pullRequests(first: 10, headRefName: $headRefName, states: [OPEN]) {
       nodes {
         id
         number
         isDraft
+        isCrossRepository
+        headRepositoryOwner {
+          __typename
+          login
+        }
       }
     }
   }

--- a/forges/josh-github-graphql/src/operations/pull_request.rs
+++ b/forges/josh-github-graphql/src/operations/pull_request.rs
@@ -75,11 +75,17 @@ pub struct PrSummary {
 
 impl GithubApiConnection {
     /// Find an open PR by head branch name. Returns (node_id, number, is_draft) if found.
+    ///
+    /// `head_owner`, when set, restricts the match to a PR whose head lives in
+    /// that owner's repository — needed to disambiguate cross-fork PRs, where
+    /// several forks may push the same head branch name. When `None`, the first
+    /// open PR with the given head branch name is returned.
     pub async fn find_pull_request_by_head(
         &self,
         owner: &str,
         name: &str,
         head_ref_name: &str,
+        head_owner: Option<&str>,
     ) -> anyhow::Result<Option<(String, i64, bool)>> {
         let variables = get_pr_by_head::Variables {
             owner: owner.to_string(),
@@ -92,7 +98,13 @@ impl GithubApiConnection {
             None => return Ok(None),
         };
         let nodes = repo.pull_requests.nodes.unwrap_or_default();
-        let pr = nodes.into_iter().flatten().next();
+        let pr = nodes.into_iter().flatten().find(|n| match head_owner {
+            Some(head_owner) => n
+                .head_repository_owner
+                .as_ref()
+                .is_some_and(|o| o.login == head_owner),
+            None => true,
+        });
         Ok(pr.map(|n| (n.id, n.number, n.is_draft)))
     }
 

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -97,6 +97,12 @@ pub struct CloneArgs {
     #[arg(short = 'b', long = "branch", default_value = "HEAD")]
     pub branch: String,
 
+    /// Separate push destination (a fork) for `josh changes publish`.
+    ///
+    /// See `josh remote add --push-url`.
+    #[arg(long = "push-url")]
+    pub push_url: Option<String>,
+
     #[command(flatten)]
     pub forge_args: ForgeArgs,
 }
@@ -175,6 +181,14 @@ pub struct RemoteAddArgs {
     /// Workspace/projection identifier or path to spec
     #[arg()]
     pub filter: String,
+
+    /// Separate push destination (a fork) for `josh changes publish`.
+    ///
+    /// When set, change branches are pushed here while the main URL stays the
+    /// fetch source and pull-request target. Pull requests (including upstack
+    /// drafts) are opened against the main URL with a cross-fork head.
+    #[arg(long = "push-url")]
+    pub push_url: Option<String>,
 
     #[command(flatten)]
     pub forge_args: ForgeArgs,
@@ -337,6 +351,7 @@ fn clone_repo(args: &CloneArgs) -> anyhow::Result<std::path::PathBuf> {
         name: "origin".to_string(),
         url: to_absolute_remote_url(&args.url)?,
         filter: args.filter.clone(),
+        push_url: args.push_url.clone(),
         forge_args: args.forge_args.clone(),
     };
 
@@ -567,6 +582,12 @@ fn handle_remote_add_repo(args: &RemoteAddArgs, repo_path: &std::path::Path) -> 
             .or_else(|| josh_cli::forge::guess_forge(&remote_url))
     };
 
+    let push_url = args
+        .push_url
+        .as_deref()
+        .map(to_absolute_remote_url)
+        .transpose()?;
+
     // Write remote config to .git/josh/remotes/<name>.josh
     write_remote_config(
         repo_path,
@@ -575,6 +596,7 @@ fn handle_remote_add_repo(args: &RemoteAddArgs, repo_path: &std::path::Path) -> 
         &filter_to_store,
         &refspec,
         forge,
+        push_url.as_deref(),
     )
     .context("Failed to write remote config file")?;
 

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -286,9 +286,13 @@ fn push_refs(
 }
 
 /// Create or update GitHub PRs for the collected push refs.
+///
+/// `url` is the PR target (upstream). `fork_url`, when set, is the repo the
+/// change branches were pushed to; PRs are then opened with a cross-fork head.
 fn create_prs(
     pr_infos: &[josh_github_changes::PrInfo],
     url: &str,
+    fork_url: Option<&str>,
     dry_run: bool,
 ) -> anyhow::Result<()> {
     if pr_infos.is_empty() {
@@ -303,7 +307,8 @@ fn create_prs(
         let api_connection = github::make_api_connection().await;
         let api_connection = api_connection.with_context(|| github::api_connection_hint())?;
 
-        josh_github_changes::create_or_update_prs(&api_connection, url, pr_infos, dry_run).await
+        josh_github_changes::create_or_update_prs(&api_connection, url, fork_url, pr_infos, dry_run)
+            .await
     }) {
         eprintln!("Warning: failed to create/update GitHub PRs: {}", e);
     }
@@ -330,7 +335,16 @@ fn orchestrate_push(
     let config = read_remote_config(&repo_path, remote_name)
         .with_context(|| format!("Failed to read remote config for '{}'", remote_name))?;
     let filter = config.semantic_filter();
-    let RemoteConfig { url, forge, .. } = config;
+    let RemoteConfig {
+        url,
+        forge,
+        push_url,
+        ..
+    } = config;
+
+    // Branches go to the fork (push_url) when configured; otherwise to `url`.
+    // PRs are always opened against `url`.
+    let push_target = push_url.as_deref().unwrap_or(&url);
 
     let refspecs = if refspecs_arg.is_empty() {
         let head = repo.head().context("Failed to get HEAD")?;
@@ -384,13 +398,13 @@ fn orchestrate_push(
         transaction,
         remote_name,
         &to_push,
-        &url,
+        push_target,
         force,
         atomic,
         dry_run,
     )?;
 
-    create_prs(&pr_infos, &url, dry_run)?;
+    create_prs(&pr_infos, &url, push_url.as_deref(), dry_run)?;
 
     Ok(())
 }

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -463,7 +463,7 @@ pub fn handle_sync(
                     };
 
                     match api
-                        .find_pull_request_by_head(&owner, &repo_name, &pr.head_ref_name)
+                        .find_pull_request_by_head(&owner, &repo_name, &pr.head_ref_name, None)
                         .await
                     {
                         Ok(Some((pr_node_id, _, _))) => {

--- a/josh-cli/src/config.rs
+++ b/josh-cli/src/config.rs
@@ -3,13 +3,17 @@ use anyhow::{Context, anyhow};
 use crate::forge::Forge;
 
 /// Meta keys that configure the remote itself rather than the filter semantics.
-pub const TRANSPORT_META_KEYS: &[&str] = &["url", "fetch", "forge"];
+pub const TRANSPORT_META_KEYS: &[&str] = &["url", "fetch", "forge", "push"];
 
 pub struct RemoteConfig {
     pub url: String,
     pub ref_spec: String,
     pub filter_with_meta: josh_core::filter::Filter,
     pub forge: Option<Forge>,
+    /// Optional separate push destination (a fork). When set, branches are
+    /// pushed here while `url` remains the fetch source and PR target. Analogous
+    /// to git's `remote.<name>.pushurl`.
+    pub push_url: Option<String>,
 }
 
 impl RemoteConfig {
@@ -70,8 +74,16 @@ pub fn migrate_legacy_config(
         .with_context(|| format!("Legacy config missing fetch for remote '{}'", remote_name))?;
 
     // Migrate to new format by writing the file
-    write_remote_config(repo_path, remote_name, &url, &filter_str, &fetch, None)
-        .context("Failed to migrate legacy config to new format")?;
+    write_remote_config(
+        repo_path,
+        remote_name,
+        &url,
+        &filter_str,
+        &fetch,
+        None,
+        None,
+    )
+    .context("Failed to migrate legacy config to new format")?;
 
     // Parse the filter to return
     let filter_obj = josh_core::filter::parse(&filter_str)
@@ -89,6 +101,7 @@ pub fn migrate_legacy_config(
         ref_spec: fetch,
         filter_with_meta,
         forge: None,
+        push_url: None,
     })
 }
 
@@ -138,11 +151,14 @@ pub fn read_remote_config(
         .transpose()
         .map_err(|f| anyhow!("Unknown forge: {f}"))?;
 
+    let push_url = filter.get_meta("push");
+
     Ok(RemoteConfig {
         url,
         ref_spec: fetch,
         filter_with_meta: filter,
         forge,
+        push_url,
     })
 }
 
@@ -154,6 +170,7 @@ pub fn write_remote_config(
     filter: &str,
     fetch: &str,
     forge: Option<Forge>,
+    push_url: Option<&str>,
 ) -> anyhow::Result<()> {
     let remotes_dir = remotes_dir(repo_path)?;
 
@@ -185,6 +202,10 @@ pub fn write_remote_config(
 
     if let Some(forge) = forge {
         filter_with_meta = filter_with_meta.with_meta("forge", forge.to_string());
+    }
+
+    if let Some(push_url) = push_url {
+        filter_with_meta = filter_with_meta.with_meta("push", push_url);
     }
 
     // Serialize the filter with metadata

--- a/tests/cli/push_stacked_fork.t
+++ b/tests/cli/push_stacked_fork.t
@@ -1,0 +1,81 @@
+Publishing from a fork: change branches are pushed to the fork (push-url),
+while the upstream repo receives nothing.
+
+  $ export TESTTMP=${PWD}
+
+Create an upstream bare repo with initial content
+
+  $ git init -q --bare upstream
+  $ git init -q seed
+  $ cd seed
+  $ mkdir -p sub1
+  $ echo "file1 content" > sub1/file1
+  $ git add .
+  $ git commit -q -m "add file1"
+  $ git remote add origin ${TESTTMP}/upstream
+  $ git push -q origin master
+  $ cd ..
+
+Create an empty bare fork to receive the pushed change branches
+
+  $ git init -q --bare fork
+
+Clone with a filter and a separate push-url pointing at the fork
+
+  $ josh clone ${TESTTMP}/upstream :/sub1 filtered --push-url ${TESTTMP}/fork
+  Added remote 'origin' with filter ':/sub1'
+  From file://${TESTTMP}/upstream
+   * [new branch]      master     -> refs/josh/remotes/origin/master
+  
+  From file://${TESTTMP}/filtered
+   * [new branch]      master     -> origin/master
+  
+  Fetched from remote: origin
+  Already on 'master'
+  
+  Cloned repository to: ${TESTTMP}/filtered/
+  $ cd filtered
+
+Make two stacked changes
+
+  $ echo "contents2" > file2
+  $ git add file2
+  $ git commit -q -m "Change-Id: 1234"
+  $ echo "contents3" > file3
+  $ git add file3
+  $ git commit -q -m "Change-Id: foo7"
+  $ git config user.email "josh@example.com"
+  $ git config user.name "Josh Test"
+
+Publish the stack; branches are routed to the fork
+
+  $ josh changes publish
+  Pushing 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/1234
+  Pushing 115b269a011d493259a125fa941fd790b903175f to origin/refs/heads/@base/master/josh@example.com/foo7
+  Pushing 478c423aa5b34433bcb04513deb8f788958099c1 to origin/refs/heads/@changes/master/josh@example.com/1234
+  Pushing 225aa057b057ef4fafbc2cd6916680e176dc4152 to origin/refs/heads/@changes/master/josh@example.com/foo7
+  Pushing 39844a5762c65ef897eb0d7efcfa446d5d99fcea to origin/refs/heads/@heads/master/josh@example.com
+  To file://${TESTTMP}/fork
+   * [new branch]      115b269a011d493259a125fa941fd790b903175f -> @base/master/josh@example.com/1234
+   * [new branch]      115b269a011d493259a125fa941fd790b903175f -> @base/master/josh@example.com/foo7
+   * [new branch]      478c423aa5b34433bcb04513deb8f788958099c1 -> @changes/master/josh@example.com/1234
+   * [new branch]      225aa057b057ef4fafbc2cd6916680e176dc4152 -> @changes/master/josh@example.com/foo7
+   * [new branch]      39844a5762c65ef897eb0d7efcfa446d5d99fcea -> @heads/master/josh@example.com
+  
+  Pushed 5 ref(s) to origin
+  Fetched from remote: origin
+
+The upstream repo must NOT have received any change refs (only master)
+
+  $ git ls-remote ${TESTTMP}/upstream
+  115b269a011d493259a125fa941fd790b903175f\tHEAD (esc)
+  115b269a011d493259a125fa941fd790b903175f\trefs/heads/master (esc)
+
+The fork must have received the @changes / @base / @heads refs
+
+  $ git ls-remote ${TESTTMP}/fork
+  115b269a011d493259a125fa941fd790b903175f\trefs/heads/@base/master/josh@example.com/1234 (esc)
+  115b269a011d493259a125fa941fd790b903175f\trefs/heads/@base/master/josh@example.com/foo7 (esc)
+  478c423aa5b34433bcb04513deb8f788958099c1\trefs/heads/@changes/master/josh@example.com/1234 (esc)
+  225aa057b057ef4fafbc2cd6916680e176dc4152\trefs/heads/@changes/master/josh@example.com/foo7 (esc)
+  39844a5762c65ef897eb0d7efcfa446d5d99fcea\trefs/heads/@heads/master/josh@example.com (esc)


### PR DESCRIPTION
Support publishing josh changes from a fork

Add an optional per-remote push URL so `josh changes publish` can push change
branches to a fork while opening all pull requests — including upstack drafts —
against the target repository.

The push URL is stored as a `push` meta key in the remote config and set via
`josh remote add --push-url` (or `josh clone --push-url`). When present, branches
go to the fork and PRs are opened against the main URL with a cross-fork head
(`fork_owner:@changes/...`). Because a pull request's base branch must live in the
target repo, fork PRs base on the target's default branch; a change that still
depends on unmerged predecessors is opened as a draft and promoted once they merge.

PR lookup now disambiguates by head repository owner so that same-named branches
across forks do not collide.

Assisted-By: anthropic/claude-opus-4-8
Change: changes-publish-fork