### PR TITLE
Rephrase byte-parity helper docs and rename normalize_filemode

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2416,7 +2416,7 @@ pub fn downstack(
     Ok(new_oid)
 }
 
-/// Memo libgit2's 3-way `merge_trees` + `write_tree_to` pair within the
+/// Memo git2's 3-way `merge_trees` + `write_tree_to` pair within the
 /// active transaction. The merged tree oid is a pure function of the three
 /// input tree oids (with `MergeOptions::None`), and `split_changes` issues
 /// many identical triples across per-tip `downstack` calls; turning each
@@ -2480,7 +2480,7 @@ fn downstack_commit_deps(
         return Ok(hit);
     }
 
-    // Use the in-crate `tree::diff_paths` rather than libgit2's full diff
+    // Use the in-crate `tree::diff_paths` rather than git2's full diff
     // pipeline: it short-circuits subtrees by oid equality, which collapses
     // the typical "stack of single-file commits" deps walk down to a few
     // tree lookups per call.

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -128,7 +128,7 @@ fn regex_replace_inner(
 
             if objects::tree_entry_name_valid(entry.filename) {
                 rebuild.keep(gix_object::tree::Entry {
-                    mode: entry_mode(objects::normalize_filemode(raw_mode)),
+                    mode: entry_mode(objects::canonical_filemode(raw_mode)),
                     filename: entry.filename.to_owned(),
                     oid: objects::gix_oid(repo.blob(replaced.as_bytes())?),
                 });
@@ -172,15 +172,15 @@ fn git_tree_entry_cmp(a: &[u8], a_is_tree: bool, b: &[u8], b_is_tree: bool) -> s
     ca.cmp(&cb)
 }
 
-/// Accumulator for rebuilding a tree entry-by-entry, encapsulating the libgit2-treebuilder
-/// parity rules: canonical-order tracking, last-wins dedup of duplicate names, and the
+/// Accumulator for rebuilding a tree entry-by-entry, encapsulating the parity rules of the
+/// git2 treebuilder it replaced: canonical-order tracking, last-wins dedup of duplicate names, and the
 /// unchanged fast path guarded by `changed`. Callers report the fate of each input entry
 /// (`keep` for survivors, `mark_changed` for anything dropped, rewritten, renamed-away or
 /// mode-normalized) and `finish` writes the rebuilt tree or returns the input oid.
 ///
 /// TODO(byte-preservation): the last-wins dedup in `keep`, the order-violation handling
 /// (forcing `changed` so non-canonical trees skip the unchanged fast path), and the
-/// unconditional sort in `write_tree_now` together replicate libgit2's treebuilder
+/// unconditional sort in `write_tree_now` together keep the old treebuilder's
 /// normalization of fsck-invalid input trees. That normalization is a bug of the same kind as
 /// git2's gpgsig header line-ending normalization: it re-encodes bytes the operation was
 /// never asked to change, so non-canonical trees do not round-trip through a filter even when
@@ -192,7 +192,7 @@ fn git_tree_entry_cmp(a: &[u8], a_is_tree: bool, b: &[u8], b_is_tree: bool) -> s
 /// `write_tree_now` and tolerant (non-bisecting) name lookups in subtract/intersect/overlay,
 /// and it changes filtered oids for repos containing such trees, so it must land as its own
 /// change with tests -- not inside the gix port, which is validated on byte-identity against
-/// the libgit2 baseline and keeps this wart until then.
+/// the pre-port git2 baseline and keeps this wart until then.
 struct TreeRebuild {
     out: Vec<gix_object::tree::Entry>,
     /// Whether the rebuilt entry set could serialize to anything other than the input
@@ -225,7 +225,7 @@ impl TreeRebuild {
     }
 
     /// Append a surviving entry, replacing an earlier kept entry of the same name like
-    /// libgit2's name-keyed treebuilder did (last insert wins).
+    /// git2's name-keyed treebuilder did (last insert wins).
     ///
     /// Also verifies the kept entries arrive in canonical git order with no duplicate names:
     /// a violation forces `changed` (non-canonical input trees must not take the unchanged
@@ -270,8 +270,8 @@ impl TreeRebuild {
     }
 }
 
-/// Clone a parsed tree's entries for use as the starting set of a rebuild, replicating what
-/// seeding a libgit2 treebuilder from a tree did: entry names and raw modes are taken over
+/// Clone a parsed tree's entries for use as the starting set of a rebuild, keeping what
+/// seeding a git2 treebuilder from a tree did: entry names and raw modes are taken over
 /// unvalidated and unnormalized, but duplicate names collapse to the last occurrence (the
 /// treebuilder was a name-keyed map). [`TreeRebuild::keep`] owns that dedup and the
 /// order-violation detection arming it; `keep` is usable standalone here because seeded
@@ -285,7 +285,7 @@ fn seed_entries(tree: &gix_object::TreeRef) -> Vec<gix_object::tree::Entry> {
     rebuild.out
 }
 
-/// Look up an entry by name irrespective of its kind, like libgit2's `git_tree_entry_byname`.
+/// Look up an entry by name irrespective of its kind, like git2's `Tree::get_name`.
 /// Canonical order sorts a blob before a same-named tree, so the blob probe comes first.
 fn lookup_entry<'a>(
     tree: &gix_object::TreeRef<'a>,
@@ -295,7 +295,7 @@ fn lookup_entry<'a>(
         .or_else(|| tree.bisect_entry(name, true))
 }
 
