### PR TITLE
Support publishing josh changes to Gerrit

### DIFF
--- a/docs/src/guide/stacked-changes.md
+++ b/docs/src/guide/stacked-changes.md
@@ -195,6 +195,31 @@ pull requests base on the upstream **default branch** rather than on an intermed
 **draft** — its diff temporarily includes those predecessors — and is promoted to ready
 automatically once they merge and you re-publish.
 
+## Publishing to Gerrit
+
+Select the Gerrit forge when cloning (it cannot be auto-detected from the URL):
+
+```shell
+josh clone https://gerrit.example.com/repo :/ work --forge gerrit
+```
+
+`josh changes publish` then pushes to Gerrit's magic ref `refs/for/<branch>`, where the
+push itself creates or updates the review. No `@changes/@base` refs are written and no
+forge API is called, so there is nothing to `josh auth login`: authentication is handled
+by git (your SSH key or HTTP credential helper).
+
+Two publish modes are available, selected with `--gerrit-mode` and stored per-remote:
+
+- **`independent`** (default) publishes only the changes that have no unmerged
+  dependencies, each as its own separately-submittable review; dependent changes wait
+  until their predecessors merge.
+- **`stack`** publishes the whole history at once as a single Gerrit relation chain.
+
+Josh generates the required `Change-Id: I<40 hex>` trailer for every pushed commit,
+deterministically derived from the change's josh id — re-publishing therefore lands as a
+new patchset on the same Gerrit change rather than a duplicate. See the
+[forge reference](../reference/forge.md#gerrit) for details.
+
 ## Without forge integration
 
 `josh changes publish` works without [forge integration](../reference/forge.md). Josh still

--- a/docs/src/reference/forge.md
+++ b/docs/src/reference/forge.md
@@ -1,17 +1,21 @@
 # Forge Integration
 
 Forge integration is an **optional** feature that connects `josh` to a code hosting
-platform (a "forge") such as GitHub. It is not required for normal git operations —
-cloning, pushing, and pulling all work without it, even with private repositories.
+platform (a "forge") such as GitHub or Gerrit. It is not required for normal git
+operations — cloning, pushing, and pulling all work without it, even with private
+repositories.
 
-Forge integration is specifically used for **automatic pull request management** during
-[stacked changes](../guide/stacked-changes.md) workflows. When you push a stack of
-commits with `josh changes publish`, `josh` can automatically
-create or update one pull request per commit on the forge.
+Forge integration shapes how `josh changes publish` turns a stack of commits into
+reviews. On GitHub it manages one pull request per commit; on Gerrit it pushes each
+change to the server's magic `refs/for/<branch>` ref, where the push itself creates or
+updates the review.
+
+The forge is chosen per remote with `--forge <github|gerrit>` on `josh clone` /
+`josh remote add`. GitHub is auto-detected from the URL; Gerrit is not identifiable from
+a URL and must be selected explicitly. It is stored as a `forge` meta key in the remote
+config file (`<git-common-dir>/josh/remotes/<name>.josh`).
 
 ## GitHub
-
-GitHub is currently the only supported forge.
 
 ### Authentication
 
@@ -77,3 +81,48 @@ against, fork PRs always target the upstream **default branch**. A change that s
 depends on unmerged predecessors is opened as a **draft** (its diff temporarily includes
 those dependencies) and is automatically promoted to "ready for review" once they merge
 and you re-publish.
+
+## Gerrit
+
+Gerrit is selected explicitly, since a Gerrit server cannot be recognized from its URL:
+
+```shell
+josh clone https://gerrit.example.com/repo :/ work --forge gerrit
+```
+
+### Authentication
+
+Gerrit publishing is a plain `git push` to the server's magic `refs/for/<branch>` ref,
+so `josh` manages **no** Gerrit credentials — authentication is handled by git itself
+(an SSH key, or an HTTP credential helper with your Gerrit HTTP password). There is
+nothing to `josh auth login`.
+
+### What forge integration enables
+
+With the Gerrit forge selected, `josh changes publish` pushes to `refs/for/<branch>`
+instead of GitHub's `@changes`/`@base` ref pairs. No API call is made — the push itself
+creates or updates the reviews.
+
+### Publish modes
+
+Because Gerrit keys a change by its `Change-Id` and expects it to appear exactly once
+with a single parent, josh's `downstack` model (where one change can belong to several
+stacks with differing ancestry) cannot be mapped onto Gerrit one-to-one. Two modes
+resolve this, selected per remote with `--gerrit-mode` on `josh clone` /
+`josh remote add` and stored as a `gerrit-mode` meta key:
+
+- **`independent`** (default) — push only the changes that have **no dependencies**:
+  those sitting directly on the target base. Each becomes its own independent, separately
+  submittable review (one `git push` per change). A change that still depends on unmerged
+  work is skipped until its dependencies merge and it becomes a root itself. Because only
+  roots are pushed, no change is ever duplicated across stacks.
+- **`stack`** — push the entire commit history once as a single Gerrit **relation
+  chain**: one change per commit, each with exactly one parent. This publishes the whole
+  stack at once, at the cost of Gerrit ordering the changes (they submit bottom-up).
+
+In both modes, Gerrit requires every pushed commit to carry a `Change-Id: I<40 hex>`
+trailer. `josh` generates one automatically, derived deterministically from the change's
+josh id (and reused as-is if the commit already carries a valid Gerrit Change-Id). The
+deterministic derivation is what makes re-publishing land as a **new patchset on the same
+Gerrit change** rather than creating a duplicate. The trailer is written only onto the
+commits that are pushed; your local history is left untouched.

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -388,6 +388,210 @@ pub fn build_to_push(
     }
 }
 
