### PR TITLE
Add josh-starlark-guest Starlark interpreter targeting wasm32

### DIFF
--- a/josh-guest/.cargo/config.toml
+++ b/josh-guest/.cargo/config.toml
@@ -1,0 +1,7 @@
+# getrandom (pulled in transitively by the starlark crate) refuses to build
+# for wasm32-unknown-unknown unless a backend is selected. The "custom"
+# backend routes to the deterministic stub in
+# josh-starlark-guest/src/getrandom_backend.rs — the wasm_js backend would
+# pull in wasm-bindgen imports that the josh host cannot link.
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="custom"']

--- a/josh-guest/Cargo.lock
+++ b/josh-guest/Cargo.lock
@@ -3,8 +3,1442 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocative"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8cf9afc79c83d514444b55df3935d317da54b1ce3b17a133c646889cc260de8"
+dependencies = [
+ "allocative_derive",
+ "bumpalo",
+ "ctor",
+ "hashbrown 0.16.1",
+ "num-bigint",
+]
+
+[[package]]
+name = "allocative_derive"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614043c56c1173b800acb007b81fd0cbc0a0d7d717b71ba705fc2230d0760a23"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "digest",
+ "rayon-core",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "cmp_any"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "ctor"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "debugserver-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf6834a70ed14e8e4e41882df27190bea150f1f6ecf461f1033f8739cd8af4a"
+dependencies = [
+ "schemafy",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "unicode-xid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "display_container"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a110a75c96bedec8e65823dea00a1d710288b7a369d95fd8a0f5127639466fa"
+dependencies = [
+ "either",
+ "indenter",
+]
+
+[[package]]
+name = "dupe"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed2bc011db9c93fbc2b6cdb341a53737a55bafb46dbb74cf6764fc33a2fbf9c"
+dependencies = [
+ "dupe_derive",
+]
+
+[[package]]
+name = "dupe_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "env_filter",
+ "log",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "indenter"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "josh-filter-guest"
 version = "26.7.28"
+
+[[package]]
+name = "josh-starlark-guest"
+version = "26.7.28"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "getrandom",
+ "josh-filter-guest",
+ "starlark",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "link-section"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_free_hashtable"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf3631712f5b790675292ff827af269f5d9f920c920b77dc41d0485e3719612"
+dependencies = [
+ "atomic",
+ "parking_lot",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "logos"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "rustc_version",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pagable"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3658968938a4d1eaa1987e69dcd84b01fb067c5b3416dccc8d71373b6ded6821"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "async-trait",
+ "blake3",
+ "bytemuck",
+ "dashmap",
+ "dupe",
+ "either",
+ "erased-serde 0.4.10",
+ "fancy-regex",
+ "indexmap",
+ "inventory",
+ "num-bigint",
+ "once_cell",
+ "pagable_derive",
+ "parking_lot",
+ "postcard",
+ "regex",
+ "sequence_trie",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "sorted_vector_map",
+ "static_assertions",
+ "static_interner",
+ "strong_hash",
+ "take_mut",
+ "triomphe",
+]
+
+[[package]]
+name = "pagable_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "838d17166587914f4e99353766c29160462b681511f08679545a0d07a0dc9415"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "crc",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quickcheck"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c589f335db0f6aaa168a7cd27b1fc6920f5e1470c804f814d9cd6e62a0f70b"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "getrandom",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "schemafy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aea5ba40287dae331f2c48b64dbc8138541f5e97ee8793caa7948c1f31d86d5"
+dependencies = [
+ "Inflector",
+ "schemafy_core",
+ "schemafy_lib",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "schemafy_core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41781ae092f4fd52c9287efb74456aea0d3b90032d2ecad272bd14dbbcb0511b"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemafy_lib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e953db32579999ca98c451d80801b6f6a7ecba6127196c5387ec0774c528befa"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "schemafy_core",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "sequence_trie"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee22067b7ccd072eeb64454b9c6e1b33b61cd0d49e895fd48676a184580e0c3"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "sorted_vector_map"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bf565ee1681b4473aa5a9d71d807347c28021bd1d8947cb626b02f42a0141f"
+dependencies = [
+ "itertools",
+ "quickcheck",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "starlark"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9062e866918dc4c9701c98ac99f7f4fa9e4b3b4edce306e147393bc75458c4fc"
+dependencies = [
+ "allocative",
+ "anyhow",
+ "blake3",
+ "bumpalo",
+ "cmp_any",
+ "dashmap",
+ "debugserver-types",
+ "derivative",
+ "derive_more",
+ "display_container",
+ "dupe",
+ "either",
+ "erased-serde 0.3.31",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "inventory",
+ "itertools",
+ "maplit",
+ "memoffset",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "pagable",
+ "paste",
+ "ref-cast",
+ "regex",
+ "rustyline",
+ "serde",
+ "serde_json",
+ "starlark_derive",
+ "starlark_map",
+ "starlark_syntax",
+ "static_assertions",
+ "strong_hash",
+ "strsim",
+ "textwrap",
+ "thiserror",
+]
+
+[[package]]
+name = "starlark_derive"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797e235eb70936bfa14fabf490bf7453e6f0caaf6b9c56fe4c9aff02aee7e66d"
+dependencies = [
+ "dupe",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "starlark_map"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234877898fd216af93b2f5798b08cbbdc1a2e8f16a622a258b1db23a61a1c4ba"
+dependencies = [
+ "allocative",
+ "dupe",
+ "equivalent",
+ "fxhash",
+ "hashbrown 0.16.1",
+ "pagable",
+ "serde",
+ "strong_hash",
+]
+
+[[package]]
+name = "starlark_syntax"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7492c571c531e68099c911cfd909d32659f1cc0910cf3adee9fce66e39d21f14"
+dependencies = [
+ "allocative",
+ "annotate-snippets",
+ "anyhow",
+ "derivative",
+ "derive_more",
+ "dupe",
+ "logos",
+ "lsp-types",
+ "memchr",
+ "num-bigint",
+ "num-traits",
+ "once_cell",
+ "pagable",
+ "starlark_map",
+ "thiserror",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "static_interner"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a72d2480db611b8ee9287b4a2e0adc63c4d7fdd647d2a1a65d529fc234fd16"
+dependencies = [
+ "equivalent",
+ "lock_free_hashtable",
+]
+
+[[package]]
+name = "strong_hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0831334aea34390b6b6ec7af0a27f9ee6324ad3a69463e6b240d83d6b7bce9c9"
+dependencies = [
+ "ref-cast",
+ "strong_hash_derive",
+]
+
+[[package]]
+name = "strong_hash_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace6b48b7c4383a39bd3b966cca41bc999003aab9f690a2f355525c924296928"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subdirs-prefixed"
@@ -12,3 +1446,238 @@ version = "0.0.0"
 dependencies = [
  "josh-filter-guest",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/josh-guest/Cargo.toml
+++ b/josh-guest/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 resolver = "2"
-members = ["josh-filter-guest", "examples/subdirs-prefixed"]
+members = [
+    "josh-filter-guest",
+    "josh-starlark-guest",
+    "examples/subdirs-prefixed",
+]
 
 # Guest modules are committed as blobs into user repositories and loaded on
 # every proxy evaluation, so release builds are tuned for size, not speed.

--- a/josh-guest/examples/subdirs-prefixed/src/lib.rs
+++ b/josh-guest/examples/subdirs-prefixed/src/lib.rs
@@ -8,7 +8,7 @@
 
 #![no_std]
 
-use josh_filter_guest::{Filter, Tree, compose, josh_filter_entry, nop};
+use josh_filter_guest::{Filter, Tree, compose, josh_filter_entry, josh_guest_rt, nop};
 
 fn run(tree: Tree) -> Filter {
     compose(
@@ -19,3 +19,4 @@ fn run(tree: Tree) -> Filter {
 }
 
 josh_filter_entry!(run);
+josh_guest_rt!();

--- a/josh-guest/josh-filter-guest/Cargo.toml
+++ b/josh-guest/josh-filter-guest/Cargo.toml
@@ -13,9 +13,11 @@ crate-type = ["rlib"]
 
 [features]
 default = ["rt"]
-# Bump allocator and aborting panic handler for pure-`no_std` guests. Must be
-# disabled for guests that link `std` (e.g. an interpreter build): `std`
-# already provides an allocator and a panic handler.
+# Bump allocator and aborting panic handler for pure-`no_std` guests,
+# installed by invoking `josh_guest_rt!()` in the guest crate. Guests that
+# link `std` (e.g. an interpreter build) must not invoke the macro and should
+# disable this feature: `std` already provides an allocator and a panic
+# handler.
 rt = []
 
 [dependencies]

--- a/josh-guest/josh-filter-guest/src/lib.rs
+++ b/josh-guest/josh-filter-guest/src/lib.rs
@@ -10,13 +10,14 @@
 //! ```ignore
 //! #![no_std]
 //!
-//! use josh_filter_guest::{Filter, Tree, compose, josh_filter_entry, nop};
+//! use josh_filter_guest::{Filter, Tree, compose, josh_filter_entry, josh_guest_rt, nop};
 //!
 //! fn run(tree: Tree) -> Filter {
 //!     compose(tree.dirs("").into_iter().map(|d| nop().subdir(&d).prefix(&d)))
 //! }
 //!
 //! josh_filter_entry!(run);
+//! josh_guest_rt!(); // no_std runtime: bump allocator + aborting panic handler
 //! ```
 //!
 //! # ABI (v1)
@@ -43,6 +44,12 @@
 //! `josh_run` returns, so everything — `josh_alloc` buffers and the `rt`
 //! feature's bump allocator alike — simply leaks into instance memory that
 //! dies with the evaluation.
+//!
+//! Pure-`no_std` guests install the runtime (global allocator + panic
+//! handler) by invoking [`josh_guest_rt!`] once; guests that link `std`
+//! must not, and should depend on this crate with `default-features =
+//! false` (the lang items live in the guest crate, not this rlib, so one
+//! workspace can build both kinds side by side).
 //!
 //! # Determinism
 //!
@@ -71,7 +78,7 @@ pub mod abi;
 mod args;
 mod filter;
 #[cfg(all(feature = "rt", target_arch = "wasm32"))]
-mod rt;
+pub mod rt;
 mod tree;
 
 pub use args::args;

--- a/josh-guest/josh-filter-guest/src/rt.rs
+++ b/josh-guest/josh-filter-guest/src/rt.rs
@@ -1,6 +1,9 @@
-//! Minimal runtime for pure-`no_std` guests (feature `rt`, on by default):
-//! a leak-only bump allocator plus an aborting panic handler. Guests built
-//! with `std` must disable this feature — `std` provides both already.
+//! Minimal runtime pieces for pure-`no_std` guests (feature `rt`, on by
+//! default): a leak-only bump allocator, installed together with an aborting
+//! panic handler by invoking [`josh_guest_rt!`](crate::josh_guest_rt) in the
+//! guest crate. The lang items are deliberately NOT defined here: this rlib
+//! may be shared (via cargo feature unification) with guests that link `std`,
+//! which brings its own allocator and panic handler.
 
 use core::alloc::{GlobalAlloc, Layout};
 use core::cell::UnsafeCell;
@@ -10,9 +13,17 @@ const PAGE: usize = 65536;
 /// Bump allocator over pages appended to the end of linear memory via
 /// `memory.grow`. `dealloc` is a no-op: the instance is discarded right
 /// after `josh_run`, so everything leaks by design.
-struct BumpAlloc {
+pub struct BumpAlloc {
     /// `(next free byte, end of owned region)`; `(0, 0)` = uninitialized.
     state: UnsafeCell<(usize, usize)>,
+}
+
+impl BumpAlloc {
+    pub const fn new() -> BumpAlloc {
+        BumpAlloc {
+            state: UnsafeCell::new((0, 0)),
+        }
+    }
 }
 
 // SAFETY: wasm32-unknown-unknown guests are single-threaded.
@@ -51,14 +62,21 @@ unsafe impl GlobalAlloc for BumpAlloc {
     unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
 }
 
-#[global_allocator]
-static ALLOC: BumpAlloc = BumpAlloc {
-    state: UnsafeCell::new((0, 0)),
-};
+/// Install the `no_std` guest runtime: the [`BumpAlloc`] global allocator
+/// and an aborting panic handler (a panic traps, which the host reports as
+/// an evaluation error — no message plumbing). Invoke once at the top level
+/// of a pure-`no_std` guest crate; guests that link `std` (e.g. an
+/// interpreter build) must NOT invoke this and should depend on the SDK with
+/// `default-features = false`.
+#[macro_export]
+macro_rules! josh_guest_rt {
+    () => {
+        #[global_allocator]
+        static __JOSH_GUEST_ALLOC: $crate::rt::BumpAlloc = $crate::rt::BumpAlloc::new();
 
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    // Trap: the host reports an evaluation error. No message plumbing — a
-    // guest that wants diagnostics should avoid panicking.
-    core::arch::wasm32::unreachable()
+        #[panic_handler]
+        fn __josh_guest_panic(_info: &::core::panic::PanicInfo) -> ! {
+            ::core::arch::wasm32::unreachable()
+        }
+    };
 }

--- a/josh-guest/josh-starlark-guest/Cargo.toml
+++ b/josh-guest/josh-starlark-guest/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "josh-starlark-guest"
+version = "26.7.28"
+edition = "2024"
+authors = ["Josh Project authors <contact@josh-project.dev>"]
+license-file = "../../LICENSE"
+description = "Starlark interpreter compiled to wasm32 as a josh filter guest module"
+keywords = ["git", "monorepo", "workflow", "scm", "starlark"]
+repository = "https://github.com/josh-project/josh"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+allocative = "0.3"
+anyhow = "1"
+getrandom = "0.4"
+starlark = "0.14.2"
+
+# default-features = false: this is a `std` guest, so the SDK's `rt` feature
+# (bump allocator + panic handler) must stay off — std provides both.
+josh-filter-guest = { path = "../josh-filter-guest", default-features = false }

--- a/josh-guest/josh-starlark-guest/README.md
+++ b/josh-guest/josh-starlark-guest/README.md
@@ -1,0 +1,61 @@
+# josh-starlark-guest
+
+A Starlark interpreter compiled to `wasm32-unknown-unknown`, usable as an
+ordinary josh wasm filter guest module. It provides the same script API as
+the old native `josh-starlark` filter (pre-set `filter` and `tree` module
+variables, global `compose()`), with `filter.starlark(path, sub)` replaced by
+`filter.wasm(path, args, sub)`.
+
+## Usage
+
+Commit the built blob once into the repository that uses it (e.g. as
+`tools/starlark.wasm`) and reference it from filter specs with the script
+path as the first invocation argument:
+
+```
+:!tools/starlark=st/config.star[::st/]
+```
+
+The script path is looked up in the context-filtered tree; a missing
+invocation argument or an absent script is a deterministic evaluation error
+(trap → the filter degrades to `:empty`). Note the difference from the old
+native filter, which treated a missing script as an empty script (nop).
+
+## Building
+
+From the repository root:
+
+```
+sh scripts/build-starlark-guest.sh
+```
+
+which is equivalent to, inside `josh-guest/`:
+
+```
+RUSTFLAGS='--cfg getrandom_backend="custom"' \
+    cargo build --release --target wasm32-unknown-unknown -p josh-starlark-guest
+```
+
+The blob lands at
+`josh-guest/target/wasm32-unknown-unknown/release/josh_starlark_guest.wasm`.
+It is multi-MiB and deliberately **not** committed to this repository; test
+fixtures copy it from the build output.
+
+`josh-guest/.cargo/config.toml` sets the `getrandom_backend="custom"` cfg for
+all wasm32 builds in this workspace, so a plain `cargo build`/`cargo check`
+run from inside `josh-guest/` works too.
+
+## Determinism
+
+Filter evaluation must be a pure function of
+`(module blob OID, invocation args, context-filtered tree OID)` — josh caches
+results under exactly that key. Two measures keep the interpreter
+deterministic:
+
+- The wasm sandbox has no clock, environment, filesystem or randomness
+  imports; the only host API is the `josh` import module.
+- `getrandom` (a transitive dependency of the starlark crate, used for hash
+  seeds) is routed to a stub that returns zeros
+  (`src/getrandom_backend.rs`), so hash seeds are fixed. Using the `wasm_js`
+  backend instead would add `__wbindgen_*` imports the josh host cannot link;
+  the import section of the built blob must contain only `josh` entries.

--- a/josh-guest/josh-starlark-guest/src/evaluate.rs
+++ b/josh-guest/josh-starlark-guest/src/evaluate.rs
@@ -1,0 +1,61 @@
+//! Script evaluation, mirroring the old native `josh-starlark/src/evaluate.rs`.
+
+use crate::filter::StarlarkFilter;
+use crate::module::filter_module;
+use crate::tree::StarlarkTree;
+use anyhow::anyhow;
+use josh_filter_guest::Filter;
+use starlark::{
+    environment::{GlobalsBuilder, Module},
+    eval::Evaluator,
+    syntax::{AstModule, Dialect},
+    values::ValueLike,
+};
+
+/// Evaluate a starlark script and return the resulting Filter.
+///
+/// The script must not use josh filter language strings - all filters
+/// must be constructed using the Filter builder methods, starting from the
+/// pre-set module variable `filter` (the nop filter). The context-filtered
+/// tree is available as the pre-set module variable `tree`. An empty script
+/// leaves `filter` untouched and therefore yields the nop filter.
+pub fn evaluate(script: &str) -> anyhow::Result<Filter> {
+    // Parse the starlark script
+    let ast = AstModule::parse("script.star", script.to_owned(), &Dialect::Standard)
+        .map_err(|e| anyhow!("Failed to parse starlark script: {}", e))?;
+
+    // Create a new module scoped to a temporary heap
+    Module::with_temp_heap(|module| {
+        // Build globals with our filter module
+        let globals = GlobalsBuilder::standard().with(filter_module).build();
+
+        // Add a global "filter" value (nop filter) to the module
+        let filter_value = module.heap().alloc(StarlarkFilter::new());
+        module.set("filter", filter_value);
+
+        // Add a global "tree" value (the context-filtered tree) to the module
+        let tree_value = module.heap().alloc(StarlarkTree::root());
+        module.set("tree", tree_value);
+
+        // Create an evaluator
+        let mut eval = Evaluator::new(&module);
+
+        // Evaluate the script
+        let _result = eval
+            .eval_module(ast, &globals)
+            .map_err(|e| anyhow!("Failed to evaluate starlark script: {}", e))?;
+
+        // Try to get the filter from the module
+        // Look for a variable named "filter"
+        let filter_value = module
+            .get("filter")
+            .ok_or_else(|| anyhow!("Script must define 'filter' variable returning a Filter"))?;
+
+        // Extract the Filter from the StarlarkFilter value
+        let filter = filter_value
+            .downcast_ref::<StarlarkFilter>()
+            .ok_or_else(|| anyhow!("Expected Filter value, got {}", filter_value.get_type()))?;
+
+        Ok(filter.filter)
+    })
+}

--- a/josh-guest/josh-starlark-guest/src/filter.rs
+++ b/josh-guest/josh-starlark-guest/src/filter.rs
@@ -1,0 +1,334 @@
+//! The script-facing `filter.*` method surface, mirroring the old native
+//! `josh-starlark/src/filter.rs` on top of the guest SDK's handle-based
+//! builder. One change: `starlark(path, sub)` is replaced by
+//! `wasm(path, args, sub)`.
+//!
+//! Methods that raised catchable evaluation errors natively (`pattern` with an
+//! invalid glob, `treeid`/`wasm` with the experimental gate disabled) now trap
+//! in the host import instead, aborting the whole evaluation — the end state
+//! (evaluation failure, empty projection) is the same.
+
+use allocative::Allocative;
+use josh_filter_guest::Filter;
+use starlark::{
+    environment::MethodsBuilder,
+    starlark_module, starlark_simple_value,
+    values::{NoSerialize, ProvidesStaticType, StarlarkValue, StringValue, list::UnpackList},
+};
+use std::fmt::{self, Display};
+
+/// Opaque Filter type for Starlark
+/// We wrap the guest SDK's Filter handle in a newtype that implements the
+/// required traits
+#[derive(Debug, Clone, Copy, ProvidesStaticType, NoSerialize)]
+pub struct StarlarkFilter {
+    pub filter: Filter,
+}
+
+// Implement Allocative manually since Filter doesn't implement it
+// Filter is just a Copy wrapper around a u32 host handle
+impl Allocative for StarlarkFilter {
+    fn visit<'a, 'b: 'a>(&self, _visitor: &'a mut allocative::Visitor<'b>) {
+        // Filter contains only a u32 handle which is Copy and doesn't need visiting
+    }
+}
+
+starlark_simple_value!(StarlarkFilter);
+
+impl Display for StarlarkFilter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The native implementation printed the filter's content OID; the
+        // guest only holds an opaque handle, which is still deterministic.
+        write!(f, "Filter(#{})", self.filter.handle())
+    }
+}
+
+impl<'v> StarlarkValue<'v> for StarlarkFilter {
+    type Canonical = Self;
+
+    const TYPE: &'static str = "Filter";
+
+    fn get_type_starlark_repr() -> starlark::typing::Ty {
+        starlark::typing::Ty::starlark_value::<Self>()
+    }
+
+    fn get_methods() -> Option<&'static starlark::environment::Methods> {
+        starlark::methods_static!(RES = filter_methods);
+        Some(RES.methods())
+    }
+}
+
+#[starlark_module]
+fn filter_methods(builder: &mut MethodsBuilder) {
+    // Builder methods that return Filter
+    fn chain(this: &StarlarkFilter, other: &StarlarkFilter) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.chain(*other))
+    }
+    fn nop(this: &StarlarkFilter) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.nop())
+    }
+    fn empty(this: &StarlarkFilter) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.empty())
+    }
+    fn linear(this: &StarlarkFilter) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.linear())
+    }
+    fn file(this: &StarlarkFilter, path: StringValue) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.file(path))
+    }
+    fn rename(
+        this: &StarlarkFilter,
+        dst: StringValue,
+        src: StringValue,
+    ) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.rename(dst, src))
+    }
+    fn subdir(this: &StarlarkFilter, path: StringValue) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.subdir(path))
+    }
+    fn prefix(this: &StarlarkFilter, path: StringValue) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.prefix(path))
+    }
+    fn stored(this: &StarlarkFilter, path: StringValue) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.stored(path))
+    }
+    fn pattern(this: &StarlarkFilter, pattern: StringValue) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.pattern(pattern))
+    }
+    fn workspace(this: &StarlarkFilter, path: StringValue) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.workspace(path))
+    }
+    fn author(
+        this: &StarlarkFilter,
+        name: StringValue,
+        email: StringValue,
+    ) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.author(name, email))
+    }
+    fn committer(
+        this: &StarlarkFilter,
+        name: StringValue,
+        email: StringValue,
+    ) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.committer(name, email))
+    }
+    fn prune_trivial_merge(this: &StarlarkFilter) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.prune_trivial_merge())
+    }
+    fn unsign(this: &StarlarkFilter) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.unsign())
+    }
+    fn message(this: &StarlarkFilter, message: StringValue) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.message(message))
+    }
+    fn hook(this: &StarlarkFilter, hook: StringValue) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.hook(hook))
+    }
+    fn with_meta(
+        this: &StarlarkFilter,
+        key: StringValue,
+        value: StringValue,
+    ) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.with_meta(key, value))
+    }
+    fn is_nop(this: &StarlarkFilter) -> anyhow::Result<bool> {
+        Ok(this.is_nop())
+    }
+    fn peel(this: &StarlarkFilter) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.peel())
+    }
+    fn insert(
+        this: &StarlarkFilter,
+        path: StringValue,
+        content: StringValue,
+    ) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.insert(path, content))
+    }
+    fn treeid(
+        this: &StarlarkFilter,
+        path: StringValue,
+        subfilter: &StarlarkFilter,
+    ) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.treeid(path, *subfilter))
+    }
+    fn wasm(
+        this: &StarlarkFilter,
+        path: StringValue,
+        args: UnpackList<String>,
+        subfilter: &StarlarkFilter,
+    ) -> anyhow::Result<StarlarkFilter> {
+        Ok(this.wasm(path, &args.items, *subfilter))
+    }
+}
+
+impl StarlarkFilter {
+    /// Create a new Filter
+    pub fn new() -> Self {
+        Self {
+            filter: josh_filter_guest::nop(),
+        }
+    }
+
+    /// Chain a filter
+    pub fn chain(&self, other: StarlarkFilter) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.chain(other.filter),
+        }
+    }
+
+    /// No-op filter — returns self unchanged (NOT a reset to nop)
+    pub fn nop(&self) -> StarlarkFilter {
+        *self
+    }
+
+    /// Check if filter is nop
+    pub fn is_nop(&self) -> bool {
+        self.filter.is_nop()
+    }
+
+    /// Create an empty filter — discards the receiver
+    pub fn empty(&self) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: josh_filter_guest::empty(),
+        }
+    }
+
+    /// Linear history filter
+    pub fn linear(&self) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.linear(),
+        }
+    }
+
+    /// File filter
+    pub fn file(&self, path: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.file(path.as_str()),
+        }
+    }
+
+    /// Rename filter — the DESTINATION is the first argument
+    pub fn rename(&self, dst: StringValue, src: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.rename(dst.as_str(), src.as_str()),
+        }
+    }
+
+    /// Subdir filter
+    pub fn subdir(&self, path: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.subdir(path.as_str()),
+        }
+    }
+
+    /// Prefix filter
+    pub fn prefix(&self, path: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.prefix(path.as_str()),
+        }
+    }
+
+    /// Stored filter
+    pub fn stored(&self, path: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.stored(path.as_str()),
+        }
+    }
+
+    /// Pattern filter — an invalid glob traps in the host
+    pub fn pattern(&self, pattern: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.pattern(pattern.as_str()),
+        }
+    }
+
+    /// Workspace filter
+    pub fn workspace(&self, path: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.workspace(path.as_str()),
+        }
+    }
+
+    /// Author filter
+    pub fn author(&self, name: StringValue, email: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.author(name.as_str(), email.as_str()),
+        }
+    }
+
+    /// Committer filter
+    pub fn committer(&self, name: StringValue, email: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.committer(name.as_str(), email.as_str()),
+        }
+    }
+
+    /// Prune trivial merge filter
+    pub fn prune_trivial_merge(&self) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.prune_trivial_merge(),
+        }
+    }
+
+    /// Unsign filter
+    pub fn unsign(&self) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.unsign(),
+        }
+    }
+
+    /// Message filter
+    pub fn message(&self, message: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.message(message.as_str()),
+        }
+    }
+
+    /// Hook filter
+    pub fn hook(&self, hook: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.hook(hook.as_str()),
+        }
+    }
+
+    /// With metadata
+    pub fn with_meta(&self, key: StringValue, value: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.with_meta(key.as_str(), value.as_str()),
+        }
+    }
+
+    /// Insert a blob at path with the given content
+    pub fn insert(&self, path: StringValue, content: StringValue) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.insert(path.as_str(), content.as_str()),
+        }
+    }
+
+    /// Create a blob at path containing the tree OID of subfilter applied to the input
+    pub fn treeid(&self, path: StringValue, subfilter: StarlarkFilter) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.treeid(path.as_str(), subfilter.filter),
+        }
+    }
+
+    /// A nested wasm filter op (replaces the old `starlark(path, sub)`)
+    pub fn wasm(
+        &self,
+        path: StringValue,
+        args: &[String],
+        subfilter: StarlarkFilter,
+    ) -> StarlarkFilter {
+        let args: Vec<&str> = args.iter().map(|a| a.as_str()).collect();
+        StarlarkFilter {
+            filter: self.filter.wasm(path.as_str(), &args, subfilter.filter),
+        }
+    }
+
+    /// Peel metadata
+    pub fn peel(&self) -> StarlarkFilter {
+        StarlarkFilter {
+            filter: self.filter.peel(),
+        }
+    }
+}

