### PR TITLE
Express squash IDs as a :rev() filter

### DIFF
--- a/derive-josh-migration-filter.sh
+++ b/derive-josh-migration-filter.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+# Derive the josh-sync migration filters for rust-lang/rust subtrees that are synced
+# with git-subtree-style merges. Prints, per subtree:
+#
+#   :~(history="keep-trivial-merges,no-splice")[:rev(<=TIP:prefix=DIR,<=LANDING:SQUASH)]:/DIR
+#
+#   TIP     = last standalone-repo commit merged into rust. Its ancestry (the whole
+#             shared subtree lineage) is reproduced SHA-identically, so the subtree repo
+#             keeps a merge base with the filtered history and pushes keep working.
+#   LANDING = the rust commit that landed the sync merge bringing TIP in. Rust-native
+#             history <=LANDING (but not <=TIP) is squashed away instead of minted, which
+#             removes the mass commit duplication otherwise seen on the initial josh-sync
+#             pull.
+#
+# Commits in the squash range whose changes are NOT part of TIP are whitelisted with
+# additional ==sha rev entries so they survive the squash:
+#   - standalone-layout side commits on the sync branch (TIP..sync) via ==sha:prefix=DIR
+#     (reproduced SHA-identically, like the TIP lineage)
+#   - rust-layout fixups on the sync PR branch (sync..LANDING) that touch DIR via ==sha:/
+#     (minted: new SHA, but message/author/diff preserved as their own commit)
+# A remaining delta can survive only in tree form: rust-side changes to DIR that were
+# never upstreamed and got preserved by the sync merge's resolution -- their original
+# commits are squashed (that is the point of the squash). This delta folds into the
+# first post-LANDING filtered commit; the filtered(LANDING) check below verifies nothing is
+# silently lost.
+#
+# Each derived TIP and LANDING is also written to refs/heads/subtree-migration/<name>/{TIP,LANDING}
+# for inspection (in single-subtree mode <name> is the basename of the directory), and
+# the derived filter is applied with josh-filter to produce the resulting subtree
+# history under refs/heads/subtree-migration/<name>/filtered (skipped in partial
+# clones, where josh-filter would fetch all trees). The filtered tip tree is compared
+# against the subtree directory in rust as an extra check.
+#
+# The filter is additionally applied to LANDING itself (-> .../<name>/filtered-at-LANDING): the
+# result must be TIP plus exactly the whitelisted commits, and content-complete at LANDING.
+# If DIR's content at LANDING still differs (never-upstreamed rust-side changes whose
+# original commits are squashed), that is fine as long as post-LANDING commits exist for it
+# to fold into -- otherwise the subtree FAILS, because the delta would be silently lost.
+#
+# Both SHAs are derived from the commit graphs alone (merge base + landing merge).
+# Both history flags and the entry order are required for correctness. The `:SQUASH`
+# rev-entry semantics require josh release r26.07.28 or newer.
+#
+# Usage:
+#   derive-josh-migration-filter.sh [-C <rust-clone>] [--at <date|committish>] [--no-fetch]
+#
+# Run inside (or point -C at) any clone of rust-lang/rust -- bare or non-bare, full or
+# partial (tree:0 partial clones keep everything small and fast). With no further
+# arguments it fetches what it needs by itself (rust from origin, each remaining
+# subtree repo's head into refs/subtrees/<name>, using --filter=tree:0 when the clone
+# is partial), writes a commit-graph for fast graph walks, and derives the filters for
+# all remaining git-subtree directories:
+#   clippy, rustc_codegen_cranelift, rustc_codegen_gcc, rustfmt, portable-simd
+#
+# A single subtree (also ones not in the builtin list) can be derived with:
+#   derive-josh-migration-filter.sh -C <rust-clone> --dir <subtree-dir> --standalone <ref>
+# (no fetching happens in this mode; the ref must already exist)
+#
+#   -C <path>              rust clone (default .)
+#   --dir <path>           single-subtree mode: subtree directory in rust
+#   --standalone <ref>     single-subtree mode: ref of the standalone repo's main branch
+#   --rust-ref <ref>       default: auto-detect (origin/main, main, origin/master, master)
+#   --at <date|committish> derive as of that point in time instead of now
+#   --no-fetch             skip all fetching, use the refs as they are
+#   --history-flags <s>    default keep-trivial-merges,no-splice (both are required)
+#   --josh-filter <bin>    josh-filter binary to apply the filter with (default:
+#                          josh-filter from PATH; needs josh >= r26.07.28 for :SQUASH)
+#   --no-apply             don't apply the filter / don't write the filtered ref
+#
+# Exit codes: 0 ok, 1 one or more subtrees failed, 2 usage,
+# 3 not a git-subtree repo (use plain ':/DIR' filter), 4 ambiguous graph.
+#
+# Before freezing a filter: re-run right before the migration (a new sync moves both
+# SHAs). In a full clone the post-LANDING path check runs automatically; in partial clones
+# verify manually: git log <LANDING>..<rust-ref> -- <DIR>
+
+set -euo pipefail
+
+SUBTREES="\
+clippy src/tools/clippy https://github.com/rust-lang/rust-clippy.git
+cranelift compiler/rustc_codegen_cranelift https://github.com/rust-lang/rustc_codegen_cranelift.git
+gcc compiler/rustc_codegen_gcc https://github.com/rust-lang/rustc_codegen_gcc.git
+rustfmt src/tools/rustfmt https://github.com/rust-lang/rustfmt.git
+portable-simd library/portable-simd https://github.com/rust-lang/portable-simd.git"
+
+RUST_REPO=.
+RUST_REF=
+DIR=
+STANDALONE=
+AT=
+FETCH=1
+HISTORY_FLAGS='keep-trivial-merges,no-splice'
+JOSH_FILTER=${JOSH_FILTER:-josh-filter}
+APPLY=1
+UNCLEAN=
+
+usage() { grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 2; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -C) RUST_REPO=$2; shift 2 ;;
+        --dir) DIR=$2; shift 2 ;;
+        --standalone) STANDALONE=$2; shift 2 ;;
+        --rust-ref) RUST_REF=$2; shift 2 ;;
+        --at) AT=$2; shift 2 ;;
+        --no-fetch) FETCH=0; shift ;;
+        --history-flags) HISTORY_FLAGS=$2; shift 2 ;;
+        --josh-filter) JOSH_FILTER=$2; shift 2 ;;
+        --no-apply) APPLY=0; shift ;;
+        *) usage ;;
+    esac
+done
+
+g() { git -C "$RUST_REPO" "$@"; }
+
+# --- setup ------------------------------------------------------------------------------
+detect_rust_ref() {
+    for r in refs/remotes/origin/main refs/heads/main refs/remotes/origin/master refs/heads/master; do
+        if g rev-parse --verify --quiet "$r^{commit}" >/dev/null; then echo "$r"; return; fi
+    done
+    echo "error: no main/master ref found in $RUST_REPO -- is this a rust-lang/rust clone?" >&2
+    exit 2
+}
+
+fetch_filter_arg() {
+    # --filter fetches only work when the clone is configured for partial clone.
+    if [ -n "$(g config --get extensions.partialclone 2>/dev/null)" ] \
+        || [ "$(g config --get remote.origin.promisor 2>/dev/null)" = "true" ]; then
+        echo "--filter=tree:0"
+    fi
+}
+
+setup() {
+    local farg
+    farg=$(fetch_filter_arg)
+    if [ "$FETCH" = 1 ]; then
+        if g remote get-url origin >/dev/null 2>&1; then
+            echo "fetching rust from origin..." >&2
+            g fetch -q origin || echo "warning: fetching origin failed, using existing refs" >&2
+        fi
+        while read -r name dir url; do
+            echo "fetching $name..." >&2
+            # shellcheck disable=SC2086
+            g fetch -q $farg "$url" "+HEAD:refs/subtrees/$name" \
+                || echo "warning: fetching $name failed, using existing refs/subtrees/$name" >&2
+        done <<< "$SUBTREES"
+    fi
+    echo "updating commit-graph (speeds up the graph walks)..." >&2
+    g commit-graph write --reachable 2>/dev/null || true
+}
+
+# --- resolve the two branch states at the requested point in time -----------------------
+resolve_at() { # $1 = ref
+    if [ -z "$AT" ]; then
+        g rev-parse --verify "$1^{commit}"
+    elif g rev-parse --verify --quiet "$AT^{commit}" >/dev/null; then
+        # --at is a committish: use it verbatim for the rust side, time-resolve standalone
+        if [ "$1" = "$RUST_REF" ]; then
+            g rev-parse --verify "$AT^{commit}"
+        else
+            local t; t=$(g log -1 --format=%cI "$AT")
+            g rev-list -1 --first-parent --before="$t" "$1"
+        fi
+    else
+        # --first-parent: stay on the branch spine; a plain walk can surface
+        # date-skewed commits from merged side histories.
+        g rev-list -1 --first-parent --before="$AT" "$1"
+    fi
+}
+
+# --- apply the derived filter, write the filtered ref ------------------------------------
+apply_filter() { # $1=NAME $2=filter $3=rust commit $4=DIR $5=TIP $6=LANDING $7=post-LANDING count
+    local NAME=$1 FILTER=$2 MASTER=$3 DIR=$4 TIP=$5 LANDING=$6 POSTN=${7:-0}
+    local ref="refs/heads/subtree-migration/$NAME/filtered"
+    local rref="refs/heads/subtree-migration/$NAME/filtered-at-LANDING"
+    [ "$APPLY" = 1 ] || return 0
+    if ! command -v "$JOSH_FILTER" >/dev/null 2>&1; then
+        echo "filtered:   SKIPPED ($JOSH_FILTER not found; pass --josh-filter <bin>)"
+        return 0
+    fi
+    if [ -n "$(fetch_filter_arg)" ]; then
+        echo "filtered:   SKIPPED (partial clone; josh-filter would fetch all trees)"
+        return 0
+    fi
+    echo "applying filter with $JOSH_FILTER..." >&2
+    local OUT_TMP rc=0
+    OUT_TMP=$(mktemp)
+    # josh-filter operates on the repo in its cwd
+    (cd "$RUST_REPO" && "$JOSH_FILTER" --update "$ref" "$FILTER" "$MASTER" \
+                     && "$JOSH_FILTER" --update "$rref" "$FILTER" "$LANDING") \
+        >"$OUT_TMP" 2>&1 || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "filtered:   FAILED ($JOSH_FILTER exited $rc; josh >= r26.07.28 needed for :SQUASH)"
+        sed 's/^/            /' "$OUT_TMP" | tail -5
+        rm -f "$OUT_TMP"
+        return 0
+    fi
+    rm -f "$OUT_TMP"
+    local match
+    if [ "$(g rev-parse "$ref^{tree}")" = "$(g rev-parse "$MASTER:$DIR")" ]; then
+        match="tree matches $DIR in rust"
+    else
+        match="tree DIFFERS from $DIR in rust -- inspect!"
+    fi
+    echo "filtered:   $ref"
+    echo "            tip $(g rev-parse --short "$ref"), $match"
+
+    # filtered(LANDING) check: the filter applied to LANDING must give TIP plus exactly the
+    # whitelisted commits; any remaining DIR delta at LANDING (never-upstreamed rust-side
+    # changes) needs post-LANDING commits to fold into, else it is lost.
+    local FR desc stat
+    FR=$(g rev-parse "$rref")
+    if [ "$FR" = "$TIP" ]; then
+        desc="TIP exactly"
+    else
+        if ! g merge-base --is-ancestor "$TIP" "$FR"; then
+            echo "filter(LANDING): FAIL -- TIP is not an ancestor of filtered(LANDING) ($rref)"
+            return 1
+        fi
+        desc="TIP + $(g rev-list --count "$TIP..$FR") whitelisted commit(s)"
+    fi
+    echo "filter(LANDING):"
+    echo "            graph:   $desc ($rref)"
+    if [ "$(g rev-parse "$FR^{tree}")" = "$(g rev-parse "$LANDING:$DIR")" ]; then
+        echo "            content: matches DIR@LANDING -- complete"
+    else
+        stat=$(g diff --shortstat "$FR" "$LANDING:$DIR" | sed 's/^ //')
+        if [ "${POSTN:-0}" -gt 0 ]; then
+            echo "            content: DIR@LANDING differs ($stat) -- never-upstreamed rust-side"
+            echo "                     changes, preserved by the sync resolution, whose original"
+            echo "                     commits are squashed; carried by the first post-LANDING filtered"
+            echo "                     commit's diff"
+            UNCLEAN="$UNCLEAN $NAME"
+        else
+            echo "            content: FAIL -- DIR@LANDING differs ($stat) and NO post-LANDING commit"
+            echo "                     touches $DIR: the delta would be silently lost"
+            return 1
+        fi
+    fi
+}
+
+# --- derivation for one subtree ---------------------------------------------------------
+derive_one() { # $1 = DIR, $2 = standalone ref, $3 = name; prints report, sets DERIVED_FILTER
+    local DIR=$1 STANDALONE=$2 NAME=$3
+    DERIVED_FILTER=
+
+    local MASTER STAND
+    MASTER=$(resolve_at "$RUST_REF")
+    STAND=$(resolve_at "$STANDALONE")
+    [ -n "$MASTER" ] && [ -n "$STAND" ] || { echo "error: could not resolve refs at '$AT'" >&2; return 2; }
+
+    # TIP: last standalone commit merged into rust = merge base
+    local BASES
+    BASES=$(g merge-base --all "$MASTER" "$STAND" 2>/dev/null || true)
+    if [ -z "$BASES" ]; then
+        echo "error: $DIR: no shared history between rust and the standalone repo." >&2
+        echo "       This subtree was not synced with git-subtree merges; the plain filter" >&2
+        echo "       ':/$DIR' (no :rev entry) is the right starting point." >&2
+        return 3
+    fi
+    if [ "$(echo "$BASES" | wc -l)" -ne 1 ]; then
+        echo "error: $DIR: multiple merge bases -- ambiguous TIP, refusing to guess:" >&2
+        echo "$BASES" >&2
+        return 4
+    fi
+    local TIP=$BASES
+
+    # Direction guard: the merge base must be a STANDALONE-side commit (last
+    # standalone->rust sync). If the standalone repo imports real rust history (e.g.
+    # cranelift's "Sync from rust" merges) and that import postdates the last push-back,
+    # the merge base is a RUST commit and the derivation would be nonsense.
+    # (grep -q on a pipe would SIGPIPE rev-list and, under pipefail, read as a miss)
+    local SPINE_TMP
+    SPINE_TMP=$(mktemp)
+    g rev-list --first-parent "$STAND" > "$SPINE_TMP"
+    if grep -qFx "$TIP" "$SPINE_TMP"; then
+        : # TIP is on the standalone branch spine -- the normal case
+    elif g rev-list --first-parent "$MASTER" > "$SPINE_TMP" && grep -qFx "$TIP" "$SPINE_TMP"; then
+        rm -f "$SPINE_TMP"
+        echo "error: $DIR: merge base $TIP is a rust-side commit -- the standalone repo has" >&2
+        echo "       imported rust history more recently than it was last merged back into" >&2
+        echo "       rust. Pick an earlier --at, or wait for the next standalone->rust sync." >&2
+        return 4
+    else
+        echo "warning: merge base $TIP is on neither branch spine; inspect it manually" >&2
+    fi
+    rm -f "$SPINE_TMP"
+
+    # LANDING: the first-parent commit of MASTER that landed TIP (git-when-merged algorithm).
+    # rev-list emits newest-first, so the last ancestry-path line also in the
+    # first-parent set is the oldest such commit = the landing merge.
+    # (temp files, not <(...): process substitution is a syntax error when bash runs
+    # in POSIX mode ("sh script"), and it fails silently inside the $() here)
+    local LANDING FP_TMP AP_TMP
+    FP_TMP=$(mktemp) AP_TMP=$(mktemp)
+    g rev-list --first-parent "$TIP..$MASTER" > "$FP_TMP"
+    g rev-list --ancestry-path "$TIP..$MASTER" > "$AP_TMP"
+    LANDING=$(awk 'NR==FNR {fp[$0]=1; next} $0 in fp {last=$0} END {print last}' "$FP_TMP" "$AP_TMP")
+    rm -f "$FP_TMP" "$AP_TMP"
+    if [ -z "$LANDING" ]; then
+        echo "error: $DIR: could not locate the landing merge of TIP on the first-parent chain." >&2
+        return 4
+    fi
+
+    # Inspection refs (written even if the sanity checks below fail -- that is
+    # exactly when you want to look at these commits).
+    g update-ref "refs/heads/subtree-migration/$NAME/TIP" "$TIP"
+    g update-ref "refs/heads/subtree-migration/$NAME/LANDING" "$LANDING"
+
+    # The sync merge: the most ancestral merge on the ancestry path TIP..LANDING. (Not
+    # necessarily the merge with TIP as a direct parent: with side commits on the
+    # sync branch, the merge lands the last side commit instead of TIP.)
+    local SYNC
+    SYNC=$(g rev-list --topo-order --ancestry-path --merges "$TIP..$LANDING" | tail -1)
+
+    # Whitelist entries: commits in the squash range whose changes are not part of TIP.
+    #  - TIP..SYNC: standalone-layout side commits committed on the sync branch before
+    #    the merge -> ==sha:prefix=DIR, reproduced SHA-identically.
+    #  - SYNC..LANDING (ancestry path, needs trees): rust-layout fixups on the sync PR branch
+    #    touching DIR -> ==sha:/, minted with message/author/diff preserved.
+    # Merges and concurrent master-side landings are left to fold into the first
+    # post-LANDING filtered commit; the filtered(LANDING) check verifies nothing is lost.
+    local WL_ENTRIES= WL_A= WL_C= WL_STAND=0 WL_RUST=0 c
+    if [ -n "$SYNC" ]; then
+        WL_A=$(g rev-list --topo-order --reverse --ancestry-path "$TIP..$SYNC" \
+               | grep -vFx "$SYNC" || true)
+        for c in $WL_A; do
+            WL_ENTRIES="$WL_ENTRIES,==$c:prefix=$DIR"; WL_STAND=$((WL_STAND+1))
+        done
+        if [ -z "$(fetch_filter_arg)" ]; then
+            WL_C=$(g rev-list --reverse --no-merges --ancestry-path "$SYNC..$LANDING" -- "$DIR")
+            for c in $WL_C; do
+                WL_ENTRIES="$WL_ENTRIES,==$c:/"; WL_RUST=$((WL_RUST+1))
+            done
+        else
+            echo "warning: $DIR: partial clone: cannot derive rust-side whitelist entries (needs trees)" >&2
+        fi
+    fi
+
+    # --- sanity checks
+    local fail=0
+    g merge-base --is-ancestor "$TIP" "$LANDING"      || { echo "FAIL: TIP not ancestor of LANDING" >&2; fail=1; }
+    g merge-base --is-ancestor "$LANDING" "$MASTER"   || { echo "FAIL: LANDING not ancestor of rust ref" >&2; fail=1; }
+    local UNSYNCED PATHCHECK POSTN=
+    UNSYNCED=$(g rev-list --count "$TIP..$STAND")
+
+    # Commits after LANDING touching DIR become the only new filtered commits beyond the
+    # whitelist; with none, the filtered history equals the subtree lineage exactly.
+    # Also the fold-forward target for any remaining tree-level delta at LANDING. Needs
+    # trees, which a partial clone lazily fetches -- skip there.
+    if [ -n "$(fetch_filter_arg)" ]; then
+        PATHCHECK="SKIPPED (partial clone; inspect in a full clone: git log $LANDING..$MASTER -- $DIR)"
+    else
+        POSTN=$(g rev-list --count "$LANDING..$MASTER" -- "$DIR")
+        PATHCHECK="$POSTN commits touch $DIR after LANDING (these become the only new filtered commits)"
+    fi
+
+    # --- report
+    show() { g log -1 --date=short --format="    $1 %H%n        %ad %an: %s" "$2"; }
+    echo "subtree:    $DIR"
+    echo "rust ref:   $RUST_REF @ ${AT:-now}"
+    echo "  standalone side:"
+    show "head    " "$STAND"
+    echo "  shared (in both histories):"
+    show "TIP     " "$TIP"
+    echo "  rust side:"
+    show "head    " "$MASTER"
+    [ -n "$SYNC" ] && show "sync    " "$SYNC"
+    show "LANDING " "$LANDING"
+    echo "checks:     unsynced standalone commits ahead of TIP: $UNSYNCED"
+    [ -n "$SYNC" ] || echo "            (no sync merge located -- no whitelist derived; inspect manually)"
+    echo "            post-LANDING path check: $PATHCHECK"
+    if [ "$WL_STAND" -gt 0 ] || [ "$WL_RUST" -gt 0 ]; then
+        echo "whitelist:  $WL_STAND standalone side commit(s) (==sha:prefix), $WL_RUST rust-side fixup(s) (==sha:/):"
+        for c in $WL_A $WL_C; do
+            g log -1 --date=short --format="              ==%h %ad %an: %s" "$c"
+        done
+    fi
+    echo "refs:       refs/heads/subtree-migration/$NAME/{TIP,LANDING} updated"
+    [ "$fail" -eq 0 ] || return 1
+    DERIVED_FILTER=":~(history=\"$HISTORY_FLAGS\")[:rev(<=$TIP:prefix=$DIR$WL_ENTRIES,<=$LANDING:SQUASH)]:/$DIR"
+    apply_filter "$NAME" "$DERIVED_FILTER" "$MASTER" "$DIR" "$TIP" "$LANDING" "$POSTN" || return 1
+    return 0
+}
+
+print_unclean_note() {
+    [ -n "$UNCLEAN" ] || return 0
+    local n
+    echo
+    echo "NOTE: never-upstreamed rust-side changes detected in:"
+    for n in $UNCLEAN; do echo "  - $n"; done
+    echo "For these the migrated history starts \"unclean\": the rust-side delta is carried"
+    echo "by the diff of the first post-LANDING filtered commit instead of by proper commits."
+    echo "Recommended: run one more regular git-subtree sync for these first (upstreaming"
+    echo "the rust-side changes), then re-derive. Right after a sync the delta is empty"
+    echo "and the filtered history starts exactly at the subtree tip."
+}
+
+# --- main -------------------------------------------------------------------------------
+if [ -n "$DIR" ] || [ -n "$STANDALONE" ]; then
+    [ -n "$DIR" ] && [ -n "$STANDALONE" ] || usage
+    [ -n "$RUST_REF" ] || RUST_REF=$(detect_rust_ref)
+    derive_one "$DIR" "$STANDALONE" "$(basename "$DIR")" || exit $?
+    echo
+    echo "filter:"
+    echo "$DERIVED_FILTER"
+    print_unclean_note
+    exit 0
+fi
+
+setup
+[ -n "$RUST_REF" ] || RUST_REF=$(detect_rust_ref)
+
+RESULTS=
+FAILED=0
+while read -r name dir url; do
+    echo "================================================================"
+    if derive_one "$dir" "refs/subtrees/$name" "$name"; then
+        RESULTS="$RESULTS$name $DERIVED_FILTER
+"
+    else
+        echo "($name failed, see above)" >&2
+        FAILED=1
+    fi
+    echo
+done <<< "$SUBTREES"
+
+echo "================================================================"
+echo "filters:"
+printf '%s' "$RESULTS" | while read -r name filter; do
+    printf '\n%s:\n%s\n' "$name" "$filter"
+done
+print_unclean_note
+exit $FAILED

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -21,6 +21,12 @@ fn resolve_input_ref(
     Ok((ref_string, oid))
 }
 