+/// A valid Gerrit Change-Id is the letter `I` followed by 40 hex digits.
+fn is_gerrit_change_id(id: &str) -> bool {
+    let bytes = id.as_bytes();
+    bytes.len() == 41 && bytes[0] == b'I' && bytes[1..].iter().all(u8::is_ascii_hexdigit)
+}
+
+/// Map a josh change id to a Gerrit-format Change-Id (`I` + 40 hex).
+///
+/// If the josh id already looks like a Gerrit Change-Id it is used verbatim.
+/// Otherwise the id is derived deterministically by hashing the josh id, so
+/// re-publishing an unchanged change lands as a new patchset on the *same*
+/// Gerrit change rather than creating a duplicate.
+fn gerrit_change_id(josh_id: &str) -> anyhow::Result<String> {
+    if is_gerrit_change_id(josh_id) {
+        return Ok(josh_id.to_string());
+    }
+    let oid = git2::Oid::hash_object(git2::ObjectType::Blob, josh_id.as_bytes())
+        .map_err(|e| anyhow!("failed to derive Gerrit Change-Id: {}", e))?;
+    Ok(format!("I{}", oid))
+}
+
+/// Return `message` with any existing `Change:`/`Change-Id:` trailer replaced by
+/// a single `Change-Id: <gerrit_id>` trailer in the footer block.
+fn message_with_gerrit_change_id(message: &str, gerrit_id: &str) -> String {
+    let lines: Vec<&str> = message.lines().collect();
+
+    // Find the footer block the same way `parse_change_meta` does.
+    let mut footer_start = lines.len();
+    for (i, line) in lines.iter().enumerate().rev() {
+        if line.is_empty() || josh_core::trailers::is_trailer_line(line) {
+            footer_start = i;
+        } else {
+            break;
+        }
+    }
+
+    let mut kept: Vec<&str> = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        if i >= footer_start && (line.starts_with("Change: ") || line.starts_with("Change-Id: ")) {
+            continue;
+        }
+        kept.push(line);
+    }
+    while matches!(kept.last(), Some(l) if l.is_empty()) {
+        kept.pop();
+    }
+
+    let trailer = format!("Change-Id: {}", gerrit_id);
+    if kept.is_empty() {
+        return trailer;
+    }
+
+    let mut body = kept.join("\n");
+    if josh_core::trailers::is_trailer_line(kept.last().unwrap()) {
+        // Extend the existing trailer block.
+        body.push('\n');
+    } else {
+        // Start a fresh footer block after the message body.
+        body.push_str("\n\n");
+    }
+    body.push_str(&trailer);
+    body
+}
+
+/// Rewrite the linear first-parent chain `(base, tip]` so every commit carries a
+/// deterministic Gerrit `Change-Id` trailer, and return the new tip oid.
+///
+/// Commits are rebuilt bottom-up with their trees preserved. The Change-Id is
+/// derived from each commit's josh change id, so an unchanged change rewrites to
+/// a stable id and re-publishing lands as a new patchset on the same Gerrit
+/// change rather than a duplicate.
+fn rewrite_chain_with_gerrit_ids(
+    repo: &git2::Repository,
+    tip: git2::Oid,
+    base: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    // Collect the chain from tip down to (but excluding) base, first parent only.
+    let mut chain: Vec<git2::Oid> = Vec::new();
+    let mut cur = tip;
+    while cur != base {
+        chain.push(cur);
+        match repo.find_commit(cur)?.parent_ids().next() {
+            Some(p) => cur = p,
+            None => break,
+        }
+    }
+    chain.reverse();
+
+    let mut new_parent = (base != git2::Oid::ZERO_SHA1).then_some(base);
+    for oid in chain {
+        let commit = repo.find_commit(oid)?;
+        let (josh_id, _) = josh_core::trailers::commit_change_meta(&commit);
+        // A commit with no josh change id gets one derived from its own oid: rare
+        // for a change stack, but Gerrit requires a Change-Id on every commit.
+        let gerrit_id = gerrit_change_id(josh_id.as_deref().unwrap_or(&oid.to_string()))?;
+        let new_message = message_with_gerrit_change_id(commit.message().unwrap_or(""), &gerrit_id);
+
+        let parents: Vec<git2::Commit> = new_parent
+            .map(|p| repo.find_commit(p))
+            .transpose()?
+            .into_iter()
+            .collect();
+        let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+        new_parent = Some(repo.commit(
+            None,
+            &commit.author(),
+            &commit.committer(),
+            &new_message,
+            &commit.tree()?,
+            &parent_refs,
+        )?);
+    }
+
+    Ok(new_parent.unwrap_or(base))
+}
+
+/// Build the ref to push when publishing a stacked change series to a Gerrit
+/// server.
+///
+/// Unlike the GitHub path, which splits each change into an independent
+/// `downstack` diff, Gerrit publishing pushes the **actual linear commit
+/// history** `(base, tip]` once to `refs/for/<branch>`. Gerrit then makes one
+/// change per commit and chains them into a relation chain by commit ancestry.
+///
+/// This is deliberate: Gerrit keys a change by its `Change-Id` and expects it to
+/// appear exactly once with a single parent. The `downstack` model, where one
+/// change can belong to several stacks with differing ancestry, cannot be
+/// represented consistently in Gerrit -- so we push the real history instead,
+/// where every change appears once with exactly one parent. Each commit is
+/// rewritten to carry a deterministic Gerrit `Change-Id`.
+pub fn build_gerrit_push(
+    repo: &git2::Repository,
+    branch: &str,
+    tip: git2::Oid,
+    base: git2::Oid,
+) -> anyhow::Result<Vec<PushRef>> {
+    if tip == base {
+        return Ok(vec![]);
+    }
+
+    let new_tip = rewrite_chain_with_gerrit_ids(repo, tip, base)?;
+    Ok(vec![PushRef {
+        ref_name: format!("refs/for/{}", branch),
+        oid: new_tip,
+        change_id: "JOSH_GERRIT_PUSH".to_string(),
+    }])
+}
+
+/// Build the refs to push when publishing to Gerrit in `independent` mode.
+///
+/// Only changes with **no dependencies** are pushed -- those whose `downstack`
+/// decomposition sits directly on the target base. Each is pushed as its own
+/// single-commit review on `refs/for/<branch>`, so it is independently
+/// reviewable and submittable. Changes that still depend on unmerged work are
+/// skipped; they become roots (and get published) once their dependencies
+/// merge. Because only roots are pushed, no change ever appears inside another
+/// change's stack, so there is no duplicated or conflicting ancestry.
+///
+/// The returned `PushRef`s all target the same `refs/for/<branch>` ref with
+/// distinct oids; the caller pushes each in its own `git push` invocation.
+pub fn build_gerrit_independent_push(
+    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
+    branch: &str,
+    tip: git2::Oid,
+    base: git2::Oid,
+) -> anyhow::Result<Vec<PushRef>> {
+    let changes = get_changes(repo, tip, base)?;
+    let changes = split_changes(repo, transaction, changes)?;
+
+    // `get_changes` collects into a HashMap, so sort for a deterministic push order.
+    let mut changes: Vec<Change> = changes.into_iter().collect();
+    changes.sort_by_key(|c| c.commit);
+
+    let ref_name = format!("refs/for/{}", branch);
+    let mut refs = Vec::new();
+    for change in changes {
+        let Some(josh_id) = change.id.clone() else {
+            continue;
+        };
+
+        // A change has no dependencies when its split commit sits directly on
+        // the target base (nothing else was pulled in below it by `downstack`).
+        let parent = repo.find_commit(change.commit)?.parent_ids().next();
+        let has_no_deps = if base == git2::Oid::ZERO_SHA1 {
+            parent.is_none()
+        } else {
+            parent == Some(base)
+        };
+        if !has_no_deps {
+            continue;
+        }
+
+        let gerrit_id = gerrit_change_id(&josh_id)?;
+        let new_tip = rewrite_chain_with_gerrit_ids(repo, change.commit, base)?;
+        refs.push(PushRef {
+            ref_name: ref_name.clone(),
+            oid: new_tip,
+            change_id: gerrit_id,
+        });
+    }
+    Ok(refs)
+}
+
 pub fn sync_changes(
     repo: &git2::Repository,
     transaction: &josh_core::cache::Transaction,
@@ -2017,4 +2221,70 @@ pub fn read_vote_in_scopes(
         }
     }
     Ok(None)
