### PR TITLE
Port apply_to_commit2 and the history walk loops to oid currency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,6 +3526,7 @@ dependencies = [
  "git2",
  "gix-hash",
  "gix-object",
+ "tempfile",
 ]
 
 [[package]]

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -240,7 +240,6 @@ pub fn baseref_and_options(
 }
 
 fn split_changes(
-    repo: &git2::Repository,
     transaction: &josh_core::cache::Transaction,
     changes: std::collections::HashMap<git2::Oid, Change>,
 ) -> anyhow::Result<Vec<Change>> {
@@ -252,8 +251,7 @@ fn split_changes(
         .into_values()
         .map(|c| {
             let filter = josh_core::filter::Filter::new().downstack(c.base);
-            let commit = repo.find_commit(c.commit)?;
-            let new_oid = josh_core::filter::apply_to_commit(filter, &commit, transaction)?;
+            let new_oid = josh_core::filter::apply_to_commit(filter, c.commit, transaction)?;
             let mut result = c;
             result.commit = new_oid;
             Ok(result)
@@ -358,7 +356,7 @@ pub fn build_to_push(
     match push_mode {
         PushMode::Publish(author) => {
             let changes = get_changes(repo, oid_to_push, base_oid)?;
-            let changes = split_changes(repo, transaction, changes)?;
+            let changes = split_changes(transaction, changes)?;
 
             let mut push_refs = changes_to_refs(repo, baseref, author, changes)?;
 
@@ -556,7 +554,7 @@ pub fn build_gerrit_independent_push(
     base: git2::Oid,
 ) -> anyhow::Result<Vec<PushRef>> {
     let changes = get_changes(repo, tip, base)?;
-    let changes = split_changes(repo, transaction, changes)?;
+    let changes = split_changes(transaction, changes)?;
 
     // `get_changes` collects into a HashMap, so sort for a deterministic push order.
     let mut changes: Vec<Change> = changes.into_iter().collect();
@@ -600,7 +598,7 @@ pub fn sync_changes(
     branch: &str,
 ) -> anyhow::Result<Vec<Change>> {
     let changes = get_changes(repo, tip, base)?;
-    let changes = split_changes(repo, transaction, changes)?;
+    let changes = split_changes(transaction, changes)?;
     let scope = ChangesRef::Local {
         branch: branch.to_string(),
     };

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use anyhow::anyhow;
+use gix_object::bstr::BString;
 use josh_filter::check_experimental_features_enabled;
 pub use josh_filter::experimental_features_enabled;
 
@@ -42,13 +43,24 @@ pub fn clear_caches() {
 // and we cannot implement external traits for external types.
 // These conversions should be done via parse() and spec() functions directly.
 
+/// A signature override for `rewrite_commit`.
+#[derive(Debug, Clone)]
+pub enum SigRewrite {
+    /// Re-serialize the signature from this name/email pair, keeping the base
+    /// commit's timestamp (`:author`/`:committer`, whose specs carry no time).
+    NameEmail(BString, BString),
+    /// Raw signature field bytes, transplanted verbatim -- timestamp included,
+    /// nothing parsed (the squash path copying the squash-result's signature).
+    Raw(BString),
+}
+
 #[derive(Debug)]
 pub struct Rewrite<'a> {
     tree: git2::Tree<'a>,
     commit: git2::Oid,
-    pub author: Option<(String, String)>,
-    pub committer: Option<(String, String)>,
-    pub message: Option<String>,
+    pub author: Option<SigRewrite>,
+    pub committer: Option<SigRewrite>,
+    pub message: Option<BString>,
 }
 
 impl<'a> Clone for Rewrite<'a> {
@@ -76,9 +88,9 @@ impl<'a> Rewrite<'a> {
 
     pub fn from_tree_with_metadata(
         tree: git2::Tree<'a>,
-        author: Option<(String, String)>,
-        committer: Option<(String, String)>,
-        message: Option<String>,
+        author: Option<SigRewrite>,
+        committer: Option<SigRewrite>,
+        message: Option<BString>,
     ) -> Self {
         Rewrite {
             tree,
@@ -89,74 +101,49 @@ impl<'a> Rewrite<'a> {
         }
     }
 
-    pub fn from_commit(commit: &git2::Commit<'a>) -> anyhow::Result<Self> {
-        let tree = commit.tree()?;
-        let author = commit
-            .author()
-            .name()
-            .ok()
-            .map(|name| name.to_owned())
-            .zip(commit.author().email().ok().map(|email| email.to_owned()));
-        let committer = commit
-            .committer()
-            .name()
-            .ok()
-            .map(|name| name.to_owned())
-            .zip(
-                commit
-                    .committer()
-                    .email()
-                    .ok()
-                    .map(|email| email.to_owned()),
-            );
-        let message = commit.message_raw().ok().map(|msg| msg.to_owned());
-
+    /// The metadata slots stay `None`: rewrite_commit keeps the base commit's raw
+    /// signature and message bytes verbatim unless a filter overrides them, so the
+    /// commit's author/committer/message are never parsed on the passthrough path.
+    pub fn from_commit_data(
+        repo: &'a git2::Repository,
+        commit: &objects::CommitData,
+    ) -> anyhow::Result<Self> {
         Ok(Rewrite {
-            tree,
+            tree: repo.find_tree(commit.tree_id()?)?,
             commit: commit.id(),
-            author,
-            committer,
-            message,
+            author: None,
+            committer: None,
+            message: None,
         })
     }
 
-    pub fn with_author(self, author: (String, String)) -> Self {
+    pub fn with_author(self, author: (BString, BString)) -> Self {
         Rewrite {
             tree: self.tree,
-            author: Some(author),
+            author: Some(SigRewrite::NameEmail(author.0, author.1)),
             commit: self.commit,
             committer: self.committer,
             message: self.message,
         }
     }
 
-    pub fn with_committer(self, committer: (String, String)) -> Self {
+    pub fn with_committer(self, committer: (BString, BString)) -> Self {
         Rewrite {
             tree: self.tree,
             author: self.author,
             commit: self.commit,
-            committer: Some(committer),
+            committer: Some(SigRewrite::NameEmail(committer.0, committer.1)),
             message: self.message,
         }
     }
 
-    pub fn with_message(self, message: String) -> Self {
+    pub fn with_message(self, message: BString) -> Self {
         Rewrite {
             tree: self.tree,
             author: self.author,
             commit: self.commit,
             committer: self.committer,
             message: Some(message),
-        }
-    }
-
-    pub fn with_commit(self, commit: git2::Oid) -> Self {
-        Rewrite {
-            tree: self.tree,
-            author: self.author,
-            commit,
-            committer: self.committer,
-            message: self.message,
         }
     }
 
@@ -389,7 +376,7 @@ fn propagate_meta(filter: Filter, meta: &std::collections::BTreeMap<String, Stri
 /// for the first time and thus should generally be done asynchronously.
 pub fn apply_to_commit(
     filter: Filter,
-    commit: &git2::Commit,
+    commit: git2::Oid,
     transaction: &cache::Transaction,
 ) -> anyhow::Result<git2::Oid> {
     let filter = opt::optimize(filter);
@@ -546,11 +533,9 @@ fn read_josh_link<'a>(
 
 fn get_rev_filter(
     transaction: &cache::Transaction,
-    commit: &git2::Commit,
+    commit_id: git2::Oid,
     filters: &[(RevMatch, LazyRef, Filter)],
 ) -> anyhow::Result<Filter> {
-    let commit_id = commit.id();
-
     // First match wins - iterate in order
     for (match_op, filter_tip_ref, startfilter) in filters.iter() {
         let filter_tip = if let LazyRef::Resolved(filter_tip) = filter_tip_ref {
@@ -594,27 +579,28 @@ fn get_rev_filter(
 
 pub fn apply_to_commit2(
     filter: Filter,
-    commit: &git2::Commit,
+    commit_id: git2::Oid,
     transaction: &cache::Transaction,
 ) -> anyhow::Result<Option<git2::Oid>> {
     let repo = transaction.repo();
     let op = peel_op(filter);
 
     if filter == Filter::new() {
-        return Ok(Some(commit.id()));
+        return Ok(Some(commit_id));
     }
 
+    // First match: oid-only fast paths, no object loads. The commit bytes are only read
+    // after the memo gate below, so memo hits stay zero-I/O.
     match &op {
         Op::Empty => return Ok(Some(git2::Oid::ZERO_SHA1)),
 
         Op::Chain(_) => {
-            let mut current_oid = commit.id();
+            let mut current_oid = commit_id;
             for f in flatten_chain(filter) {
                 if current_oid == git2::Oid::ZERO_SHA1 {
                     break;
                 }
-                let current_commit = repo.find_commit(current_oid)?;
-                let r = some_or!(apply_to_commit2(f, &current_commit, transaction)?, {
+                let r = some_or!(apply_to_commit2(f, current_oid, transaction)?, {
                     return Ok(None);
                 });
                 current_oid = r;
@@ -622,40 +608,45 @@ pub fn apply_to_commit2(
             return Ok(Some(current_oid));
         }
         Op::Squash(None) => {
+            let odb = repo.odb()?;
+            let commit = objects::CommitData::read(&odb, commit_id)?;
             return Some(history::rewrite_commit(
                 repo,
-                commit,
+                &commit,
                 &[],
-                Rewrite::from_commit(commit)?,
+                Rewrite::from_commit_data(repo, &commit)?,
                 history::GpgsigMode::Remove,
             ))
             .transpose();
         }
         Op::Downstack(LazyRef::Resolved(base)) => {
-            if let Some(oid) = transaction.get(filter, commit.id())? {
+            if let Some(oid) = transaction.get(filter, commit_id)? {
                 return Ok(Some(oid));
             }
-            let new_oid = downstack(repo, transaction, commit.id(), *base)?;
-            transaction.insert(filter, commit.id(), new_oid, false)?;
+            let new_oid = downstack(repo, transaction, commit_id, *base)?;
+            transaction.insert(filter, commit_id, new_oid, false)?;
             return Ok(Some(new_oid));
         }
         Op::Downstack(LazyRef::Lazy(_)) => {
             return Err(anyhow!("`:_=...` with unresolved base ref"));
         }
         _ => {
-            if let Some(oid) = transaction.get(filter, commit.id())? {
+            if let Some(oid) = transaction.get(filter, commit_id)? {
                 return Ok(Some(oid));
             }
             // Continue to process the filter if not cached
         }
     };
 
+    let odb = repo.odb()?;
+    let commit = objects::CommitData::read(&odb, commit_id)?;
+
     let rewrite_data = match &op {
         Op::Squash(Some(ids)) => {
             if let Some(sq) = ids.get(&LazyRef::Resolved(commit.id())) {
                 let oid = if let Some(oid) = apply_to_commit2(
                     filter::Filter::new().squash(None).chain(*sq),
-                    commit,
+                    commit_id,
                     transaction,
                 )? {
                     oid
@@ -663,43 +654,33 @@ pub fn apply_to_commit2(
                     return Ok(None);
                 };
 
-                let rc = transaction.repo().find_commit(oid)?;
-                let author = rc
-                    .author()
-                    .name()
-                    .ok()
-                    .map(|x| x.to_owned())
-                    .zip(rc.author().email().ok().map(|x| x.to_owned()));
-                let committer = rc
-                    .committer()
-                    .name()
-                    .ok()
-                    .map(|x| x.to_owned())
-                    .zip(rc.committer().email().ok().map(|x| x.to_owned()));
+                // Transplant the squash result's metadata verbatim onto the rewrite of the
+                // original commit (which must stay the base: memoization keys on its id).
+                // Timestamps are the base's own anyway -- no filter alters them.
+                let rc = objects::CommitData::read(&odb, oid)?;
+                let rcr = rc.parsed()?;
                 Rewrite::from_tree_with_metadata(
-                    rc.tree()?,
-                    author,
-                    committer,
-                    rc.message_raw().ok().map(|x| x.to_owned()),
+                    repo.find_tree(rc.tree_id()?)?,
+                    Some(SigRewrite::Raw(rcr.author.to_owned())),
+                    Some(SigRewrite::Raw(rcr.committer.to_owned())),
+                    Some(rcr.message.to_owned()),
                 )
                 //commit.tree()?
             } else {
-                if let Some(parent) = commit.parents().next() {
-                    return Ok(
-                        if let Some(fparent) = transaction.get(filter, parent.id())? {
-                            Some(history::drop_commit(
-                                commit,
-                                vec![fparent],
-                                transaction,
-                                filter,
-                            )?)
-                        } else {
-                            None
-                        },
-                    );
+                if let Some(parent) = commit.first_parent_id() {
+                    return Ok(if let Some(fparent) = transaction.get(filter, parent)? {
+                        Some(history::drop_commit(
+                            commit.id(),
+                            vec![fparent],
+                            transaction,
+                            filter,
+                        )?)
+                    } else {
+                        None
+                    });
                 }
                 return Ok(Some(history::drop_commit(
-                    commit,
+                    commit.id(),
                     vec![],
                     transaction,
                     filter,
@@ -714,11 +695,11 @@ pub fn apply_to_commit2(
                     return Ok(None);
                 });
 
-                let parent_tree = transaction.repo().find_commit(parent)?.tree_id();
+                let parent_tree = history::filtered_parent_tree_id(transaction, parent)?;
 
-                if parent_tree == commit.tree_id() {
+                if parent_tree == commit.tree_id()? {
                     return Ok(Some(history::drop_commit(
-                        commit,
+                        commit.id(),
                         vec![parent],
                         transaction,
                         filter,
@@ -726,7 +707,7 @@ pub fn apply_to_commit2(
                 }
             }
 
-            Rewrite::from_commit(commit)?
+            Rewrite::from_commit_data(repo, &commit)?
         }
         Op::Export => {
             check_experimental_features_enabled("export filter")?;
@@ -756,12 +737,10 @@ pub fn apply_to_commit2(
             //         return Err(anyhow!("missing commit"));
             //     }
 
-            if let Some(link_file) = read_josh_link(
-                repo,
-                &commit.tree()?,
-                &std::path::PathBuf::new(),
-                ".link.josh",
-            ) {
+            let tree = repo.find_tree(commit.tree_id()?)?;
+            if let Some(link_file) =
+                read_josh_link(repo, &tree, &std::path::PathBuf::new(), ".link.josh")
+            {
                 if let Some(commit_str) = link_file.get_meta("commit") {
                     if let Ok(commit_oid) = git2::Oid::from_str(&commit_str) {
                         if filtered_parent_ids.contains(&commit_oid) {
@@ -774,9 +753,13 @@ pub fn apply_to_commit2(
             }
 
             return Some(history::create_filtered_commit(
-                commit,
+                &commit,
                 filtered_parent_ids,
-                apply(transaction, filter, Rewrite::from_commit(commit)?)?,
+                apply(
+                    transaction,
+                    filter,
+                    Rewrite::from_commit_data(repo, &commit)?,
+                )?,
                 transaction,
                 filter,
             ))
@@ -796,8 +779,9 @@ pub fn apply_to_commit2(
             let mut filtered_parent_ids: Vec<git2::Oid> =
                 some_or!(filtered_parent_ids, { return Ok(None) });
 
+            let tree = repo.find_tree(commit.tree_id()?)?;
             let mut link_parents = vec![];
-            for (link_path, link_file) in find_link_files(&repo, &commit.tree()?)?.into_iter() {
+            for (link_path, link_file) in find_link_files(&repo, &tree)?.into_iter() {
                 if let Some(commit_str) = link_file.get_meta("commit") {
                     if let Ok(commit_oid) = git2::Oid::from_str(&commit_str) {
                         if let Some(cmt) =
@@ -815,12 +799,16 @@ pub fn apply_to_commit2(
                 }
             }
 
-            let new_tree = apply(transaction, filter, Rewrite::from_commit(commit)?)?;
+            let new_tree = apply(
+                transaction,
+                filter,
+                Rewrite::from_commit_data(repo, &commit)?,
+            )?;
 
             filtered_parent_ids.retain(|c| !link_parents.contains(c));
 
             return Some(history::create_filtered_commit(
-                commit,
+                &commit,
                 filtered_parent_ids,
                 new_tree,
                 transaction,
@@ -830,14 +818,19 @@ pub fn apply_to_commit2(
         }
         Op::Link(mode) => {
             check_experimental_features_enabled("link filter")?;
-            let mut roots = get_link_roots(repo, transaction, &commit.tree()?)?;
+            let tree = repo.find_tree(commit.tree_id()?)?;
+            let mut roots = get_link_roots(repo, transaction, &tree)?;
 
-            if let Some(parent) = commit.parents().next() {
+            // A root commit (no first parent) keeps every root; when a first
+            // parent is present its tree must be readable.
+            let parent_tree = match commit.first_parent_id() {
+                Some(parent) => Some(repo.find_tree(git::read_tree_id(repo, parent)?)?),
+                None => None,
+            };
+            if let Some(parent_tree) = parent_tree {
                 roots.retain(|root| {
-                    if let (Ok(a), Ok(b)) = (
-                        commit.tree().and_then(|x| x.get_path(&root)),
-                        parent.tree().and_then(|x| x.get_path(&root)),
-                    ) && a.id() == b.id()
+                    if let (Ok(a), Ok(b)) = (tree.get_path(&root), parent_tree.get_path(&root))
+                        && a.id() == b.id()
                     {
                         false
                     } else {
@@ -846,7 +839,7 @@ pub fn apply_to_commit2(
                 });
             };
 
-            let all_links = links_from_roots(repo, &commit.tree()?, roots)?;
+            let all_links = links_from_roots(repo, &tree, roots)?;
 
             // Only embedded-mode links get extra parent commits spliced in
             let embedded_links: Vec<_> = all_links
@@ -863,7 +856,11 @@ pub fn apply_to_commit2(
                 .collect();
 
             if embedded_links.is_empty() {
-                apply(transaction, filter, Rewrite::from_commit(commit)?)?
+                apply(
+                    transaction,
+                    filter,
+                    Rewrite::from_commit_data(repo, &commit)?,
+                )?
             } else {
                 let normal_parents = commit
                     .parent_ids()
@@ -878,7 +875,7 @@ pub fn apply_to_commit2(
                         let embeding = some_or!(
                             apply_to_commit2(
                                 Filter::new().message("{@}").file(root.join(".link.josh")),
-                                &commit,
+                                commit_id,
                                 transaction
                             )?,
                             {
@@ -888,8 +885,7 @@ pub fn apply_to_commit2(
 
                         let f = to_filter(Op::Embed(root));
 
-                        let embeding = repo.find_commit(embeding)?;
-                        let r = some_or!(apply_to_commit2(f, &embeding, transaction)?, {
+                        let r = some_or!(apply_to_commit2(f, embeding, transaction)?, {
                             return Ok(None);
                         });
 
@@ -899,14 +895,18 @@ pub fn apply_to_commit2(
                     extra_parents
                 };
 
-                let filtered_tree = apply(transaction, filter, Rewrite::from_commit(commit)?)?;
+                let filtered_tree = apply(
+                    transaction,
+                    filter,
+                    Rewrite::from_commit_data(repo, &commit)?,
+                )?;
                 let filtered_parent_ids = normal_parents
                     .into_iter()
                     .chain(extra_parents)
                     .collect::<Vec<_>>();
 
                 return Some(history::create_filtered_commit(
-                    commit,
+                    &commit,
                     filtered_parent_ids,
                     filtered_tree,
                     transaction,
@@ -916,9 +916,9 @@ pub fn apply_to_commit2(
             }
         }
         Op::Workspace(ws_path) => {
-            if let Some((redirect, _)) = resolve_workspace_redirect(repo, &commit.tree()?, ws_path)
-            {
-                if let Some(r) = apply_to_commit2(redirect, commit, transaction)? {
+            let tree = repo.find_tree(commit.tree_id()?)?;
+            if let Some((redirect, _)) = resolve_workspace_redirect(repo, &tree, ws_path) {
+                if let Some(r) = apply_to_commit2(redirect, commit_id, transaction)? {
                     transaction.insert(filter, commit.id(), r, true)?;
                     return Ok(Some(r));
                 } else {
@@ -926,70 +926,67 @@ pub fn apply_to_commit2(
                 }
             }
 
-            let commit_filter = get_workspace(transaction, &commit.tree()?, ws_path);
+            let commit_filter = get_workspace(transaction, &tree, ws_path);
 
             let parent_filters = commit
-                .parents()
+                .parent_ids()
                 .map(|parent| {
-                    let pcw = get_workspace(
-                        transaction,
-                        &parent.tree().unwrap_or_else(|_| tree::empty(repo)),
-                        ws_path,
-                    );
+                    let tree_id = git::read_tree_id(repo, parent)?;
+                    let pcw = get_workspace(transaction, &repo.find_tree(tree_id)?, ws_path);
                     Ok((parent, pcw))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
-            return per_rev_filter(transaction, commit, filter, commit_filter, parent_filters);
+            return per_rev_filter(transaction, &commit, filter, commit_filter, parent_filters);
         }
         Op::Stored(s_path) => {
-            let commit_filter = get_stored(transaction, &commit.tree()?, s_path);
+            let commit_filter =
+                get_stored(transaction, &repo.find_tree(commit.tree_id()?)?, s_path);
 
             let parent_filters = commit
-                .parents()
+                .parent_ids()
                 .map(|parent| {
-                    let pcs = get_stored(
-                        transaction,
-                        &parent.tree().unwrap_or_else(|_| tree::empty(repo)),
-                        s_path,
-                    );
+                    let tree_id = git::read_tree_id(repo, parent)?;
+                    let pcs = get_stored(transaction, &repo.find_tree(tree_id)?, s_path);
                     Ok((parent, pcs))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
-            return per_rev_filter(transaction, commit, filter, commit_filter, parent_filters);
+            return per_rev_filter(transaction, &commit, filter, commit_filter, parent_filters);
         }
         Op::Starlark(s_path, s_subfilter) => {
             check_experimental_features_enabled("Starlark filter")?;
-            let commit_filter = get_starlark(transaction, &commit.tree()?, s_path, *s_subfilter);
+            let commit_filter = get_starlark(
+                transaction,
+                &repo.find_tree(commit.tree_id()?)?,
+                s_path,
+                *s_subfilter,
+            );
 
             let parent_filters = commit
-                .parents()
+                .parent_ids()
                 .map(|parent| {
-                    let pcs = get_starlark(
-                        transaction,
-                        &parent.tree().unwrap_or_else(|_| tree::empty(repo)),
-                        s_path,
-                        *s_subfilter,
-                    );
+                    let tree_id = git::read_tree_id(repo, parent)?;
+                    let pcs =
+                        get_starlark(transaction, &repo.find_tree(tree_id)?, s_path, *s_subfilter);
                     Ok((parent, pcs))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
-            return per_rev_filter(transaction, commit, filter, commit_filter, parent_filters);
+            return per_rev_filter(transaction, &commit, filter, commit_filter, parent_filters);
         }
         Op::Rev(filters) => {
-            let commit_filter = get_rev_filter(transaction, commit, filters)?;
+            let commit_filter = get_rev_filter(transaction, commit.id(), filters)?;
 
             let parent_filters = commit
-                .parents()
+                .parent_ids()
                 .map(|parent| {
-                    let pcw = get_rev_filter(transaction, &parent, filters)?;
+                    let pcw = get_rev_filter(transaction, parent, filters)?;
                     Ok((parent, pcw))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
-            return per_rev_filter(transaction, commit, filter, commit_filter, parent_filters);
+            return per_rev_filter(transaction, &commit, filter, commit_filter, parent_filters);
         }
         Op::Fold => {
             let filtered_parent_ids = commit
@@ -1001,38 +998,41 @@ pub fn apply_to_commit2(
 
             let trees: Vec<git2::Oid> = filtered_parent_ids
                 .iter()
-                .map(|x| Ok(repo.find_commit(*x)?.tree_id()))
+                .map(|x| history::filtered_parent_tree_id(transaction, *x))
                 .collect::<anyhow::Result<_>>()?;
 
-            let mut filtered_tree = commit.tree_id();
+            let mut filtered_tree = commit.tree_id()?;
 
             for t in trees {
                 filtered_tree = tree::overlay(transaction, filtered_tree, t)?;
             }
 
             let filtered_tree = repo.find_tree(filtered_tree)?;
-            Rewrite::from_commit(commit)?.with_tree(filtered_tree)
+            Rewrite::from_commit_data(repo, &commit)?.with_tree(filtered_tree)
         }
         Op::Hook(hook) => {
             let commit_filter = transaction.lookup_filter_hook(hook, commit.id())?;
 
             let parent_filters = commit
-                .parents()
+                .parent_ids()
                 .map(|parent| {
-                    let pcw = transaction.lookup_filter_hook(hook, parent.id())?;
+                    let pcw = transaction.lookup_filter_hook(hook, parent)?;
                     Ok((parent, pcw))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
-            return per_rev_filter(transaction, commit, filter, commit_filter, parent_filters);
+            return per_rev_filter(transaction, &commit, filter, commit_filter, parent_filters);
         }
         Op::Unapply(target, uf) => {
             check_experimental_features_enabled("unapply filter")?;
             if let LazyRef::Resolved(target) = target {
                 /* dbg!(target); */
-                let target = repo.find_commit(*target)?;
-                if let Some(parent) = target.parents().next() {
-                    let ptree = apply(transaction, *uf, Rewrite::from_commit(&parent)?)?;
+                let target = objects::CommitData::read(&odb, *target)?;
+                // Only a root commit (no first parent) skips link detection; a
+                // first parent that is present must be readable.
+                if let Some(parent_id) = target.first_parent_id() {
+                    let parent = objects::CommitData::read(&odb, parent_id)?;
+                    let ptree = apply(transaction, *uf, Rewrite::from_commit_data(repo, &parent)?)?;
                     if let Some(link) = read_josh_link(
                         repo,
                         &ptree.tree(),
@@ -1061,13 +1061,14 @@ pub fn apply_to_commit2(
             apply(
                 transaction,
                 filter,
-                Rewrite::from_commit(commit)?, /* Rewrite::from_commit(commit)?.with_parents(filtered_parent_ids), */
+                Rewrite::from_commit_data(repo, &commit)?, /* Rewrite::from_commit_data(repo, &commit)?.with_parents(filtered_parent_ids), */
             )?
         }
         Op::Embed(path) => {
             check_experimental_features_enabled("embed filter")?;
 
-            if let Some(link) = read_josh_link(repo, &commit.tree()?, &path, ".link.josh") {
+            let tree = repo.find_tree(commit.tree_id()?)?;
+            if let Some(link) = read_josh_link(repo, &tree, &path, ".link.josh") {
                 let subdir = filter::invert(link.peel())?;
                 let unapply = to_filter(Op::Unapply(LazyRef::Resolved(commit.id()), subdir));
                 if let Some(commit_str) = link.get_meta("commit") {
@@ -1083,7 +1084,11 @@ pub fn apply_to_commit2(
             return Ok(Some(git2::Oid::ZERO_SHA1));
         }
 
-        _ => apply(transaction, filter, Rewrite::from_commit(commit)?)?,
+        _ => apply(
+            transaction,
+            filter,
+            Rewrite::from_commit_data(repo, &commit)?,
+        )?,
     };
 
     let tree_data = rewrite_data;
@@ -1098,7 +1103,7 @@ pub fn apply_to_commit2(
     let filtered_parent_ids = some_or!(filtered_parent_ids, { return Ok(None) });
 
     Some(history::create_filtered_commit(
-        commit,
+        &commit,
         filtered_parent_ids,
         tree_data,
         transaction,
@@ -1206,28 +1211,31 @@ pub fn apply<'a>(
         Op::Empty => Ok(x.with_tree(tree::empty(repo))),
         Op::Fold => Ok(x),
         Op::Squash(None) => Ok(x),
-        Op::Author(author, email) => Ok(x.with_author((author.clone(), email.clone()))),
-        Op::Committer(author, email) => Ok(x.with_committer((author.clone(), email.clone()))),
+        Op::Author(author, email) => {
+            Ok(x.with_author((author.clone().into(), email.clone().into())))
+        }
+        Op::Committer(author, email) => {
+            Ok(x.with_committer((author.clone().into(), email.clone().into())))
+        }
         Op::Squash(Some(_)) => Err(anyhow!("not applicable to tree: squash")),
         Op::Message(m, r) => {
             let tree_id = x.tree().id().to_string();
             let commit = x.commit;
             let commit_id = commit.to_string();
 
+            // The template transform is the one consumer that needs the message as text, so
+            // the UTF-8 decode happens here (and only here), erroring loudly.
             let message = if let Some(ref m) = x.message {
-                m.to_string()
+                std::str::from_utf8(m.as_ref())?.to_string()
             } else if let Ok(c) = transaction.repo().find_commit(commit) {
-                c.message_raw().unwrap_or_default().to_string()
+                std::str::from_utf8(c.message_raw_bytes())?.to_string()
             } else {
                 "".to_string()
             };
 
             let tree = x.tree().clone();
-            Ok(x.with_message(text::transform_with_template(
-                r,
-                m,
-                &message,
-                |key: &str| -> Option<String> {
+            Ok(x.with_message(
+                text::transform_with_template(r, m, &message, |key: &str| -> Option<String> {
                     match key {
                         "#" => Some(tree_id.clone()),
                         "@" => Some(commit_id.clone()),
@@ -1243,8 +1251,9 @@ pub fn apply<'a>(
                         ),
                         _ => None,
                     }
-                },
-            )?))
+                })?
+                .into(),
+            ))
         }
         Op::Prune => Ok(x),
         Op::Adapt(adapter) => {
@@ -1457,12 +1466,17 @@ pub fn apply<'a>(
             )?))
         }
 
-        Op::Subdir(path) => Ok(x.clone().with_tree(
-            x.tree()
-                .get_path(path)
-                .and_then(|x| repo.find_tree(x.id()))
-                .unwrap_or_else(|_| tree::empty(repo)),
-        )),
+        Op::Subdir(path) => {
+            // A missing path or a non-tree entry (e.g. a blob) has no subtree;
+            // a present tree entry must load.
+            let subtree = match x.tree().get_path(path) {
+                Ok(entry) if entry.kind() == Some(git2::ObjectType::Tree) => {
+                    repo.find_tree(entry.id())?
+                }
+                _ => tree::empty(repo),
+            };
+            Ok(x.clone().with_tree(subtree))
+        }
         Op::Prefix(path) => Ok(x.clone().with_tree(tree::insert(
             repo,
             &tree::empty(repo),
@@ -1765,7 +1779,7 @@ fn resolve_commit_filter(
     commit: &git2::Commit,
 ) -> anyhow::Result<Filter> {
     match op {
-        Op::Rev(revs) => get_rev_filter(transaction, commit, revs),
+        Op::Rev(revs) => get_rev_filter(transaction, commit.id(), revs),
         Op::Hook(hook) => transaction.lookup_filter_hook(hook, commit.id()),
         _ => Err(anyhow!("not a per-commit (rev/hook) filter")),
     }
@@ -2090,7 +2104,7 @@ fn legalize_stored(t: &cache::Transaction, f: Filter, tree: &git2::Tree) -> anyh
 fn compute_splice_parents(
     transaction: &cache::Transaction,
     commit_filter: Filter,
-    parent_filters: Vec<(git2::Commit, Filter)>,
+    parent_filters: Vec<(git2::Oid, Filter)>,
     meta: &std::collections::BTreeMap<String, String>,
 ) -> anyhow::Result<Option<Vec<git2::Oid>>> {
     // This is only reached when history splicing is enabled, and `per_rev_filter` rejects `:pin`
@@ -2107,7 +2121,7 @@ fn compute_splice_parents(
             // `step`'s set-difference the flat form it needs to cancel.
             let f = opt::minimize(to_filter(Op::Subtract(commit_filter.peel(), pcw.peel())));
             let f = propagate_meta(f, meta);
-            apply_to_commit2(f, &parent, transaction)
+            apply_to_commit2(f, parent, transaction)
         })
         .collect::<anyhow::Result<Option<Vec<_>>>>()?;
 
@@ -2123,10 +2137,10 @@ fn compute_splice_parents(
 
 fn per_rev_filter(
     transaction: &cache::Transaction,
-    commit: &git2::Commit,
+    commit: &objects::CommitData,
     filter: Filter,
     commit_filter: Filter,
-    parent_filters: Vec<(git2::Commit, Filter)>,
+    parent_filters: Vec<(git2::Oid, Filter)>,
 ) -> anyhow::Result<Option<git2::Oid>> {
     // Propagate any meta-options from the outer filter (e.g. :~(gpgsig="norm-lf")[:rev(...)])
     // into the per-commit filter so they are applied during commit rewriting.
@@ -2171,17 +2185,16 @@ fn per_rev_filter(
             let pin_subtract = apply(
                 transaction,
                 opt::optimize(to_filter(Op::Subtract(legalized_a, legalized_b))),
-                Rewrite::from_commit(commit)?,
+                Rewrite::from_commit_data(transaction.repo(), commit)?,
             )?;
 
-            let parent = transaction.repo().find_commit(parent)?;
+            let parent_tree_id = history::filtered_parent_tree_id(transaction, parent)?;
 
             // Re-content the pinned path set from the parent's filtered tree: keep exactly the
             // parent's entries whose path is pinned. Equivalent to the older
             // `populate(pathstree(pin_subtract), parent)` spelling of "select the pinned paths out
             // of the previous tree", but in a single path-intersection pass.
-            let pin_overlay =
-                tree::intersect(transaction, parent.tree_id(), pin_subtract.tree.id())?;
+            let pin_overlay = tree::intersect(transaction, parent_tree_id, pin_subtract.tree.id())?;
 
             Some((pin_subtract.tree.id(), pin_overlay))
         } else {
@@ -2232,14 +2245,18 @@ fn per_rev_filter(
             }
         }
         return Ok(Some(history::drop_commit(
-            commit,
+            commit.id(),
             target.map(|(_, id)| id).into_iter().collect(),
             transaction,
             filter,
         )?));
     }
 
-    let mut tree_data = apply(transaction, commit_filter, Rewrite::from_commit(commit)?)?;
+    let mut tree_data = apply(
+        transaction,
+        commit_filter,
+        Rewrite::from_commit_data(transaction.repo(), commit)?,
+    )?;
 
     if let Some((pin_subtract, pin_overlay)) = pin_details {
         let with_exclude = tree::subtract(transaction, tree_data.tree().id(), pin_subtract)?;
@@ -2310,6 +2327,7 @@ pub fn downstack(
     }
 
     // Rebase needed intermediates forward onto current_base.
+    let odb = repo.odb()?;
     let mut current_base = repo.find_commit(base_oid)?;
     for (intermediate, is_needed) in commits.iter().zip(needed.iter()) {
         if !is_needed {
@@ -2326,7 +2344,7 @@ pub fn downstack(
         let new_tree = repo.find_tree(new_tree_oid)?;
         let new_oid = history::rewrite_commit(
             repo,
-            intermediate,
+            &objects::CommitData::read(&odb, intermediate.id())?,
             &[current_base.id()],
             Rewrite::from_tree(new_tree),
             history::GpgsigMode::Preserve,
@@ -2354,7 +2372,7 @@ pub fn downstack(
 
     let new_oid = history::rewrite_commit(
         repo,
-        &change_commit,
+        &objects::CommitData::read(&odb, change_commit.id())?,
         &new_parents,
         Rewrite::from_tree(new_tree),
         history::GpgsigMode::Preserve,

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -246,9 +246,54 @@ impl GitCommand {
 pub fn read_parent_ids(repo: &git2::Repository, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
     let odb = repo.odb()?;
     let odb_commit = odb.read(oid)?;
-    debug_assert_eq!(odb_commit.kind(), git2::ObjectType::Commit);
+    // A hard error, not an assert: this is reachable from inside libgit2 revwalk callbacks,
+    // where unwinding across the FFI frame would abort.
+    if odb_commit.kind() != git2::ObjectType::Commit {
+        return Err(anyhow::anyhow!(
+            "object {} is not a commit but a {:?}",
+            oid,
+            odb_commit.kind()
+        ));
+    }
     gix_object::CommitRefIter::from_bytes(odb_commit.data(), gix_hash::Kind::Sha1)
         .parent_ids()
         .map(|p| Ok(git2::Oid::from_bytes(p.as_bytes())?))
         .collect()
+}
+
+/// Sibling of [`read_parent_ids`]: read a commit's tree OID from the raw ODB bytes via
+/// `gix_object::CommitRefIter`, replacing `find_commit(oid)?.tree_id()` without touching
+/// libgit2's commit parse cache.
+pub fn read_tree_id(repo: &git2::Repository, oid: git2::Oid) -> anyhow::Result<git2::Oid> {
+    let odb = repo.odb()?;
+    let odb_commit = odb.read(oid)?;
+    // Same hard-error rationale as read_parent_ids.
+    if odb_commit.kind() != git2::ObjectType::Commit {
+        return Err(anyhow::anyhow!(
+            "object {} is not a commit but a {:?}",
+            oid,
+            odb_commit.kind()
+        ));
+    }
+    let tree_id =
+        gix_object::CommitRefIter::from_bytes(odb_commit.data(), gix_hash::Kind::Sha1).tree_id()?;
+    Ok(git2::Oid::from_bytes(tree_id.as_bytes())?)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn read_tree_id_matches_find_commit() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
+        let tree_id = repo.treebuilder(None).unwrap().write().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let commit_id = repo.commit(None, &sig, &sig, "test", &tree, &[]).unwrap();
+
+        assert_eq!(
+            super::read_tree_id(&repo, commit_id).unwrap(),
+            repo.find_commit(commit_id).unwrap().tree_id()
+        );
+    }
 }

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -24,9 +24,12 @@ pub fn walk2(
         return Ok(());
     }
 
-    let input_commit = ok_or!(transaction.repo().find_commit(input), {
-        return Ok(());
-    });
+    // A missing or non-commit input aborts the walk quietly; read_header avoids
+    // decompressing the object.
+    match transaction.repo().odb()?.read_header(input) {
+        Ok((_, git2::ObjectType::Commit)) => {}
+        _ => return Ok(()),
+    }
 
     let walk = {
         let mut walk = transaction.repo().revwalk()?;
@@ -47,7 +50,7 @@ pub fn walk2(
         "Walking {} commits for: {} {:?}",
         crate::cache::compute_sequence_number(transaction, input)?,
         filter::spec(filter),
-        input_commit,
+        input,
     );
     let mut n_in = 0;
     let mut n_out = 0;
@@ -55,9 +58,7 @@ pub fn walk2(
     for original_commit_id in walk {
         let id = original_commit_id?;
 
-        if filter::apply_to_commit2(filter, &transaction.repo().find_commit(id)?, transaction)?
-            .is_some()
-        {
+        if filter::apply_to_commit2(filter, id, transaction)?.is_some() {
             n_out += 1;
         } else {
             break;
@@ -104,8 +105,7 @@ fn find_unapply_base(
         return Ok(git2::Oid::ZERO_SHA1);
     }
 
-    let contained_in_commit = transaction.repo().find_commit(contained_in)?;
-    let oid = filter::apply_to_commit(filter, &contained_in_commit, transaction)?;
+    let oid = filter::apply_to_commit(filter, contained_in, transaction)?;
     if oid != git2::Oid::ZERO_SHA1 {
         filtered_to_original.insert(oid, contained_in);
     }
@@ -168,15 +168,8 @@ fn find_unapply_base(
         {
             ctx.pending.remove(&pending_oid);
 
-            let commit = match transaction.repo().find_commit(pending_oid) {
-                Ok(commit) => commit,
-                Err(e) => {
-                    ctx.result = Some(Err(e.into()));
-                    return true;
-                }
-            };
-
-            let original_filtered = match filter::apply_to_commit(filter, &commit, transaction) {
+            let original_filtered = match filter::apply_to_commit(filter, pending_oid, transaction)
+            {
                 Ok(oid) => oid,
                 Err(e) => {
                     ctx.result = Some(Err(e));
@@ -189,7 +182,14 @@ fn find_unapply_base(
                 return true;
             }
 
-            for parent_id in commit.parent_ids() {
+            let parent_ids = match git::read_parent_ids(transaction.repo(), pending_oid) {
+                Ok(parent_ids) => parent_ids,
+                Err(e) => {
+                    ctx.result = Some(Err(e));
+                    return true;
+                }
+            };
+            for parent_id in parent_ids {
                 ctx.unlocked.insert(parent_id);
             }
         }
@@ -242,20 +242,17 @@ pub fn find_original(
     walk.push(contained_in)?;
 
     for original in walk {
-        let original = transaction.repo().find_commit(original?)?;
-        if filtered == filter::apply_to_commit(filter, &original, transaction)? {
-            if original.parent_ids().count() == 1 {
-                let fp = filter::apply_to_commit(
-                    filter,
-                    &original.parents().next().unwrap(),
-                    transaction,
-                )?;
+        let original = original?;
+        if filtered == filter::apply_to_commit(filter, original, transaction)? {
+            let parent_ids = git::read_parent_ids(transaction.repo(), original)?;
+            if parent_ids.len() == 1 {
+                let fp = filter::apply_to_commit(filter, parent_ids[0], transaction)?;
 
                 if fp == filtered {
                     continue;
                 }
             }
-            return Ok(original.id());
+            return Ok(original);
         }
     }
 
@@ -266,7 +263,7 @@ pub fn find_original(
 // given
 pub fn rewrite_commit(
     repo: &git2::Repository,
-    base: &git2::Commit,
+    base: &objects::CommitData,
     parents: &[git2::Oid],
     rewrite_data: filter::Rewrite,
     gpgsig: GpgsigMode,
@@ -274,8 +271,6 @@ pub fn rewrite_commit(
     use gix_object::bstr::BString;
 
     let odb = repo.odb()?;
-    let odb_commit = odb.read(base.id())?;
-    assert_eq!(odb_commit.kind(), git2::ObjectType::Commit);
 
     // gix_object::CommitRef uses byte strings for Oids, but in hex representation, not raw bytes.
     // Its `Format` implementation writes out hex-encoded bytes. Because of CommitRef's reference
@@ -288,9 +283,9 @@ pub fn rewrite_commit(
 
     let mut author = None;
     let mut committer = None;
-    let message = rewrite_data.message.map(|s| BString::from(s));
+    let message = rewrite_data.message;
 
-    let mut commit = gix_object::CommitRef::from_bytes(odb_commit.data(), gix_hash::Kind::Sha1)?;
+    let mut commit = gix_object::CommitRef::from_bytes(base.bytes(), gix_hash::Kind::Sha1)?;
     commit.tree = tree_id.as_ref();
 
     commit.parents.clear();
@@ -298,36 +293,38 @@ pub fn rewrite_commit(
         .parents
         .extend(parent_ids.iter().map(BString::as_ref));
 
-    let rewrite_signature = |name: String, email: String, time: &str| -> anyhow::Result<BString> {
-        let name = BString::from(name);
-        let email = BString::from(email);
+    let rewrite_signature =
+        |name: BString, email: BString, time: &str| -> anyhow::Result<BString> {
+            let signature = gix_actor::SignatureRef {
+                name: name.as_ref(),
+                email: email.as_ref(),
+                time,
+            };
 
-        let signature = gix_actor::SignatureRef {
-            name: name.as_ref(),
-            email: email.as_ref(),
-            time,
+            let mut buffer = Vec::new();
+            signature.write_to(&mut buffer)?;
+
+            Ok(BString::from(buffer))
         };
 
-        let mut buffer = Vec::new();
-        signature.write_to(&mut buffer)?;
-
-        Ok(BString::from(buffer))
-    };
-
-    if let Some(rewrite_author) = rewrite_data
-        .author
-        .map(|(name, email)| rewrite_signature(name, email, commit.author()?.time))
-        .transpose()?
-    {
-        author = Some(rewrite_author);
+    // NameEmail re-serializes with the base commit's own timestamp; Raw is a verbatim
+    // byte transplant of a complete signature field, nothing parsed.
+    if let Some(sig) = rewrite_data.author {
+        author = Some(match sig {
+            filter::SigRewrite::NameEmail(name, email) => {
+                rewrite_signature(name, email, commit.author()?.time)?
+            }
+            filter::SigRewrite::Raw(raw) => raw,
+        });
     }
 
-    if let Some(rewrite_committer) = rewrite_data
-        .committer
-        .map(|(name, email)| rewrite_signature(name, email, commit.committer()?.time))
-        .transpose()?
-    {
-        committer = Some(rewrite_committer);
+    if let Some(sig) = rewrite_data.committer {
+        committer = Some(match sig {
+            filter::SigRewrite::NameEmail(name, email) => {
+                rewrite_signature(name, email, commit.committer()?.time)?
+            }
+            filter::SigRewrite::Raw(raw) => raw,
+        });
     }
 
     if let Some(author) = &author {
@@ -380,14 +377,12 @@ fn find_oldest_similar_commit(
         walk
     };
     tracing::info!("oldest similar?");
-    let unfiltered_commit = transaction.repo().find_commit(unfiltered)?;
-    let filtered = filter::apply_to_commit(filter, &unfiltered_commit, transaction)?;
+    let filtered = filter::apply_to_commit(filter, unfiltered, transaction)?;
     let mut prev_rev = unfiltered;
     for rev in walk {
         let rev = rev?;
         tracing::info!("next");
-        let rev_commit = transaction.repo().find_commit(rev)?;
-        if filtered != filter::apply_to_commit(filter, &rev_commit, transaction)? {
+        if filtered != filter::apply_to_commit(filter, rev, transaction)? {
             tracing::info!("diff! {}", prev_rev);
             return Ok(prev_rev);
         }
@@ -500,6 +495,8 @@ pub fn unapply_filter(
     }
 
     tracing::info!("before walk");
+
+    let odb = transaction.repo().odb()?;
 
     let walk = {
         let mut walk = transaction.repo().revwalk()?;
@@ -770,7 +767,7 @@ pub fn unapply_filter(
             original_parents.iter().map(|c| c.id()).collect();
         ret = rewrite_commit(
             transaction.repo(),
-            &module_commit,
+            &objects::CommitData::read(&odb, module_commit.id())?,
             &original_parent_oids,
             apply,
             GpgsigMode::Preserve,
@@ -793,29 +790,35 @@ pub fn unapply_filter(
 }
 
 fn select_parent_commits(
-    original_commit: &git2::Commit,
+    repo: &git2::Repository,
+    original_commit: &objects::CommitData,
     filtered_tree_id: git2::Oid,
     filtered_parents: &[(git2::Oid, git2::Oid)],
-) -> Vec<git2::Oid> {
+) -> anyhow::Result<Vec<git2::Oid>> {
     let affects_filtered = filtered_parents
         .iter()
         .any(|(_, tree_id)| filtered_tree_id != *tree_id);
 
-    let all_diffs_empty = original_commit
-        .parents()
-        .all(|x| x.tree_id() == original_commit.tree_id());
+    let original_tree_id = original_commit.tree_id()?;
+    let mut all_diffs_empty = true;
+    for p in original_commit.parent_ids() {
+        if git::read_tree_id(repo, p)? != original_tree_id {
+            all_diffs_empty = false;
+            break;
+        }
+    }
 
-    if affects_filtered || all_diffs_empty {
+    Ok(if affects_filtered || all_diffs_empty {
         filtered_parents.iter().map(|(id, _)| *id).collect()
     } else {
         vec![]
-    }
+    })
 }
 
 // parents={none, linear, keep-trivial, default}
 
 pub fn drop_commit(
-    original_commit: &git2::Commit,
+    original_commit: git2::Oid,
     filtered_parent_ids: Vec<git2::Oid>,
     transaction: &cache::Transaction,
     filter: filter::Filter,
@@ -826,13 +829,13 @@ pub fn drop_commit(
         git2::Oid::ZERO_SHA1
     };
 
-    transaction.insert(filter, original_commit.id(), r, false)?;
+    transaction.insert(filter, original_commit, r, false)?;
 
     Ok(r)
 }
 
 pub fn create_filtered_commit_with_meta(
-    original_commit: &git2::Commit,
+    original_commit: &objects::CommitData,
     filtered_parent_ids: Vec<git2::Oid>,
     rewrite_data: filter::Rewrite,
     transaction: &cache::Transaction,
@@ -847,7 +850,7 @@ pub fn create_filtered_commit_with_meta(
         meta,
     )?;
 
-    let store = is_new || original_commit.parent_ids().len() != 1;
+    let store = is_new || original_commit.parent_count() != 1;
 
     transaction.insert(filter, original_commit.id(), r, store)?;
 
@@ -855,7 +858,7 @@ pub fn create_filtered_commit_with_meta(
 }
 
 pub fn create_filtered_commit(
-    original_commit: &git2::Commit,
+    original_commit: &objects::CommitData,
     filtered_parent_ids: Vec<git2::Oid>,
     rewrite_data: filter::Rewrite,
     transaction: &cache::Transaction,
@@ -871,9 +874,9 @@ pub fn create_filtered_commit(
     )
 }
 
-fn create_filtered_commit2<'a>(
-    transaction: &'a cache::Transaction,
-    original_commit: &'a git2::Commit,
+fn create_filtered_commit2(
+    transaction: &cache::Transaction,
+    original_commit: &objects::CommitData,
     filtered_parent_ids: Vec<git2::Oid>,
     rewrite_data: filter::Rewrite,
     options: BTreeMap<String, String>,
@@ -923,10 +926,12 @@ fn create_filtered_commit2<'a>(
     ) {
         if filtered_parents.len() > 1 {
             let is_trivial_merge = filtered_parents[0].1 == rewrite_data.tree().id();
-            let was_trivial_merge = original_commit
-                .parents()
-                .next()
-                .is_some_and(|c| c.tree_id() == original_commit.tree_id());
+            // No first parent is not a trivial merge; a present first parent
+            // must have a readable tree.
+            let was_trivial_merge = match original_commit.first_parent_id() {
+                Some(parent) => git::read_tree_id(repo, parent)? == original_commit.tree_id()?,
+                None => false,
+            };
 
             if is_trivial_merge && !was_trivial_merge {
                 // Returning the parent id here means the commit is dropped from the output history
@@ -935,11 +940,16 @@ fn create_filtered_commit2<'a>(
         }
     }
 
-    let selected_filtered_parent_ids: Vec<git2::Oid> =
-        select_parent_commits(original_commit, rewrite_data.tree().id(), &filtered_parents);
+    let selected_filtered_parent_ids: Vec<git2::Oid> = select_parent_commits(
+        repo,
+        original_commit,
+        rewrite_data.tree().id(),
+        &filtered_parents,
+    )?;
 
     if selected_filtered_parent_ids.is_empty()
-        && !(original_commit.parents().len() == 0 && is_empty_root(repo, &original_commit.tree()?))
+        && !(original_commit.parent_count() == 0
+            && is_empty_root(repo, &repo.find_tree(original_commit.tree_id()?)?))
     {
         if !filtered_parents.is_empty() {
             // Returning the parent id here means the commit is dropped from the output history
@@ -974,7 +984,7 @@ fn create_filtered_commit2<'a>(
 /// child, so the parent is almost always the last commit josh wrote and its tree is served from the
 /// transaction's single-slot cache; anything else (merge parents, non-linear order) falls back to
 /// parsing the commit from the odb.
-fn filtered_parent_tree_id(
+pub(crate) fn filtered_parent_tree_id(
     transaction: &cache::Transaction,
     oid: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
@@ -983,7 +993,7 @@ fn filtered_parent_tree_id(
             return Ok(tree_id);
         }
     }
-    Ok(transaction.repo().find_commit(oid)?.tree_id())
+    git::read_tree_id(transaction.repo(), oid)
 }
 
 fn is_empty_root(repo: &git2::Repository, tree: &git2::Tree) -> bool {

--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -206,7 +206,7 @@ pub fn get_info(
 
     let mut meta = HashMap::new();
     meta.insert("sha1".to_owned(), "".to_owned());
-    let filtered = filter::apply_to_commit(filter, &commit, transaction)?;
+    let filtered = filter::apply_to_commit(filter, commit.id(), transaction)?;
 
     let parent_ids = |commit: &git2::Commit| {
         commit

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -180,7 +180,7 @@ pub fn filter_commit(
     } else {
         tracing::trace!("apply_to_commit");
 
-        filter::apply_to_commit(filterobj, &original_commit, transaction)?
+        filter::apply_to_commit(filterobj, original_commit.id(), transaction)?
     };
 
     transaction.insert_ref(filterobj, oid, filter_commit);

--- a/josh-gix-ext/Cargo.toml
+++ b/josh-gix-ext/Cargo.toml
@@ -14,3 +14,6 @@ anyhow.workspace = true
 git2.workspace = true
 gix-hash.workspace = true
 gix-object.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -155,6 +155,75 @@ pub fn write_tree_now(
     Ok(odb.write(git2::ObjectType::Tree, &buffer)?)
 }
 
+/// A commit's id + raw odb bytes, owned. Send + Sync plain data; never stored in a transaction.
+/// Parse-on-demand: `CommitRef`/`CommitRefIter` borrow `&self` and never outlive the frame.
+/// The internal representation can become `Arc<[u8]>` later without any signature change.
+#[derive(Clone, Debug)]
+pub struct CommitData {
+    id: git2::Oid,
+    bytes: Vec<u8>,
+}
+
+impl CommitData {
+    /// odb.read + kind check. Errors if the object is missing or not a commit -- matching
+    /// `find_commit`'s contract (both are hard errors there too). Reads go through the odb's
+    /// registered backends (memodb visibility preserved).
+    pub fn read(odb: &git2::Odb<'_>, oid: git2::Oid) -> anyhow::Result<CommitData> {
+        let obj = odb.read(oid)?;
+        if obj.kind() != git2::ObjectType::Commit {
+            return Err(anyhow::anyhow!(
+                "object {} is not a commit but a {:?}",
+                oid,
+                obj.kind()
+            ));
+        }
+        Ok(CommitData {
+            id: oid,
+            bytes: obj.data().to_vec(),
+        })
+    }
+
+    pub fn id(&self) -> git2::Oid {
+        self.id
+    }
+
+    /// The raw serialized commit, exactly as stored in the odb.
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Full parse of the raw bytes. Cheap (winnow over a few hundred bytes; no lock, no FFI),
+    /// so callers just parse again when they need a second look.
+    pub fn parsed(&self) -> anyhow::Result<gix_object::CommitRef<'_>> {
+        Ok(gix_object::CommitRef::from_bytes(
+            &self.bytes,
+            gix_hash::Kind::Sha1,
+        )?)
+    }
+
+    pub fn tree_id(&self) -> anyhow::Result<git2::Oid> {
+        let id =
+            gix_object::CommitRefIter::from_bytes(&self.bytes, gix_hash::Kind::Sha1).tree_id()?;
+        Ok(git2_oid(&id))
+    }
+
+    /// Binary parent ids read from the parsed commit header id array via
+    /// `CommitRefIter::parent_ids`; never does odb lookups.
+    pub fn parent_ids(&self) -> impl Iterator<Item = git2::Oid> + '_ {
+        gix_object::CommitRefIter::from_bytes(&self.bytes, gix_hash::Kind::Sha1)
+            .parent_ids()
+            .map(|p| git2_oid(&p))
+    }
+
+    pub fn first_parent_id(&self) -> Option<git2::Oid> {
+        self.parent_ids().next()
+    }
+
+    pub fn parent_count(&self) -> usize {
+        self.parent_ids().count()
+    }
+}
+
 /// An in-memory staging store over an optional read-through object database.
 ///
 /// Writes stage objects in a hash map; reads (via the [`gix_object::Find`] family) consult the

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -102,17 +102,18 @@ impl Revision {
 
     fn hash(&self, context: &Context) -> FieldResult<String> {
         let transaction = context.transaction.lock().unwrap();
-        let commit = transaction.repo().find_commit(self.commit_id)?;
-        let filter_commit = filter::apply_to_commit(self.filter, &commit, &transaction)?;
+        // Existence/type probe: a bogus id (e.g. the zero oid from a target-less symbolic
+        // ref) must error here, not filter to a bogus hash under a nop filter.
+        transaction.repo().find_commit(self.commit_id)?;
+        let filter_commit = filter::apply_to_commit(self.filter, self.commit_id, &transaction)?;
         Ok(format!("{}", filter_commit))
     }
 
     fn author_email(&self, context: &Context) -> FieldResult<String> {
         let transaction = context.transaction.lock().unwrap();
-        let commit = transaction.repo().find_commit(self.commit_id)?;
         let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
             self.filter,
-            &commit,
+            self.commit_id,
             &transaction,
         )?)?;
         let a = filter_commit.author();
@@ -121,10 +122,9 @@ impl Revision {
 
     fn summary(&self, context: &Context) -> FieldResult<String> {
         let transaction = context.transaction.lock().unwrap();
-        let commit = transaction.repo().find_commit(self.commit_id)?;
         let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
             self.filter,
-            &commit,
+            self.commit_id,
             &transaction,
         )?)?;
         Ok(filter_commit
@@ -137,10 +137,9 @@ impl Revision {
 
     fn message(&self, context: &Context) -> FieldResult<String> {
         let transaction = context.transaction.lock().unwrap();
-        let commit = transaction.repo().find_commit(self.commit_id)?;
         let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
             self.filter,
-            &commit,
+            self.commit_id,
             &transaction,
         )?)?;
         Ok(filter_commit.message().unwrap_or("").to_owned())
@@ -148,10 +147,9 @@ impl Revision {
 
     fn date(&self, format: String, context: &Context) -> FieldResult<String> {
         let transaction = context.transaction.lock().unwrap();
-        let commit = transaction.repo().find_commit(self.commit_id)?;
         let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
             self.filter,
-            &commit,
+            self.commit_id,
             &transaction,
         )?)?;
 
@@ -170,10 +168,9 @@ impl Revision {
     ) -> FieldResult<Option<Revision>> {
         let commit_id = if let Some(true) = original {
             let transaction = context.transaction.lock().unwrap();
-            let commit = transaction.repo().find_commit(self.commit_id)?;
             let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
                 self.filter,
-                &commit,
+                self.commit_id,
                 &transaction,
             )?)?;
 
@@ -196,8 +193,7 @@ impl Revision {
 
     fn parents(&self, context: &Context) -> FieldResult<Vec<Revision>> {
         let transaction = context.transaction.lock().unwrap();
-        let commit = transaction.repo().find_commit(self.commit_id)?;
-        let filter_commit_id = filter::apply_to_commit(self.filter, &commit, &transaction)?;
+        let filter_commit_id = filter::apply_to_commit(self.filter, self.commit_id, &transaction)?;
 
         let parents = josh_core::git::read_parent_ids(transaction.repo(), filter_commit_id)?
             .into_iter()
@@ -226,10 +222,9 @@ impl Revision {
         let limit = limit.unwrap_or(1) as usize;
         let offset = offset.unwrap_or(0) as usize;
         let transaction = context.transaction.lock().unwrap();
-        let commit = transaction.repo().find_commit(self.commit_id)?;
         let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
             self.filter,
-            &commit,
+            self.commit_id,
             &transaction,
         )?)?;
 
@@ -298,10 +293,9 @@ impl Revision {
         context: &Context,
     ) -> FieldResult<Option<Vec<DiffPath>>> {
         let transaction = context.transaction.lock().unwrap();
-        let commit = transaction.repo().find_commit(self.commit_id)?;
         let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
             self.filter,
-            &commit,
+            self.commit_id,
             &transaction,
         )?)?;
 
@@ -936,15 +930,10 @@ struct RevMut {
 impl RevMut {
     fn push(&self, target: String, repo: Option<String>, context: &Context) -> FieldResult<bool> {
         let transaction = context.transaction.lock().unwrap();
-        let transaction_mirror = context.transaction_mirror.lock().unwrap();
-
-        let commit = transaction_mirror
-            .repo()
-            .find_commit(git2::Oid::from_str(&self.at)?)?;
 
         let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
             self.filter,
-            &commit,
+            git2::Oid::from_str(&self.at)?,
             &transaction,
         )?)?;
 

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -536,11 +536,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
             }
         }
 
-        let reapply = josh_core::filter::apply_to_commit(
-            filter,
-            &transaction.repo().find_commit(oid_to_push)?,
-            &transaction,
-        )?;
+        let reapply = josh_core::filter::apply_to_commit(filter, oid_to_push, &transaction)?;
 
         if new_oid != reapply {
             if std::env::var("JOSH_REWRITE_REFS").is_ok() {

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -266,8 +266,6 @@ Flushed credential cache
       |   `-- pack
       |       |-- pack-6094f48eea5b3933a6584a6925dac03cf644f01e.idx
       |       |-- pack-6094f48eea5b3933a6584a6925dac03cf644f01e.pack
-      |       |-- pack-7118fd5d4e16516ded4435a0e2ebddbde19ded1b.idx
-      |       |-- pack-7118fd5d4e16516ded4435a0e2ebddbde19ded1b.pack
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
       |       |-- pack-9f918747f4ae3e54ccf603a1e77dd40c584aa821.idx
@@ -277,4 +275,4 @@ Flushed credential cache
           |-- namespaces
           `-- tags
   
-  50 directories, 44 files
+  50 directories, 42 files


### PR DESCRIPTION
Port apply_to_commit2 and the history walk loops to oid currency

apply_to_commit2 now takes a git2::Oid instead of &git2::Commit. Commit
data comes from a new owned CommitData (id + raw odb bytes, in
josh-gix-ext) parsed on demand via gix_object::CommitRef, and is loaded
once per call, after the memoization gate: memo hits do zero object
I/O, and every remaining load is a raw odb read plus a gix parse
instead of a full parsed-object-cache commit lookup. The per-commit
find_commit calls in walk2, find_unapply_base's hide callback,
find_original and find_oldest_similar_commit are gone; recursion sites
(Chain, splice parents, workspace redirects, Link embedding) pass oids.

Rewrite::from_commit_data replaces from_commit and no longer parses
commit metadata at all: its author/committer/message slots stay None,
so rewrite_commit keeps the base commit's raw signature and message
bytes verbatim on the passthrough path. Non-canonical, non-UTF-8 and
NUL-carrying signatures now filter losslessly, where git2's &str
accessors made the old code normalize, truncate or silently skip.
Canonical signatures re-serialized to the same bytes anyway, so
typical filtered output is unchanged; histories whose signatures the
old code "cleaned up" keep them verbatim now -- a deliberate
divergence. The overrides are byte strings (gix is bstr-native), split
by SigRewrite: :author/:committer set a NameEmail pair that
rewrite_commit re-serializes with the base commit's own timestamp,
while Squash(Some) transplants the squash-result's complete raw
signature fields (SigRewrite::Raw) and message onto the rewrite of the
original commit -- verbatim, nothing parsed; the base must stay the
original since memoization keys on its id, and the timestamps are the
base's own anyway because no filter alters them. :message decodes the
message at its point of use, erroring loudly on non-UTF-8.
rewrite_commit takes the CommitData base, dropping its duplicate odb
read for every written commit; create_filtered_commit and
select_parent_commits read parent trees via a raw read_tree_id, with
the filtered-parent slot cache now also serving the Prune, Fold and
pin paths. The remaining loud-failure shifts are limited to corrupt or
fsck-flagged objects and are recorded in the design notes: a first
parent or tree entry that is present but unreadable now errors loudly
instead of emulating git2's silent Parents-iterator truncation, while
a genuinely absent parent, missing path or non-tree entry keeps its
legitimate empty-or-skip result.

Benches vs the pre-gix baseline: deephistory_subdir -25 to -28%,
deephistory_glob -22 to -49%, widetree_glob -14 to -63%,
ultrawide_pin_hook -17 to -56%, deephistory_prefix_flush -15 to -18%,
refs_filter_update -2 to -4%, rest flat.

Change: apply-to-commit-oid-currency
Assisted-By: Claude Fable 5 (claude-fable-5)
Assisted-By: Claude Opus 4.8 (claude-opus-4-8)