--- a/josh-guest/josh-starlark-guest/src/getrandom_backend.rs
+++ b/josh-guest/josh-starlark-guest/src/getrandom_backend.rs
@@ -1,0 +1,20 @@
+//! Deterministic `getrandom` backend stub.
+//!
+//! `getrandom` arrives transitively (starlark → pagable → sorted_vector_map →
+//! quickcheck → rand) and refuses to compile for wasm32-unknown-unknown
+//! without a backend. The build selects the "custom" backend
+//! (`--cfg getrandom_backend="custom"`, see `josh-guest/.cargo/config.toml`),
+//! which resolves to this symbol. Filter evaluation must be a pure function
+//! of its inputs, so the only correct "randomness" is a constant: hash seeds
+//! and the like become fixed, which is exactly what the evaluation cache
+//! requires.
+
+#[unsafe(no_mangle)]
+unsafe extern "Rust" fn __getrandom_v03_custom(
+    dest: *mut u8,
+    len: usize,
+) -> Result<(), getrandom::Error> {
+    // SAFETY: the caller (getrandom) passes a valid buffer of `len` bytes.
+    unsafe { core::ptr::write_bytes(dest, 0, len) };
+    Ok(())
+}

--- a/josh-guest/josh-starlark-guest/src/lib.rs
+++ b/josh-guest/josh-starlark-guest/src/lib.rs
@@ -1,0 +1,54 @@
+//! A Starlark interpreter as a josh wasm filter guest module.
+//!
+//! This is the RFC's Starlark compatibility path (deployment variant 1): the
+//! built blob is committed once into a user repository (e.g. as
+//! `tools/starlark.wasm`) and every scripted filter site references it with
+//! the script path as its first invocation argument:
+//!
+//! ```text
+//! :!tools/starlark=st/config.star[::st/]
+//! ```
+//!
+//! The script sees the same API as the old native `josh-starlark` filter:
+//! pre-set module variables `filter` (starts as the nop filter) and `tree`
+//! (the root of the context-filtered tree), plus the global `compose()`. The
+//! script builds its result by reassigning `filter`; an empty script yields
+//! the nop filter. The one API change: `filter.starlark(path, sub)` is
+//! replaced by `filter.wasm(path, args, sub)`.
+//!
+//! The script must be visible in the context-filtered tree (`::st/` above
+//! includes `st/config.star`). A missing invocation argument or an absent
+//! script is a deterministic evaluation error: this module panics, the panic
+//! aborts (trap), and josh degrades the filter to `:empty`. This differs
+//! deliberately from the old native behavior, where a missing script was
+//! treated as an empty script (nop).
+//!
+//! Build with `scripts/build-starlark-guest.sh`; see README.md for the
+//! getrandom determinism notes.
+
+mod evaluate;
+mod filter;
+mod getrandom_backend;
+mod module;
+mod tree;
+
+use josh_filter_guest::{Filter, Tree, josh_filter_entry};
+
+fn run(tree: Tree) -> Filter {
+    let args = josh_filter_guest::args();
+    let script_path = args
+        .first()
+        .expect("josh-starlark-guest: missing script path invocation argument");
+    // `tree.file` cannot distinguish a missing script from an empty one, so
+    // absence is detected via the entry OID and turned into a trap.
+    if tree.entry_oid(script_path).is_none() {
+        panic!("josh-starlark-guest: script not found in context tree: {script_path}");
+    }
+    let script = tree.file(script_path);
+    match evaluate::evaluate(&script) {
+        Ok(filter) => filter,
+        Err(e) => panic!("josh-starlark-guest: {e}"),
+    }
+}
+
+josh_filter_entry!(run);