+}
+
+#[cfg(test)]
+mod gerrit_tests {
+    use super::*;
+
+    #[test]
+    fn gerrit_change_id_is_deterministic_and_well_formed() {
+        let a = gerrit_change_id("my-josh-change").unwrap();
+        let b = gerrit_change_id("my-josh-change").unwrap();
+        assert_eq!(a, b, "same josh id must map to the same Gerrit Change-Id");
+        assert!(is_gerrit_change_id(&a), "must be I + 40 hex, got {a}");
+        assert_ne!(
+            a,
+            gerrit_change_id("other-change").unwrap(),
+            "different josh ids should not collide"
+        );
+    }
+
+    #[test]
+    fn gerrit_change_id_passes_through_valid_ids() {
+        let existing = "I0123456789abcdef0123456789abcdef01234567";
+        assert_eq!(gerrit_change_id(existing).unwrap(), existing);
+    }
+
+    #[test]
+    fn is_gerrit_change_id_rejects_bad_shapes() {
+        assert!(!is_gerrit_change_id("I0123")); // too short
+        assert!(!is_gerrit_change_id(
+            "0123456789abcdef0123456789abcdef01234567"
+        )); // no leading I
+        assert!(!is_gerrit_change_id(
+            "Ixyz456789abcdef0123456789abcdef01234567"
+        )); // non-hex
+        assert!(!is_gerrit_change_id("my-josh-change"));
+    }
+
+    #[test]
+    fn message_replaces_josh_change_trailer() {
+        let msg = "Subject\n\nBody.\n\nChange: my-id\n";
+        let out = message_with_gerrit_change_id(msg, "Iabc");
+        assert_eq!(out, "Subject\n\nBody.\n\nChange-Id: Iabc");
+    }
+
+    #[test]
+    fn message_keeps_other_trailers_in_block() {
+        let msg = "Subject\n\nBody.\n\nSigned-off-by: a <a@b>\nChange-Id: old\n";
+        let out = message_with_gerrit_change_id(msg, "Inew");
+        assert_eq!(
+            out,
+            "Subject\n\nBody.\n\nSigned-off-by: a <a@b>\nChange-Id: Inew"
+        );
+    }
+
+    #[test]
+    fn message_appends_footer_when_none_present() {
+        let msg = "Just a subject";
+        let out = message_with_gerrit_change_id(msg, "Iabc");
+        assert_eq!(out, "Just a subject\n\nChange-Id: Iabc");
+    }
+
+    #[test]
+    fn message_from_single_change_trailer_line() {
+        let out = message_with_gerrit_change_id("Change: only-line", "Iabc");
+        assert_eq!(out, "Change-Id: Iabc");
+    }
 }

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -12,7 +12,7 @@ use josh_cli::commands::push::{PublishArgs, PushArgs};
 use josh_cli::commands::run::ComposeArgs;
 use josh_cli::commands::sync::SyncArgs;
 use josh_cli::config::{read_remote_config, write_remote_config};