+fn squash_ids_filter(
+    ids: &[(josh_core::filter::LazyRef, josh_core::filter::Filter)],
+) -> josh_core::filter::Filter {
+    josh_core::filter::to_filter(josh_core::filter::squash_to_rev(ids.iter().cloned()))
+}
+
 fn make_app() -> clap::Command {
     let app = clap::Command::new("josh-filter");
 
@@ -217,9 +223,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     refs.push((input_ref.clone(), oid));
 
     if args.get_flag("single") {
-        filterobj = josh_core::filter::Filter::new()
-            .squash(None)
-            .chain(filterobj);
+        filterobj = josh_core::filter::Filter::new().squash().chain(filterobj);
     }
 
     if let Some(pattern) = args.get_one::<String>("squash-pattern") {
@@ -232,13 +236,14 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
                 return Ok(());
             }
             let target = josh_core::objects::peel_to_commit(transaction.odb(), oid)?;
-            ids.push((target, josh_core::filter::Filter::new().message(name)));
+            ids.push((
+                josh_core::filter::LazyRef::Resolved(target),
+                josh_core::filter::Filter::new().message(name),
+            ));
             refs.push((name.to_string(), target));
             Ok(())
         })?;
-        filterobj = josh_core::filter::Filter::new()
-            .squash(Some(&ids))
-            .chain(filterobj);
+        filterobj = squash_ids_filter(&ids).chain(filterobj);
     };
 
     if let Some(filename) = args.get_one::<String>("squash-file") {
@@ -249,15 +254,16 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             if let [sha, name] = split.as_slice() {
                 let target = gix_hash::ObjectId::from_str(sha)?;
                 let target = josh_core::objects::peel_to_commit(transaction.odb(), target)?;
-                ids.push((target, josh_core::filter::Filter::new().message(name)));
+                ids.push((
+                    josh_core::filter::LazyRef::Resolved(target),
+                    josh_core::filter::Filter::new().message(name),
+                ));
                 refs.push((name.to_string(), target));
             } else if !split.is_empty() {
                 eprintln!("Warning: malformed line: {:?}", line);
             }
         }
