### PR TITLE
Make josh-starlark test repos unique across parallel tests

### DIFF
--- a/josh-starlark/src/tests.rs
+++ b/josh-starlark/src/tests.rs
@@ -71,8 +71,13 @@ filter = compose([f1, f2])
 
 // Helper function to create a test repository with files and directories
 fn create_test_repo() -> anyhow::Result<(git2::Repository, git2::Oid)> {
+    // Process id and a counter keep the directory unique across parallel tests; the
+    // timestamp alone collides when two tests read the clock in the same tick.
+    static DIR_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let temp_dir = std::env::temp_dir().join(format!(
-        "josh_starlark_tree_test_{}",
+        "josh_starlark_tree_test_{}_{}_{}",
+        std::process::id(),
+        DIR_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)?
             .as_nanos()


### PR DESCRIPTION
Make josh-starlark test repos unique across parallel tests

create_test_repo named its temp directory by the current timestamp alone,
so two tests reading the clock in the same tick raced git-init on the same
path and failed on config.lock. Add the process id and a counter to the
name.

Change: starlark-test-repo-race

Assisted-By: anthropic/claude-fable-5