-use josh_cli::forge::Forge;
+use josh_cli::forge::{Forge, GerritMode};
 use josh_core::git::{GitCommand, normalize_repo_path};
 
 #[derive(Debug, clap::Parser)]
@@ -174,6 +174,13 @@ pub struct ForgeArgs {
     /// Explicitly disable forge integration
     #[arg(long = "no-forge", conflicts_with = "forge")]
     pub no_forge: bool,
+
+    /// For a Gerrit remote, how `josh changes publish` maps the stack onto
+    /// Gerrit changes: `independent` (default) publishes only dependency-free
+    /// changes as separate reviews; `stack` pushes the whole history as one
+    /// relation chain.
+    #[arg(long = "gerrit-mode", value_enum)]
+    pub gerrit_mode: Option<GerritMode>,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -473,6 +480,7 @@ fn handle_remote_add_repo(args: &RemoteAddArgs, repo_path: &std::path::Path) -> 
         &refspec,
         forge,
         push_url.as_deref(),
+        args.forge_args.gerrit_mode,
     )
     .context("Failed to write remote config file")?;
 

--- a/josh-cli/src/commands/auth.rs
+++ b/josh-cli/src/commands/auth.rs
@@ -35,14 +35,28 @@ pub fn handle_auth(args: &AuthArgs) -> anyhow::Result<()> {
                     tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
                 rt.block_on(crate::forge::github::login())
             }
+            Forge::Gerrit => gerrit_auth_not_needed(),
         },
         AuthCommand::Logout(forge_args) => match forge_args.forge {
             Forge::Github => crate::forge::github::logout(),
+            Forge::Gerrit => gerrit_auth_not_needed(),
         },
         AuthCommand::Debug(forge_args) => match forge_args.forge {
             Forge::Github => handle_debug_github_auth(),
+            Forge::Gerrit => gerrit_auth_not_needed(),
         },
     }
