### PR TITLE
Introduce StackedRef for stacked-changes ref names

### DIFF
--- a/forges/josh-github-changes/src/lib.rs
+++ b/forges/josh-github-changes/src/lib.rs
@@ -32,14 +32,22 @@ pub fn collect_pr_infos(repo: &git2::Repository, to_push: &[josh_changes::PushRe
     let mut by_change_id: HashMap<String, ByIdEntry> = HashMap::new();
     for push_ref in to_push {
         let branch = branch_name(&push_ref.ref_name).to_string();
-        if push_ref.ref_name.contains("@changes") {
-            let entry = by_change_id.entry(push_ref.change_id.clone()).or_default();
-            entry.head_branch = Some(branch);
-            entry.head_oid = Some(push_ref.oid);
-        } else if push_ref.ref_name.contains("@base") {
-            let entry = by_change_id.entry(push_ref.change_id.clone()).or_default();
-            entry.base_branch = Some(branch);
-            entry.base_oid = Some(push_ref.oid);
+        match josh_changes::StackedRef::parse(&push_ref.ref_name) {
+            Some(josh_changes::StackedRef::ChangeRef(josh_changes::StackedChangeRef::Change {
+                ..
+            })) => {
+                let entry = by_change_id.entry(push_ref.change_id.clone()).or_default();
+                entry.head_branch = Some(branch);
+                entry.head_oid = Some(push_ref.oid);
+            }
+            Some(josh_changes::StackedRef::ChangeRef(josh_changes::StackedChangeRef::Base {
+                ..
+            })) => {
+                let entry = by_change_id.entry(push_ref.change_id.clone()).or_default();
+                entry.base_branch = Some(branch);
+                entry.base_oid = Some(push_ref.oid);
+            }
+            _ => {}
         }
     }
 

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1,6 +1,9 @@
 use anyhow::anyhow;
 pub use josh_core::trailers::{commit_change_meta, parse_change_meta};
 
+mod refs;
+pub use refs::{StackedChangeRef, StackedRef};
+
 /// Which `refs/josh/...` ref holds a piece of change metadata.
 ///
 /// Scoped by the target branch of the change, so a single repo can host
@@ -296,21 +299,19 @@ fn changes_to_refs(
     let mut refs = vec![];
     for change in changes {
         if let Some(change_id) = change.id {
-            let ref_name = format!(
-                "refs/heads/@changes/{}/{}/{}",
-                baseref.replacen("refs/heads/", "", 1),
-                change.author,
-                change_id,
-            );
-            let base_ref_name = ref_name.replacen("refs/heads/@changes", "refs/heads/@base", 1);
+            let change_ref = StackedChangeRef::Change {
+                target: baseref.replacen("refs/heads/", "", 1),
+                author: change.author,
+                change_id: change_id.clone(),
+            };
             refs.push(PushRef {
-                ref_name,
+                ref_name: StackedRef::ChangeRef(change_ref.clone()).ref_name(),
                 oid: change.commit,
                 change_id: change_id.clone(),
             });
             if let Some(parent_sha) = repo.find_commit(change.commit)?.parent_ids().next() {
                 refs.push(PushRef {
-                    ref_name: base_ref_name,
+                    ref_name: StackedRef::ChangeRef(change_ref.as_base()).ref_name(),
                     oid: parent_sha,
                     change_id,
                 });
@@ -363,14 +364,15 @@ pub fn build_to_push(
 
             let mut push_refs = changes_to_refs(repo, baseref, author, changes)?;
 
+            let target = baseref.replacen("refs/heads/", "", 1);
             push_refs.push(PushRef {
-                ref_name: format!(
-                    "refs/heads/@heads/{}/{}",
-                    baseref.replacen("refs/heads/", "", 1),
-                    author,
-                ),
+                ref_name: StackedRef::StackHead {
+                    target: target.clone(),
+                    author: author.clone(),
+                }
+                .ref_name(),
                 oid: oid_to_push,
-                change_id: baseref.replacen("refs/heads/", "", 1),
+                change_id: target,
             });
 
             push_refs.sort_by(|a, b| a.ref_name.cmp(&b.ref_name));

--- a/josh-changes/src/refs.rs
+++ b/josh-changes/src/refs.rs
@@ -1,0 +1,293 @@
+//! Typed model of the refs josh publishes for a change stack.
+//!
+//! Three ref families exist on the remote:
+//!
+//! - `refs/heads/@changes/<target>/<author>/<change-id>` — head commit of a change
+//! - `refs/heads/@base/<target>/<author>/<change-id>` — commit the change is based on
+//! - `refs/heads/@heads/<target>/<author>` — tip of the developer's published stack
+//!
+//! `<target>` is a branch name and may contain `/`. `<author>` is an email
+//! address; it is located during parsing as the first `/`-separated segment
+//! containing `@`, which is also why change-ids containing `@` are rejected at
+//! push time (see `changes_to_refs`). `<change-id>` may itself contain `/`
+//! (e.g. synthetic `owner/repo/pull/N` ids), so everything after the author
+//! segment is treated as the change-id.
+
+/// A change-scoped ref: either the change's head commit (`Change`) or the
+/// commit it is based on (`Base`). Both spellings carry the same identity, so
+/// they convert freely via [`StackedChangeRef::as_change`] and
+/// [`StackedChangeRef::as_base`].
+///
+/// This type is pure data; the ref-name grammar lives on [`StackedRef`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum StackedChangeRef {
+    Change {
+        target: String,
+        author: String,
+        change_id: String,
+    },
+    Base {
+        target: String,
+        author: String,
+        change_id: String,
+    },
+}
+
+impl StackedChangeRef {
+    /// The same change, spelled as its `@changes` ref.
+    pub fn as_change(&self) -> StackedChangeRef {
+        match self {
+            StackedChangeRef::Change { .. } => self.clone(),
+            StackedChangeRef::Base {
+                target,
+                author,
+                change_id,
+            } => StackedChangeRef::Change {
+                target: target.clone(),
+                author: author.clone(),
+                change_id: change_id.clone(),
+            },
+        }
+    }
+
+    /// The same change, spelled as its `@base` ref.
+    pub fn as_base(&self) -> StackedChangeRef {
+        match self {
+            StackedChangeRef::Base { .. } => self.clone(),
+            StackedChangeRef::Change {
+                target,
+                author,
+                change_id,
+            } => StackedChangeRef::Base {
+                target: target.clone(),
+                author: author.clone(),
+                change_id: change_id.clone(),
+            },
+        }
+    }
+
+    pub fn target(&self) -> &str {
+        match self {
+            StackedChangeRef::Change { target, .. } | StackedChangeRef::Base { target, .. } => {
+                target
+            }
+        }
+    }
+
+    pub fn author(&self) -> &str {
+        match self {
+            StackedChangeRef::Change { author, .. } | StackedChangeRef::Base { author, .. } => {
+                author
+            }
+        }
+    }
+
+    pub fn change_id(&self) -> &str {
+        match self {
+            StackedChangeRef::Change { change_id, .. }
+            | StackedChangeRef::Base { change_id, .. } => change_id,
+        }
+    }
+}
+
+/// Any ref josh publishes for a change stack. Owns the ref-name grammar:
+/// the only place that knows the `@changes` / `@base` / `@heads` spellings.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum StackedRef {
+    /// A `@changes/...` or `@base/...` ref.
+    ChangeRef(StackedChangeRef),
+    /// A `@heads/<target>/<author>` ref: tip of a developer's published stack.
+    StackHead { target: String, author: String },
+}
+
+impl StackedRef {
+    /// The full `refs/heads/@...` name of this ref.
+    pub fn ref_name(&self) -> String {
+        match self {
+            StackedRef::ChangeRef(StackedChangeRef::Change {
+                target,
+                author,
+                change_id,
+            }) => format!("refs/heads/@changes/{}/{}/{}", target, author, change_id),
+            StackedRef::ChangeRef(StackedChangeRef::Base {
+                target,
+                author,
+                change_id,
+            }) => format!("refs/heads/@base/{}/{}/{}", target, author, change_id),
+            StackedRef::StackHead { target, author } => {
+                format!("refs/heads/@heads/{}/{}", target, author)
+            }
+        }
+    }
+
+    /// Parse a stacked-changes ref name. Accepts the full `refs/heads/@...`
+    /// form, the remote-tracking `refs/remotes/<remote>/@...` form, and the
+    /// bare `@...` shorthand. Returns `None` for refs outside the three
+    /// families.
+    pub fn parse(ref_name: &str) -> Option<StackedRef> {
+        let name = if let Some(rest) = ref_name.strip_prefix("refs/heads/") {
+            rest
+        } else if let Some(rest) = ref_name.strip_prefix("refs/remotes/") {
+            // Skip the remote name (cannot contain '/').
+            rest.split_once('/')?.1
+        } else {
+            ref_name
+        };
+
+        let (is_base, rest) = if let Some(rest) = name.strip_prefix("@changes/") {
+            (false, rest)
+        } else if let Some(rest) = name.strip_prefix("@base/") {
+            (true, rest)
+        } else if let Some(rest) = name.strip_prefix("@heads/") {
+            let (target, author, trailing) = split_target_author(rest)?;
+            if !trailing.is_empty() {
+                return None;
+            }
+            return Some(StackedRef::StackHead { target, author });
+        } else {
+            return None;
+        };
+
+        let (target, author, change_id) = split_target_author(rest)?;
+        if change_id.is_empty() {
+            return None;
+        }
+        let change = StackedChangeRef::Change {
+            target,
+            author,
+            change_id,
+        };
+        Some(StackedRef::ChangeRef(if is_base {
+            change.as_base()
+        } else {
+            change
+        }))
+    }
+}
+
+/// Split `<target>/<author>[/<change-id>]` into its three parts. The author
+/// is the first `/`-separated segment containing `@`; the target is
+/// everything before it, and the change-id (possibly empty, possibly
+/// containing `/`) is everything after it.
+fn split_target_author(rest: &str) -> Option<(String, String, String)> {
+    let mut target_end = 0;
+    for segment in rest.split('/') {
+        if segment.contains('@') {
+            if target_end == 0 {
+                return None;
+            }
+            let target = &rest[..target_end - 1];
+            let after_author = &rest[target_end + segment.len()..];
+            let change_id = after_author.strip_prefix('/').unwrap_or(after_author);
+            return Some((
+                target.to_string(),
+                segment.to_string(),
+                change_id.to_string(),
+            ));
+        }
+        target_end += segment.len() + 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn change() -> StackedChangeRef {
+        StackedChangeRef::Change {
+            target: "master".to_string(),
+            author: "josh@example.com".to_string(),
+            change_id: "1234".to_string(),
+        }
+    }
+
+    #[test]
+    fn ref_name_round_trips() {
+        for stacked in [
+            StackedRef::ChangeRef(change()),
+            StackedRef::ChangeRef(change().as_base()),
+            StackedRef::StackHead {
+                target: "master".to_string(),
+                author: "josh@example.com".to_string(),
+            },
+        ] {
+            assert_eq!(StackedRef::parse(&stacked.ref_name()), Some(stacked));
+        }
+    }
+
+    #[test]
+    fn base_change_conversion_is_lossless() {
+        let c = change();
+        assert_eq!(c.as_base().as_change(), c);
+        let b = c.as_base();
+        assert_eq!(b.as_change().as_base(), b);
+        assert_eq!(
+            StackedRef::ChangeRef(c.as_base()).ref_name(),
+            "refs/heads/@base/master/josh@example.com/1234"
+        );
+    }
+
+    #[test]
+    fn parses_shorthand_and_remote_forms() {
+        assert_eq!(
+            StackedRef::parse("@changes/master/josh@example.com/1234"),
+            Some(StackedRef::ChangeRef(change()))
+        );
+        assert_eq!(
+            StackedRef::parse("refs/remotes/origin/@changes/master/josh@example.com/1234"),
+            Some(StackedRef::ChangeRef(change()))
+        );
+        assert_eq!(
+            StackedRef::parse("refs/remotes/origin/@heads/master/josh@example.com"),
+            Some(StackedRef::StackHead {
+                target: "master".to_string(),
+                author: "josh@example.com".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_target_with_slashes() {
+        assert_eq!(
+            StackedRef::parse("refs/heads/@changes/feature/foo/josh@example.com/1234"),
+            Some(StackedRef::ChangeRef(StackedChangeRef::Change {
+                target: "feature/foo".to_string(),
+                author: "josh@example.com".to_string(),
+                change_id: "1234".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn parses_change_id_with_slashes() {
+        assert_eq!(
+            StackedRef::parse("refs/heads/@changes/master/josh@example.com/o/r/pull/1"),
+            Some(StackedRef::ChangeRef(StackedChangeRef::Change {
+                target: "master".to_string(),
+                author: "josh@example.com".to_string(),
+                change_id: "o/r/pull/1".to_string(),
+            }))
+        );
+    }
+
+    #[test]
+    fn rejects_non_stacked_refs() {
+        assert_eq!(StackedRef::parse("refs/heads/master"), None);
+        assert_eq!(StackedRef::parse("refs/remotes/origin/master"), None);
+        assert_eq!(StackedRef::parse("master"), None);
+        // A branch merely containing the substring is not a stacked ref.
+        assert_eq!(StackedRef::parse("refs/heads/foo@changes-bar"), None);
+        // Missing change-id or author.
+        assert_eq!(
+            StackedRef::parse("refs/heads/@changes/master/josh@example.com"),
+            None
+        );
+        assert_eq!(StackedRef::parse("refs/heads/@changes/master/1234"), None);
+        // A stack head must have nothing after the author.
+        assert_eq!(
+            StackedRef::parse("refs/heads/@heads/master/josh@example.com/extra"),
+            None
+        );
+    }
+}

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -134,11 +134,11 @@ pub fn handle_sync(
             let mut target_branch_shas: std::collections::HashMap<String, git2::Oid> =
                 std::collections::HashMap::new();
             {
-                let mut seen_targets: std::collections::HashSet<&str> =
+                let mut seen_targets: std::collections::HashSet<String> =
                     std::collections::HashSet::new();
                 for pr in &prs {
                     if let Some(target) = parse_changes_target(&pr.head_ref_name) {
-                        if seen_targets.insert(target) {
+                        if seen_targets.insert(target.clone()) {
                             let refspec = format!("refs/heads/{}", target);
                             let fetch_args: Vec<&str> =
                                 vec!["fetch", &github_url, "--no-tags", &refspec];
@@ -154,7 +154,7 @@ pub fn handle_sync(
                                 )?;
                             let sha_str = String::from_utf8(output.stdout)?.trim().to_string();
                             let oid = git2::Oid::from_str(&sha_str)?;
-                            target_branch_shas.insert(target.to_string(), oid);
+                            target_branch_shas.insert(target, oid);
                         }
                     }
                 }
@@ -230,9 +230,11 @@ pub fn handle_sync(
                 // Target branch for scoping: stacked changes encode the ultimate target
                 // in the head ref (@changes/<target>/...); otherwise fall back to the
                 // PR's immediate base.
-                let target_branch = parse_changes_target(&pr.head_ref_name)
-                    .unwrap_or_else(|| pr.base_ref_name.trim_start_matches("refs/heads/"))
-                    .to_string();
+                let target_branch = parse_changes_target(&pr.head_ref_name).unwrap_or_else(|| {
+                    pr.base_ref_name
+                        .trim_start_matches("refs/heads/")
+                        .to_string()
+                });
                 let remote_scope = josh_changes::ChangesRef::Remote {
                     remote: remote_name.clone(),
                     branch: target_branch.clone(),
@@ -242,7 +244,7 @@ pub fn handle_sync(
                     let change = if existing_change_id.is_some() {
                         let mut change = josh_changes::Change::new(repo, &pr_head);
                         let base = match parse_changes_target(&pr.head_ref_name)
-                            .and_then(|t| target_branch_shas.get(t))
+                            .and_then(|t| target_branch_shas.get(&t))
                         {
                             Some(tip) => repo.merge_base(*tip, pr_head.id())?,
                             None => repo.merge_base(target.id(), pr_head.id())?,
@@ -454,9 +456,12 @@ pub fn handle_sync(
                         .unwrap_or_else(|| format!("{}/{}/pull/{}", owner, repo_name, pr.number));
 
                     // Same target-branch derivation as the per-PR sync above.
-                    let target_branch = parse_changes_target(&pr.head_ref_name)
-                        .unwrap_or_else(|| pr.base_ref_name.trim_start_matches("refs/heads/"))
-                        .to_string();
+                    let target_branch =
+                        parse_changes_target(&pr.head_ref_name).unwrap_or_else(|| {
+                            pr.base_ref_name
+                                .trim_start_matches("refs/heads/")
+                                .to_string()
+                        });
                     let remote_scope = josh_changes::ChangesRef::Remote {
                         remote: remote_name.clone(),
                         branch: target_branch.clone(),
@@ -547,19 +552,12 @@ pub fn handle_sync(
     Ok(())
 }
 
-/// Extract the target branch name from a `@changes/<target>/<author>/<change-id>` ref name.
-fn parse_changes_target(head_ref_name: &str) -> Option<&str> {
-    let name = head_ref_name
-        .strip_prefix("refs/heads/@changes/")
-        .or_else(|| head_ref_name.strip_prefix("@changes/"))?;
-    let mut end = 0;
-    for part in name.split('/') {
-        if part.contains('@') {
-            return Some(&name[..end].trim_end_matches('/'));
-        }
-        end += part.len() + 1;
+/// Extract the target branch name from a stacked-changes ref name.
+fn parse_changes_target(head_ref_name: &str) -> Option<String> {
+    match josh_changes::StackedRef::parse(head_ref_name)? {
+        josh_changes::StackedRef::ChangeRef(change) => Some(change.target().to_string()),
+        josh_changes::StackedRef::StackHead { target, .. } => Some(target),
     }
-    None
 }
 
 /// Extract the PR number from a synthetic change ID of the form `{owner}/{repo}/pull/{N}`.


### PR DESCRIPTION
Introduce StackedRef for stacked-changes ref names

Stacked-changes refs (refs/heads/@changes/<target>/<author>/<change-id>,
@base/..., @heads/<target>/<author>) were formatted and parsed with ad-hoc
string manipulation at each call site.

Centralize this in the josh-changes crate: StackedChangeRef models a single
change's ref (Change or Base variant, convertible via as_change()/as_base()),
and the StackedRef top-level enum distinguishes change refs from stack heads,
with parse() and ref_name() exposed only at that level. Callers in
josh-github-changes and josh-cli sync switch to the typed API.

Change: stacked-ref-type
Change-Series: changes-pull-porcelain
Assisted-By: kimi-code/k3