### PR TITLE
Replace the git2 revwalk with native walkers in josh-gix-ext

### DIFF
--- a/josh-core/src/cache/history_graph.rs
+++ b/josh-core/src/cache/history_graph.rs
@@ -150,28 +150,26 @@ fn ensure_hint_cached(
     }
 
     log::info!("ensure_hint_cached: new_walk for {:?}", input);
-    let mut walk = transaction.repo().revwalk()?;
-    walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
+    let odb = transaction.repo().odb()?;
+    let mut walk = crate::objects::RevWalk::new(&odb);
     walk.push(input)?;
 
-    // Hide ancestors that already have *both* pieces cached. Hiding on seq#
+    // Prune ancestors that already have *both* pieces cached. Pruning on seq#
     // alone would skip commits with cached seq# but missing roots, leaving
     // their roots unpopulated.
     // The callback cannot propagate errors, so treat a failed lookup as "not
     // cached": the walk then visits the commit and the fallible body reports
     // the same error properly.
-    let mut hide = |id| {
+    let sorted = walk.into_topo_vec(|id| {
         transaction
             .known(crate::filter::sequence_number(), id)
             .unwrap_or(false)
             && transaction
                 .known(crate::filter::reachable_roots(), id)
                 .unwrap_or(false)
-    };
-    let walk = walk.with_hide_callback(&mut hide)?;
+    })?;
 
-    for c in walk {
-        let oid = c?;
+    for &oid in sorted.iter().rev() {
         let parents_hint: Vec<(u64, git2::Oid)> =
             crate::git::read_parent_ids(transaction.repo(), oid)?
                 .into_iter()

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2293,14 +2293,32 @@ pub fn downstack(
         ));
     }
 
-    // Collect commits from base to change (exclusive of base, inclusive of change)
-    let mut walk = repo.revwalk()?;
-    walk.simplify_first_parent()?;
-    walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
+    // Collect commits from base to change (exclusive of base, inclusive of
+    // change). On the first-parent spine there is exactly one path, so
+    // pruning at the base is the same as excluding its history -- no
+    // RangeWalk needed. A base that passes the descendant check but is NOT on
+    // the spine would make "the stack from base" ill-defined; error instead
+    // of answering.
+    let odb = repo.odb()?;
+    let mut walk = objects::RevWalk::new(&odb);
+    walk.simplify_first_parent();
     walk.push(change_oid)?;