-        filterobj = josh_core::filter::Filter::new()
-            .squash(Some(&ids))
-            .chain(filterobj);
+        filterobj = squash_ids_filter(&ids).chain(filterobj);
     };
 
     if args.get_flag("print-filter") {

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -21,6 +21,13 @@ fn resolve_input_ref(
     Ok((ref_string, oid))
 }
 
+fn squash_ids_filter(ids: &[(git2::Oid, josh_core::filter::Filter)]) -> josh_core::filter::Filter {
+    josh_core::filter::to_filter(josh_core::filter::squash_to_rev(
+        ids.iter()
+            .map(|(x, y)| (josh_core::filter::LazyRef::Resolved(*x), *y)),
+    ))
+}
+
 fn make_app() -> clap::Command {
     let app = clap::Command::new("josh-filter");
 
@@ -235,9 +242,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     refs.push((input_ref.clone(), oid));
 
     if args.get_flag("single") {
-        filterobj = josh_core::filter::Filter::new()
-            .squash(None)
-            .chain(filterobj);
+        filterobj = josh_core::filter::Filter::new().squash().chain(filterobj);
     }
 
     if let Some(pattern) = args.get_one::<String>("squash-pattern") {
@@ -251,9 +256,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             ));
             refs.push((reference.name().unwrap().to_string(), target));
         }
-        filterobj = josh_core::filter::Filter::new()
-            .squash(Some(&ids))
-            .chain(filterobj);
+        filterobj = squash_ids_filter(&ids).chain(filterobj);
     };
 
     if let Some(filename) = args.get_one::<String>("squash-file") {
@@ -270,9 +273,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
                 eprintln!("Warning: malformed line: {:?}", line);
             }
         }
-        filterobj = josh_core::filter::Filter::new()
-            .squash(Some(&ids))
-            .chain(filterobj);
+        filterobj = squash_ids_filter(&ids).chain(filterobj);
     };
 
     if args.get_flag("print-filter") {

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -12,6 +12,7 @@ pub use josh_filter::LinkMode;
 pub use josh_filter::filter::MESSAGE_MATCH_ALL_REGEX;
 pub use josh_filter::filter::reachable_roots;
 pub use josh_filter::filter::sequence_number;
+pub use josh_filter::filter::squash_to_rev;
 pub use josh_filter::flang::parse::{get_comments, parse};
 pub use josh_filter::opt;
 pub use josh_filter::opt::invert;
@@ -209,17 +210,6 @@ fn lazy_refs2(op: &Op) -> Vec<String> {
             lr.dedup();
             lr
         }
-        Op::Squash(Some(revs)) => {
-            let mut lr = vec![];
-            lr.extend(revs.keys().filter_map(|nested| {
-                if let LazyRef::Lazy(s) = nested {
-                    Some(s.to_owned())
-                } else {
-                    None
-                }
-            }));
-            lr
-        }
         Op::Downstack(LazyRef::Lazy(s)) => vec![s.to_owned()],
         Op::Downstack(_) => vec![],
         _ => vec![],
@@ -261,23 +251,6 @@ fn resolve_refs2(refs: &std::collections::HashMap<String, git2::Oid>, op: &Op) -
                 })
                 .collect();
             Op::Rev(lr)