-/// The [`gix_object::tree::EntryMode`] for a libgit2-normalized mode value.
+/// The [`gix_object::tree::EntryMode`] for a canonicalized mode value.
 fn entry_mode(norm: u16) -> gix_object::tree::EntryMode {
     gix_object::tree::EntryMode::try_from(norm as u32).expect("normalized modes are valid")
 }
@@ -362,7 +362,7 @@ fn remove_pred_inner(
                 key,
             )?;
             // `entry.mode` compares by the serialized form, so the fsck-invalid "040000"
-            // spelling also counts as changed (libgit2 could not distinguish it).
+            // spelling also counts as changed (the old treebuilder could not distinguish it).
             if s != objects::git2_oid(entry.oid)
                 || s == empty
                 || entry.mode != gix_object::tree::EntryKind::Tree.into()
@@ -387,10 +387,10 @@ fn remove_pred_inner(
             // take the unchanged fast path.
             rebuild.mark_changed();
         } else if pred(path, true) {
-            // The normalized mode is what libgit2's treebuilder would have stored: if it
+            // The canonical mode is what the old treebuilder would have stored: if it
             // differs from the raw on-disk mode (e.g. legacy 100664 blobs), the rebuilt tree
             // differs from the input.
-            let norm = objects::normalize_filemode(raw_mode);
+            let norm = objects::canonical_filemode(raw_mode);
             if raw_mode != norm {
                 rebuild.mark_changed();
             }
@@ -558,7 +558,7 @@ fn remove_pattern_inner(
             if keep {
                 // See remove_pred for why legacy filemodes and rejected names count as
                 // changed.
-                let norm = objects::normalize_filemode(raw_mode);
+                let norm = objects::canonical_filemode(raw_mode);
                 if raw_mode != norm {
                     rebuild.mark_changed();
                 }
@@ -621,9 +621,9 @@ fn subtract_inner(
         let tree2 = gix_object::TreeRef::from_bytes(&bytes2, gix_hash::Kind::Sha1)?;
         // Start from `tree1` and drop or replace each path that also appears in `tree2`.
         // Modifications are collected by name first and applied in one pass, mirroring the
-        // name-keyed libgit2 treebuilder: `None` removes the entry, `Some` replaces its oid with
-        // the subtraction result (a tree, hence the normalized tree mode). Names that libgit2's
-        // insert would have rejected silently keep their original entry.
+        // name-keyed git2 treebuilder: `None` removes the entry, `Some` replaces its oid with
+        // the subtraction result (a tree, hence the canonical tree mode). Names that a
+        // treebuilder insert would have rejected silently keep their original entry.
         let mut mods: std::collections::HashMap<&[u8], Option<git2::Oid>> =
             std::collections::HashMap::new();
         for entry in &tree2.entries {
@@ -704,7 +704,7 @@ fn intersect_inner(
         let tree2 = gix_object::TreeRef::from_bytes(&bytes2, gix_hash::Kind::Sha1)?;
         // Iterate the selector (`input2`), keeping each of its paths that also exists in `tree1`
         // with `tree1`'s content and normalized mode; cost tracks the size of the selected set.
-        // Entries with invalid names are dropped silently (libgit2 insert-name parity).
+        // Entries with invalid names are dropped silently (treebuilder insert-name parity).
         let mut rebuild = TreeRebuild::new(0);
         for entry in &tree2.entries {
             if let Some(e1) = lookup_entry(&tree1, entry.filename) {
@@ -718,7 +718,7 @@ fn intersect_inner(
                     && objects::tree_entry_name_valid(entry.filename)
                 {
                     rebuild.keep(gix_object::tree::Entry {
-                        mode: entry_mode(objects::normalize_filemode(e1.mode.value())),
+                        mode: entry_mode(objects::canonical_filemode(e1.mode.value())),
                         filename: entry.filename.to_owned(),
                         oid: objects::gix_oid(child),
                     });
@@ -753,8 +753,8 @@ fn tree_object<'a>(odb: &'a git2::Odb, oid: git2::Oid) -> Option<git2::OdbObject
 }
 
 /// Rebuild the tree `tree_oid` with the single-component `child` replaced by (`oid`, `mode`), or
-/// removed when `oid` is the zero or empty-tree oid. Like a seeded libgit2 treebuilder: other
-/// entries keep their raw modes, the inserted mode is normalized, and an invalid child name
+/// removed when `oid` is the zero or empty-tree oid. Like a seeded git2 treebuilder: other
+/// entries keep their raw modes, the inserted mode is canonicalized, and an invalid child name
 /// silently leaves the tree unchanged.
 fn replace_child_inner(
     odb: &git2::Odb,
@@ -778,7 +778,7 @@ fn replace_child_inner(
         }
     } else if objects::tree_entry_name_valid(child) {
         let entry = gix_object::tree::Entry {
-            mode: entry_mode(objects::normalize_filemode(mode as u16)),
+            mode: entry_mode(objects::canonical_filemode(mode as u16)),
             filename: child.into(),
             oid: objects::gix_oid(oid),
         };
@@ -999,13 +999,13 @@ fn overlay_inner(
                 )?;
                 mods.insert(
                     &**entry.filename,
-                    (id, entry_mode(objects::normalize_filemode(e1.mode.value()))),
+                    (id, entry_mode(objects::canonical_filemode(e1.mode.value()))),
                 );
             } else {
                 new_entries.insert(
                     &**entry.filename,
                     gix_object::tree::Entry {
-                        mode: entry_mode(objects::normalize_filemode(entry.mode.value())),
+                        mode: entry_mode(objects::canonical_filemode(entry.mode.value())),
                         filename: entry.filename.to_owned(),
                         oid: entry.oid.to_owned(),
                     },
@@ -1275,7 +1275,7 @@ mod tests {
 
         let blob = repo.blob(b"content").unwrap();
         let link = repo.blob(b"target").unwrap();
-        // Gitlinks reference commits in other repositories; libgit2 does not require the oid
+        // Gitlinks reference commits in other repositories; git does not require the oid
         // to exist locally.
         let sub = git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap();
 

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -83,7 +83,7 @@ fn parse_git_env_date(s: &str) -> Option<git2::Time> {
 }
 
 /// Like `repo.signature()` but honors `GIT_COMMITTER_*` / `GIT_AUTHOR_*` env vars
-/// the way `git` itself does. libgit2's `git_signature_default` ignores the date
+/// the way `git` itself does. git2's `Repository::signature` ignores the date
 /// env vars, which breaks reproducibility in tests.
 pub fn user_signature(repo: &git2::Repository) -> anyhow::Result<git2::Signature<'static>> {
     let default = repo.signature()?;
@@ -246,8 +246,8 @@ impl GitCommand {
 pub fn read_parent_ids(repo: &git2::Repository, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
     let odb = repo.odb()?;
     let odb_commit = odb.read(oid)?;
-    // A hard error, not an assert: this is reachable from inside libgit2 revwalk callbacks,
-    // where unwinding across the FFI frame would abort.
+    // A hard error, not an assert: this is reachable from inside git2 callback frames,
+    // where unwinding across the FFI boundary would abort.
     if odb_commit.kind() != git2::ObjectType::Commit {
         return Err(anyhow::anyhow!(
             "object {} is not a commit but a {:?}",

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -59,17 +59,18 @@ pub fn git2_oid(oid: &gix_hash::oid) -> git2::Oid {
     git2::Oid::from_bytes(oid.as_bytes()).expect("oid sizes match")
 }
 
-/// Whether `name` is acceptable as a tree entry name, replicating libgit2's `valid_entry_name`
-/// under default configuration. gix by design performs no name validation when writing trees, so
-/// josh owns this check; tree rewriting drops entries with invalid names (and marks the tree as
-/// changed), exactly like the failed `git_treebuilder_insert` did before the gix port.
+/// Whether `name` is acceptable as a tree entry name, keeping the checks git2's treebuilder
+/// enforced under default configuration. gix by design performs no name validation when writing
+/// trees, so josh owns this check; tree rewriting drops entries with invalid names (and marks
+/// the tree as changed), exactly like the failed treebuilder insert did before the gix port.
 ///
 /// Rejected are: the empty name, names containing `/`, `.` and `..`, and `.git` including its
 /// NTFS-style aliases (`.git.`, `.git `, `.git:x`, `.git\x`, case-insensitive) and HFS-style
-/// aliases (`.git` with HFS-ignorable code points interspersed). libgit2 applies the NTFS check
-/// everywhere (`core.protectNTFS` defaults to true) but the HFS check only on Apple platforms;
-/// josh applies both everywhere so filtered output does not depend on the host OS -- for the
-/// HFS-alias corner case on non-Apple hosts this is deliberately stricter than libgit2 was.
+/// aliases (`.git` with HFS-ignorable code points interspersed) -- the protections git itself
+/// applies under `core.protectNTFS`/`core.protectHFS`. git2 ran the NTFS check everywhere
+/// (`core.protectNTFS` defaults to true) but the HFS check only on Apple platforms; josh
+/// applies both everywhere so filtered output does not depend on the host OS -- for the
+/// HFS-alias corner case on non-Apple hosts this is deliberately stricter than git2 was.
 pub fn tree_entry_name_valid(name: &[u8]) -> bool {
     if name.is_empty() || name == b"." || name == b".." {
         return false;
@@ -96,8 +97,8 @@ pub fn tree_entry_name_valid(name: &[u8]) -> bool {
     true
 }
 
-/// True if `name` equals ".git" case-insensitively once HFS-ignorable code points are removed.
-/// Mirrors libgit2's `validate_dotgit_hfs`. Non-UTF-8 names cannot alias ".git" this way.
+/// True if `name` equals ".git" case-insensitively once HFS-ignorable code points are removed
+/// (the `core.protectHFS` alias rule). Non-UTF-8 names cannot alias ".git" this way.
 fn hfs_reads_as_dotgit(name: &[u8]) -> bool {
     let Ok(s) = std::str::from_utf8(name) else {
         return false;
@@ -119,12 +120,12 @@ fn hfs_reads_as_dotgit(name: &[u8]) -> bool {
     }
 }
 
-/// Normalize a raw tree entry mode exactly like libgit2's `normalize_filemode` (which every
-/// `git_treebuilder_insert` applied): trees stay trees, any exec bit makes an executable blob,
-/// gitlinks and symlinks keep their type, everything else becomes a plain blob. Note the exec
-/// check precedes the gitlink/symlink checks and tests all three exec bits -- both quirks are
-/// libgit2's, kept for byte-identical rebuilt trees.
-pub fn normalize_filemode(raw: u16) -> u16 {
+/// Reduce a raw tree entry mode to the canonical form git2's treebuilder stored on every
+/// insert: trees stay trees, any exec bit makes an executable blob, gitlinks and symlinks keep
+/// their type, everything else becomes a plain blob. Note the exec check precedes the
+/// gitlink/symlink checks and tests all three exec bits -- both quirks are kept from the old
+/// treebuilder for byte-identical rebuilt trees.
+pub fn canonical_filemode(raw: u16) -> u16 {
     if raw & 0o170000 == 0o040000 {
         0o040000
     } else if raw & 0o111 != 0 {
@@ -143,7 +144,7 @@ pub fn normalize_filemode(raw: u16) -> u16 {
 /// the repository (and lands in the in-memory memodb store when one is registered), so ported and
 /// unported code can interleave freely.
 ///
-/// TODO(byte-preservation): the unconditional sort is part of the libgit2-parity normalization
+/// TODO(byte-preservation): the unconditional sort is part of the treebuilder-parity normalization
 /// of fsck-invalid input trees described on `TreeRebuild` in josh-core's filter/tree.rs. Once
 /// filters preserve non-canonical trees byte-for-byte, rebuilds seeded from such trees will need
 /// an order-preserving variant of this function (callers building entry sets from scratch keep
@@ -447,13 +448,13 @@ mod tests {
             (0o040755, 0o040000),
             (0o120000, 0o120000),
             (0o160000, 0o160000),
-            // libgit2 quirks: exec bits win over the gitlink/symlink type checks.
+            // Old-treebuilder quirks: exec bits win over the gitlink/symlink type checks.
             (0o120755, 0o100755),
             (0o160755, 0o100755),
             // Garbage type bits collapse to a plain blob.
             (0o110644, 0o100644),
         ] {
-            assert_eq!(normalize_filemode(raw), norm, "raw mode {raw:o}");
+            assert_eq!(canonical_filemode(raw), norm, "raw mode {raw:o}");
         }
     }
 }


### PR DESCRIPTION
Rephrase byte-parity helper docs and rename normalize_filemode

The tree helpers in josh-gix-ext and filter/tree.rs documented
themselves as replicas of internals of the replaced library, down to
its function names. What josh actually guarantees is behavioral: the
rebuilt trees must be byte-identical to what the git2 treebuilder
based code produced, and the name checks are git's own
core.protectNTFS/core.protectHFS rules. Reword the doc comments to
state that contract directly, and rename normalize_filemode to
canonical_filemode ("reduce a raw mode to the canonical stored form")
across its seven call sites. No behavior change; the mode table and
entry-name tests pin the semantics as before.

Change: parity-helper-docs
Assisted-By: Claude Fable 5 (claude-fable-5)