--- a/josh-guest/josh-starlark-guest/src/module.rs
+++ b/josh-guest/josh-starlark-guest/src/module.rs
@@ -1,0 +1,43 @@
+//! The one global function: `compose(filters)`, mirroring the old native
+//! `josh-starlark/src/module.rs`.
+
+use crate::filter::StarlarkFilter;
+use anyhow::anyhow;
+use starlark::{
+    environment::GlobalsBuilder,
+    starlark_module,
+    values::{Value, ValueLike},
+};
+
+#[starlark_module]
+pub fn filter_module(builder: &mut GlobalsBuilder) {
+    /// Compose multiple filters together
+    /// Creates a filter that overlays the output of filters sequentially
+    fn compose<'v>(
+        filters: Value<'v>,
+        heap: starlark::values::Heap<'v>,
+    ) -> anyhow::Result<StarlarkFilter> {
+        // Get iterator from the value
+        let mut iter = filters
+            .iterate(heap)
+            .map_err(|e| anyhow!("Failed to iterate over filters: {}", e))?;
+
+        // Convert to Vec<Filter>
+        let mut filter_vec = Vec::new();
+
+        while let Some(item) = iter.next() {
+            let starlark_filter = item.downcast_ref::<StarlarkFilter>().ok_or_else(|| {
+                anyhow!("Expected Filter in compose list, got {}", item.get_type())
+            })?;
+            filter_vec.push(starlark_filter.filter);
+        }
+
+        // Compose on the host
+        let composed = josh_filter_guest::compose(filter_vec);
+        Ok(StarlarkFilter { filter: composed })
+    }
+
+    // All methods are available directly on Filter instances via the builder API
+    // A global "filter" value (nop filter) is available in scripts
+    // e.g., filter.subdir("src").prefix("lib")
+}