+}
+
+/// Gerrit publishing is a plain `git push` to `refs/for/<branch>`, so josh does
+/// not manage Gerrit credentials -- authentication is handled by git itself
+/// (SSH keys or an HTTP credential helper).
+fn gerrit_auth_not_needed() -> anyhow::Result<()> {
+    println!(
+        "Gerrit needs no josh login: publishing pushes over git, so authentication \
+         is handled by your SSH key or git credential helper."
+    );
+    Ok(())
 }
 
 fn handle_debug_github_auth() -> anyhow::Result<()> {

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -4,7 +4,7 @@ use josh_changes::{PushMode, PushRef, StackedChangeRef, StackedRef, build_to_pus
 use josh_core::git::normalize_repo_path;
 
 use crate::config::{RemoteConfig, read_remote_config};
-use crate::forge::Forge;
+use crate::forge::{Forge, GerritMode};
 use crate::porcelain::PushRefUpdate;
 
 #[derive(Debug, clap::Parser)]
@@ -107,6 +107,7 @@ fn prepare_push(
     filter: josh_core::filter::Filter,
     push_mode: &PushMode,
     forge: &Option<Forge>,
+    gerrit_mode: GerritMode,
     dry_run: bool,
 ) -> anyhow::Result<PreparedPush> {
     let repo = transaction.repo();
@@ -207,16 +208,37 @@ fn prepare_push(
 
     log::debug!("unfiltered_oid: {:?}", unfiltered_oid);
 
-    let to_push = build_to_push(
-        repo,
-        transaction,
-        &push_mode,
-        remote_ref,
-        remote_ref,
-        unfiltered_oid,
-        original_target,
-    )
-    .context("Failed to build to push")?;
+    // Gerrit publishing pushes to the magic ref `refs/for/<branch>` instead of
+    // josh's `@changes`/`@base` ref pairs, and needs no PR API call. The mode
+    // decides the mapping: `independent` (default) pushes only dependency-free
+    // changes as separate reviews; `stack` pushes the whole history as one
+    // relation chain.
+    let to_push = match (forge, push_mode) {
+        (Some(Forge::Gerrit), PushMode::Publish(_)) => match gerrit_mode {
+            GerritMode::Independent => josh_changes::build_gerrit_independent_push(
+                repo,
+                transaction,
+                remote_ref,
+                unfiltered_oid,
+                original_target,
+            )
+            .context("Failed to build Gerrit push")?,
+            GerritMode::Stack => {
+                josh_changes::build_gerrit_push(repo, remote_ref, unfiltered_oid, original_target)
+                    .context("Failed to build Gerrit push")?
+            }
+        },
+        _ => build_to_push(
+            repo,
+            transaction,
+            push_mode,
+            remote_ref,
+            remote_ref,
+            unfiltered_oid,
+            original_target,
+        )
+        .context("Failed to build to push")?,
+    };
 
     log::debug!("to_push: {:?}", to_push);
 
@@ -313,7 +335,48 @@ pub fn render_push_summary(
     Ok(lines)
 }
 
-/// Push all refs to the remote in a single bundled `git push` invocation.
+/// Push each change to a change-based forge (Gerrit), one `git push` per ref.
+///
+/// Every change targets the same magic ref `refs/for/<branch>`, so a single
+/// bundled push (multiple source commits, one destination ref) is not
+/// possible -- each ref goes in its own invocation. `refs/for` refs are never
+/// force-pushed; the forge keys patchsets by Change-Id instead.
+fn push_change_based(
+    transaction: &josh_core::cache::Transaction,
+    remote_name: &str,
+    to_push: &[PushRef],
+    url: &str,
+    atomic: bool,
+    dry_run: bool,
+) -> anyhow::Result<()> {
+    if to_push.is_empty() {
+        return Ok(());
+    }
+
+    for push_ref in to_push {
+        eprintln!(
+            "Pushing {} to {}/{}",
+            push_ref.oid, remote_name, push_ref.ref_name
+        );
+        let mut git_push_args = vec!["push"];
+        if atomic {
+            git_push_args.push("--atomic");
+        }
+        if dry_run {
+            git_push_args.push("--dry-run");
+        }
+        git_push_args.push(url);
+        let refspec = format!("{}:{}", push_ref.oid, push_ref.ref_name);
+        git_push_args.push(&refspec);
+        transaction
+            .spawn_git(&git_push_args, &[])
+            .with_context(|| format!("Failed to push to {}", remote_name))?;
+    }
+    eprintln!("Pushed {} ref(s) to {}", to_push.len(), remote_name);
+    Ok(())
+}
+
+/// Push all refs to a branch-based forge in a single bundled `git push` invocation.
 ///
 /// Every ref shares one remote URL and a uniform set of flags, so they are pushed together
 /// rather than one process per ref. This also makes `--atomic` meaningful across the whole
@@ -323,7 +386,7 @@ pub fn render_push_summary(
 /// stdout is captured and rendered as a summary via `render_push_summary`,
 /// while stderr keeps the default handling (inherited on a TTY, forwarded
 /// otherwise) so progress/errors reach the user.
-fn push_refs(
+fn push_branch_based(
     transaction: &josh_core::cache::Transaction,
     remote_name: &str,
     to_push: &[PushRef],
@@ -449,6 +512,7 @@ fn orchestrate_push(
         url,
         forge,
         push_url,
+        gerrit_mode,
         ..
     } = config;
 
@@ -479,21 +543,24 @@ fn orchestrate_push(
                 filter,
                 &push_mode,
                 &forge,
+                gerrit_mode,
                 dry_run,
             )
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    // Phase 2: Flatten the prepared pushes into one bundled set. Dedup by destination ref
-    // name (keep first) to tolerate duplicate or colliding refspec arguments, which an
-    // atomic push would otherwise reject.
+    // Phase 2: Flatten the prepared pushes into one bundled set. Dedup by
+    // (destination ref, oid) (keep first) to tolerate duplicate or colliding
+    // refspec arguments, which an atomic push would otherwise reject. The oid is
+    // part of the key because Gerrit publishing intentionally routes several
+    // distinct change commits to the same `refs/for/<branch>` ref.
     let mut seen = std::collections::HashSet::new();
     let mut to_push: Vec<PushRef> = Vec::new();
     let mut pr_infos: Vec<josh_github_changes::PrInfo> = Vec::new();
 
     for prepared in prepared_pushes {
         for push_ref in prepared.to_push {
-            if seen.insert(push_ref.ref_name.clone()) {
+            if seen.insert((push_ref.ref_name.clone(), push_ref.oid)) {
                 to_push.push(push_ref);
             }
         }
@@ -507,17 +574,30 @@ fn orchestrate_push(
     // git output.
     let curated = matches!(push_mode, PushMode::Publish(_));
 
-    // Phase 3: Execute the side effects.
-    push_refs(
-        transaction,
-        remote_name,
-        &to_push,
-        push_target,
-        force,
-        atomic,
-        dry_run,
-        curated,
-    )?;
+    // Phase 3: Execute the side effects. Publishing to a change-based forge
+    // (Gerrit) pushes magic `refs/for/<branch>` refs; everything else is a
+    // branch push. This mirrors the dispatch in `prepare_push`.
+    if forge == Some(Forge::Gerrit) && matches!(push_mode, PushMode::Publish(_)) {
+        push_change_based(
+            transaction,
+            remote_name,
+            &to_push,
+            push_target,
+            atomic,
+            dry_run,
+        )?;
+    } else {
+        push_branch_based(
+            transaction,
+            remote_name,
+            &to_push,
+            push_target,
+            force,
+            atomic,
+            dry_run,
+            curated,
+        )?;
+    }
 
     create_prs(&pr_infos, &url, push_url.as_deref(), dry_run)?;
 

--- a/josh-cli/src/config.rs
+++ b/josh-cli/src/config.rs
@@ -1,9 +1,9 @@
 use anyhow::{Context, anyhow};
 
-use crate::forge::Forge;
+use crate::forge::{Forge, GerritMode};
 
 /// Meta keys that configure the remote itself rather than the filter semantics.
-pub const TRANSPORT_META_KEYS: &[&str] = &["url", "fetch", "forge", "push"];
+pub const TRANSPORT_META_KEYS: &[&str] = &["url", "fetch", "forge", "push", "gerrit-mode"];
 
 pub struct RemoteConfig {
     pub url: String,
@@ -14,6 +14,9 @@ pub struct RemoteConfig {
     /// pushed here while `url` remains the fetch source and PR target. Analogous
     /// to git's `remote.<name>.pushurl`.
     pub push_url: Option<String>,
+    /// How `josh changes publish` maps a stack onto Gerrit changes. Only
+    /// meaningful when `forge` is `Gerrit`; defaults to `Independent`.
+    pub gerrit_mode: GerritMode,
 }
 
 impl RemoteConfig {
@@ -82,6 +85,7 @@ pub fn migrate_legacy_config(
         &fetch,
         None,
         None,
+        None,
     )
     .context("Failed to migrate legacy config to new format")?;
 
@@ -102,6 +106,7 @@ pub fn migrate_legacy_config(
         filter_with_meta,
         forge: None,
         push_url: None,
+        gerrit_mode: GerritMode::default(),
     })
 }
 
@@ -153,16 +158,28 @@ pub fn read_remote_config(
 
     let push_url = filter.get_meta("push");
 
+    let gerrit_mode = filter
+        .get_meta("gerrit-mode")
+        .map(|m| {
+            use clap::ValueEnum;
+            GerritMode::from_str(&m, true)
+        })
+        .transpose()
+        .map_err(|m| anyhow!("Unknown gerrit-mode: {m}"))?
+        .unwrap_or_default();
+
     Ok(RemoteConfig {
         url,
         ref_spec: fetch,
         filter_with_meta: filter,
         forge,
         push_url,
+        gerrit_mode,
     })
 }
 
 /// Write remote configuration to .git/josh/remotes/<name>.josh file
+#[allow(clippy::too_many_arguments)]
 pub fn write_remote_config(
     repo_path: &std::path::Path,
     remote_name: &str,
@@ -171,6 +188,7 @@ pub fn write_remote_config(
     fetch: &str,
     forge: Option<Forge>,
     push_url: Option<&str>,
+    gerrit_mode: Option<GerritMode>,
 ) -> anyhow::Result<()> {
     let remotes_dir = remotes_dir(repo_path)?;
 
@@ -206,6 +224,10 @@ pub fn write_remote_config(
 
     if let Some(push_url) = push_url {
         filter_with_meta = filter_with_meta.with_meta("push", push_url);
+    }
+
+    if let Some(gerrit_mode) = gerrit_mode {
+        filter_with_meta = filter_with_meta.with_meta("gerrit-mode", gerrit_mode.to_string());
     }
 
     // Serialize the filter with metadata

--- a/josh-cli/src/forge/mod.rs
+++ b/josh-cli/src/forge/mod.rs
@@ -7,12 +7,35 @@ pub mod github;
 pub enum Forge {
     /// GitHub
     Github,
+    /// Gerrit
+    Gerrit,
 }
 
 impl std::fmt::Display for Forge {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Forge::Github => f.write_str("github"),
+            Forge::Gerrit => f.write_str("gerrit"),
+        }
+    }
+}
+
+/// How `josh changes publish` maps a stack onto Gerrit changes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub enum GerritMode {
+    /// Push only dependency-free changes, each as its own independent review.
+    /// Changes that still have unmerged dependencies wait until those merge.
+    #[default]
+    Independent,
+    /// Push the whole commit history once as a single Gerrit relation chain.
+    Stack,
+}
+
+impl std::fmt::Display for GerritMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GerritMode::Independent => f.write_str("independent"),
+            GerritMode::Stack => f.write_str("stack"),
         }
     }
 }

--- a/tests/cli/push_stacked_gerrit.t
+++ b/tests/cli/push_stacked_gerrit.t
@@ -1,0 +1,68 @@
+Publishing to a Gerrit remote in the default `independent` mode: only changes
+with no dependencies are pushed to refs/for/master, each as its own independent
+review. A change that still depends on unmerged work is skipped until its
+dependencies merge. This keeps each change on a single, unambiguous ancestry
+(one commit on the target base), so no change is ever duplicated across stacks.
+A dry-run is used so the plain bare repo does not need to accept the magic ref.
+
+  $ export TESTTMP=${PWD}
+
+  $ git init -q --bare upstream
+  $ git init -q seed
+  $ cd seed
+  $ mkdir -p sub1
+  $ echo "file1 content" > sub1/file1
+  $ git add .
+  $ git commit -q -m "add file1"
+  $ git remote add origin ${TESTTMP}/upstream
+  $ git push -q origin master
+  $ cd ..
+
+Clone with the Gerrit forge. No --gerrit-mode is given, so the default
+(independent) applies.
+
+  $ josh clone ${TESTTMP}/upstream :/sub1 filtered --forge gerrit > /dev/null 2>&1
+  $ cd filtered
+  $ git config user.email "josh@example.com"
+  $ git config user.name "Josh Test"
+
+alpha and gamma share Change-Series dep1 (so gamma depends on alpha); beta is
+independent.
+
+  $ echo "aaa" > fileA
+  $ git add fileA
+  $ printf "Add fileA\n\nChange: alpha\nChange-Series: dep1" | git commit -q -F -
+  $ echo "bbb" > fileB
+  $ git add fileB
+  $ printf "Add fileB\n\nChange: beta" | git commit -q -F -
+  $ echo "ccc" > fileC
+  $ git add fileC
+  $ printf "Add fileC\n\nChange: gamma\nChange-Series: dep1" | git commit -q -F -
+
+Publish: only the dependency-free changes (alpha, beta) are pushed, each in its
+own push. gamma depends on alpha, so it is skipped this round.
+
+  $ josh changes publish --dry-run
+  Pushing e042bde9d87ed49a86e729ab6c936aa349a610bc to origin/refs/for/master
+  To file://${TESTTMP}/upstream
+   * [new reference]   e042bde9d87ed49a86e729ab6c936aa349a610bc -> refs/for/master
+  
+  Pushing 18954accacea27a2fe6bd457cca353b9e3b0897e to origin/refs/for/master
+  To file://${TESTTMP}/upstream
+   * [new reference]   18954accacea27a2fe6bd457cca353b9e3b0897e -> refs/for/master
+  
+  Pushed 2 ref(s) to origin
+
+Each pushed change is a single commit sitting directly on the target base (an
+independent review), with a generated Gerrit Change-Id and its subject.
+
+  $ git log --pretty="%s | %(trailers:key=Change-Id,valueonly,separator=%x20)" e042bde9d87ed49a86e729ab6c936aa349a610bc ^refs/josh/remotes/origin/master
+  Add fileA | I7e74e68b2a782a3aead46d987a63ca1c91091c13
+  $ git log --pretty="%s | %(trailers:key=Change-Id,valueonly,separator=%x20)" 18954accacea27a2fe6bd457cca353b9e3b0897e ^refs/josh/remotes/origin/master
+  Add fileB | Ie1d65540f4fdf72431ec47e001282cc7e8ed7c0c
+
+The upstream repo received nothing (dry-run) and no @changes/@base refs exist.
+
+  $ git ls-remote ${TESTTMP}/upstream
+  115b269a011d493259a125fa941fd790b903175f\tHEAD (escaped)
+  115b269a011d493259a125fa941fd790b903175f\trefs/heads/master (escaped)

--- a/tests/cli/push_stacked_gerrit_stack.t
+++ b/tests/cli/push_stacked_gerrit_stack.t
@@ -1,0 +1,54 @@
+Publishing to a Gerrit remote in `stack` mode (opted in via --gerrit-mode): the
+whole commit history is pushed once to refs/for/master as a single relation
+chain -- one change per commit, each with exactly one parent. A dry-run is used
+so the plain bare repo does not need to accept the magic ref.
+
+  $ export TESTTMP=${PWD}
+
+  $ git init -q --bare upstream
+  $ git init -q seed
+  $ cd seed
+  $ mkdir -p sub1
+  $ echo "file1 content" > sub1/file1
+  $ git add .
+  $ git commit -q -m "add file1"
+  $ git remote add origin ${TESTTMP}/upstream
+  $ git push -q origin master
+  $ cd ..
+
+Clone selecting the Gerrit forge and the `stack` publish mode. The mode is
+stored per-remote in the remote config.
+
+  $ josh clone ${TESTTMP}/upstream :/sub1 filtered --forge gerrit --gerrit-mode stack > /dev/null 2>&1
+  $ cd filtered
+  $ grep gerrit-mode "$(git rev-parse --git-common-dir)/josh/remotes/origin.josh"
+      gerrit-mode="stack"
+  $ git config user.email "josh@example.com"
+  $ git config user.name "Josh Test"
+
+  $ echo "aaa" > fileA
+  $ git add fileA
+  $ printf "Add fileA\n\nChange: alpha\nChange-Series: dep1" | git commit -q -F -
+  $ echo "bbb" > fileB
+  $ git add fileB
+  $ printf "Add fileB\n\nChange: beta" | git commit -q -F -
+  $ echo "ccc" > fileC
+  $ git add fileC
+  $ printf "Add fileC\n\nChange: gamma\nChange-Series: dep1" | git commit -q -F -
+
+Publish: the entire stack goes to refs/for/master in a single push.
+
+  $ josh changes publish --dry-run
+  Pushing 4b0fa539289928ceea5f36fa8d7c5b7688b4b0eb to origin/refs/for/master
+  To file://${TESTTMP}/upstream
+   * [new reference]   4b0fa539289928ceea5f36fa8d7c5b7688b4b0eb -> refs/for/master
+  
+  Pushed 1 ref(s) to origin
+
+The pushed tip is one relation chain over the target branch: every change
+appears exactly once with a single parent, each carrying a Gerrit Change-Id.
+
+  $ git log --pretty="%s | %(trailers:key=Change-Id,valueonly,separator=%x20)" 4b0fa539289928ceea5f36fa8d7c5b7688b4b0eb ^refs/josh/remotes/origin/master
+  Add fileC | If6ce3c605d8e619e80eb03eb65fc984a940abde7
+  Add fileB | Ie1d65540f4fdf72431ec47e001282cc7e8ed7c0c
+  Add fileA | I7e74e68b2a782a3aead46d987a63ca1c91091c13


### PR DESCRIPTION
Support publishing josh changes to Gerrit

Add Gerrit as a forge for `josh changes publish`, selected explicitly with
`--forge gerrit` (Gerrit servers are not identifiable from their URL). Unlike
the GitHub path, publishing to Gerrit is a plain `git push` to the magic
`refs/for/<branch>` ref -- the push itself creates or updates the reviews, so
there is no API call or token and authentication is handled by git.

Because Gerrit keys a change by its Change-Id and expects it to appear exactly
once with a single parent, josh's `downstack` model (where a change can belong
to several stacks with differing ancestry) cannot be mapped one-to-one. Two
per-remote modes, selected with `--gerrit-mode` and stored as a `gerrit-mode`
meta key, resolve this:

- `independent` (default): push only the changes that have no dependencies --
  those sitting directly on the target base -- each as its own separately
  submittable review. A change that still depends on unmerged work is skipped
  until its predecessors merge. Only roots are pushed, so no change is ever
  duplicated across stacks.
- `stack`: push the whole commit history once as a single Gerrit relation
  chain -- one change per commit, each with exactly one parent.

Every pushed commit is rewritten to carry a `Change-Id: I<40 hex>` trailer,
derived deterministically from the change's josh id (and reused as-is if already
valid), so re-publishing lands as a new patchset on the same Gerrit change
rather than a duplicate. The trailer is written only onto the pushed commits;
local history is untouched.

Assisted-By: anthropic/claude-opus-4-8
Assisted-By: anthropic/claude-fable-5
Change: changes-publish-gerrit