-        }
-        Op::Squash(Some(filters)) => {
-            let lr = filters
-                .iter()
-                .map(|(r, m)| {
-                    if let LazyRef::Lazy(s) = r {
-                        if let Some(res) = refs.get(s) {
-                            (LazyRef::Resolved(*res), *m)
-                        } else {
-                            (r.clone(), *m)
-                        }
-                    } else {
-                        (r.clone(), *m)
-                    }
-                })
-                .collect();
-            Op::Squash(Some(lr))
         }
         Op::Downstack(LazyRef::Lazy(s)) => {
             if let Some(res) = refs.get(s) {
@@ -607,7 +580,7 @@ pub fn apply_to_commit2(
             }
             return Ok(Some(current_oid));
         }
-        Op::Squash(None) => {
+        Op::Squash => {
             let odb = repo.odb()?;
             let commit = objects::CommitData::read(&odb, commit_id)?;
             return Some(history::rewrite_commit(
@@ -642,51 +615,6 @@ pub fn apply_to_commit2(
     let commit = objects::CommitData::read(&odb, commit_id)?;
 
     let rewrite_data = match &op {
-        Op::Squash(Some(ids)) => {
-            if let Some(sq) = ids.get(&LazyRef::Resolved(commit.id())) {
-                let oid = if let Some(oid) = apply_to_commit2(
-                    filter::Filter::new().squash(None).chain(*sq),
-                    commit_id,
-                    transaction,
-                )? {
-                    oid
-                } else {
-                    return Ok(None);
-                };
-
-                // Transplant the squash result's metadata verbatim onto the rewrite of the
-                // original commit (which must stay the base: memoization keys on its id).
-                // Timestamps are the base's own anyway -- no filter alters them.
-                let rc = objects::CommitData::read(&odb, oid)?;
-                let rcr = rc.parsed()?;
-                Rewrite::from_tree_with_metadata(
-                    repo.find_tree(rc.tree_id()?)?,
-                    Some(SigRewrite::Raw(rcr.author.to_owned())),
-                    Some(SigRewrite::Raw(rcr.committer.to_owned())),
-                    Some(rcr.message.to_owned()),
-                )
-                //commit.tree()?
-            } else {
-                if let Some(parent) = commit.first_parent_id() {
-                    return Ok(if let Some(fparent) = transaction.get(filter, parent)? {
-                        Some(history::drop_commit(
-                            commit.id(),
-                            vec![fparent],
-                            transaction,
-                            filter,
-                        )?)
-                    } else {
-                        None
-                    });
-                }
-                return Ok(Some(history::drop_commit(
-                    commit.id(),
-                    vec![],
-                    transaction,
-                    filter,
-                )?));
-            }
-        }
         Op::Prune => {
             let p: Vec<_> = commit.parent_ids().collect();
 
@@ -924,13 +852,14 @@ pub fn apply_to_commit2(
                 .collect::<anyhow::Result<Option<Vec<git2::Oid>>>>()?;
             let normal_parents = some_or!(normal_parents, { return Ok(None) });
 
-            let current_submodules = extract_submodule_commits(repo, &commit.tree()?)?;
+            let current_submodules =
+                extract_submodule_commits(repo, &repo.find_tree(commit.tree_id()?)?)?;
 
-            let first_parent_submodules = if let Some(parent) = commit.parents().next() {
-                extract_submodule_commits(
-                    repo,
-                    &parent.tree().unwrap_or_else(|_| tree::empty(repo)),
-                )?
+            let first_parent_submodules = if let Some(parent) = commit.parent_ids().next() {
+                let parent_tree = git::read_tree_id(repo, parent)
+                    .and_then(|tid| repo.find_tree(tid).map_err(Into::into))
+                    .unwrap_or_else(|_| tree::empty(repo));
+                extract_submodule_commits(repo, &parent_tree)?
             } else {
                 std::collections::BTreeMap::new()
             };
@@ -972,12 +901,16 @@ pub fn apply_to_commit2(
                 }
             }
 
-            let filtered_tree = apply(transaction, filter, Rewrite::from_commit(commit)?)?;
+            let filtered_tree = apply(
+                transaction,
+                filter,
+                Rewrite::from_commit_data(repo, &commit)?,
+            )?;
             let filtered_parent_ids: Vec<git2::Oid> =
                 normal_parents.into_iter().chain(extra_parents).collect();
 
             return Some(history::create_filtered_commit(
-                commit,
+                &commit,
                 filtered_parent_ids,
                 filtered_tree,
                 transaction,
@@ -1280,14 +1213,13 @@ pub fn apply<'a>(
         Op::Nop => Ok(x),
         Op::Empty => Ok(x.with_tree(tree::empty(repo))),
         Op::Fold => Ok(x),
-        Op::Squash(None) => Ok(x),
+        Op::Squash => Ok(x),
         Op::Author(author, email) => {
             Ok(x.with_author((author.clone().into(), email.clone().into())))
         }
         Op::Committer(author, email) => {
             Ok(x.with_committer((author.clone().into(), email.clone().into())))
         }
-        Op::Squash(Some(_)) => Err(anyhow!("not applicable to tree: squash")),
         Op::Message(m, r) => {
             let tree_id = x.tree().id().to_string();
             let commit = x.commit;
@@ -2312,7 +2244,7 @@ fn per_rev_filter(
 
     let filtered_parent_ids: Vec<_> = normal_parents.into_iter().chain(splice_parents).collect();
 
-    if let Op::Squash(None) = to_op(commit_filter.peel()) {
+    if let Op::Squash = to_op(commit_filter.peel()) {
         // `:SQUASH` as a per-commit filter squashes the commit away, mapping it
         // to the surviving filtered parent with the largest sequence number.
         // Ancestors have strictly smaller sequence numbers, so a parent that

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -14,6 +14,7 @@ pub use josh_filter::filter::MESSAGE_MATCH_ALL_REGEX;
 pub use josh_filter::filter::index;
 pub use josh_filter::filter::reachable_roots;
 pub use josh_filter::filter::sequence_number;
+pub use josh_filter::filter::squash_to_rev;
 pub use josh_filter::flang::parse::{get_comments, parse};
 pub use josh_filter::opt;
 pub use josh_filter::opt::invert;
@@ -202,17 +203,6 @@ fn lazy_refs2(op: &Op) -> Vec<String> {
             lr.dedup();
             lr
         }
-        Op::Squash(Some(revs)) => {
-            let mut lr = vec![];
-            lr.extend(revs.keys().filter_map(|nested| {
-                if let LazyRef::Lazy(s) = nested {
-                    Some(s.to_owned())
-                } else {
-                    None
-                }
-            }));
-            lr
-        }
         Op::Downstack(LazyRef::Lazy(s)) => vec![s.to_owned()],
         Op::Downstack(_) => vec![],
         _ => vec![],
@@ -258,23 +248,7 @@ fn resolve_refs2(refs: &std::collections::HashMap<String, gix_hash::ObjectId>, o
                 .collect();
             Op::Rev(lr)
         }
-        Op::Squash(Some(filters)) => {
-            let lr = filters
-                .iter()
-                .map(|(r, m)| {
-                    if let LazyRef::Lazy(s) = r {
-                        if let Some(res) = refs.get(s) {
-                            (LazyRef::Resolved(*res), *m)
-                        } else {
-                            (r.clone(), *m)
-                        }
-                    } else {
-                        (r.clone(), *m)
-                    }
-                })
-                .collect();
-            Op::Squash(Some(lr))
-        }
+
         Op::Downstack(LazyRef::Lazy(s)) => {
             if let Some(res) = refs.get(s) {
                 Op::Downstack(LazyRef::Resolved(*res))
@@ -627,7 +601,7 @@ pub fn apply_to_commit2(
             }
             return Ok(Some(current_oid));
         }
-        Op::Squash(None) => {
+        Op::Squash => {
             let odb = transaction.odb();
             let commit = objects::CommitData::read(odb, commit_id)?;
             odb.read_header(commit.tree_id()?)?;
@@ -668,50 +642,6 @@ pub fn apply_to_commit2(
     odb.read_header(commit.tree_id()?)?;
 
     let rewrite_data = match &op {
-        Op::Squash(Some(ids)) => {
-            if let Some(sq) = ids.get(&LazyRef::Resolved(commit.id())) {
-                let oid = if let Some(oid) = apply_to_commit2(
-                    filter::Filter::new().squash(None).chain(*sq),
-                    commit_id,
-                    transaction,
-                )? {
-                    oid
-                } else {
-                    return Ok(None);
-                };
-
-                // Transplant the squash result's metadata verbatim onto the rewrite of the
-                // original commit (which must stay the base: memoization keys on its id).
-                // Timestamps are the base's own anyway -- no filter alters them.
-                let rc = objects::CommitData::read(odb, oid)?;
-                let rcr = rc.parsed()?;
-                Rewrite::from_tree_with_metadata(
-                    rc.tree_id()?,
-                    Some(SigRewrite::Raw(rcr.author.to_owned())),
-                    Some(SigRewrite::Raw(rcr.committer.to_owned())),
-                    Some(rcr.message.to_owned()),
-                )
-            } else {
-                if let Some(parent) = commit.first_parent_id() {
-                    return Ok(if let Some(fparent) = transaction.get(filter, parent)? {
-                        Some(history::drop_commit(
-                            commit.id(),
-                            vec![fparent],
-                            transaction,
-                            filter,
-                        )?)
-                    } else {
-                        None
-                    });
-                }
-                return Ok(Some(history::drop_commit(
-                    commit.id(),
-                    vec![],
-                    transaction,
-                    filter,
-                )?));
-            }
-        }
         Op::Prune => {
             let p: Vec<_> = commit.parent_ids().collect();
 
@@ -1329,14 +1259,13 @@ fn apply_impl(
         Op::Nop => Ok(x),
         Op::Empty => Ok(x.with_tree(tree::empty_id())),
         Op::Fold => Ok(x),
-        Op::Squash(None) => Ok(x),
+        Op::Squash => Ok(x),
         Op::Author(author, email) => {
             Ok(x.with_author((author.clone().into(), email.clone().into())))
         }
         Op::Committer(author, email) => {
             Ok(x.with_committer((author.clone().into(), email.clone().into())))
         }
-        Op::Squash(Some(_)) => Err(anyhow!("not applicable to tree: squash")),
         Op::Message(m, r) => {
             // Rewriting a message leaves the tree alone, so with neither a commit nor a
             // message to transform this is identity, like the other history-only filters.
@@ -2402,7 +2331,7 @@ fn per_rev_filter(
 
     let filtered_parent_ids: Vec<_> = normal_parents.into_iter().chain(splice_parents).collect();
 
-    if let Op::Squash(None) = to_op(commit_filter.peel()) {
+    if let Op::Squash = to_op(commit_filter.peel()) {
         // `:SQUASH` as a per-commit filter squashes the commit away, mapping it
         // to the surviving filtered parent with the largest sequence number.
         // Ancestors have strictly smaller sequence numbers, so a parent that

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -242,16 +242,8 @@ impl Filter {
     }
 
     /// Chain a squash filter
-    pub fn squash(self, ids: Option<&[(git2::Oid, Filter)]>) -> Filter {
-        self.chain(if let Some(ids) = ids {
-            to_filter(Op::Squash(Some(
-                ids.iter()
-                    .map(|(x, y)| (LazyRef::Resolved(*x), *y))
-                    .collect(),
-            )))
-        } else {
-            to_filter(Op::Squash(None))
-        })
+    pub fn squash(self) -> Filter {
+        self.chain(to_filter(Op::Squash))
     }
 
     /// Chain a downstack filter that rebuilds the stack from `base` to the input commit,
@@ -368,6 +360,21 @@ pub fn compose(filters: &[Filter]) -> Filter {
 
 pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
     opt::invert(filter)
+}
+
+/// Expand squash-with-ids into its `:rev(...)` form: one `==` entry per listed commit,
+/// followed by a default entry squashing everything else away.
+pub fn squash_to_rev(ids: impl IntoIterator<Item = (LazyRef, Filter)>) -> Op {
+    let mut entries: Vec<(RevMatch, LazyRef, Filter)> = ids
+        .into_iter()
+        .map(|(r, f)| (RevMatch::Equal, r, f))
+        .collect();
+    entries.push((
+        RevMatch::Default,
+        LazyRef::Resolved(git2::Oid::zero()),
+        to_filter(Op::Squash),
+    ));
+    Op::Rev(entries)
 }
 
 /// The sequence_number filter used for tracking commit sequence numbers. A memoized sentinel

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -242,16 +242,8 @@ impl Filter {
     }
 
     /// Chain a squash filter
-    pub fn squash(self, ids: Option<&[(gix_hash::ObjectId, Filter)]>) -> Filter {
-        self.chain(if let Some(ids) = ids {
-            to_filter(Op::Squash(Some(
-                ids.iter()
-                    .map(|(x, y)| (LazyRef::Resolved(*x), *y))
-                    .collect(),
-            )))
-        } else {
-            to_filter(Op::Squash(None))
-        })
+    pub fn squash(self) -> Filter {
+        self.chain(to_filter(Op::Squash))
     }
 
     /// Chain a downstack filter that rebuilds the stack from `base` to the input commit,
@@ -368,6 +360,20 @@ pub fn compose(filters: &[Filter]) -> Filter {
 
 pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
     opt::invert(filter)
+}
+
+/// Lower squash-with-ids to a deterministic `:rev(...)` filter.
+pub fn squash_to_rev(ids: impl IntoIterator<Item = (LazyRef, Filter)>) -> Op {
+    let mut entries: Vec<(RevMatch, LazyRef, Filter)> = ids
+        .into_iter()
+        .map(|(r, f)| (RevMatch::Equal, r, f))
+        .collect();
+    entries.push((
+        RevMatch::Default,
+        LazyRef::Resolved(gix_hash::ObjectId::null(gix_hash::Kind::Sha1)),
+        to_filter(Op::Squash),
+    ));
+    Op::Rev(entries)
 }
 
 /// The sequence_number filter used for tracking commit sequence numbers. A memoized sentinel

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -116,14 +116,6 @@ fn pretty2(op: &Op, indent: usize, compose: bool) -> String {
                 .collect::<Vec<_>>();
             format!(":replace(\n{}\n)", v.join("\n"))
         }
-        Op::Squash(Some(ids)) => {
-            let mut v = ids
-                .iter()
-                .map(|(oid, f)| format!("{}{}{}", " ".repeat(indent), &oid.to_string(), spec(*f)))
-                .collect::<Vec<_>>();
-            v.sort();
-            format!(":squash(\n{}\n)", v.join("\n"))
-        }
         Op::Meta(meta, filter) => {
             let ind2 = std::cmp::max(indent, 4);
             let mut meta_parts: Vec<_> = meta
@@ -253,15 +245,7 @@ pub(crate) fn spec2(op: &Op) -> String {
         Op::Invert => ":INVERT".to_string(),
         Op::Index => ":INDEX".to_string(),
         Op::Fold => ":FOLD".to_string(),
-        Op::Squash(None) => ":SQUASH".to_string(),
-        Op::Squash(Some(ids)) => {
-            let mut v = ids
-                .iter()
-                .map(|(oid, f)| format!("{}{}", oid, spec(*f)))
-                .collect::<Vec<_>>();
-            v.sort();
-            format!(":squash({})", v.join(","))
-        }
+        Op::Squash => ":SQUASH".to_string(),
         Op::Adapt(adapter) => format!(":adapt={}", adapter),
         Op::Link(None) => ":link".to_string(),
         Op::Link(Some(mode)) => format!(":link={}", mode),

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -44,7 +44,7 @@ fn make_filter(args: &[&str]) -> anyhow::Result<Filter> {
             Where `path` is path to the directory where workspace.josh file is located
             "#
         ))),
-        ["SQUASH"] => Ok(f.squash(None)),
+        ["SQUASH"] => Ok(f.squash()),
         ["SQUASH", _ids @ ..] => Err(anyhow!("SQUASH with ids can't be parsed")),
         ["linear"] => Ok(f.linear()),
         ["prune", "trivial-merge"] => Ok(f.prune_trivial_merge()),
@@ -352,6 +352,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
             Ok(to_filter(Op::RegexReplace(replacements)))
         }
         Rule::filter_squash => {
+            // BTreeMap deduplicates IDs and makes the expansion deterministic.
             let ids: std::collections::BTreeMap<LazyRef, Filter> = pair
                 .into_inner()
                 .tuples()
@@ -362,7 +363,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
                 .into_iter()
                 .collect();
 
-            Ok(to_filter(Op::Squash(Some(ids))))
+            Ok(to_filter(crate::filter::squash_to_rev(ids)))
         }
         Rule::filter_meta => {
             let inner = pair.into_inner();

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -44,7 +44,7 @@ fn make_filter(args: &[&str]) -> anyhow::Result<Filter> {
             Where `path` is path to the directory where workspace.josh file is located
             "#
         ))),
-        ["SQUASH"] => Ok(f.squash(None)),
+        ["SQUASH"] => Ok(f.squash()),
         ["SQUASH", _ids @ ..] => Err(anyhow!("SQUASH with ids can't be parsed")),
         ["linear"] => Ok(f.linear()),
         ["prune", "trivial-merge"] => Ok(f.prune_trivial_merge()),
@@ -354,6 +354,8 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
             Ok(to_filter(Op::RegexReplace(replacements)))
         }
         Rule::filter_squash => {
+            // Collect into a BTreeMap first so duplicate ids collapse and the resulting
+            // `:rev(...)` expansion is deterministic regardless of input order.
             let ids: std::collections::BTreeMap<LazyRef, Filter> = pair
                 .into_inner()
                 .tuples()
@@ -364,7 +366,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
                 .into_iter()
                 .collect();
 
-            Ok(to_filter(Op::Squash(Some(ids))))
+            Ok(to_filter(crate::filter::squash_to_rev(ids)))
         }
         Rule::filter_meta => {
             let inner = pair.into_inner();

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -121,9 +121,7 @@ pub enum Op {
     Export,
     Embed(std::path::PathBuf),
 
-    // We use BTreeMap rather than HashMap to guarantee deterministic results when
-    // converting to Filter
-    Squash(Option<std::collections::BTreeMap<LazyRef, Filter>>),
+    Squash,
     Author(String, String),
     Committer(String, String),
 

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -120,9 +120,7 @@ pub enum Op {
     Export,
     Embed(std::path::PathBuf),
 
-    // We use BTreeMap rather than HashMap to guarantee deterministic results when
-    // converting to Filter
-    Squash(Option<std::collections::BTreeMap<LazyRef, Filter>>),
+    Squash,
     Author(String, String),
     Committer(String, String),
 

--- a/josh-filter/src/opt/invert.rs
+++ b/josh-filter/src/opt/invert.rs
@@ -15,7 +15,7 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
             Op::Message(..) => Some(Op::Nop),
             // `:SQUASH` only rewrites history; at tree level it is identity,
             // so content pushed through it maps back unchanged.
-            Op::Squash(None) => Some(Op::Nop),
+            Op::Squash => Some(Op::Nop),
             Op::Prune => Some(Op::Prune),
             Op::Export => Some(Op::Export),
             Op::Empty => Some(Op::Empty),

--- a/josh-filter/src/opt/step.rs
+++ b/josh-filter/src/opt/step.rs
@@ -9,6 +9,16 @@ fn is_prefix(op: Op) -> bool {
     matches!(op, Op::Prefix(_))
 }
 
+/// Filters that only rewrite commit metadata and are identity on trees. Subtracting one
+/// such filter from another therefore always yields the empty path set.
+fn is_tree_identity(filter: Filter) -> bool {
+    match to_op_ref(filter) {
+        Op::Nop | Op::Squash | Op::Message(..) | Op::Author(..) | Op::Committer(..) => true,
+        Op::Chain(v) | Op::Compose(v) => v.iter().all(|f| is_tree_identity(*f)),
+        _ => false,
+    }
+}
+
 fn prefix_of(op: Op) -> Filter {
     let last = to_op(last_chain(to_filter(Op::Nop), to_filter(op)).1);
     to_filter(if is_prefix(last.clone()) {
@@ -201,7 +211,7 @@ pub(super) fn step(filter: Filter) -> Filter {
             let (af, bf) = (*af, *bf);
             match (to_op(af), to_op(bf)) {
                 (Op::Empty, _) => Op::Empty,
-                (Op::Message(..), Op::Message(..)) => Op::Empty,
+                _ if is_tree_identity(af) && is_tree_identity(bf) => Op::Empty,
                 (_, Op::Nop) => Op::Empty,
                 (a, Op::Empty) => a,
                 // `Select(F)` and `Exclude(F)` partition the input tree by path: one keeps exactly

--- a/josh-filter/src/opt/step.rs
+++ b/josh-filter/src/opt/step.rs
@@ -9,6 +9,15 @@ fn is_prefix(op: Op) -> bool {
     matches!(op, Op::Prefix(_))
 }
 
+/// Filters that preserve trees, so subtracting one from another yields no paths.
+fn is_tree_identity(filter: Filter) -> bool {
+    match to_op_ref(filter) {
+        Op::Nop | Op::Squash | Op::Message(..) | Op::Author(..) | Op::Committer(..) => true,
+        Op::Chain(v) | Op::Compose(v) => v.iter().all(|f| is_tree_identity(*f)),
+        _ => false,
+    }
+}
+
 fn prefix_of(op: Op) -> Filter {
     let last = to_op(last_chain(to_filter(Op::Nop), to_filter(op)).1);
     to_filter(if is_prefix(last.clone()) {
@@ -201,7 +210,7 @@ pub(super) fn step(filter: Filter) -> Filter {
             let (af, bf) = (*af, *bf);
             match (to_op(af), to_op(bf)) {
                 (Op::Empty, _) => Op::Empty,
-                (Op::Message(..), Op::Message(..)) => Op::Empty,
+                _ if is_tree_identity(af) && is_tree_identity(bf) => Op::Empty,
                 (_, Op::Nop) => Op::Empty,
                 (a, Op::Empty) => a,
                 // `Select(F)` and `Exclude(F)` partition the input tree by path: one keeps exactly

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -64,7 +64,6 @@ fn child_filters(op: &Op) -> Vec<Filter> {
         Op::Subtract(a, b) => vec![*a, *b],
         Op::Compose(v) | Op::Chain(v) => v.clone(),
         Op::Rev(v) => v.iter().map(|(_, _, f)| *f).collect(),
-        Op::Squash(Some(m)) => m.values().copied().collect(),
         _ => vec![],
     }
 }
@@ -265,44 +264,6 @@ impl<'a> InMemoryBuilder<'a> {
             filename: BString::from("0"),
             oid: inner_oid,
         }];
-        let outer_tree = gix_object::Tree {
-            entries: outer_entries,
-        };
-        Ok(self.write_tree(outer_tree))
-    }
-
-    fn build_squash_params(
-        &mut self,
-        params: &std::collections::BTreeMap<LazyRef, Filter>,
-    ) -> anyhow::Result<gix_hash::ObjectId> {
-        let mut outer_entries = Vec::new();
-        for (i, (lazy_ref, filter)) in params.iter().enumerate() {
-            let key_blob = self.write_blob(lazy_ref.to_string().as_bytes());
-            let filter_tree = self.node_oid(*filter);
-
-            let inner_entries = vec![
-                gix_object::tree::Entry {
-                    mode: gix_object::tree::EntryKind::Blob.into(),
-                    filename: BString::from("o"),
-                    oid: key_blob,
-                },
-                gix_object::tree::Entry {
-                    mode: gix_object::tree::EntryKind::Tree.into(),
-                    filename: BString::from("f"),
-                    oid: filter_tree,
-                },
-            ];
-            let inner_tree = gix_object::Tree {
-                entries: inner_entries,
-            };
-            let inner_oid = self.write_tree(inner_tree);
-
-            outer_entries.push(gix_object::tree::Entry {
-                mode: gix_object::tree::EntryKind::Tree.into(),
-                filename: BString::from(i.to_string()),
-                oid: inner_oid,
-            });
-        }
         let outer_tree = gix_object::Tree {
             entries: outer_entries,
         };
@@ -518,7 +479,7 @@ impl<'a> InMemoryBuilder<'a> {
                 let blob = self.write_blob(b"");
                 push_blob_entries(&mut entries, [("fold", blob)]);
             }
-            Op::Squash(None) => {
+            Op::Squash => {
                 let blob = self.write_blob(b"");
                 push_blob_entries(&mut entries, [("squash", blob)]);
             }
@@ -534,10 +495,6 @@ impl<'a> InMemoryBuilder<'a> {
             Op::Unapply(lr, f) => {
                 let params_tree = self.build_lazyref_filter_params(lr, *f)?;
                 push_tree_entries(&mut entries, [("unapply", params_tree)]);
-            }
-            Op::Squash(Some(ids)) => {
-                let params_tree = self.build_squash_params(ids)?;
-                push_tree_entries(&mut entries, [("squash", params_tree)]);
             }
             Op::RegexReplace(replacements) => {
                 let params_tree = self.build_regex_replace_params(replacements);
@@ -665,7 +622,6 @@ pub fn as_tree(
 struct PersistedEntry {
     name: BString,
     oid: gix_hash::ObjectId,
-    is_tree: bool,
 }
 
 impl PersistedEntry {
@@ -704,7 +660,6 @@ impl PersistedTree {
                 .map(|e| PersistedEntry {
                     name: e.filename.into(),
                     oid: e.oid.to_owned(),
-                    is_tree: e.mode.is_tree(),
                 })
                 .collect(),
         })
@@ -1228,35 +1183,8 @@ fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyh
             Ok(Op::Unapply(LazyRef::parse(&key)?, to_filter(filter)))
         }
         "squash" => {
-            // blob -> Squash(None), tree -> Squash(Some(...))
-            if !entry.is_tree {
-                let _ = Blob::read(src, entry.id())?;
-                return Ok(Op::Squash(None));
-            }
-            let squash_tree = PersistedTree::read(src, entry.id())?;
-            let mut filters = std::collections::BTreeMap::new();
-            for i in 0..squash_tree.len() {
-                let squash_entry = squash_tree.get(i).context("squash: missing entry")?;
-                let inner_tree = PersistedTree::read(src, squash_entry.id())?;
-                let key_blob = Blob::read(
-                    src,
-                    inner_tree
-                        .get_name("o")
-                        .context("squash: missing key")?
-                        .id(),
-                )?;
-                let filter_tree = PersistedTree::read(
-                    src,
-                    inner_tree
-                        .get_name("f")
-                        .context("squash: missing filter")?
-                        .id(),
-                )?;
-                let key = std::str::from_utf8(key_blob.content())?;
-                let filter = from_tree2(src, filter_tree.id())?;
-                filters.insert(LazyRef::parse(&key)?, to_filter(filter));
-            }
-            Ok(Op::Squash(Some(filters)))
+            let _ = Blob::read(src, entry.id())?;
+            Ok(Op::Squash)
         }
         "regex_replace" => {
             let regex_replace_tree = PersistedTree::read(src, entry.id())?;

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -64,7 +64,6 @@ fn child_filters(op: &Op) -> Vec<Filter> {
         Op::Subtract(a, b) => vec![*a, *b],
         Op::Compose(v) | Op::Chain(v) => v.clone(),
         Op::Rev(v) => v.iter().map(|(_, _, f)| *f).collect(),
-        Op::Squash(Some(m)) => m.values().copied().collect(),
         _ => vec![],
     }
 }
@@ -265,44 +264,6 @@ impl<'a> InMemoryBuilder<'a> {
             filename: BString::from("0"),
             oid: inner_oid,
         }];
-        let outer_tree = gix_object::Tree {
-            entries: outer_entries,
-        };
-        Ok(self.write_tree(outer_tree))
-    }
-
-    fn build_squash_params(
-        &mut self,
-        params: &std::collections::BTreeMap<LazyRef, Filter>,
-    ) -> anyhow::Result<gix_hash::ObjectId> {
-        let mut outer_entries = Vec::new();
-        for (i, (lazy_ref, filter)) in params.iter().enumerate() {
-            let key_blob = self.write_blob(lazy_ref.to_string().as_bytes());
-            let filter_tree = self.node_oid(*filter);
-
-            let inner_entries = vec![
-                gix_object::tree::Entry {
-                    mode: gix_object::tree::EntryKind::Blob.into(),
-                    filename: BString::from("o"),
-                    oid: key_blob,
-                },
-                gix_object::tree::Entry {
-                    mode: gix_object::tree::EntryKind::Tree.into(),
-                    filename: BString::from("f"),
-                    oid: filter_tree,
-                },
-            ];
-            let inner_tree = gix_object::Tree {
-                entries: inner_entries,
-            };
-            let inner_oid = self.write_tree(inner_tree);
-
-            outer_entries.push(gix_object::tree::Entry {
-                mode: gix_object::tree::EntryKind::Tree.into(),
-                filename: BString::from(i.to_string()),
-                oid: inner_oid,
-            });
-        }
         let outer_tree = gix_object::Tree {
             entries: outer_entries,
         };
@@ -521,7 +482,7 @@ impl<'a> InMemoryBuilder<'a> {
                 let blob = self.write_blob(b"");
                 push_blob_entries(&mut entries, [("fold", blob)]);
             }
-            Op::Squash(None) => {
+            Op::Squash => {
                 let blob = self.write_blob(b"");
                 push_blob_entries(&mut entries, [("squash", blob)]);
             }
@@ -537,10 +498,6 @@ impl<'a> InMemoryBuilder<'a> {
             Op::Unapply(lr, f) => {
                 let params_tree = self.build_lazyref_filter_params(lr, *f)?;
                 push_tree_entries(&mut entries, [("unapply", params_tree)]);
-            }
-            Op::Squash(Some(ids)) => {
-                let params_tree = self.build_squash_params(ids)?;
-                push_tree_entries(&mut entries, [("squash", params_tree)]);
             }
             Op::RegexReplace(replacements) => {
                 let params_tree = self.build_regex_replace_params(replacements);
@@ -1082,35 +1039,8 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             Ok(Op::Unapply(LazyRef::parse(&key)?, to_filter(filter)))
         }
         "squash" => {
-            // blob -> Squash(None), tree -> Squash(Some(...))
-            if let Some(kind) = entry.kind()
-                && kind == git2::ObjectType::Blob
-            {
-                let _ = repo.find_blob(entry.id())?;
-                return Ok(Op::Squash(None));
-            }
-            let squash_tree = repo.find_tree(entry.id())?;
-            let mut filters = std::collections::BTreeMap::new();
-            for i in 0..squash_tree.len() {
-                let squash_entry = squash_tree.get(i).context("squash: missing entry")?;
-                let inner_tree = repo.find_tree(squash_entry.id())?;
-                let key_blob = repo.find_blob(
-                    inner_tree
-                        .get_name("o")
-                        .context("squash: missing key")?
-                        .id(),
-                )?;
-                let filter_tree = repo.find_tree(
-                    inner_tree
-                        .get_name("f")
-                        .context("squash: missing filter")?
-                        .id(),
-                )?;
-                let key = std::str::from_utf8(key_blob.content())?;
-                let filter = from_tree2(repo, filter_tree.id())?;
-                filters.insert(LazyRef::parse(&key)?, to_filter(filter));
-            }
-            Ok(Op::Squash(Some(filters)))
+            let _ = repo.find_blob(entry.id())?;
+            Ok(Op::Squash)
         }
         "regex_replace" => {
             let regex_replace_tree = repo.find_tree(entry.id())?;

--- a/tests/filter/squash.t
+++ b/tests/filter/squash.t
@@ -31,9 +31,7 @@
   $ josh-filter -s --squash-pattern "refs/tags/*" --update refs/heads/filtered
   Warning: reference refs/heads/filtered wasn't updated
   0000000000000000000000000000000000000000
-  [1] :squash(
-  
-  )
+  [1] :rev(_:SQUASH)
   [5] reachable_roots
   [5] sequence_number
 
@@ -47,16 +45,11 @@ This one tag is an annotated tag, to make sure those are handled as well
   $ git tag -a tag_a -m "created a tag" 1d69b7d
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
   977cc3ee14c0d6163ba63bd96f4aeedd43916ba7
-  [1] :"refs/tags/tag_a"
   [1] :author="New Author";"new@e.mail"
-  [1] :squash(
-  
-  )
-  [2] :squash(
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-  )
-  [7] reachable_roots
-  [7] sequence_number
+  [1] :rev(_:SQUASH)
+  [2] :rev(==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",_:SQUASH)
+  [6] reachable_roots
+  [6] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   * 977cc3ee14c0d6163ba63bd96f4aeedd43916ba7 (tag: filtered/tag_a, filtered) refs/tags/tag_a
@@ -74,23 +67,12 @@ This one tag is an annotated tag, to make sure those are handled as well
 
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
   be41caf35896090033cfd103e06aae721a3ce541
-  [1] :"refs/tags/filtered/tag_a"
-  [1] :"refs/tags/tag_a"
-  [1] :"refs/tags/tag_b"
-  [1] :squash(
-  
-  )
-  [2] :squash(
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-  )
-  [3] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a"
-  )
+  [1] :rev(_:SQUASH)
+  [2] :rev(==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",_:SQUASH)
+  [3] :rev(==977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",_:SQUASH)
   [4] :author="New Author";"new@e.mail"
-  [11] reachable_roots
-  [11] sequence_number
+  [10] reachable_roots
+  [10] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   * be41caf35896090033cfd103e06aae721a3ce541 (tag: filtered/tag_a, filtered) refs/tags/tag_a
@@ -112,33 +94,14 @@ This one tag is an annotated tag, to make sure those are handled as well
 
   $ josh-filter -s --squash-pattern "refs/tags/*" :committer=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
   97c6007771c497c9530d61aa89af663daebb1625
-  [1] :"refs/tags/filtered/filtered/tag_a"
-  [1] :"refs/tags/filtered/tag_a"
-  [1] :"refs/tags/filtered/tag_b"
-  [1] :"refs/tags/tag_a"
-  [1] :"refs/tags/tag_b"
-  [1] :squash(
-  
-  )
-  [2] :squash(
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-  )
-  [3] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a"
-  )
+  [1] :rev(_:SQUASH)
+  [2] :rev(==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",_:SQUASH)
+  [3] :rev(==977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",_:SQUASH)
   [4] :author="New Author";"new@e.mail"
   [5] :committer="New Author";"new@e.mail"
-  [5] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      64f712c4615dbf5e9e0a1c4cdf65b2da2138f4be:"refs/tags/filtered/tag_b"
-      a68763bdf2f45a44304067954855749e366a5533:"refs/tags/filtered/filtered/tag_a"
-      be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a"
-  )
-  [16] reachable_roots
-  [16] sequence_number
+  [5] :rev(==a68763bdf2f45a44304067954855749e366a5533:"refs/tags/filtered/filtered/tag_a",==be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a",==64f712c4615dbf5e9e0a1c4cdf65b2da2138f4be:"refs/tags/filtered/tag_b",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",_:SQUASH)
+  [15] reachable_roots
+  [15] sequence_number
   $ git log --graph --pretty=%an:%ae-%cn:%ce refs/heads/filtered
   * Josh:josh@example.com-New Author:new@e.mail
   |\
@@ -153,64 +116,22 @@ This one tag is an annotated tag, to make sure those are handled as well
   1d69b7d2651f744be3416f2ad526aeccefb99310 refs/heads/master
   $ josh-filter -s --squash-file squashlist :author=\"John\ Doe\"\;\"new@e.mail\" --update refs/heads/filtered -p > filter.josh
   $ cat filter.josh
-  :squash(
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/heads/master"
-      86871b8775ad3baca86484337d1072aa1d386f7e:"refs/heads/branch2"
-      97c6007771c497c9530d61aa89af663daebb1625:"refs/heads/filtered"
-  ):author="John Doe";"new@e.mail"
+  :rev(==86871b8775ad3baca86484337d1072aa1d386f7e:"refs/heads/branch2",==97c6007771c497c9530d61aa89af663daebb1625:"refs/heads/filtered",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/heads/master",_:SQUASH):author="John Doe";"new@e.mail"
 
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered -p > filter.josh
   $ cat filter.josh
-  :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      1dd879133bc80f7d180bd98268412f8ee61226f2:"refs/tags/filtered/tag_b"
-      975d4c4975912729482cc864d321c5196a969271:"refs/tags/tag_c"
-      97c6007771c497c9530d61aa89af663daebb1625:"refs/tags/filtered/tag_a"
-      a91f2e4061d13b9adcb6d8ca63e17c8bbc5bed55:"refs/tags/filtered/filtered/tag_a"
-      b7e3b7815c4d7c8738545526b20308b1240137c7:"refs/tags/filtered/filtered/filtered/tag_a"
-      c4215db39f3cd96f07fe4c1f701dad39d5f5dec3:"refs/tags/filtered/filtered/tag_b"
-  ):author="New Author";"new@e.mail"
+  :rev(==b7e3b7815c4d7c8738545526b20308b1240137c7:"refs/tags/filtered/filtered/filtered/tag_a",==a91f2e4061d13b9adcb6d8ca63e17c8bbc5bed55:"refs/tags/filtered/filtered/tag_a",==c4215db39f3cd96f07fe4c1f701dad39d5f5dec3:"refs/tags/filtered/filtered/tag_b",==97c6007771c497c9530d61aa89af663daebb1625:"refs/tags/filtered/tag_a",==1dd879133bc80f7d180bd98268412f8ee61226f2:"refs/tags/filtered/tag_b",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",==975d4c4975912729482cc864d321c5196a969271:"refs/tags/tag_c",_:SQUASH):author="New Author";"new@e.mail"
   $ josh-filter -s --file filter.josh --update refs/heads/filtered
   2826b9a173c7a7d5c83d9ae2614de89c77205d83
-  [1] :"refs/tags/filtered/filtered/tag_a"
-  [1] :"refs/tags/filtered/tag_a"
-  [1] :"refs/tags/filtered/tag_b"
-  [1] :"refs/tags/tag_a"
-  [1] :"refs/tags/tag_b"
-  [1] :"refs/tags/tag_c"
-  [1] :squash(
-  
-  )
-  [2] :squash(
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-  )
-  [3] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      1dd879133bc80f7d180bd98268412f8ee61226f2:"refs/tags/filtered/tag_b"
-      975d4c4975912729482cc864d321c5196a969271:"refs/tags/tag_c"
-      97c6007771c497c9530d61aa89af663daebb1625:"refs/tags/filtered/tag_a"
-      a91f2e4061d13b9adcb6d8ca63e17c8bbc5bed55:"refs/tags/filtered/filtered/tag_a"
-      b7e3b7815c4d7c8738545526b20308b1240137c7:"refs/tags/filtered/filtered/filtered/tag_a"
-      c4215db39f3cd96f07fe4c1f701dad39d5f5dec3:"refs/tags/filtered/filtered/tag_b"
-  )
-  [3] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a"
-  )
+  [1] :rev(_:SQUASH)
+  [2] :rev(==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",_:SQUASH)
+  [3] :rev(==977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",_:SQUASH)
+  [3] :rev(==b7e3b7815c4d7c8738545526b20308b1240137c7:"refs/tags/filtered/filtered/filtered/tag_a",==a91f2e4061d13b9adcb6d8ca63e17c8bbc5bed55:"refs/tags/filtered/filtered/tag_a",==c4215db39f3cd96f07fe4c1f701dad39d5f5dec3:"refs/tags/filtered/filtered/tag_b",==97c6007771c497c9530d61aa89af663daebb1625:"refs/tags/filtered/tag_a",==1dd879133bc80f7d180bd98268412f8ee61226f2:"refs/tags/filtered/tag_b",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",==975d4c4975912729482cc864d321c5196a969271:"refs/tags/tag_c",_:SQUASH)
   [5] :committer="New Author";"new@e.mail"
-  [5] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      64f712c4615dbf5e9e0a1c4cdf65b2da2138f4be:"refs/tags/filtered/tag_b"
-      a68763bdf2f45a44304067954855749e366a5533:"refs/tags/filtered/filtered/tag_a"
-      be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a"
-  )
+  [5] :rev(==a68763bdf2f45a44304067954855749e366a5533:"refs/tags/filtered/filtered/tag_a",==be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a",==64f712c4615dbf5e9e0a1c4cdf65b2da2138f4be:"refs/tags/filtered/tag_b",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",_:SQUASH)
   [6] :author="New Author";"new@e.mail"
-  [19] reachable_roots
-  [19] sequence_number
+  [17] reachable_roots
+  [17] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   *   2826b9a173c7a7d5c83d9ae2614de89c77205d83 (filtered) refs/tags/tag_a
@@ -218,4 +139,3 @@ This one tag is an annotated tag, to make sure those are handled as well
   | * 63f8653625759f860ee31cce2d4e207974da1c37 refs/tags/tag_c
   |/  
   * 64f712c4615dbf5e9e0a1c4cdf65b2da2138f4be refs/tags/tag_b
-

--- a/tests/filter/squash.t
+++ b/tests/filter/squash.t
@@ -44,13 +44,10 @@ This one tag is an annotated tag, to make sure those are handled as well
   $ git tag -a tag_a -m "created a tag" 1d69b7d
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
   977cc3ee14c0d6163ba63bd96f4aeedd43916ba7
-  [1] :"refs/tags/tag_a"
   [1] :author="New Author";"new@e.mail"
-  [1] :squash(
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-  )
-  [7] reachable_roots
-  [7] sequence_number
+  [1] :rev(==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",_:SQUASH)
+  [6] reachable_roots
+  [6] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   * 977cc3ee14c0d6163ba63bd96f4aeedd43916ba7 (tag: filtered/tag_a, filtered) refs/tags/tag_a
@@ -68,20 +65,11 @@ This one tag is an annotated tag, to make sure those are handled as well
 
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
   be41caf35896090033cfd103e06aae721a3ce541
-  [1] :"refs/tags/filtered/tag_a"
-  [1] :"refs/tags/tag_a"
-  [1] :"refs/tags/tag_b"
-  [1] :squash(
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-  )
-  [3] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a"
-  )
+  [1] :rev(==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",_:SQUASH)
+  [3] :rev(==977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",_:SQUASH)
   [4] :author="New Author";"new@e.mail"
-  [11] reachable_roots
-  [11] sequence_number
+  [10] reachable_roots
+  [10] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   * be41caf35896090033cfd103e06aae721a3ce541 (tag: filtered/tag_a, filtered) refs/tags/tag_a
@@ -103,30 +91,13 @@ This one tag is an annotated tag, to make sure those are handled as well
 
   $ josh-filter -s --squash-pattern "refs/tags/*" :committer=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
   97c6007771c497c9530d61aa89af663daebb1625
-  [1] :"refs/tags/filtered/filtered/tag_a"
-  [1] :"refs/tags/filtered/tag_a"
-  [1] :"refs/tags/filtered/tag_b"
-  [1] :"refs/tags/tag_a"
-  [1] :"refs/tags/tag_b"
-  [1] :squash(
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-  )
-  [3] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a"
-  )
+  [1] :rev(==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",_:SQUASH)
+  [3] :rev(==977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",_:SQUASH)
   [4] :author="New Author";"new@e.mail"
   [5] :committer="New Author";"new@e.mail"
-  [5] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      64f712c4615dbf5e9e0a1c4cdf65b2da2138f4be:"refs/tags/filtered/tag_b"
-      a68763bdf2f45a44304067954855749e366a5533:"refs/tags/filtered/filtered/tag_a"
-      be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a"
-  )
-  [16] reachable_roots
-  [16] sequence_number
+  [5] :rev(==a68763bdf2f45a44304067954855749e366a5533:"refs/tags/filtered/filtered/tag_a",==be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a",==64f712c4615dbf5e9e0a1c4cdf65b2da2138f4be:"refs/tags/filtered/tag_b",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",_:SQUASH)
+  [15] reachable_roots
+  [15] sequence_number
   $ git log --graph --pretty=%an:%ae-%cn:%ce refs/heads/filtered
   * Josh:josh@example.com-New Author:new@e.mail
   |\
@@ -141,61 +112,21 @@ This one tag is an annotated tag, to make sure those are handled as well
   1d69b7d2651f744be3416f2ad526aeccefb99310 refs/heads/master
   $ josh-filter -s --squash-file squashlist :author=\"John\ Doe\"\;\"new@e.mail\" --update refs/heads/filtered -p > filter.josh
   $ cat filter.josh
-  :squash(
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/heads/master"
-      86871b8775ad3baca86484337d1072aa1d386f7e:"refs/heads/branch2"
-      97c6007771c497c9530d61aa89af663daebb1625:"refs/heads/filtered"
-  ):author="John Doe";"new@e.mail"
+  :rev(==86871b8775ad3baca86484337d1072aa1d386f7e:"refs/heads/branch2",==97c6007771c497c9530d61aa89af663daebb1625:"refs/heads/filtered",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/heads/master",_:SQUASH):author="John Doe";"new@e.mail"
 
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered -p > filter.josh
   $ cat filter.josh
-  :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      1dd879133bc80f7d180bd98268412f8ee61226f2:"refs/tags/filtered/tag_b"
-      975d4c4975912729482cc864d321c5196a969271:"refs/tags/tag_c"
-      97c6007771c497c9530d61aa89af663daebb1625:"refs/tags/filtered/tag_a"
-      a91f2e4061d13b9adcb6d8ca63e17c8bbc5bed55:"refs/tags/filtered/filtered/tag_a"
-      b7e3b7815c4d7c8738545526b20308b1240137c7:"refs/tags/filtered/filtered/filtered/tag_a"
-      c4215db39f3cd96f07fe4c1f701dad39d5f5dec3:"refs/tags/filtered/filtered/tag_b"
-  ):author="New Author";"new@e.mail"
+  :rev(==b7e3b7815c4d7c8738545526b20308b1240137c7:"refs/tags/filtered/filtered/filtered/tag_a",==a91f2e4061d13b9adcb6d8ca63e17c8bbc5bed55:"refs/tags/filtered/filtered/tag_a",==c4215db39f3cd96f07fe4c1f701dad39d5f5dec3:"refs/tags/filtered/filtered/tag_b",==97c6007771c497c9530d61aa89af663daebb1625:"refs/tags/filtered/tag_a",==1dd879133bc80f7d180bd98268412f8ee61226f2:"refs/tags/filtered/tag_b",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",==975d4c4975912729482cc864d321c5196a969271:"refs/tags/tag_c",_:SQUASH):author="New Author";"new@e.mail"
   $ josh-filter -s --file filter.josh --update refs/heads/filtered
   2826b9a173c7a7d5c83d9ae2614de89c77205d83
-  [1] :"refs/tags/filtered/filtered/tag_a"
-  [1] :"refs/tags/filtered/tag_a"
-  [1] :"refs/tags/filtered/tag_b"
-  [1] :"refs/tags/tag_a"
-  [1] :"refs/tags/tag_b"
-  [1] :"refs/tags/tag_c"
-  [1] :squash(
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-  )
-  [3] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      1dd879133bc80f7d180bd98268412f8ee61226f2:"refs/tags/filtered/tag_b"
-      975d4c4975912729482cc864d321c5196a969271:"refs/tags/tag_c"
-      97c6007771c497c9530d61aa89af663daebb1625:"refs/tags/filtered/tag_a"
-      a91f2e4061d13b9adcb6d8ca63e17c8bbc5bed55:"refs/tags/filtered/filtered/tag_a"
-      b7e3b7815c4d7c8738545526b20308b1240137c7:"refs/tags/filtered/filtered/filtered/tag_a"
-      c4215db39f3cd96f07fe4c1f701dad39d5f5dec3:"refs/tags/filtered/filtered/tag_b"
-  )
-  [3] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a"
-  )
+  [1] :rev(==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",_:SQUASH)
+  [3] :rev(==977cc3ee14c0d6163ba63bd96f4aeedd43916ba7:"refs/tags/filtered/tag_a",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",_:SQUASH)
+  [3] :rev(==b7e3b7815c4d7c8738545526b20308b1240137c7:"refs/tags/filtered/filtered/filtered/tag_a",==a91f2e4061d13b9adcb6d8ca63e17c8bbc5bed55:"refs/tags/filtered/filtered/tag_a",==c4215db39f3cd96f07fe4c1f701dad39d5f5dec3:"refs/tags/filtered/filtered/tag_b",==97c6007771c497c9530d61aa89af663daebb1625:"refs/tags/filtered/tag_a",==1dd879133bc80f7d180bd98268412f8ee61226f2:"refs/tags/filtered/tag_b",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",==975d4c4975912729482cc864d321c5196a969271:"refs/tags/tag_c",_:SQUASH)
   [5] :committer="New Author";"new@e.mail"
-  [5] :squash(
-      0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b"
-      1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
-      64f712c4615dbf5e9e0a1c4cdf65b2da2138f4be:"refs/tags/filtered/tag_b"
-      a68763bdf2f45a44304067954855749e366a5533:"refs/tags/filtered/filtered/tag_a"
-      be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a"
-  )
+  [5] :rev(==a68763bdf2f45a44304067954855749e366a5533:"refs/tags/filtered/filtered/tag_a",==be41caf35896090033cfd103e06aae721a3ce541:"refs/tags/filtered/tag_a",==64f712c4615dbf5e9e0a1c4cdf65b2da2138f4be:"refs/tags/filtered/tag_b",==1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a",==0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:"refs/tags/tag_b",_:SQUASH)
   [6] :author="New Author";"new@e.mail"
-  [19] reachable_roots
-  [19] sequence_number
+  [17] reachable_roots
+  [17] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   *   2826b9a173c7a7d5c83d9ae2614de89c77205d83 (filtered) refs/tags/tag_a

--- a/tests/filter/squash_empty_initial.t
+++ b/tests/filter/squash_empty_initial.t
@@ -38,9 +38,7 @@
   $ josh-filter -s --squash-pattern "refs/tags/*" --update refs/heads/filtered
   Warning: reference refs/heads/filtered wasn't updated
   0000000000000000000000000000000000000000
-  [1] :squash(
-  
-  )
+  [1] :rev(_:SQUASH)
   [5] reachable_roots
   [5] sequence_number
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
@@ -52,16 +50,11 @@
   $ git tag -a tag_a -m "created a tag" 882f2656a5075936eb37bfefde740e0b453e4479
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
   977cc3ee14c0d6163ba63bd96f4aeedd43916ba7
-  [1] :"refs/tags/tag_a"
   [1] :author="New Author";"new@e.mail"
-  [1] :squash(
-  
-  )
-  [2] :squash(
-      882f2656a5075936eb37bfefde740e0b453e4479:"refs/tags/tag_a"
-  )
-  [7] reachable_roots
-  [7] sequence_number
+  [1] :rev(_:SQUASH)
+  [2] :rev(==882f2656a5075936eb37bfefde740e0b453e4479:"refs/tags/tag_a",_:SQUASH)
+  [6] reachable_roots
+  [6] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   * 977cc3ee14c0d6163ba63bd96f4aeedd43916ba7 (tag: filtered/tag_a, filtered) refs/tags/tag_a

--- a/tests/filter/squash_empty_initial.t
+++ b/tests/filter/squash_empty_initial.t
@@ -49,13 +49,10 @@
   $ git tag -a tag_a -m "created a tag" 882f2656a5075936eb37bfefde740e0b453e4479
   $ josh-filter -s --squash-pattern "refs/tags/*" :author=\"New\ Author\"\;\"new@e.mail\" --update refs/heads/filtered
   977cc3ee14c0d6163ba63bd96f4aeedd43916ba7
-  [1] :"refs/tags/tag_a"
   [1] :author="New Author";"new@e.mail"
-  [1] :squash(
-      882f2656a5075936eb37bfefde740e0b453e4479:"refs/tags/tag_a"
-  )
-  [7] reachable_roots
-  [7] sequence_number
+  [1] :rev(==882f2656a5075936eb37bfefde740e0b453e4479:"refs/tags/tag_a",_:SQUASH)
+  [6] reachable_roots
+  [6] sequence_number
 
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
   * 977cc3ee14c0d6163ba63bd96f4aeedd43916ba7 (tag: filtered/tag_a, filtered) refs/tags/tag_a

--- a/tests/filter/squash_same_oid.t
+++ b/tests/filter/squash_same_oid.t
@@ -5,20 +5,17 @@
   $ git add .
   $ git commit -m "add file1" 1> /dev/null
 
-Two tags on one commit: refs are enumerated byte-sorted and a duplicate target oid
-takes the last-inserted message filter, so the byte-greatest refname wins the
 message collision.
 
   $ git tag tag_a
   $ git tag tag_b
 
   $ josh-filter --squash-pattern "refs/tags/*" --update refs/heads/filtered
-  077b2cad7b3fbc393b6320b90c9c0be1255ac309
+  62b5931076aa99843beabf8686ac8dcb7aecf130
 
   $ git log --pretty=%s refs/heads/filtered
-  refs/tags/tag_b
+  refs/tags/tag_a
 
-A pattern the glob parser rejects (non-component "**") errors instead of matching
 like "*".
 
   $ josh-filter --squash-pattern "refs/tags/t**" --update refs/heads/filtered


### PR DESCRIPTION
Express squash IDs as a :rev() filter

Reuse :rev() expansion and tree-identity optimization instead of storing
per-squash filter maps.

Change: squash-filter-as-rev
Assisted-By: anthropic/claude-fable-5
Assisted-By: openai-codex/gpt-5.6-sol