--- a/josh-guest/josh-starlark-guest/src/tree.rs
+++ b/josh-guest/josh-starlark-guest/src/tree.rs
@@ -1,0 +1,144 @@
+//! The script-facing `tree.*` surface, mirroring the old native
+//! `josh-starlark/src/tree.rs` — same collapse-to-empty semantics, but no
+//! unsafe repo pointer: all access goes through the host tree imports, which
+//! address entries by full path from the context root. A sub-tree is
+//! therefore nothing but a path prefix.
+
+use allocative::Allocative;
+use starlark::{
+    environment::MethodsBuilder,
+    starlark_module, starlark_simple_value,
+    values::{NoSerialize, ProvidesStaticType, StarlarkValue, StringValue, Value},
+};
+use std::fmt::{self, Display};
+
+/// OID of the empty tree, printed for sub-trees at nonexistent paths to match
+/// the old native repr.
+const EMPTY_TREE_OID: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+/// Opaque Tree type for Starlark
+#[derive(Clone, ProvidesStaticType, NoSerialize)]
+pub(crate) struct StarlarkTree {
+    /// Path of this tree relative to the context root; empty for the root.
+    prefix: String,
+}
+
+impl Allocative for StarlarkTree {
+    fn visit<'a, 'b: 'a>(&self, _visitor: &'a mut allocative::Visitor<'b>) {
+        // Only a path prefix; nothing worth visiting.
+    }
+}
+
+starlark_simple_value!(StarlarkTree);
+
+impl Display for StarlarkTree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let oid = josh_filter_guest::Tree::root()
+            .entry_oid(&self.prefix)
+            .unwrap_or_else(|| String::from(EMPTY_TREE_OID));
+        write!(f, "Tree({})", oid)
+    }
+}
+
+impl fmt::Debug for StarlarkTree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "StarlarkTree(prefix: {:?})", self.prefix)
+    }
+}
+
+impl<'v> StarlarkValue<'v> for StarlarkTree {
+    type Canonical = Self;
+
+    const TYPE: &'static str = "Tree";
+
+    fn get_type_starlark_repr() -> starlark::typing::Ty {
+        starlark::typing::Ty::starlark_value::<Self>()
+    }
+
+    fn get_methods() -> Option<&'static starlark::environment::Methods> {
+        starlark::methods_static!(RES = tree_methods);
+        Some(RES.methods())
+    }
+}
+
+impl StarlarkTree {
+    /// The root of the context-filtered tree.
+    pub(crate) fn root() -> Self {
+        Self {
+            prefix: String::new(),
+        }
+    }
+
+    /// Full path from the context root for a script-supplied path.
+    fn join(&self, path: &str) -> String {
+        if self.prefix.is_empty() {
+            String::from(path)
+        } else if path.is_empty() {
+            self.prefix.clone()
+        } else {
+            format!("{}/{}", self.prefix, path)
+        }
+    }
+
+    /// The host returns full paths from the context root; the script expects
+    /// paths relative to this tree (i.e. starting with the path it passed).
+    fn strip_prefix(&self, full: Vec<String>) -> Vec<String> {
+        if self.prefix.is_empty() {
+            return full;
+        }
+        let prefix = format!("{}/", self.prefix);
+        full.into_iter()
+            .map(|p| match p.strip_prefix(&prefix) {
+                Some(rel) => String::from(rel),
+                None => p,
+            })
+            .collect()
+    }
+}
+
+#[starlark_module]
+fn tree_methods(_builder: &mut MethodsBuilder) {
+    /// Get the content of a file at the given path
+    /// Returns empty string if the file doesn't exist or is binary
+    fn file(this: &StarlarkTree, path: StringValue) -> anyhow::Result<String> {
+        Ok(josh_filter_guest::Tree::root().file(&this.join(path.as_str())))
+    }
+
+    /// Get a list of full paths to child directories at the given path
+    /// Returns empty list if the path doesn't exist
+    fn dirs<'v>(
+        this: &StarlarkTree,
+        path: StringValue,
+        heap: starlark::values::Heap<'v>,
+    ) -> anyhow::Result<Vec<Value<'v>>> {
+        let dirs = josh_filter_guest::Tree::root().dirs(&this.join(path.as_str()));
+        Ok(this
+            .strip_prefix(dirs)
+            .into_iter()
+            .map(|p| heap.alloc_str(&p).to_value())
+            .collect())
+    }
+
+    /// Get a list of full paths to child files (blobs) at the given path
+    /// Returns empty list if the path doesn't exist
+    fn files<'v>(
+        this: &StarlarkTree,
+        path: StringValue,
+        heap: starlark::values::Heap<'v>,
+    ) -> anyhow::Result<Vec<Value<'v>>> {
+        let files = josh_filter_guest::Tree::root().files(&this.join(path.as_str()));
+        Ok(this
+            .strip_prefix(files)
+            .into_iter()
+            .map(|p| heap.alloc_str(&p).to_value())
+            .collect())
+    }
+
+    /// Get the tree at the given path
+    /// Returns an empty tree if the path doesn't exist
+    fn tree(this: &StarlarkTree, path: StringValue) -> anyhow::Result<StarlarkTree> {
+        Ok(StarlarkTree {
+            prefix: this.join(path.as_str()),
+        })
+    }
+}

