### PR TITLE
Keep and restack local commits without a Change-Id on pull

### DIFF
--- a/josh-cli/src/commands/pull.rs
+++ b/josh-cli/src/commands/pull.rs
@@ -299,8 +299,9 @@ fn restack_commits(
 ///
 /// Linear-history only: fast-forward, rewind over already-applied changes
 /// (detected by Change-Id trailers), and cherry-pick the remaining local
-/// changes on top. Anything more complex (merge commits, diverged commits
-/// without a Change-Id, conflicts, dirty worktree) bails out with refs
+/// changes on top. Local commits without a Change-Id cannot be matched against
+/// the upstream stack, so they are always kept and restacked. Anything more
+/// complex (merge commits, conflicts, dirty worktree) bails out with refs
 /// untouched.
 pub fn integrate(
     transaction: &josh_core::cache::Transaction,
@@ -374,12 +375,12 @@ pub fn integrate(
             let commit = repo.find_commit(oid)?;
             match commit_change_meta(&commit) {
                 (Some(id), _) if applied.contains(&id) => skipped.push(id),
-                (Some(_), _) => remaining.push(oid),
-                (None, _) => anyhow::bail!(
-                    "local commit {} has no Change-Id and history has diverged; \
-                     cannot integrate automatically",
-                    short_oid(oid)
-                ),
+                // A commit with a Change-Id not yet applied upstream, or one
+                // without a Change-Id at all, is a local-only commit we keep and
+                // restack. A missing Change-Id just means we cannot match it
+                // against the upstream stack; restacking cherry-picks it on top
+                // and drops it if its content already landed (becomes empty).
+                _ => remaining.push(oid),
             }
         }
 

--- a/tests/cli/pull_stacked_restacks.t
+++ b/tests/cli/pull_stacked_restacks.t
@@ -83,7 +83,8 @@ Pull again: no-op
   $ josh changes pull
   Already up to date.
 
-Bail out on diverged commit without a Change-Id
+Restack a diverged local commit that has no Change-Id: it cannot be matched
+against the upstream stack, so it is simply kept and cherry-picked on top.
 
   $ echo "contents5" > file5
   $ git add file5
@@ -94,11 +95,23 @@ Bail out on diverged commit without a Change-Id
   $ git commit -q -m "unrelated upstream commit"
   $ git push -q origin master
   $ cd ${TESTTMP}/filtered
-  $ git rev-parse master > before
   $ josh changes pull
   updated master (e19e334..649a1fa)
-  Error: local commit 8e601d3 has no Change-Id and history has diverged; cannot integrate automatically
-  local commit 8e601d3 has no Change-Id and history has diverged; cannot integrate automatically
-  [1]
-  $ git rev-parse master > after
-  $ diff before after
+  Restacked master: kept 2 changes
+  $ git log --graph --pretty="%s"
+  * no change id
+  * change 4
+  * unrelated upstream commit
+  * landed change 3
+  * landed change 2
+  * add file1
+  $ tree
+  .
+  |-- file1
+  |-- file2
+  |-- file3
+  |-- file4
+  |-- file5
+  `-- file9
+  
+  1 directory, 6 files


### PR DESCRIPTION
Keep and restack local commits without a Change-Id on pull

When `josh changes pull` integrated a diverged local stack, any commit
lacking a Change-Id trailer aborted the whole pull with refs untouched.
An ordinary local commit (WIP, fixup, or anything not made via the
changes flow) sitting on the stack was enough to break the pull.

A commit without a Change-Id cannot be matched against the upstream
stack, so treat it as a local-only commit: keep it and restack it on top
of the new upstream tip. This is safe because restack_commits already
drops any commit that becomes empty (content already landed upstream).

Change: pull-keep-no-change-id
Assisted-By: anthropic/claude-opus-4-8