-    walk.hide(base_oid)?;
-
-    let oids: Vec<git2::Oid> = walk.collect::<Result<Vec<_>, _>>()?;
+    let mut seen_base = false;
+    // Reverse-topo order: oldest first, `change` last.
+    let mut oids = walk.into_topo_vec(|oid| {
+        if oid == base_oid {
+            seen_base = true;
+        }
+        oid == base_oid
+    })?;
+    if !seen_base {
+        return Err(anyhow!(
+            "base {} is not on the first-parent chain of {}",
+            base_oid,
+            change_oid
+        ));
+    }
+    oids.reverse();
 
     if oids.is_empty() {
         return Ok(change_oid);
@@ -2327,7 +2345,6 @@ pub fn downstack(
     }
 
     // Rebase needed intermediates forward onto current_base.
-    let odb = repo.odb()?;
     let mut current_base = repo.find_commit(base_oid)?;
     for (intermediate, is_needed) in commits.iter().zip(needed.iter()) {
         if !is_needed {

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -1,6 +1,5 @@
 use super::*;
 use anyhow::anyhow;
-use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 pub enum GpgsigMode {
@@ -24,27 +23,14 @@ pub fn walk2(
         return Ok(());
     }
 
-    // A missing or non-commit input aborts the walk quietly; read_header avoids
-    // decompressing the object.
-    match transaction.repo().odb()?.read_header(input) {
-        Ok((_, git2::ObjectType::Commit)) => {}
-        _ => return Ok(()),
+    let odb = transaction.repo().odb()?;
+
+    // `walk.push` rejects a missing or non-commit input as a hard error.
+    let mut walk = objects::RevWalk::new(&odb);
+    if history_flag(filter.get_meta("history").as_deref(), "linear") {
+        walk.simplify_first_parent();
     }
-
-    let walk = {
-        let mut walk = transaction.repo().revwalk()?;
-        if history_flag(filter.get_meta("history").as_deref(), "linear") {
-            walk.simplify_first_parent()?;
-        }
-        walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
-
-        walk.push(input)?;
-        walk
-    };
-    // The callback cannot propagate errors, so treat a failed lookup as "not known": the walk
-    // then visits the commit and the fallible body reports the same error properly.
-    let mut hide_callback = |id| transaction.known(filter, id).unwrap_or(false);
-    let walk = walk.with_hide_callback(&mut hide_callback)?;
+    walk.push(input)?;
 
     log::info!(
         "Walking {} commits for: {} {:?}",
@@ -52,12 +38,15 @@ pub fn walk2(
         filter::spec(filter),
         input,
     );
+
+    // The prune callback cannot propagate errors, so treat a failed lookup as "not known":
+    // the walk then visits the commit and the fallible body reports the same error properly.
+    let sorted = walk.into_topo_vec(|id| transaction.known(filter, id).unwrap_or(false))?;
+
     let mut n_in = 0;
     let mut n_out = 0;
 
-    for original_commit_id in walk {
-        let id = original_commit_id?;
-
+    for &id in sorted.iter().rev() {
         if filter::apply_to_commit2(filter, id, transaction)?.is_some() {
             n_out += 1;
         } else {
@@ -110,110 +99,57 @@ fn find_unapply_base(
         filtered_to_original.insert(oid, contained_in);
     }
 
-    // Start a revwalk in the original history tree starting from the
-    // contained_in "hint"
-    let mut walk = transaction.repo().revwalk()?;
-    walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+    // Walk the original history starting from the contained_in "hint" in lazy
+    // discovery order (the tip first, then the parents of each visited commit as
+    // the frontier expands), stopping at the first match. Because discovery order
+    // is only loosely child-before-parent, commits are held as pending until at
+    // least one other commit references them as a parent ("unlocked"); the start
+    // commit has no children in this subgraph, so it's unlocked immediately.
+    // Processing a commit may unlock pending ones, which are then processed too.
+    let odb = transaction.repo().odb()?;
+    let mut walk = objects::RevWalk::new(&odb);
     walk.push(contained_in)?;
 
-    // libgit2 does not read the list of commits lazily; instead,
-    // it reads the whole list, sorts it according to user's preference,
-    // and then lets the user iterate.
-    //
-    // while this does ensure the desired iteration order, it also means
-    // revwalks don't really scale. this approach below uses "hide callbacks"
-    // feature to stop iteration early - for real this time. hide callbacks
-    // are invoked during commit graph index read, and affect which commits
-    // are added to the traversal list.
-    //
-    // because we still want topological order - but it would be impossible to
-    // guarantee without reading full graph - we instead use something like
-    // "best effort" topo sorting, where commits are held as pending until
-    // at least one other commit references them as a parent.
-    #[derive(Default)]
-    struct CallbackContext {
-        result: Option<anyhow::Result<(git2::Oid, git2::Oid)>>,
-        unlocked: HashSet<git2::Oid>,
-        pending: HashSet<git2::Oid>,
-    }
+    let mut result: Option<(git2::Oid, git2::Oid)> = None;
+    let mut unlocked = HashSet::new();
+    let mut pending = HashSet::new();
+    unlocked.insert(contained_in);
 
-    let ctx = RefCell::new(CallbackContext::default());
-
-    // The start commit has no children in this subgraph, so it's immediately unlocked
-    ctx.borrow_mut().unlocked.insert(contained_in);
-
-    let mut hide_callback = |oid: git2::Oid| {
-        let mut ctx = ctx.borrow_mut();
-
-        // Returning true once is not enough: we need to ensure
-        // we don't add more commits to walk list as the loop
-        // in libgit2 continues if callback returns true
-        //
-        // https://github.com/libgit2/libgit2/blob/610dcaac065c0f27daca84b87795ed26926864f5/src/libgit2/revwalk.c#L428-L429
-        if ctx.result.is_some() {
-            return true;
-        }
-
-        ctx.pending.insert(oid);
-        if !ctx.unlocked.contains(&oid) {
-            return false;
+    walk.discover(|oid| {
+        pending.insert(oid);
+        if !unlocked.contains(&oid) {
+            return Ok(std::ops::ControlFlow::Continue(()));
         }
 
         // Check if any pending commits are now unlocked
         // Processing one might unlock another
-        while let Some(&pending_oid) = ctx
-            .pending
+        while let Some(&pending_oid) = pending
             .iter()
-            .find(|&pending_oid| ctx.unlocked.contains(pending_oid))
+            .find(|&pending_oid| unlocked.contains(pending_oid))
         {
-            ctx.pending.remove(&pending_oid);
+            pending.remove(&pending_oid);
 
-            let original_filtered = match filter::apply_to_commit(filter, pending_oid, transaction)
-            {
-                Ok(oid) => oid,
-                Err(e) => {
-                    ctx.result = Some(Err(e));
-                    return true;
-                }
-            };
+            let original_filtered = filter::apply_to_commit(filter, pending_oid, transaction)?;
 
             if filtered == original_filtered {
-                ctx.result = Some(Ok((filtered, pending_oid)));
-                return true;
+                result = Some((filtered, pending_oid));
+                return Ok(std::ops::ControlFlow::Break(()));
             }
 
-            let parent_ids = match git::read_parent_ids(transaction.repo(), pending_oid) {
-                Ok(parent_ids) => parent_ids,
-                Err(e) => {
-                    ctx.result = Some(Err(e));
-                    return true;
-                }
-            };
-            for parent_id in parent_ids {
-                ctx.unlocked.insert(parent_id);
+            for parent_id in git::read_parent_ids(transaction.repo(), pending_oid)? {
+                unlocked.insert(parent_id);
             }
         }
 
-        false
-    };
+        Ok(std::ops::ControlFlow::Continue(()))
+    })?;
 
-    let walk = walk.with_hide_callback(&mut hide_callback)?;
-    for original in walk {
-        // Only propagate errors; value is unused. Drives iteration to trigger hide_callback.
-        original?;
-
-        if ctx.borrow().result.is_some() {
-            break;
-        }
-    }
-
-    match ctx.into_inner().result {
-        Some(Ok((filtered, original))) => {
+    match result {
+        Some((filtered, original)) => {
             filtered_to_original.insert(filtered, original);
             tracing::info!("found original properly {}", original);
             Ok(original)
         }
-        Some(Err(e)) => Err(e),
         None => {
             tracing::info!("Didn't find original",);
             Ok(git2::Oid::ZERO_SHA1)
@@ -234,15 +170,14 @@ pub fn find_original(
     if filter.is_nop() {
         return Ok(filtered);
     }
-    let mut walk = transaction.repo().revwalk()?;
-    walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+    let odb = transaction.repo().odb()?;
+    let mut walk = objects::RevWalk::new(&odb);
     if linear {
-        walk.simplify_first_parent()?;
+        walk.simplify_first_parent();
     }
     walk.push(contained_in)?;
 
-    for original in walk {
-        let original = original?;
+    for original in walk.into_topo_vec(|_| false)? {
         if filtered == filter::apply_to_commit(filter, original, transaction)? {
             let parent_ids = git::read_parent_ids(transaction.repo(), original)?;
             if parent_ids.len() == 1 {
@@ -370,17 +305,13 @@ fn find_oldest_similar_commit(
     filter: filter::Filter,
     unfiltered: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let walk = {
-        let mut walk = transaction.repo().revwalk()?;
-        walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
-        walk.push(unfiltered)?;
-        walk
-    };
+    let odb = transaction.repo().odb()?;
+    let mut walk = objects::RevWalk::new(&odb);
+    walk.push(unfiltered)?;
     tracing::info!("oldest similar?");
     let filtered = filter::apply_to_commit(filter, unfiltered, transaction)?;
     let mut prev_rev = unfiltered;
-    for rev in walk {
-        let rev = rev?;
+    for rev in walk.into_topo_vec(|_| false)? {
         tracing::info!("next");
         if filtered != filter::apply_to_commit(filter, rev, transaction)? {
             tracing::info!("diff! {}", prev_rev);
@@ -400,17 +331,13 @@ fn find_new_branch_base(
     contained_in: git2::Oid,
     filtered: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let walk = {
-        let mut walk = transaction.repo().revwalk()?;
-        walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
-        walk.push(filtered)?;
-        walk
-    };
+    let odb = transaction.repo().odb()?;
+    let mut walk = objects::RevWalk::new(&odb);
+    walk.push(filtered)?;
     tracing::info!("new branch base?");
 
     // Walk filtered history, trying to find a base for every commit
-    for rev in walk {
-        let rev = rev?;
+    for rev in walk.into_topo_vec(|_| false)? {
         if let Ok(base) =
             find_unapply_base(transaction, filtered_to_original, filter, contained_in, rev)
             && base != git2::Oid::ZERO_SHA1
@@ -498,26 +425,30 @@ pub fn unapply_filter(
 
     let odb = transaction.repo().odb()?;
 
-    let walk = {
-        let mut walk = transaction.repo().revwalk()?;
-
-        walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
+    // The old filtered oid can be missing from the repo (e.g. a new branch);
+    // there is no range to exclude then, so take everything reachable.
+    let old_filtered_exists = matches!(
+        odb.read_header(old_filtered_oid),
+        Ok((_, git2::ObjectType::Commit))
+    );
+    let revs = if old_filtered_exists {
+        // The sequence lookup computes hints on demand and is only consulted
+        // when the fast-forward path cannot answer, so linear pushes never
+        // touch the hint cache; computed hints persist, making later
+        // non-linear walks incremental. The hint walk is itself a plain
+        // pruned RevWalk, so the nested walker cannot recurse further.
+        let walk =
+            objects::RangeWalk::new(&odb, |oid| cache::compute_sequence_number(transaction, oid));
+        walk.into_topo_vec(new_filtered_oid, old_filtered_oid)?
+    } else {
+        tracing::warn!("range walk: old filtered oid not found");
+        let mut walk = objects::RevWalk::new(&odb);
         walk.push(new_filtered_oid)?;
-
-        // The main reason hide() can fail is if old_filtered_oid is not found in the repo
-        if walk.hide(old_filtered_oid).is_ok() {
-            tracing::info!("walk: hidden {}", old_filtered_oid);
-        } else {
-            tracing::warn!("walk: can't hide");
-        }
-
-        walk
+        walk.into_topo_vec(|_| false)?
     };
 
-    // Walk starting from new filtered OID
-    for rev in walk {
-        let rev = rev?;
-
+    // Walk starting from new filtered OID, parents before children
+    for &rev in revs.iter().rev() {
         let span = tracing::span!(tracing::Level::TRACE, "walk commit", ?rev);
         let _span_guard = span.enter();
 

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -23,6 +23,10 @@ use std::collections::HashMap;
 
 use gix_object::WriteTo;
 
+pub mod revwalk;
+
+pub use revwalk::{RangeWalk, RevWalk};
+
 /// Map the kind of a raw object between the two libraries. Infallible: both enums cover exactly
 /// the four git object kinds.
 pub fn git2_kind(kind: gix_object::Kind) -> git2::ObjectType {

--- a/josh-gix-ext/src/revwalk.rs
+++ b/josh-gix-ext/src/revwalk.rs
@@ -1,0 +1,1107 @@
+//! josh's revision walkers, working over raw odb bytes: [`RevWalk`] for
+//! pruned topological walks and [`RangeWalk`] for `base..tip` deltas.
+//!
+//! josh's walks need two things no gitoxide traversal provides:
+//!
+//! - Traversal pruning. walk2 and ensure_hint_cached make incremental walks
+//!   cheap by skipping already-processed subgraphs (the prune callback).
+//!   `gix_traverse::commit::topo::Builder` cannot do this: `with_predicate`
+//!   only filters yields after parent expansion.
+//! - Laziness without a commit-graph. josh repos have no commit-graph file, and
+//!   without one the gix topo builder assigns every commit generation INFINITY
+//!   and drains the entire reachable graph before the first yield.
+//!   [`RevWalk::discover`] streams visits with early exit.
+//!
+//! Commits are parsed only up to their parent headers (one raw odb read, one
+//! `CommitRefIter` pass; committer lines are never read), so malformed
+//! author/committer lines (fsck-invalid objects) do not affect a walk. Tags
+//! are NOT peeled: any non-commit input is an error (josh only ever walks
+//! commit oids; the git2 walks this module replaces peeled).
+//!
+//! Differential tests below pin the yield sets against an independent
+//! reference model (and against `git2::Revwalk` for [`RevWalk`], where the
+//! sets provably coincide), and pin topological validity and order
+//! determinism, over fixed shapes and seeded random DAGs.
+
+use std::collections::HashMap;
+use std::ops::ControlFlow;
+
+use crate::git2_oid;
+
+type Visit<'v> = &'v mut dyn FnMut(git2::Oid) -> anyhow::Result<ControlFlow<()>>;
+
+/// Read a commit's parent ids: one raw odb read, one `CommitRefIter` pass
+/// stopped at the first non-tree/parent header. A missing or non-commit
+/// object is a hard error; headers past the parents (author, committer,
+/// message) are never read or validated.
+fn read_parent_oids(odb: &git2::Odb, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
+    let obj = odb.read(oid)?;
+    if obj.kind() != git2::ObjectType::Commit {
+        anyhow::bail!("object {} is not a commit", oid);
+    }
+    let mut parents = Vec::new();
+    for token in gix_object::CommitRefIter::from_bytes(obj.data(), gix_hash::Kind::Sha1) {
+        use gix_object::commit::ref_iter::Token;
+        match token? {
+            Token::Tree { .. } => {}
+            Token::Parent { id } => parents.push(git2_oid(&id)),
+            _ => break,
+        }
+    }
+    Ok(parents)
+}
+
+/// Verify `oid` names a commit without decompressing it.
+fn ensure_commit(odb: &git2::Odb, oid: git2::Oid) -> anyhow::Result<()> {
+    let (_, kind) = odb.read_header(oid)?;
+    if kind != git2::ObjectType::Commit {
+        anyhow::bail!("object {} is not a commit", oid);
+    }
+    Ok(())
+}
+
+/// Per-commit state of a [`RevWalk`].
+struct Node {
+    oid: git2::Oid,
+    /// Parents as node indices, filled in on first visit.
+    parents: Vec<usize>,
+    parsed: bool,
+    visited: bool,
+}
+
+/// A topological walk of everything reachable from the pushed tips, with
+/// per-commit pruning. One-shot: configure via [`push`]/
+/// [`simplify_first_parent`], then consume with [`into_topo_vec`] or
+/// [`discover`].
+///
+/// - Yield set: the commits reachable from the tips, minus pruned commits and
+///   anything only reachable through them. `prune` is consulted once per
+///   commit: a pruned commit is not yielded and its parents are not explored.
+///   Pruning expresses context-free knowledge ("this subgraph is already
+///   processed"), which josh's caches answer per commit and which is
+///   ancestor-closed by construction, so cutting there is sound. For
+///   excluding a specific history ("everything reachable from that tip") use
+///   [`RangeWalk`] instead.
+/// - Yield order: a topological order (children before parents), deterministic
+///   and defined as reverse DFS postorder -- tips in push order, parents in
+///   parent order. Filtered commit content does not depend on this order
+///   (filtering a commit is a pure function of the commit and its filtered
+///   parents, applied parents-first), but first-match callers
+///   (find_unapply_base, find_original, find_oldest_similar_commit) pick among
+///   equivalent candidates by it, so it is pinned by unit tests below.
+///
+/// [`push`]: RevWalk::push
+/// [`simplify_first_parent`]: RevWalk::simplify_first_parent
+/// [`into_topo_vec`]: RevWalk::into_topo_vec
+/// [`discover`]: RevWalk::discover
+pub struct RevWalk<'a> {
+    odb: &'a git2::Odb<'a>,
+    nodes: Vec<Node>,
+    by_oid: HashMap<git2::Oid, usize>,
+    /// Pushed tips in push order; the DFS explores them in this order.
+    tips: Vec<usize>,
+    first_parent: bool,
+}
+
+impl<'a> RevWalk<'a> {
+    pub fn new(odb: &'a git2::Odb<'a>) -> Self {
+        RevWalk {
+            odb,
+            nodes: Vec::new(),
+            by_oid: HashMap::new(),
+            tips: Vec::new(),
+            first_parent: false,
+        }
+    }
+
+    /// Mark a commit to start traversal from. A missing oid or a non-commit
+    /// object errors immediately.
+    pub fn push(&mut self, tip: git2::Oid) -> anyhow::Result<()> {
+        ensure_commit(self.odb, tip)?;
+        let tip = self.intern(tip);
+        self.tips.push(tip);
+        Ok(())
+    }
+
+    /// Only the first parent of each commit is explored.
+    pub fn simplify_first_parent(&mut self) {
+        self.first_parent = true;
+    }
+
+    /// The complete walk in forward topological order (children before
+    /// parents); iterate the result back to front for parents-first order.
+    pub fn into_topo_vec(
+        mut self,
+        mut prune: impl FnMut(git2::Oid) -> bool,
+    ) -> anyhow::Result<Vec<git2::Oid>> {
+        let post = self.dfs(&mut prune, &mut None)?;
+        Ok(post.into_iter().rev().map(|i| self.nodes[i].oid).collect())
+    }
+
+    /// Lazy discovery iteration: streams oids in DFS pre-order (each commit
+    /// visited before its parents are explored). `visit` returns
+    /// [`ControlFlow::Break`] to abort the walk.
+    pub fn discover(
+        mut self,
+        mut visit: impl FnMut(git2::Oid) -> anyhow::Result<ControlFlow<()>>,
+    ) -> anyhow::Result<()> {
+        let mut keep_all = |_: git2::Oid| false;
+        let visit: Visit<'_> = &mut visit;
+        self.dfs(&mut keep_all, &mut Some(visit))?;
+        Ok(())
+    }
+
+    /// The node index for `oid`, creating blank unparsed state on first sight.
+    fn intern(&mut self, oid: git2::Oid) -> usize {
+        if let Some(&i) = self.by_oid.get(&oid) {
+            return i;
+        }
+        let i = self.nodes.len();
+        self.nodes.push(Node {
+            oid,
+            parents: Vec::new(),
+            parsed: false,
+            visited: false,
+        });
+        self.by_oid.insert(oid, i);
+        i
+    }
+
+    fn parse(&mut self, commit: usize) -> anyhow::Result<()> {
+        if self.nodes[commit].parsed {
+            return Ok(());
+        }
+        let parents = read_parent_oids(self.odb, self.nodes[commit].oid)?
+            .into_iter()
+            .map(|p| self.intern(p))
+            .collect();
+        let node = &mut self.nodes[commit];
+        node.parents = parents;
+        node.parsed = true;
+        Ok(())
+    }
+
+    /// Iterative DFS from the tips (in push order, parents in parent order),
+    /// skipping pruned commits, collecting postorder -- reversed by the
+    /// caller into forward topological order. `visit` fires in pre-order; its
+    /// `Break` aborts the walk with the partial result.
+    fn dfs(
+        &mut self,
+        prune: &mut dyn FnMut(git2::Oid) -> bool,
+        visit: &mut Option<Visit<'_>>,
+    ) -> anyhow::Result<Vec<usize>> {
+        enum Frame {
+            Explore(usize),
+            Emit(usize),
+        }
+        let mut post = Vec::new();
+        let mut stack: Vec<Frame> = self.tips.iter().rev().map(|&t| Frame::Explore(t)).collect();
+        while let Some(frame) = stack.pop() {
+            match frame {
+                Frame::Explore(c) => {
+                    if self.nodes[c].visited {
+                        continue;
+                    }
+                    self.nodes[c].visited = true;
+                    if prune(self.nodes[c].oid) {
+                        continue;
+                    }
+                    if let Some(v) = visit.as_mut() {
+                        if v(self.nodes[c].oid)?.is_break() {
+                            return Ok(post);
+                        }
+                    }
+                    self.parse(c)?;
+                    stack.push(Frame::Emit(c));
+                    let n = if self.first_parent {
+                        self.nodes[c].parents.len().min(1)
+                    } else {
+                        self.nodes[c].parents.len()
+                    };
+                    for i in (0..n).rev() {
+                        stack.push(Frame::Explore(self.nodes[c].parents[i]));
+                    }
+                }
+                Frame::Emit(c) => post.push(c),
+            }
+        }
+        Ok(post)
+    }
+}
+
+/// Probe budget for the fast-forward path of a [`RangeWalk`], after which the
+/// walk switches to the ranked strategy.
+const FAST_FORWARD_PROBE_LIMIT: usize = 1000;
+
+/// Per-commit state of a [`RangeWalk`].
+struct RangeNode {
+    oid: git2::Oid,
+    /// Parents as node indices, filled in on first visit.
+    parents: Vec<usize>,
+    parsed: bool,
+    hidden: bool,
+    /// Entered the ranked frontier (each commit is ranked once).
+    enqueued: bool,
+    /// Currently pending in the ranked frontier as a visible entry; cleared
+    /// when a hidden mark arrives first or when the entry pops.
+    queued_visible: bool,
+}
+
+/// The commits reachable from a tip but not from a base -- git's `base..tip`
+/// -- in a topological order (children before parents). The base expresses a
+/// contextual reachability boundary ("everything reachable from that tip"),
+/// which no per-commit cache lookup can answer; that is what distinguishes
+/// this from [`RevWalk`]'s pruning and why it is its own walker.
+///
+/// Construction requires josh's sequence numbers (a commit's number is
+/// strictly greater than every parent's; the lookup lives in josh-core's
+/// cache, above this crate, hence the function handle). The walk runs in one
+/// of two ways, both exact:
+///
+/// - Fast-forward path: the base is an ancestor of the tip along a
+///   single-parent chain -- the everyday shape of unapply_filter pushes. The
+///   chain from the tip down to the base is exactly the answer: the base is
+///   an ancestor of every chain commit, so no chain commit can also be an
+///   ancestor of the base (they would be ancestors of each other), and
+///   neither the base's ancestry nor the sequence numbers are touched at
+///   all. Cost is O(delta).
+/// - Ranked walk otherwise: process the frontier highest-sequence-number
+///   first, spreading hidden marks parent-ward from the base. Numbers
+///   strictly decrease along parent edges, so every commit pops after all
+///   its children -- hidden marks provably arrive before the pop -- and the
+///   walk stops the moment only hidden entries are pending: everything
+///   undiscovered is then an ancestor of hidden commits only. The walk stops
+///   at the merge-base level: O(delta + boundary). Emission order (highest
+///   number first) is already forward topological order. Lookup failures
+///   fail the walk.
+///
+/// The two strategies yield different topological orders, which is fine
+/// because the callers consume the whole yield set parents-first.
+pub struct RangeWalk<'a> {
+    odb: &'a git2::Odb<'a>,
+    sequence_numbers: Box<dyn Fn(git2::Oid) -> anyhow::Result<u64> + 'a>,
+    nodes: Vec<RangeNode>,
+    by_oid: HashMap<git2::Oid, usize>,
+}
+
+impl<'a> RangeWalk<'a> {
+    pub fn new(
+        odb: &'a git2::Odb<'a>,
+        sequence_numbers: impl Fn(git2::Oid) -> anyhow::Result<u64> + 'a,
+    ) -> Self {
+        RangeWalk {
+            odb,
+            sequence_numbers: Box::new(sequence_numbers),
+            nodes: Vec::new(),
+            by_oid: HashMap::new(),
+        }
+    }
+
+    /// The commits of `base..tip` in forward topological order (children
+    /// before parents); iterate the result back to front for parents-first
+    /// order. A missing oid or a non-commit object errors immediately; a
+    /// commit with missing ancestors errors if (and only if) the walk
+    /// actually reaches them.
+    pub fn into_topo_vec(
+        mut self,
+        tip: git2::Oid,
+        base: git2::Oid,
+    ) -> anyhow::Result<Vec<git2::Oid>> {
+        ensure_commit(self.odb, tip)?;
+        ensure_commit(self.odb, base)?;
+        if tip == base {
+            return Ok(Vec::new());
+        }
+        let tip = self.intern(tip);
+        let base = self.intern(base);
+        self.nodes[base].hidden = true;
+        if let Some(chain) = self.fast_forward_walk(tip, base)? {
+            return Ok(chain);
+        }
+        self.ranked_walk(tip, base)
+    }
+
+    /// The node index for `oid`, creating blank unparsed state on first sight.
+    fn intern(&mut self, oid: git2::Oid) -> usize {
+        if let Some(&i) = self.by_oid.get(&oid) {
+            return i;
+        }
+        let i = self.nodes.len();
+        self.nodes.push(RangeNode {
+            oid,
+            parents: Vec::new(),
+            parsed: false,
+            hidden: false,
+            enqueued: false,
+            queued_visible: false,
+        });
+        self.by_oid.insert(oid, i);
+        i
+    }
+
+    fn parse(&mut self, commit: usize) -> anyhow::Result<()> {
+        if self.nodes[commit].parsed {
+            return Ok(());
+        }
+        let parents = read_parent_oids(self.odb, self.nodes[commit].oid)?
+            .into_iter()
+            .map(|p| self.intern(p))
+            .collect();
+        let node = &mut self.nodes[commit];
+        node.parents = parents;
+        node.parsed = true;
+        Ok(())
+    }
+
+    /// Follow the parent chain from the tip; if it runs into the base within
+    /// the probe budget, the chain is exactly the yield set, already in
+    /// forward topological order. Returns `None` -- caller switches to the
+    /// ranked walk -- on a merge commit, a root, or an exhausted budget.
+    fn fast_forward_walk(
+        &mut self,
+        tip: usize,
+        base: usize,
+    ) -> anyhow::Result<Option<Vec<git2::Oid>>> {
+        let mut out = Vec::new();
+        let mut c = tip;
+        for _ in 0..FAST_FORWARD_PROBE_LIMIT {
+            if c == base {
+                return Ok(Some(out));
+            }
+            self.parse(c)?;
+            let parents = &self.nodes[c].parents;
+            let next = match parents.len() {
+                1 => parents[0],
+                _ => return Ok(None),
+            };
+            out.push(self.nodes[c].oid);
+            c = next;
+        }
+        Ok(None)
+    }
+
+    /// The ranked strategy (see the type docs): a max-heap frontier keyed by
+    /// sequence number, ties resolved by insertion order (equal numbers are
+    /// never ancestor-related, so any deterministic order is correct).
+    fn ranked_walk(&mut self, tip: usize, base: usize) -> anyhow::Result<Vec<git2::Oid>> {
+        let seq_of = std::mem::replace(&mut self.sequence_numbers, Box::new(|_| unreachable!()));
+        let mut heap: std::collections::BinaryHeap<(u64, std::cmp::Reverse<u64>, usize)> =
+            std::collections::BinaryHeap::new();
+        let mut seq = 0u64;
+        let mut visible_pending = 0usize;
+        let mut out = Vec::new();
+
+        for c in [tip, base] {
+            self.nodes[c].enqueued = true;
+            if !self.nodes[c].hidden {
+                self.nodes[c].queued_visible = true;
+                visible_pending += 1;
+            }
+            heap.push((seq_of(self.nodes[c].oid)?, std::cmp::Reverse(seq), c));
+            seq += 1;
+        }
+
+        while visible_pending > 0 {
+            let Some((_, _, c)) = heap.pop() else {
+                break;
+            };
+            if self.nodes[c].hidden {
+                // Hidden pop: spread hiding to all parents and keep them
+                // ranked so the marks keep travelling frontier-first.
+                self.parse(c)?;
+                for i in 0..self.nodes[c].parents.len() {
+                    let p = self.nodes[c].parents[i];
+                    if !self.nodes[p].hidden {
+                        self.nodes[p].hidden = true;
+                        if self.nodes[p].queued_visible {
+                            self.nodes[p].queued_visible = false;
+                            visible_pending -= 1;
+                        }
+                    }
+                    if !self.nodes[p].enqueued {
+                        self.nodes[p].enqueued = true;
+                        heap.push((seq_of(self.nodes[p].oid)?, std::cmp::Reverse(seq), p));
+                        seq += 1;
+                    }
+                }
+            } else {
+                self.nodes[c].queued_visible = false;
+                visible_pending -= 1;
+                out.push(self.nodes[c].oid);
+                self.parse(c)?;
+                for i in 0..self.nodes[c].parents.len() {
+                    let p = self.nodes[c].parents[i];
+                    if !self.nodes[p].enqueued {
+                        self.nodes[p].enqueued = true;
+                        if !self.nodes[p].hidden {
+                            self.nodes[p].queued_visible = true;
+                            visible_pending += 1;
+                        }
+                        heap.push((seq_of(self.nodes[p].oid)?, std::cmp::Reverse(seq), p));
+                        seq += 1;
+                    }
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    struct TestRepo {
+        _dir: tempfile::TempDir,
+        repo: git2::Repository,
+    }
+
+    impl TestRepo {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let repo = git2::Repository::init_bare(dir.path()).unwrap();
+            TestRepo { _dir: dir, repo }
+        }
+
+        fn commit(&self, msg: &str, parents: &[git2::Oid]) -> git2::Oid {
+            let sig = git2::Signature::new("Test", "test@example.com", &git2::Time::new(1000, 0))
+                .unwrap();
+            let tree_id = self.repo.treebuilder(None).unwrap().write().unwrap();
+            let tree = self.repo.find_tree(tree_id).unwrap();
+            let parents: Vec<_> = parents
+                .iter()
+                .map(|&p| self.repo.find_commit(p).unwrap())
+                .collect();
+            let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+            self.repo
+                .commit(None, &sig, &sig, msg, &tree, &parent_refs)
+                .unwrap()
+        }
+
+        /// Write raw commit bytes so parents don't have to exist in the odb
+        /// (and may repeat -- git2's commit builder can produce neither).
+        fn raw_commit(&self, msg: &str, parents: &[git2::Oid]) -> git2::Oid {
+            let tree_id = self.repo.treebuilder(None).unwrap().write().unwrap();
+            let mut buf = format!("tree {}\n", tree_id);
+            for p in parents {
+                buf.push_str(&format!("parent {}\n", p));
+            }
+            buf.push_str(&format!(
+                "author Test <test@example.com> 1000 +0000\n\
+                 committer Test <test@example.com> 1000 +0000\n\n{msg}\n"
+            ));
+            self.repo
+                .odb()
+                .unwrap()
+                .write(git2::ObjectType::Commit, buf.as_bytes())
+                .unwrap()
+        }
+    }
+
+    /// An exact sequence number over git2 objects: `1 + max(parent seqs)`,
+    /// memoized -- the property josh's cached sequence numbers guarantee.
+    /// Errors on missing ancestors, like the real lookup.
+    fn exact_seq(
+        repo: &git2::Repository,
+        memo: &std::cell::RefCell<HashMap<git2::Oid, u64>>,
+        oid: git2::Oid,
+    ) -> anyhow::Result<u64> {
+        if let Some(&s) = memo.borrow().get(&oid) {
+            return Ok(s);
+        }
+        let parents: Vec<git2::Oid> = repo.find_commit(oid)?.parent_ids().collect();
+        let mut max = 0;
+        for p in parents {
+            max = max.max(exact_seq(repo, memo, p)?);
+        }
+        memo.borrow_mut().insert(oid, max + 1);
+        Ok(max + 1)
+    }
+
+    /// Independent reference model of both walkers' yield sets: the excluded
+    /// closure is full ancestor reachability from `base`; the yield set is
+    /// what a naive traversal from the tips reaches without stepping on
+    /// excluded or pruned commits. Uses git2's object API throughout, sharing
+    /// no code with the walkers.
+    fn reference_set(
+        repo: &git2::Repository,
+        tips: &[git2::Oid],
+        base: Option<git2::Oid>,
+        pruned: &HashSet<git2::Oid>,
+        first_parent: bool,
+    ) -> HashSet<git2::Oid> {
+        let parents_of = |oid: git2::Oid| -> Vec<git2::Oid> {
+            let c = repo.find_commit(oid).unwrap();
+            c.parent_ids().collect()
+        };
+        let mut hidden: HashSet<git2::Oid> = HashSet::new();
+        let mut stack: Vec<git2::Oid> = base.into_iter().collect();
+        while let Some(h) = stack.pop() {
+            if hidden.insert(h) {
+                stack.extend(parents_of(h));
+            }
+        }
+        let mut out = HashSet::new();
+        let mut stack: Vec<git2::Oid> = tips.to_vec();
+        while let Some(c) = stack.pop() {
+            if out.contains(&c) || hidden.contains(&c) || pruned.contains(&c) {
+                continue;
+            }
+            out.insert(c);
+            let mut parents = parents_of(c);
+            if first_parent {
+                parents.truncate(1);
+            }
+            stack.extend(parents);
+        }
+        out
+    }
+
+    fn rev_walk(
+        repo: &git2::Repository,
+        tips: &[git2::Oid],
+        pruned: &HashSet<git2::Oid>,
+        first_parent: bool,
+    ) -> anyhow::Result<Vec<git2::Oid>> {
+        let odb = repo.odb().unwrap();
+        let mut walk = RevWalk::new(&odb);
+        if first_parent {
+            walk.simplify_first_parent();
+        }
+        for &t in tips {
+            walk.push(t)?;
+        }
+        walk.into_topo_vec(|oid| pruned.contains(&oid))
+    }
+
+    fn range_walk(
+        repo: &git2::Repository,
+        tip: git2::Oid,
+        base: git2::Oid,
+    ) -> anyhow::Result<Vec<git2::Oid>> {
+        let memo = std::cell::RefCell::new(HashMap::new());
+        let odb = repo.odb().unwrap();
+        let walk = RangeWalk::new(&odb, |oid| exact_seq(repo, &memo, oid));
+        walk.into_topo_vec(tip, base)
+    }
+
+    /// Check a yielded order for topological validity over the followed
+    /// edges: every yielded commit precedes its yielded parents.
+    fn assert_topo(repo: &git2::Repository, got: &[git2::Oid], first_parent: bool, mode: &str) {
+        let pos: HashMap<git2::Oid, usize> = got.iter().enumerate().map(|(i, &o)| (o, i)).collect();
+        assert_eq!(pos.len(), got.len(), "duplicate yields: {mode}");
+        for &c in got {
+            let commit = repo.find_commit(c).unwrap();
+            let mut parents: Vec<git2::Oid> = commit.parent_ids().collect();
+            if first_parent {
+                parents.truncate(1);
+            }
+            for p in parents {
+                if let Some(&pp) = pos.get(&p) {
+                    assert!(pos[&c] < pp, "topology violation {c} -> {p}: {mode}");
+                }
+            }
+        }
+    }
+
+    /// Assert [`RevWalk`] against the reference model: exact yield set, valid
+    /// topological order, run-to-run determinism, and (with no pruning) set
+    /// equality with `git2::Revwalk`.
+    fn assert_rev_walk(
+        repo: &git2::Repository,
+        tips: &[git2::Oid],
+        pruned: &HashSet<git2::Oid>,
+        label: &str,
+    ) {
+        for first_parent in [false, true] {
+            let mode = format!("{label} first_parent={first_parent}");
+            let got = rev_walk(repo, tips, pruned, first_parent).unwrap();
+            let want = reference_set(repo, tips, None, pruned, first_parent);
+            let got_set: HashSet<git2::Oid> = got.iter().copied().collect();
+            assert_eq!(got_set, want, "yield set mismatch: {mode}");
+            assert_topo(repo, &got, first_parent, &mode);
+            let again = rev_walk(repo, tips, pruned, first_parent).unwrap();
+            assert_eq!(got, again, "non-deterministic order: {mode}");
+
+            if pruned.is_empty() {
+                let mut g2 = repo.revwalk().unwrap();
+                g2.set_sorting(git2::Sort::TOPOLOGICAL).unwrap();
+                if first_parent {
+                    g2.simplify_first_parent().unwrap();
+                }
+                for &t in tips {
+                    g2.push(t).unwrap();
+                }
+                let theirs: HashSet<git2::Oid> = g2.map(|r| r.unwrap()).collect();
+                assert_eq!(got_set, theirs, "git2 set mismatch: {mode}");
+            }
+        }
+    }
+
+    /// Assert [`RangeWalk`] against the reference model: exact yield set,
+    /// valid topological order, run-to-run determinism.
+    fn assert_range_walk(repo: &git2::Repository, tip: git2::Oid, base: git2::Oid, label: &str) {
+        let got = range_walk(repo, tip, base).unwrap();
+        let want = reference_set(repo, &[tip], Some(base), &HashSet::new(), false);
+        let got_set: HashSet<git2::Oid> = got.iter().copied().collect();
+        assert_eq!(got_set, want, "yield set mismatch: {label}");
+        assert_topo(repo, &got, false, label);
+        let again = range_walk(repo, tip, base).unwrap();
+        assert_eq!(got, again, "non-deterministic order: {label}");
+    }
+
+    fn no_prune() -> HashSet<git2::Oid> {
+        HashSet::new()
+    }
+
+    #[test]
+    fn linear_chain() {
+        let t = TestRepo::new();
+        let mut tip = t.commit("c0", &[]);
+        let mut all = vec![tip];
+        for i in 1..12 {
+            tip = t.commit(&format!("c{i}"), &[tip]);
+            all.push(tip);
+        }
+        assert_rev_walk(&t.repo, &[tip], &no_prune(), "linear");
+        // Ranges at several depths: all take the fast-forward path.
+        for &base in [all[0], all[5], all[10]].iter() {
+            assert_range_walk(&t.repo, tip, base, "linear range");
+        }
+        // Forward order is tip-first down the chain.
+        let got = range_walk(&t.repo, tip, all[5]).unwrap();
+        let expect: Vec<git2::Oid> = all[6..].iter().rev().copied().collect();
+        assert_eq!(got, expect);
+        // An empty range yields nothing.
+        assert_eq!(range_walk(&t.repo, tip, tip).unwrap(), vec![]);
+    }
+
+    #[test]
+    fn diamond_and_criss_cross() {
+        let t = TestRepo::new();
+        let a = t.commit("a", &[]);
+        let b = t.commit("b", &[a]);
+        let c = t.commit("c", &[a]);
+        let m = t.commit("m", &[b, c]);
+        assert_rev_walk(&t.repo, &[m], &no_prune(), "diamond");
+        for base in [a, b, c] {
+            assert_range_walk(&t.repo, m, base, "diamond range");
+        }
+        // Pinned order: DFS explores b's side to the bottom first, so the
+        // forward (children-first) order emits m, then c, then b, then a.
+        let got = rev_walk(&t.repo, &[m], &no_prune(), false).unwrap();
+        assert_eq!(got, vec![m, c, b, a]);
+
+        let t = TestRepo::new();
+        let root = t.commit("root", &[]);
+        let a = t.commit("a", &[root]);
+        let b = t.commit("b", &[root]);
+        let x = t.commit("x", &[a, b]);
+        let y = t.commit("y", &[b, a]);
+        let m = t.commit("m", &[x, y]);
+        assert_rev_walk(&t.repo, &[m], &no_prune(), "criss-cross");
+        assert_rev_walk(&t.repo, &[x, y], &no_prune(), "criss-cross two tips");
+        assert_rev_walk(&t.repo, &[y, x], &no_prune(), "criss-cross two tips rev");
+        for base in [a, b, x, y] {
+            assert_range_walk(&t.repo, m, base, "criss-cross range");
+        }
+    }
+
+    #[test]
+    fn octopus_merge() {
+        let t = TestRepo::new();
+        let root = t.commit("root", &[]);
+        let b1 = t.commit("b1", &[root]);
+        let b2 = t.commit("b2", &[root]);
+        let b3 = t.commit("b3", &[root]);
+        let m = t.commit("m", &[b1, b2, b3]);
+        assert_rev_walk(&t.repo, &[m], &no_prune(), "octopus");
+        assert_range_walk(&t.repo, m, b2, "octopus range");
+    }
+
+    #[test]
+    fn merge_of_old_side_branch_is_exact() {
+        // A branch B forked below the base and merged into the tip: B's
+        // commits are reachable from the fork point but NOT from the base, so
+        // they must be yielded; the base's chain and everything below the
+        // fork must not be.
+        let t = TestRepo::new();
+        let mut fork = t.commit("f0", &[]);
+        for i in 0..30 {
+            fork = t.commit(&format!("h{i}"), &[fork]);
+        }
+        let b = t.commit("b", &[fork]);
+        let mut base = fork;
+        for i in 0..10 {
+            base = t.commit(&format!("o{i}"), &[base]);
+        }
+        let tip = t.commit("tip", &[base, b]);
+        assert_range_walk(&t.repo, tip, base, "merged-side-branch");
+        let got: HashSet<git2::Oid> = range_walk(&t.repo, tip, base)
+            .unwrap()
+            .into_iter()
+            .collect();
+        assert_eq!(got, HashSet::from([tip, b]));
+    }
+
+    #[test]
+    fn rebase_shape_is_exact() {
+        // Sibling tips (a force-push shape): base and tip share a parent; the
+        // fast-forward path bails at the root and the ranked walk yields
+        // exactly the commits not reachable from the base.
+        let t = TestRepo::new();
+        let root = t.commit("root", &[]);
+        let x = t.commit("x", &[root]);
+        let base = t.commit("base", &[x]);
+        let new1 = t.commit("new1", &[x]);
+        let new2 = t.commit("new2", &[new1]);
+        assert_range_walk(&t.repo, new2, base, "rebase");
+        assert_eq!(range_walk(&t.repo, new2, base).unwrap(), vec![new2, new1]);
+    }
+
+    #[test]
+    fn range_beyond_probe_limit() {
+        // A delta longer than the probe budget: the fast-forward path gives
+        // up and the ranked walk still produces the exact set.
+        let t = TestRepo::new();
+        let mut tip = t.commit("c0", &[]);
+        let base_at = 3;
+        let mut base = tip;
+        for i in 1..(FAST_FORWARD_PROBE_LIMIT + 50) {
+            tip = t.commit(&format!("c{i}"), &[tip]);
+            if i == base_at {
+                base = tip;
+            }
+        }
+        let got = range_walk(&t.repo, tip, base).unwrap();
+        assert_eq!(got.len(), FAST_FORWARD_PROBE_LIMIT + 50 - 1 - base_at);
+        assert!(!got.contains(&base));
+    }
+
+    #[test]
+    fn ranked_walk_is_bounded() {
+        // Deep history below the fork, small delta above it, with a merge in
+        // the delta so the fast-forward path bails. The ranked walk must stop
+        // at the fork level: the lookup-call count stays proportional to the
+        // delta, not the 600-commit history below.
+        let t = TestRepo::new();
+        let mut fork = t.commit("f0", &[]);
+        for i in 0..600 {
+            fork = t.commit(&format!("d{i}"), &[fork]);
+        }
+        let b = t.commit("b", &[fork]);
+        let mut base = fork;
+        for i in 0..5 {
+            base = t.commit(&format!("o{i}"), &[base]);
+        }
+        let tip = t.commit("tip", &[base, b]);
+
+        let memo = std::cell::RefCell::new(HashMap::new());
+        let calls = std::cell::Cell::new(0usize);
+        let odb = t.repo.odb().unwrap();
+        let walk = RangeWalk::new(&odb, |oid| {
+            calls.set(calls.get() + 1);
+            exact_seq(&t.repo, &memo, oid)
+        });
+        let got = walk.into_topo_vec(tip, base).unwrap();
+        assert_eq!(got, vec![tip, b]);
+        assert!(
+            calls.get() < 30,
+            "ranked walk touched {} commits; expected O(delta), not O(history)",
+            calls.get()
+        );
+    }
+
+    #[test]
+    fn missing_sequence_data_fails_the_walk() {
+        // The lookup is fallible; failures surface instead of degrading. The
+        // shape forces the ranked walk (merge in the delta).
+        let t = TestRepo::new();
+        let mut fork = t.commit("f0", &[]);
+        for i in 0..20 {
+            fork = t.commit(&format!("d{i}"), &[fork]);
+        }
+        let b = t.commit("b", &[fork]);
+        let mut base = fork;
+        for i in 0..4 {
+            base = t.commit(&format!("o{i}"), &[base]);
+        }
+        let tip = t.commit("tip", &[base, b]);
+
+        for blind in [tip, base, b] {
+            let memo = std::cell::RefCell::new(HashMap::new());
+            let odb = t.repo.odb().unwrap();
+            let walk = RangeWalk::new(&odb, |oid| {
+                if oid == blind {
+                    anyhow::bail!("no sequence number for {}", oid);
+                }
+                exact_seq(&t.repo, &memo, oid)
+            });
+            assert!(
+                walk.into_topo_vec(tip, base).is_err(),
+                "blind spot {blind} must fail the walk"
+            );
+        }
+    }
+
+    #[test]
+    fn prune_semantics() {
+        let t = TestRepo::new();
+        let a = t.commit("a", &[]);
+        let b = t.commit("b", &[a]);
+        let c = t.commit("c", &[a]);
+        let m = t.commit("m", &[b, c]);
+
+        // A commit reachable via both a pruned and an unpruned path IS
+        // yielded; a commit reachable only through pruned commits is not; a
+        // pruned tip yields nothing below it.
+        assert_rev_walk(&t.repo, &[m], &HashSet::from([b]), "prune-one-path");
+        assert_rev_walk(&t.repo, &[m], &HashSet::from([b, c]), "prune-both");
+        assert_rev_walk(&t.repo, &[m], &HashSet::from([m]), "prune-tip");
+
+        let got = rev_walk(&t.repo, &[m], &HashSet::from([b]), false).unwrap();
+        assert!(
+            got.contains(&a),
+            "a reachable via unpruned c must be yielded"
+        );
+        assert!(!got.contains(&b));
+
+        // The callback fires once per commit, even with duplicate edges.
+        let dup = t.raw_commit("dup", &[b, b, a]);
+        let mut calls = Vec::new();
+        let odb = t.repo.odb().unwrap();
+        let mut w = RevWalk::new(&odb);
+        w.push(dup).unwrap();
+        w.into_topo_vec(|oid| {
+            calls.push(oid);
+            false
+        })
+        .unwrap();
+        let unique: HashSet<git2::Oid> = calls.iter().copied().collect();
+        assert_eq!(calls.len(), unique.len(), "prune consulted once per commit");
+    }
+
+    #[test]
+    fn duplicate_parent_edges() {
+        let t = TestRepo::new();
+        let a = t.commit("a", &[]);
+        let b = t.commit("b", &[a]);
+        let m = t.raw_commit("m", &[b, b, a]);
+        assert_rev_walk(&t.repo, &[m], &no_prune(), "dup-edges");
+        assert_range_walk(&t.repo, m, b, "dup-edges range");
+    }
+
+    #[test]
+    fn multiple_tips_and_overlapping_pushes() {
+        let t = TestRepo::new();
+        let root = t.commit("root", &[]);
+        let a = t.commit("a", &[root]);
+        let b = t.commit("b", &[root]);
+        let c = t.commit("c", &[b]);
+        for tips in [
+            vec![a, c],
+            vec![c, a],
+            vec![a, a, c],
+            vec![b, c],
+            vec![c, b],
+        ] {
+            assert_rev_walk(&t.repo, &tips, &no_prune(), "multi-tip");
+        }
+        // A range between sibling branches: exact via the ranked walk.
+        assert_range_walk(&t.repo, c, a, "sibling range");
+        assert_range_walk(&t.repo, a, c, "sibling range rev");
+    }
+
+    #[test]
+    fn input_error_cases() {
+        let t = TestRepo::new();
+        let a = t.commit("a", &[]);
+        let missing = git2::Oid::from_str("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef").unwrap();
+        let blob = t
+            .repo
+            .odb()
+            .unwrap()
+            .write(git2::ObjectType::Blob, b"x")
+            .unwrap();
+        let tree = t.repo.treebuilder(None).unwrap().write().unwrap();
+        let sig =
+            git2::Signature::new("Test", "test@example.com", &git2::Time::new(1000, 0)).unwrap();
+        let obj = t.repo.find_object(a, None).unwrap();
+        let tag = t.repo.tag("v1", &obj, &sig, "annotated", false).unwrap();
+
+        let odb = t.repo.odb().unwrap();
+        // Missing oids and non-commits (including annotated tags, which are
+        // NOT peeled) error immediately.
+        for bad in [missing, blob, tree, tag] {
+            assert!(RevWalk::new(&odb).push(bad).is_err());
+            let w = RangeWalk::new(&odb, |_| anyhow::bail!("unused"));
+            assert!(w.into_topo_vec(bad, a).is_err());
+            let w = RangeWalk::new(&odb, |_| anyhow::bail!("unused"));
+            assert!(w.into_topo_vec(a, bad).is_err());
+        }
+    }
+
+    #[test]
+    fn missing_ancestors_error_only_when_visited() {
+        let t = TestRepo::new();
+        let missing = git2::Oid::from_str("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef").unwrap();
+        let dangling = t.raw_commit("dangling", &[missing]);
+
+        // A pushed commit with a missing parent errors during the walk.
+        let odb = t.repo.odb().unwrap();
+        let mut w = RevWalk::new(&odb);
+        w.push(dangling).unwrap();
+        assert!(w.into_topo_vec(|_| false).is_err());
+
+        // A range base with missing ancestors errors when the ranked walk
+        // must rank it (the real lookup walks the ancestry)...
+        let tip = t.commit("tip", &[]);
+        let memo = std::cell::RefCell::new(HashMap::new());
+        let w = RangeWalk::new(&odb, |oid| exact_seq(&t.repo, &memo, oid));
+        assert!(w.into_topo_vec(tip, dangling).is_err());
+
+        // ...but not when the fast-forward path answers without touching the
+        // base's ancestry: the walk stays lazy.
+        let base = t.commit("base", &[dangling]);
+        let top = t.commit("top", &[base]);
+        let w = RangeWalk::new(&odb, |_| anyhow::bail!("must not be consulted"));
+        assert_eq!(w.into_topo_vec(top, base).unwrap(), vec![top]);
+    }
+
+    #[test]
+    fn malformed_tails_are_tolerated() {
+        // Parsing stops at the parent headers: truncated or author-less
+        // commits walk fine (fsck-invalid objects; the old git2-backed walk
+        // was partially lenient here too, in different places).
+        let t = TestRepo::new();
+        let tree_id = t.repo.treebuilder(None).unwrap().write().unwrap();
+        let odb = t.repo.odb().unwrap();
+        let trunc = odb
+            .write(
+                git2::ObjectType::Commit,
+                format!("tree {}\n", tree_id).as_bytes(),
+            )
+            .unwrap();
+        let tip = t.raw_commit("tip", &[trunc]);
+        let mut w = RevWalk::new(&odb);
+        w.push(tip).unwrap();
+        assert_eq!(w.into_topo_vec(|_| false).unwrap(), vec![tip, trunc]);
+    }
+
+    #[test]
+    fn discover_streams_dfs_preorder() {
+        let t = TestRepo::new();
+        let a = t.commit("a", &[]);
+        let b = t.commit("b", &[a]);
+        let c = t.commit("c", &[a]);
+        let m = t.commit("m", &[b, c]);
+        let odb = t.repo.odb().unwrap();
+
+        // Pre-order: each commit before its parents, first parent's subgraph
+        // before the second's.
+        let mut w = RevWalk::new(&odb);
+        w.push(m).unwrap();
+        let mut visited = Vec::new();
+        w.discover(|oid| {
+            visited.push(oid);
+            Ok(ControlFlow::Continue(()))
+        })
+        .unwrap();
+        assert_eq!(visited, vec![m, b, a, c]);
+
+        // Break aborts the walk.
+        let mut w = RevWalk::new(&odb);
+        w.push(m).unwrap();
+        let mut visited = Vec::new();
+        w.discover(|oid| {
+            visited.push(oid);
+            Ok(if oid == a {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            })
+        })
+        .unwrap();
+        assert_eq!(visited, vec![m, b, a]);
+
+        // first_parent confines discovery to the first-parent chain.
+        let mut w = RevWalk::new(&odb);
+        w.push(m).unwrap();
+        w.simplify_first_parent();
+        let mut visited = Vec::new();
+        w.discover(|oid| {
+            visited.push(oid);
+            Ok(ControlFlow::Continue(()))
+        })
+        .unwrap();
+        assert_eq!(visited, vec![m, b, a]);
+
+        // Errors from the visit callback propagate.
+        let mut w = RevWalk::new(&odb);
+        w.push(m).unwrap();
+        assert!(w.discover(|_| anyhow::bail!("boom")).is_err());
+
+        // No pushes: no visits, clean return.
+        let w = RevWalk::new(&odb);
+        w.discover(|_| panic!("must not be visited")).unwrap();
+    }
+
+    struct Rng(u64);
+
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            // splitmix64: deterministic, no external deps, no wall-clock.
+            self.0 = self.0.wrapping_add(0x9e3779b97f4a7c15);
+            let mut z = self.0;
+            z = (z ^ (z >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94d049bb133111eb);
+            z ^ (z >> 31)
+        }
+
+        fn below(&mut self, n: usize) -> usize {
+            (self.next() % n as u64) as usize
+        }
+    }
+
+    #[test]
+    fn fuzz_random_dags() {
+        for seed in 0..48u64 {
+            let mut rng = Rng(seed);
+            let t = TestRepo::new();
+            let n = 20 + rng.below(30);
+            let mut commits: Vec<git2::Oid> = Vec::new();
+            for i in 0..n {
+                let parents: Vec<git2::Oid> = if commits.is_empty() || rng.below(12) == 0 {
+                    vec![]
+                } else {
+                    let k = 1 + rng.below(3.min(commits.len()));
+                    let mut ps = Vec::new();
+                    for _ in 0..k {
+                        let p = commits[rng.below(commits.len())];
+                        if !ps.contains(&p) {
+                            ps.push(p);
+                        }
+                    }
+                    ps
+                };
+                commits.push(t.commit(&format!("c{i}"), &parents));
+            }
+            let mut tips = Vec::new();
+            for _ in 0..1 + rng.below(3) {
+                tips.push(commits[rng.below(commits.len())]);
+            }
+            let pruned: HashSet<git2::Oid> = commits
+                .iter()
+                .copied()
+                .filter(|_| rng.below(6) == 0)
+                .collect();
+            assert_rev_walk(&t.repo, &tips, &no_prune(), &format!("fuzz {seed}"));
+            assert_rev_walk(&t.repo, &tips, &pruned, &format!("fuzz {seed} pruned"));
+
+            let tip = commits[rng.below(commits.len())];
+            let base = commits[rng.below(commits.len())];
+            assert_range_walk(&t.repo, tip, base, &format!("fuzz {seed} range"));
+        }
+    }
+}

--- a/tests/filter/ambiguous_merge.t
+++ b/tests/filter/ambiguous_merge.t
@@ -93,8 +93,8 @@
   8cbae19889134bd4ec430c0b79c61ee8547e0d1c
   [3] :prefix=sub1
   [4] :/sub1
-  [7] reachable_roots
-  [7] sequence_number
+  [13] reachable_roots
+  [13] sequence_number
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/reverse_merge.t
+++ b/tests/filter/reverse_merge.t
@@ -80,8 +80,8 @@
   $ josh-filter -s :exclude[::sub2/] --reverse master --update refs/heads/hidden_master
   1496b9e75273ad3a0de58812a731a7a50b0d2a66
   [3] :exclude[::sub2/]
-  [3] reachable_roots
-  [3] sequence_number
+  [8] reachable_roots
+  [8] sequence_number
 
   $ git checkout master
   Switched to branch 'master'

--- a/tests/filter/reverse_non_ff.t
+++ b/tests/filter/reverse_non_ff.t
@@ -35,8 +35,8 @@ Meanwhile a concurrent commit lands on master
 Pushing without re-pulling first is refused
   $ josh-filter -s :/sub refs/heads/master --update refs/heads/filtered --reverse
   [2] :/sub
-  [2] reachable_roots
-  [2] sequence_number
+  [5] reachable_roots
+  [5] sequence_number
   ERROR: refusing non-fast-forward update of refs/heads/master -- it contains commits that the reverse apply would discard. Re-apply the filter and rebase the filtered changes onto the result, or pass --force
   [1]
 
@@ -47,8 +47,8 @@ With --force the update happens and the concurrent commit is discarded
   $ josh-filter -s :/sub refs/heads/master --update refs/heads/filtered --reverse --force
   cae93bf6a6f602f2777c66ce12a76065b21d30f9
   [2] :/sub
-  [2] reachable_roots
-  [2] sequence_number
+  [5] reachable_roots
+  [5] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/master
   * filtered side work
@@ -59,8 +59,8 @@ After a proper pull (re-filter) the same push fast-forwards cleanly
   $ josh-filter -s :/sub refs/heads/master --update refs/heads/filtered2
   6436bdb983b15392190096cc9dd832af2ae017ed
   [2] :/sub
-  [2] reachable_roots
-  [2] sequence_number
+  [5] reachable_roots
+  [5] sequence_number
   $ git checkout -q -b work2 refs/heads/filtered2
   $ echo d > file4
   $ git add .
@@ -69,8 +69,8 @@ After a proper pull (re-filter) the same push fast-forwards cleanly
   $ josh-filter -s :/sub refs/heads/master --update refs/heads/filtered2 --reverse
   0b1cb14b07f000ffbed470ae7abc3c698ebb7781
   [2] :/sub
-  [2] reachable_roots
-  [2] sequence_number
+  [5] reachable_roots
+  [5] sequence_number
 
   $ git log --graph --pretty=%s refs/heads/master
   * rebased filtered work

--- a/tests/filter/workspace_exclude.t
+++ b/tests/filter/workspace_exclude.t
@@ -72,8 +72,8 @@
       ::sub2/subsub/
   ]
   [3] :workspace=ws
-  [4] reachable_roots
-  [4] sequence_number
+  [9] reachable_roots
+  [9] sequence_number
   $ git checkout master
   Switched to branch 'master'
 

--- a/tests/proxy/push_new_orphan_branch.t
+++ b/tests/proxy/push_new_orphan_branch.t
@@ -201,10 +201,10 @@ Make sure all temporary namespace got removed
       |   |   `-- b06d7748772bdd407c5911c0ba02b0f5fb31a4
       |   |-- info
       |   `-- pack
+      |       |-- pack-24ce4c1953f799fe03bab1d9c04cf7ec9f96814d.idx
+      |       |-- pack-24ce4c1953f799fe03bab1d9c04cf7ec9f96814d.pack
       |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
       |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
-      |       |-- pack-c304c61c7328041fd1afafa4b6328b746cad31b1.idx
-      |       |-- pack-c304c61c7328041fd1afafa4b6328b746cad31b1.pack
       |       |-- pack-ed1b2e1285c87d628ed4fedf2e84338a0fa698e1.idx
       |       `-- pack-ed1b2e1285c87d628ed4fedf2e84338a0fa698e1.pack
       `-- refs

--- a/tests/proxy/push_review_nop_behind.t
+++ b/tests/proxy/push_review_nop_behind.t
@@ -104,9 +104,11 @@ This is a regression test for that problem.
       |   |   `-- 01f09caa6b247b64793a9d8cf1db76a9e92442
       |   |-- info
       |   `-- pack
+      |       |-- pack-e8ae6eb17251286fc38f6b55dea83f85265ac92b.idx
+      |       `-- pack-e8ae6eb17251286fc38f6b55dea83f85265ac92b.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  35 directories, 20 files
+  35 directories, 22 files

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -144,10 +144,10 @@ Flushed credential cache
       |   `-- pack
       |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
       |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
-      |       |-- pack-43b004c57a05484b0057ece370e309a1528a2995.idx
-      |       |-- pack-43b004c57a05484b0057ece370e309a1528a2995.pack
       |       |-- pack-a724713a58e1918b9032aed364764a0a4cece84b.idx
-      |       `-- pack-a724713a58e1918b9032aed364764a0a4cece84b.pack
+      |       |-- pack-a724713a58e1918b9032aed364764a0a4cece84b.pack
+      |       |-- pack-d30dedde21210b124782caf6ef83f7cf4c11a181.idx
+      |       `-- pack-d30dedde21210b124782caf6ef83f7cf4c11a181.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -319,8 +319,8 @@
       |       |-- pack-810042fcc342c573b7d491be291eac8697326115.pack
       |       |-- pack-8f2ab97436b3ff8e62f3dce0c1093ce4832bca89.idx
       |       |-- pack-8f2ab97436b3ff8e62f3dce0c1093ce4832bca89.pack
-      |       |-- pack-b531b8e915c7145f1ef6b21dba15bd66a73cdc32.idx
-      |       |-- pack-b531b8e915c7145f1ef6b21dba15bd66a73cdc32.pack
+      |       |-- pack-a242cae1552f7e295b006c0963abdf9f3d89b7d7.idx
+      |       |-- pack-a242cae1552f7e295b006c0963abdf9f3d89b7d7.pack
       |       |-- pack-f3754114f5e623d4b9710175aed17f8bd2ce1f30.idx
       |       `-- pack-f3754114f5e623d4b9710175aed17f8bd2ce1f30.pack
       `-- refs


### PR DESCRIPTION
Replace the git2 revwalk with native walkers in josh-gix-ext

gitoxide cannot serve josh's walks: gix_traverse's topo::Builder is
fully eager without a commit-graph file (josh repos have none), and
with_predicate only filters yields after parent expansion, so it
cannot prune traversal the way walk2 and ensure_hint_cached need for
incremental walks.

Two walkers over raw odb bytes (parsing stops at the parent headers;
committer lines are never read) replace it. RevWalk is a pruned
topological walk: DFS from the pushed tips, reverse postorder out, a
per-commit prune callback for the caches' context-free "already
processed" knowledge, first-parent mode and a lazy early-exit discover
iteration (which replaces find_unapply_base's RefCell hide-callback
hack). RangeWalk yields base..tip -- a contextual reachability
boundary no cache lookup can answer -- exactly, either as the
fast-forward chain (the everyday push shape, O(delta)) or, for
non-linear shapes, by processing the frontier highest-sequence-number
first and stopping once only hidden entries are pending, which bounds
the walk at the merge-base level. Sequence numbers are required at
construction; unapply_filter passes a computing lookup, consulted only
when the fast-forward path cannot answer, so linear pushes never touch
the hint cache. downstack needs no RangeWalk at all: on a first-parent
spine, pruning at the base equals excluding its history, so it uses a
first-parent RevWalk and errors if the base is not on the spine.

Filtered commit content does not depend on walk order; the first-match
searches (find_unapply_base, find_original, find_oldest_similar_commit)
pick among equivalent candidates by it, so RevWalk's order is pinned by
unit tests, and both walkers' yield sets by differential tests against
an independent reference model (plus git2::Revwalk for RevWalk, where
the sets provably coincide) over fixed shapes and seeded random DAGs,
including a boundedness proof for the ranked range walk. All josh-core
walk sites move over; git2::Revwalk use in josh-core drops to zero.

Scrut suite: expectation updates in eight tests only, from the
sequence-number hints now computed (and their roots blobs written) for
filtered history on non-linear pushes. Benches vs the pre-gix baseline
are flat-or-better across the suite: widetree_glob_prefix/50000 -63%,
ultrawide_pin_hook -33 to -55%, deephistory_glob_recursive -44%,
refs_filter_update flat. The deephistory_glob_incremental cases swing
an order of magnitude between same-binary runs (accumulated cache
state) and are not comparable.

Change: native-revwalk
Assisted-By: Claude Fable 5 (claude-fable-5)