--- a/scripts/build-starlark-guest.sh
+++ b/scripts/build-starlark-guest.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Build the josh-starlark-guest interpreter blob for wasm32-unknown-unknown
+# and print its absolute path. The blob is multi-MiB and NOT committed; test
+# fixtures copy it from the path this script prints.
+set -e
+
+cd "$(dirname "$0")/../josh-guest"
+
+# getrandom (transitive via the starlark crate) needs the custom backend on
+# wasm32; the deterministic stub lives in josh-starlark-guest. The cfg is also
+# set by josh-guest/.cargo/config.toml, but RUSTFLAGS makes this script work
+# regardless of cargo config discovery.
+RUSTFLAGS='--cfg getrandom_backend="custom"' \
+    cargo build --release --target wasm32-unknown-unknown \
+    -p josh-starlark-guest 1>&2
+
+echo "$(pwd)/target/wasm32-unknown-unknown/release/josh_starlark_guest.wasm"


### PR DESCRIPTION
Add josh-starlark-guest Starlark interpreter targeting wasm32

Port the josh-starlark script surface onto the josh-filter-guest SDK as a
cdylib guest module (RFC deployment variant 1): the built blob is committed
once into a user repository and referenced from filter specs as
':!tools/starlark=path/to/script.star[context]'. Scripts see the same API as
the old native filter — pre-set 'filter' and 'tree' module variables and the
global compose() — with filter.starlark(path, sub) replaced by
filter.wasm(path, args, sub). The script path is the first invocation
argument; a missing argument or a script absent from the context-filtered
tree (detected via tree_entry_oid, since tree_file cannot distinguish missing
from empty) is a deterministic evaluation error (trap -> empty), a deliberate
change from the native missing-script => nop behavior. An empty script still
yields the nop filter.

Determinism: the sandbox has no entropy imports, and getrandom (transitive
via starlark) is built with the custom backend routed to a zero-filling
__getrandom_v03_custom stub, keeping hash seeds fixed.
josh-guest/.cargo/config.toml sets the backend cfg for all wasm32 builds in
the guest workspace; scripts/build-starlark-guest.sh builds the blob (NOT
committed - multi-MiB) and prints its path. The built blob's import section
contains only module "josh" entries.

Building a std guest next to no_std guests surfaced a lang-item conflict:
cargo feature unification enables the SDK's rt feature workspace-wide, so the
panic handler and global allocator moved out of the shared rlib into a new
josh_guest_rt!() macro that pure-no_std leaf crates invoke (the
subdirs-prefixed example does); std guests depend on the SDK with
default-features = false and invoke nothing.

Change: starlark-guest
Assisted-By: anthropic/claude-fable-5