### PR TITLE
Add josh-wasm crate with a wasmi-backed filter evaluation runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1640,6 +1640,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -2652,13 +2658,22 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2669,7 +2684,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -3736,6 +3751,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "josh-wasm"
+version = "26.7.28"
+dependencies = [
+ "anyhow",
+ "git2",
+ "josh-filter",
+ "tracing",
+ "wasmi",
+ "wat",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,6 +3842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,6 +3864,12 @@ dependencies = [
  "libz-sys",
  "pkg-config",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -5127,7 +5166,7 @@ dependencies = [
  "nix 0.28.0",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
  "utf8parse",
  "windows-sys 0.52.0",
 ]
@@ -5651,6 +5690,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fdc163db75f7b5ffa3daf0c5a7136fb0d4b2f35523cd1769da05e034159feb"
 
 [[package]]
+name = "string-interner"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23de088478b31c349c9ba67816fa55d9355232d63c3afea8bf513e31f0f1d2c0"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
+]
+
+[[package]]
 name = "strong_hash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5783,7 +5832,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6344,6 +6393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6514,6 +6569,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.255.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b524283fb5df62eec102ed0574838961bdd7ba5ac9c50d38e2756c51c971a42"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.255.0",
+]
+
+[[package]]
+name = "wasmi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2300d0f78cba12f14e29e8dd157ea64050c0a688179aefdb2050105805594a0c"
+dependencies = [
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser 0.239.0",
+ "wat",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a8c42a2a76148d43097b1d7cc2a5bf33d5c23bd4dd69015fc887e311767884"
+dependencies = [
+ "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9013136083d988725953390bf668b64b7a218fabf26f8b913bbc59546b97ee27"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1fa003f79156f406d62ef0e1464dc03e11ace37170e9fa7524299a75ad8f68"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.255.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e329ef4b5d46e73b91d3ac6924417cad55a8cbbf869c199283383427c3320b"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wast"
+version = "255.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ffec530f199bd3d553ac442c13dd108353cad533cad8514bc41e1f1f0fe686"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width 0.2.2",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.255.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda82c82e1486c7eed42a0465e544d80fff37abc3b39482e0d34dbaabe2fe5b1"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1590,6 +1590,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -2702,13 +2708,22 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2719,7 +2734,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -3896,6 +3911,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "josh-wasm"
+version = "26.8.28"
+dependencies = [
+ "anyhow",
+ "git2",
+ "josh-filter",
+ "tracing",
+ "wasmi",
+ "wat",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3975,10 +4002,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.7+1.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -5251,7 +5302,7 @@ dependencies = [
  "nix",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.14",
  "utf8parse",
  "windows-sys 0.52.0",
 ]
@@ -5765,6 +5816,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fdc163db75f7b5ffa3daf0c5a7136fb0d4b2f35523cd1769da05e034159feb"
 
 [[package]]
+name = "string-interner"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23de088478b31c349c9ba67816fa55d9355232d63c3afea8bf513e31f0f1d2c0"
+dependencies = [
+ "hashbrown 0.15.5",
+ "serde",
+]
+
+[[package]]
 name = "strong_hash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5897,7 +5958,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -6458,6 +6519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6622,6 +6689,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.255.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b524283fb5df62eec102ed0574838961bdd7ba5ac9c50d38e2756c51c971a42"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.255.0",
+]
+
+[[package]]
+name = "wasmi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2300d0f78cba12f14e29e8dd157ea64050c0a688179aefdb2050105805594a0c"
+dependencies = [
+ "spin",
+ "wasmi_collections",
+ "wasmi_core",
+ "wasmi_ir",
+ "wasmparser 0.239.0",
+ "wat",
+]
+
+[[package]]
+name = "wasmi_collections"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a8c42a2a76148d43097b1d7cc2a5bf33d5c23bd4dd69015fc887e311767884"
+dependencies = [
+ "string-interner",
+]
+
+[[package]]
+name = "wasmi_core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9013136083d988725953390bf668b64b7a218fabf26f8b913bbc59546b97ee27"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmi_ir"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1fa003f79156f406d62ef0e1464dc03e11ace37170e9fa7524299a75ad8f68"
+dependencies = [
+ "wasmi_core",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.255.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e329ef4b5d46e73b91d3ac6924417cad55a8cbbf869c199283383427c3320b"
+dependencies = [
+ "bitflags 2.13.1",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wast"
+version = "255.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ffec530f199bd3d553ac442c13dd108353cad533cad8514bc41e1f1f0fe686"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width 0.2.2",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.255.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda82c82e1486c7eed42a0465e544d80fff37abc3b39482e0d34dbaabe2fe5b1"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "josh-ssh-shell",
     "josh-templates",
     "josh-starlark",
+    "josh-wasm",
     "cq/josh-cq",
     "cq/josh-cq-test-components",
     "josh-changes",
@@ -101,6 +102,7 @@ josh-rpc = { path = "josh-rpc", version = "26.7.28" }
 josh-search = { path = "josh-search", version = "26.7.28" }
 josh-starlark = { path = "josh-starlark", version = "26.7.28" }
 josh-templates = { path = "josh-templates", version = "26.7.28" }
+josh-wasm = { path = "josh-wasm", version = "26.7.28" }
 
 # Forges support
 josh-github-changes = { path = "forges/josh-github-changes", version = "26.7.28" }
@@ -199,6 +201,7 @@ josh-link = { path = "josh-link" }
 josh-rpc = { path = "josh-rpc" }
 josh-starlark = { path = "josh-starlark" }
 josh-templates = { path = "josh-templates" }
+josh-wasm = { path = "josh-wasm" }
 josh-github-changes = { path = "forges/josh-github-changes" }
 josh-github-graphql = { path = "forges/josh-github-graphql" }
 josh-github-codegen-graphql = { path = "forges/josh-github-codegen-graphql" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "josh-ssh-shell",
     "josh-templates",
     "josh-starlark",
+    "josh-wasm",
     "cq/josh-cq",
     "cq/josh-cq-test-components",
     "josh-changes",
@@ -123,6 +124,7 @@ josh-rpc = { path = "josh-rpc", version = "26.8.28" }
 josh-search = { path = "josh-search", version = "26.8.28" }
 josh-starlark = { path = "josh-starlark", version = "26.8.28" }
 josh-templates = { path = "josh-templates", version = "26.8.28" }
+josh-wasm = { path = "josh-wasm", version = "26.8.28" }
 
 # Forges support
 josh-github-changes = { path = "forges/josh-github-changes", version = "26.8.28" }
@@ -220,6 +222,7 @@ josh-graphql = { path = "josh-graphql" }
 josh-rpc = { path = "josh-rpc" }
 josh-starlark = { path = "josh-starlark" }
 josh-templates = { path = "josh-templates" }
+josh-wasm = { path = "josh-wasm" }
 josh-github-changes = { path = "forges/josh-github-changes" }
 josh-github-graphql = { path = "forges/josh-github-graphql" }
 josh-github-codegen-graphql = { path = "forges/josh-github-codegen-graphql" }

--- a/josh-wasm/Cargo.toml
+++ b/josh-wasm/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "josh-wasm"
+version = "26.7.28"
+edition = "2024"
+authors = ["Josh Project authors <contact@josh-project.dev>"]
+license-file = "../LICENSE"
+description = "WASM filter evaluation runtime for josh"
+keywords = ["git", "monorepo", "workflow", "scm", "wasm"]
+readme = "../README.md"
+repository = "https://github.com/josh-project/josh"
+
+[dependencies]
+wasmi = "1.1"
+wat = "1"
+
+anyhow.workspace = true
+git2.workspace = true
+tracing.workspace = true
+
+josh-filter.workspace = true

--- a/josh-wasm/Cargo.toml
+++ b/josh-wasm/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "josh-wasm"
+version = "26.8.28"
+edition = "2024"
+authors = ["Josh Project authors <contact@josh-project.dev>"]
+license-file = "../LICENSE"
+description = "WASM filter evaluation runtime for josh"
+keywords = ["git", "monorepo", "workflow", "scm", "wasm"]
+readme = "../README.md"
+repository = "https://github.com/josh-project/josh"
+
+[dependencies]
+wasmi = "1.1"
+wat = "1"
+
+anyhow.workspace = true
+git2 = "0.20"
+tracing.workspace = true
+
+josh-filter.workspace = true

--- a/josh-wasm/src/cache.rs
+++ b/josh-wasm/src/cache.rs
@@ -1,0 +1,108 @@
+//! The two in-memory caches (both cleared via `josh_wasm::clear_caches`):
+//!
+//! - a bounded LRU of validated/compiled modules keyed by blob OID. Bounded
+//!   because each entry holds a compiled module of up to the module size limit
+//!   and anyone who can push to a proxied repo can mint unlimited distinct
+//!   blob OIDs.
+//! - an evaluation memo keyed by `(module blob OID, args, filtered tree OID)`.
+//!   Deliberately unbounded: entries are a few dozen bytes (OIDs plus an
+//!   interned `Filter` pointer), the same growth class as josh-core's
+//!   `WORKSPACES` map.
+
+use crate::engine::CompiledModule;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
+
+pub(crate) type EvalMemoKey = (git2::Oid, Vec<String>, git2::Oid);
+
+/// Hand-rolled LRU: last-use tick per entry, evict the smallest tick on
+/// insert at capacity. The O(n) eviction scan is fine at the default n=64.
+pub(crate) struct ModuleLru {
+    capacity: usize,
+    tick: u64,
+    entries: HashMap<git2::Oid, (Arc<dyn CompiledModule>, u64)>,
+}
+
+impl ModuleLru {
+    pub(crate) fn new(capacity: usize) -> ModuleLru {
+        ModuleLru {
+            capacity,
+            tick: 0,
+            entries: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn get(&mut self, oid: &git2::Oid) -> Option<Arc<dyn CompiledModule>> {
+        self.tick += 1;
+        let tick = self.tick;
+        self.entries.get_mut(oid).map(|entry| {
+            entry.1 = tick;
+            entry.0.clone()
+        })
+    }
+
+    pub(crate) fn insert(&mut self, oid: git2::Oid, module: Arc<dyn CompiledModule>) {
+        if self.capacity == 0 {
+            return;
+        }
+        if self.entries.len() >= self.capacity && !self.entries.contains_key(&oid) {
+            if let Some(evict) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, (_, tick))| *tick)
+                .map(|(oid, _)| *oid)
+            {
+                tracing::trace!("evicting wasm module {} from cache", evict);
+                self.entries.remove(&evict);
+            }
+        }
+        self.tick += 1;
+        self.entries.insert(oid, (module, self.tick));
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains(&self, oid: &git2::Oid) -> bool {
+        self.entries.contains_key(oid)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+    }
+}
+
+static MODULE_CACHE: LazyLock<Mutex<ModuleLru>> =
+    LazyLock::new(|| Mutex::new(ModuleLru::new(*crate::JOSH_WASM_MODULE_CACHE_SIZE)));
+
+static EVAL_MEMO: LazyLock<Mutex<HashMap<EvalMemoKey, josh_filter::Filter>>> =
+    LazyLock::new(Default::default);
+
+pub(crate) fn module_cache() -> &'static Mutex<ModuleLru> {
+    &MODULE_CACHE
+}
+
+pub(crate) fn eval_memo() -> &'static Mutex<HashMap<EvalMemoKey, josh_filter::Filter>> {
+    &EVAL_MEMO
+}
+
+pub(crate) fn clear() {
+    MODULE_CACHE.lock().unwrap().clear();
+    EVAL_MEMO.lock().unwrap().clear();
+}
+
+/// Number of memo entries for a given module blob OID. Test helper: global
+/// cache state is shared across parallel tests, so assertions must be scoped
+/// to a module OID unique to the asserting test.
+#[cfg(test)]
+pub(crate) fn eval_memo_entries_for(module_oid: git2::Oid) -> usize {
+    EVAL_MEMO
+        .lock()
+        .unwrap()
+        .keys()
+        .filter(|(oid, _, _)| *oid == module_oid)
+        .count()
+}

--- a/josh-wasm/src/engine.rs
+++ b/josh-wasm/src/engine.rs
@@ -1,0 +1,36 @@
+//! Internal engine abstraction. The concrete runtime is wasmi; keeping the
+//! surface behind these two traits is cheap insurance for a later engine swap
+//! (which must preserve determinism — see the NaN regression test).
+
+use std::sync::Arc;
+
+/// Per-evaluation resource limits.
+pub struct Limits {
+    pub fuel: u64,
+    pub memory_bytes: usize,
+    pub module_size: usize,
+    pub max_handles: usize,
+}
+
+/// Everything an evaluation may observe: the repository (for tree access), the
+/// context-filtered tree and the invocation arguments.
+pub struct EvalContext<'a> {
+    pub repo: &'a git2::Repository,
+    pub tree_oid: git2::Oid,
+    pub args: &'a [String],
+}
+
+pub trait Engine: Send + Sync {
+    /// Validate and compile a wasm binary.
+    fn load(&self, bytes: &[u8], limits: &Limits) -> anyhow::Result<Arc<dyn CompiledModule>>;
+}
+
+pub trait CompiledModule: Send + Sync {
+    /// Instantiate the module and run it to completion, returning the filter
+    /// handle produced by the guest's `josh_run`.
+    fn evaluate(
+        &self,
+        ctx: EvalContext<'_>,
+        limits: &Limits,
+    ) -> anyhow::Result<josh_filter::Filter>;
+}

--- a/josh-wasm/src/host.rs
+++ b/josh-wasm/src/host.rs
@@ -1,0 +1,582 @@
+//! Host state and the `"josh"` import module.
+//!
+//! Builder imports delegate 1:1 to `josh_filter::Filter` methods; the guest
+//! only ever holds opaque `u32` handles into the per-evaluation handle table.
+//! Tree imports operate on the context-filtered tree with no way outside it.
+//! Any invalid handle, non-UTF-8 string or out-of-bounds pointer traps, which
+//! surfaces as an evaluation error.
+
+use crate::engine::{EvalContext, Limits};
+use josh_filter::Filter;
+use std::path::Path;
+use wasmi::{Caller, Extern, Linker, Memory};
+
+pub(crate) struct HostState {
+    // Evaluation is fully synchronous: `CompiledModule::evaluate` creates the
+    // store, runs the guest to completion and drops the store before
+    // returning, so the repository always outlives this pointer. A raw
+    // pointer (instead of `&'a git2::Repository`) is needed because wasmi's
+    // host function closures must be `'static`, which forbids a lifetime
+    // parameter on the store data type.
+    repo: *const git2::Repository,
+    tree_oid: git2::Oid,
+    args: Vec<String>,
+    handles: Vec<Filter>,
+    max_handles: usize,
+    memory_bytes: usize,
+    store_limits: wasmi::StoreLimits,
+}
+
+impl HostState {
+    pub(crate) fn new(ctx: &EvalContext<'_>, limits: &Limits) -> HostState {
+        HostState {
+            repo: ctx.repo as *const _,
+            tree_oid: ctx.tree_oid,
+            args: ctx.args.to_vec(),
+            handles: Vec::new(),
+            max_handles: limits.max_handles,
+            memory_bytes: limits.memory_bytes,
+            // The memory cap alone does not bound host allocations: wasmi
+            // eagerly commits a table's declared minimum at instantiation
+            // (before any fuel is consumed), and tables/memories are separate
+            // budgets counted per instance. Cap everything a module can make
+            // the store allocate: one instance, one memory, one table, and
+            // table elements (8 bytes each) budgeted like linear memory.
+            store_limits: wasmi::StoreLimitsBuilder::new()
+                .memory_size(limits.memory_bytes)
+                .table_elements(limits.memory_bytes / 8)
+                .instances(1)
+                .memories(1)
+                .tables(1)
+                .trap_on_grow_failure(true)
+                .build(),
+        }
+    }
+
+    pub(crate) fn limiter(&mut self) -> &mut dyn wasmi::ResourceLimiter {
+        &mut self.store_limits
+    }
+
+    pub(crate) fn handle(&self, handle: u32) -> Option<Filter> {
+        self.handles.get(handle as usize).copied()
+    }
+}
+
+type HCaller<'c> = Caller<'c, HostState>;
+
+fn repo<'c>(caller: &'c HCaller<'_>) -> &'c git2::Repository {
+    // SAFETY: see the `HostState::repo` field documentation.
+    unsafe { &*caller.data().repo }
+}
+
+fn memory(caller: &HCaller<'_>) -> Result<Memory, wasmi::Error> {
+    caller
+        .get_export("memory")
+        .and_then(Extern::into_memory)
+        .ok_or_else(|| wasmi::Error::new("guest does not export \"memory\""))
+}
+
+fn read_bytes<'c>(caller: &'c HCaller<'_>, ptr: u32, len: usize) -> Result<&'c [u8], wasmi::Error> {
+    let data = memory(caller)?.data(caller);
+    let start = ptr as usize;
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| wasmi::Error::new("guest pointer range overflows"))?;
+    data.get(start..end)
+        .ok_or_else(|| wasmi::Error::new("guest pointer out of bounds"))
+}
+
+fn read_string(caller: &HCaller<'_>, ptr: u32, len: u32) -> Result<String, wasmi::Error> {
+    let bytes = read_bytes(caller, ptr, len as usize)?;
+    std::str::from_utf8(bytes)
+        .map(str::to_string)
+        .map_err(|_| wasmi::Error::new("guest string is not valid UTF-8"))
+}
+
+fn get_handle(caller: &HCaller<'_>, handle: u32) -> Result<Filter, wasmi::Error> {
+    caller
+        .data()
+        .handle(handle)
+        .ok_or_else(|| wasmi::Error::new(format!("invalid filter handle: {}", handle)))
+}
+
+/// Register a filter in the handle table. Capped (`JOSH_WASM_MAX_HANDLES`):
+/// every constructed filter is interned process-wide for the process lifetime,
+/// so unbounded construction would leak host memory that neither the fuel nor
+/// the guest memory limit accounts for.
+fn push_handle(caller: &mut HCaller<'_>, filter: Filter) -> Result<u32, wasmi::Error> {
+    let state = caller.data_mut();
+    if state.handles.len() >= state.max_handles {
+        return Err(wasmi::Error::new("filter handle limit exceeded"));
+    }
+    state.handles.push(filter);
+    Ok((state.handles.len() - 1) as u32)
+}
+
+/// Write a host string into a guest buffer obtained by re-entrantly calling
+/// the guest's exported `josh_alloc`, returning `(ptr << 32) | len`. The
+/// empty string is returned as `0` without touching the guest.
+fn return_string(caller: &mut HCaller<'_>, s: &str) -> Result<i64, wasmi::Error> {
+    if s.is_empty() {
+        return Ok(0);
+    }
+    let alloc = caller
+        .get_export("josh_alloc")
+        .and_then(Extern::into_func)
+        .ok_or_else(|| wasmi::Error::new("guest does not export \"josh_alloc\""))?
+        .typed::<u32, u32>(&*caller)?;
+    let ptr = alloc.call(&mut *caller, s.len() as u32)?;
+    memory(caller)?.write(&mut *caller, ptr as usize, s.as_bytes())?;
+    Ok((((ptr as u64) << 32) | s.len() as u64) as i64)
+}
+
+fn host_err(e: impl std::fmt::Display) -> wasmi::Error {
+    wasmi::Error::new(e.to_string())
+}
+
+/// Blob content at `path`; empty string for absent, non-blob, binary,
+/// non-UTF-8 or oversized (larger than `max_bytes`) entries (the semantics
+/// of the Starlark filter's `tree.file`).
+pub(crate) fn tree_file_content(
+    repo: &git2::Repository,
+    tree_oid: git2::Oid,
+    path: &str,
+    max_bytes: usize,
+) -> String {
+    let Ok(tree) = repo.find_tree(tree_oid) else {
+        return String::new();
+    };
+    let Ok(entry) = tree.get_path(Path::new(path)) else {
+        return String::new();
+    };
+    if entry.kind() != Some(git2::ObjectType::Blob) {
+        return String::new();
+    }
+    // Check the size from the odb header BEFORE loading the blob: a blob that
+    // could never be delivered into guest memory must not be decompressed and
+    // copied host-side either — none of fuel, module size or the guest memory
+    // limit would otherwise bound this allocation.
+    let Ok(odb) = repo.odb() else {
+        return String::new();
+    };
+    match odb.read_header(entry.id()) {
+        Ok((size, _)) if size <= max_bytes => {}
+        _ => return String::new(),
+    }
+    let Ok(blob) = repo.find_blob(entry.id()) else {
+        return String::new();
+    };
+    if blob.is_binary() {
+        return String::new();
+    }
+    std::str::from_utf8(blob.content())
+        .map(str::to_string)
+        .unwrap_or_default()
+}
+
+fn tree_at<'r>(
+    repo: &'r git2::Repository,
+    tree_oid: git2::Oid,
+    path: &str,
+) -> Option<git2::Tree<'r>> {
+    let root = repo.find_tree(tree_oid).ok()?;
+    if path.is_empty() {
+        return Some(root);
+    }
+    let entry = root.get_path(Path::new(path)).ok()?;
+    if entry.kind() != Some(git2::ObjectType::Tree) {
+        return None;
+    }
+    repo.find_tree(entry.id()).ok()
+}
+
+/// Newline-joined full slash-joined paths of the immediate child entries of
+/// `kind` at `path`, in git tree entry order. Non-UTF-8 names and paths
+/// containing a newline are skipped; a bad path yields an empty result.
+fn tree_entry_list(
+    repo: &git2::Repository,
+    tree_oid: git2::Oid,
+    path: &str,
+    kind: git2::ObjectType,
+) -> String {
+    let Some(tree) = tree_at(repo, tree_oid, path) else {
+        return String::new();
+    };
+    let mut entries = Vec::new();
+    for entry in tree.iter() {
+        if entry.kind() != Some(kind) {
+            continue;
+        }
+        let Ok(name) = entry.name() else {
+            continue;
+        };
+        let full = if path.is_empty() {
+            name.to_string()
+        } else {
+            format!("{}/{}", path, name)
+        };
+        if full.contains('\n') {
+            continue;
+        }
+        entries.push(full);
+    }
+    entries.join("\n")
+}
+
+/// Hex OID of the entry at `path`; the tree's own OID for the empty path;
+/// empty string if absent.
+fn tree_entry_oid_hex(repo: &git2::Repository, tree_oid: git2::Oid, path: &str) -> String {
+    if path.is_empty() {
+        return tree_oid.to_string();
+    }
+    let Ok(tree) = repo.find_tree(tree_oid) else {
+        return String::new();
+    };
+    match tree.get_path(Path::new(path)) {
+        Ok(entry) => entry.id().to_string(),
+        Err(_) => String::new(),
+    }
+}
+
+pub(crate) fn add_to_linker(linker: &mut Linker<HostState>) -> anyhow::Result<()> {
+    // Constructors (no receiver).
+    linker.func_wrap(
+        "josh",
+        "nop",
+        |mut caller: HCaller| -> Result<u32, wasmi::Error> {
+            push_handle(&mut caller, Filter::new())
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "empty",
+        |mut caller: HCaller| -> Result<u32, wasmi::Error> {
+            push_handle(&mut caller, Filter::new().empty())
+        },
+    )?;
+
+    // Combinators.
+    linker.func_wrap(
+        "josh",
+        "chain",
+        |mut caller: HCaller, a: u32, b: u32| -> Result<u32, wasmi::Error> {
+            let a = get_handle(&caller, a)?;
+            let b = get_handle(&caller, b)?;
+            push_handle(&mut caller, a.chain(b))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "compose",
+        |mut caller: HCaller, ptr: u32, count: u32| -> Result<u32, wasmi::Error> {
+            let len = (count as usize)
+                .checked_mul(4)
+                .ok_or_else(|| wasmi::Error::new("compose handle count overflows"))?;
+            let handles: Vec<u32> = read_bytes(&caller, ptr, len)?
+                .chunks_exact(4)
+                .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
+                .collect();
+            let mut filters = Vec::with_capacity(handles.len());
+            for handle in handles {
+                filters.push(get_handle(&caller, handle)?);
+            }
+            push_handle(&mut caller, josh_filter::compose(&filters))
+        },
+    )?;
+
+    // Builder methods (receiver handle first).
+    linker.func_wrap(
+        "josh",
+        "subdir",
+        |mut caller: HCaller, f: u32, ptr: u32, len: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let path = read_string(&caller, ptr, len)?;
+            push_handle(&mut caller, f.subdir(path))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "prefix",
+        |mut caller: HCaller, f: u32, ptr: u32, len: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let path = read_string(&caller, ptr, len)?;
+            push_handle(&mut caller, f.prefix(path))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "file",
+        |mut caller: HCaller, f: u32, ptr: u32, len: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let path = read_string(&caller, ptr, len)?;
+            push_handle(&mut caller, f.file(path))
+        },
+    )?;
+    // NOTE: destination first, matching `Filter::rename`.
+    linker.func_wrap(
+        "josh",
+        "rename",
+        |mut caller: HCaller,
+         f: u32,
+         dst_ptr: u32,
+         dst_len: u32,
+         src_ptr: u32,
+         src_len: u32|
+         -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let dst = read_string(&caller, dst_ptr, dst_len)?;
+            let src = read_string(&caller, src_ptr, src_len)?;
+            push_handle(&mut caller, f.rename(dst, src))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "pattern",
+        |mut caller: HCaller, f: u32, ptr: u32, len: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let glob = read_string(&caller, ptr, len)?;
+            let f = f.pattern(&glob).map_err(host_err)?;
+            push_handle(&mut caller, f)
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "linear",
+        |mut caller: HCaller, f: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            push_handle(&mut caller, f.linear())
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "workspace",
+        |mut caller: HCaller, f: u32, ptr: u32, len: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let path = read_string(&caller, ptr, len)?;
+            push_handle(&mut caller, f.workspace(path))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "stored",
+        |mut caller: HCaller, f: u32, ptr: u32, len: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let path = read_string(&caller, ptr, len)?;
+            push_handle(&mut caller, f.stored(path))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "author",
+        |mut caller: HCaller,
+         f: u32,
+         name_ptr: u32,
+         name_len: u32,
+         email_ptr: u32,
+         email_len: u32|
+         -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let name = read_string(&caller, name_ptr, name_len)?;
+            let email = read_string(&caller, email_ptr, email_len)?;
+            push_handle(&mut caller, f.author(name, email))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "committer",
+        |mut caller: HCaller,
+         f: u32,
+         name_ptr: u32,
+         name_len: u32,
+         email_ptr: u32,
+         email_len: u32|
+         -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let name = read_string(&caller, name_ptr, name_len)?;
+            let email = read_string(&caller, email_ptr, email_len)?;
+            push_handle(&mut caller, f.committer(name, email))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "message",
+        |mut caller: HCaller, f: u32, ptr: u32, len: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let message = read_string(&caller, ptr, len)?;
+            push_handle(&mut caller, f.message(&message))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "unsign",
+        |mut caller: HCaller, f: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            push_handle(&mut caller, f.unsign())
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "prune_trivial_merge",
+        |mut caller: HCaller, f: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            push_handle(&mut caller, f.prune_trivial_merge())
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "hook",
+        |mut caller: HCaller, f: u32, ptr: u32, len: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let hook = read_string(&caller, ptr, len)?;
+            push_handle(&mut caller, f.hook(&hook))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "with_meta",
+        |mut caller: HCaller,
+         f: u32,
+         key_ptr: u32,
+         key_len: u32,
+         value_ptr: u32,
+         value_len: u32|
+         -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let key = read_string(&caller, key_ptr, key_len)?;
+            let value = read_string(&caller, value_ptr, value_len)?;
+            push_handle(&mut caller, f.with_meta(key, value))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "insert",
+        |mut caller: HCaller,
+         f: u32,
+         path_ptr: u32,
+         path_len: u32,
+         content_ptr: u32,
+         content_len: u32|
+         -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let path = read_string(&caller, path_ptr, path_len)?;
+            let content = read_string(&caller, content_ptr, content_len)?;
+            let f = f.insert(path, content).map_err(host_err)?;
+            push_handle(&mut caller, f)
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "treeid",
+        |mut caller: HCaller, f: u32, ptr: u32, len: u32, sub: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            let path = read_string(&caller, ptr, len)?;
+            let sub = get_handle(&caller, sub)?;
+            let f = f.treeid(path, sub).map_err(host_err)?;
+            push_handle(&mut caller, f)
+        },
+    )?;
+    // `Filter::wasm` only exists after the op rename lands; registered with its
+    // final signature so modules validate, but calling it is an error for now.
+    linker.func_wrap(
+        "josh",
+        "wasm",
+        |_caller: HCaller,
+         _f: u32,
+         _path_ptr: u32,
+         _path_len: u32,
+         _args_ptr: u32,
+         _args_len: u32,
+         _ctx: u32|
+         -> Result<u32, wasmi::Error> {
+            Err(wasmi::Error::new("wasm builder import not wired yet"))
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "peel",
+        |mut caller: HCaller, f: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            push_handle(&mut caller, f.peel())
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "is_nop",
+        |caller: HCaller, f: u32| -> Result<u32, wasmi::Error> {
+            let f = get_handle(&caller, f)?;
+            Ok(f.is_nop() as u32)
+        },
+    )?;
+
+    // Tree access (context-filtered tree only).
+    linker.func_wrap(
+        "josh",
+        "tree_file",
+        |mut caller: HCaller, ptr: u32, len: u32| -> Result<i64, wasmi::Error> {
+            let path = read_string(&caller, ptr, len)?;
+            let content = tree_file_content(
+                repo(&caller),
+                caller.data().tree_oid,
+                &path,
+                caller.data().memory_bytes,
+            );
+            return_string(&mut caller, &content)
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "tree_files",
+        |mut caller: HCaller, ptr: u32, len: u32| -> Result<i64, wasmi::Error> {
+            let path = read_string(&caller, ptr, len)?;
+            let list = tree_entry_list(
+                repo(&caller),
+                caller.data().tree_oid,
+                &path,
+                git2::ObjectType::Blob,
+            );
+            return_string(&mut caller, &list)
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "tree_dirs",
+        |mut caller: HCaller, ptr: u32, len: u32| -> Result<i64, wasmi::Error> {
+            let path = read_string(&caller, ptr, len)?;
+            let list = tree_entry_list(
+                repo(&caller),
+                caller.data().tree_oid,
+                &path,
+                git2::ObjectType::Tree,
+            );
+            return_string(&mut caller, &list)
+        },
+    )?;
+    linker.func_wrap(
+        "josh",
+        "tree_entry_oid",
+        |mut caller: HCaller, ptr: u32, len: u32| -> Result<i64, wasmi::Error> {
+            let path = read_string(&caller, ptr, len)?;
+            let hex = tree_entry_oid_hex(repo(&caller), caller.data().tree_oid, &path);
+            return_string(&mut caller, &hex)
+        },
+    )?;
+
+    // Invocation context.
+    linker.func_wrap(
+        "josh",
+        "invocation_args",
+        |mut caller: HCaller| -> Result<i64, wasmi::Error> {
+            let joined = caller
+                .data()
+                .args
+                .iter()
+                .filter(|arg| !arg.contains('\n'))
+                .cloned()
+                .collect::<Vec<_>>()
+                .join("\n");
+            return_string(&mut caller, &joined)
+        },
+    )?;
+
+    Ok(())
+}

--- a/josh-wasm/src/lib.rs
+++ b/josh-wasm/src/lib.rs
@@ -1,0 +1,153 @@
+//! WASM filter evaluation runtime.
+//!
+//! A filter module is a wasm blob (or WAT text, assembled on the fly) stored in
+//! the commit tree being filtered. [`evaluate`] instantiates it in a sandboxed,
+//! deterministic runtime (no WASI, fuel- and memory-limited), gives it read-only
+//! access to the context-filtered tree and returns the `josh_filter::Filter` the
+//! module constructed through the `"josh"` host imports.
+//!
+//! All failures bubble up as errors; degrading evaluation errors to `Op::Empty`
+//! is the caller's (josh-core's) job.
+
+mod cache;
+mod engine;
+mod host;
+mod wasmi_engine;
+
+#[cfg(test)]
+mod tests;
+
+use engine::{Engine, EvalContext, Limits};
+use std::sync::{Arc, LazyLock};
+
+fn env_or<T: std::str::FromStr>(name: &str, default: T) -> T {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Fuel budget (roughly: instructions) per evaluation.
+pub static JOSH_WASM_FUEL: LazyLock<u64> = LazyLock::new(|| env_or("JOSH_WASM_FUEL", 100_000_000));
+
+/// Maximum linear memory per instance, in bytes.
+pub static JOSH_WASM_MEMORY_LIMIT: LazyLock<usize> =
+    LazyLock::new(|| env_or("JOSH_WASM_MEMORY_LIMIT", 64 << 20));
+
+/// Maximum size of a module blob, in bytes.
+pub static JOSH_WASM_MODULE_SIZE_LIMIT: LazyLock<usize> =
+    LazyLock::new(|| env_or("JOSH_WASM_MODULE_SIZE_LIMIT", 16 << 20));
+
+/// Capacity (entries) of the in-memory compiled-module LRU cache.
+pub static JOSH_WASM_MODULE_CACHE_SIZE: LazyLock<usize> =
+    LazyLock::new(|| env_or("JOSH_WASM_MODULE_CACHE_SIZE", 64));
+
+/// Maximum nesting depth of wasm filter evaluations (enforced by josh-core).
+pub static JOSH_WASM_MAX_DEPTH: LazyLock<usize> =
+    LazyLock::new(|| env_or("JOSH_WASM_MAX_DEPTH", 10));
+
+/// Maximum number of filter handles per evaluation. Every constructed filter
+/// is interned process-wide for the process lifetime, so this bounds the
+/// permanent host memory a single evaluation can allocate.
+pub static JOSH_WASM_MAX_HANDLES: LazyLock<usize> =
+    LazyLock::new(|| env_or("JOSH_WASM_MAX_HANDLES", 100_000));
+
+/// A stable string identifying the resource-limit configuration. Evaluation
+/// outcomes depend on these limits (exhaustion degrades to an error), so any
+/// cache of results that outlives the process configuration must include this
+/// in its keys.
+pub fn limits_fingerprint() -> &'static str {
+    static FINGERPRINT: LazyLock<String> = LazyLock::new(|| {
+        format!(
+            "fuel={},memory={},module_size={},handles={},depth={}",
+            *JOSH_WASM_FUEL,
+            *JOSH_WASM_MEMORY_LIMIT,
+            *JOSH_WASM_MODULE_SIZE_LIMIT,
+            *JOSH_WASM_MAX_HANDLES,
+            *JOSH_WASM_MAX_DEPTH
+        )
+    });
+    &FINGERPRINT
+}
+
+static WASMI: LazyLock<wasmi_engine::WasmiEngine> = LazyLock::new(wasmi_engine::WasmiEngine::new);
+
+fn limits() -> Limits {
+    Limits {
+        fuel: *JOSH_WASM_FUEL,
+        memory_bytes: *JOSH_WASM_MEMORY_LIMIT,
+        module_size: *JOSH_WASM_MODULE_SIZE_LIMIT,
+        max_handles: *JOSH_WASM_MAX_HANDLES,
+    }
+}
+
+fn load_module(
+    repo: &git2::Repository,
+    module_oid: git2::Oid,
+    limits: &Limits,
+) -> anyhow::Result<Arc<dyn engine::CompiledModule>> {
+    if let Some(module) = cache::module_cache().lock().unwrap().get(&module_oid) {
+        return Ok(module);
+    }
+    let blob = repo.find_blob(module_oid)?;
+    let content = blob.content();
+    if content.len() > limits.module_size {
+        anyhow::bail!(
+            "wasm module {} exceeds size limit: {} > {}",
+            module_oid,
+            content.len(),
+            limits.module_size
+        );
+    }
+    // A blob without the wasm magic that is valid UTF-8 is treated as WAT text.
+    let bytes = if content.starts_with(b"\0asm") {
+        std::borrow::Cow::Borrowed(content)
+    } else {
+        let text = std::str::from_utf8(content).map_err(|_| {
+            anyhow::anyhow!(
+                "wasm module {} is neither a wasm binary nor UTF-8 WAT text",
+                module_oid
+            )
+        })?;
+        std::borrow::Cow::Owned(wat::parse_str(text)?)
+    };
+    let module = WASMI.load(&bytes, limits)?;
+    tracing::trace!("compiled wasm module {}", module_oid);
+    cache::module_cache()
+        .lock()
+        .unwrap()
+        .insert(module_oid, module.clone());
+    Ok(module)
+}
+
+/// Evaluate the wasm filter module stored in blob `module_oid`, giving it
+/// read-only access to the (context-filtered) tree `tree_oid` and the
+/// invocation `args`, and return the filter it constructs.
+pub fn evaluate(
+    repo: &git2::Repository,
+    module_oid: git2::Oid,
+    args: &[String],
+    tree_oid: git2::Oid,
+) -> anyhow::Result<josh_filter::Filter> {
+    let key = (module_oid, args.to_vec(), tree_oid);
+    if let Some(filter) = cache::eval_memo().lock().unwrap().get(&key) {
+        return Ok(*filter);
+    }
+    let limits = limits();
+    let module = load_module(repo, module_oid, &limits)?;
+    let filter = module.evaluate(
+        EvalContext {
+            repo,
+            tree_oid,
+            args,
+        },
+        &limits,
+    )?;
+    cache::eval_memo().lock().unwrap().insert(key, filter);
+    Ok(filter)
+}
+
+/// Clear the compiled-module cache and the evaluation memo.
+pub fn clear_caches() {
+    cache::clear();
+}

--- a/josh-wasm/src/tests.rs
+++ b/josh-wasm/src/tests.rs
@@ -1,0 +1,651 @@
+use crate::cache;
+use crate::engine::{Engine, EvalContext};
+use josh_filter::spec;
+
+/// Serializes tests that assert on or clear the global caches; without this a
+/// parallel `clear_caches` drops another test's memo entries mid-assertion.
+static CACHE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+fn cache_lock() -> std::sync::MutexGuard<'static, ()> {
+    CACHE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// A fresh bare repository in a unique temp directory.
+fn temp_repo() -> anyhow::Result<git2::Repository> {
+    static DIR_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let temp_dir = std::env::temp_dir().join(format!(
+        "josh_wasm_test_{}_{}_{}",
+        std::process::id(),
+        DIR_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    Ok(git2::Repository::init_bare(&temp_dir)?)
+}
+
+fn empty_tree(repo: &git2::Repository) -> anyhow::Result<git2::Oid> {
+    Ok(repo.treebuilder(None)?.write()?)
+}
+
+fn eval(
+    repo: &git2::Repository,
+    module: &str,
+    args: &[&str],
+    tree_oid: git2::Oid,
+) -> anyhow::Result<josh_filter::Filter> {
+    let module_oid = repo.blob(module.as_bytes())?;
+    let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+    crate::evaluate(repo, module_oid, &args, tree_oid)
+}
+
+/// Standard module skeleton: ABI exports plus a bump `josh_alloc`, with the
+/// given imports, data segments and `josh_run` body spliced in.
+fn module(imports: &str, data: &str, body: &str) -> String {
+    format!(
+        r#"(module
+  {imports}
+  (memory (export "memory") 1)
+  {data}
+  (global $next (mut i32) (i32.const 4096))
+  (func (export "josh_abi_version") (result i32) (i32.const 1))
+  (func (export "josh_alloc") (param i32) (result i32)
+    (local $ptr i32)
+    (local.set $ptr (global.get $next))
+    (global.set $next (i32.add (global.get $next) (local.get 0)))
+    (local.get $ptr))
+  (func (export "josh_run") (result i32)
+    {body}))"#
+    )
+}
+
+/// Probe a `(path) -> string` host import: the guest calls it with `path` and
+/// wraps the returned string in `with_meta(nop(), "r", <string>)`, which the
+/// test reads back via `Filter::get_meta` (newline-safe, unlike specs).
+fn probe_string(
+    repo: &git2::Repository,
+    tree_oid: git2::Oid,
+    import: &str,
+    path: &str,
+    args: &[&str],
+) -> anyhow::Result<Option<String>> {
+    let path_len = path.len();
+    let (probe_import, probe_call) = if import == "invocation_args" {
+        (
+            format!(r#"(import "josh" "{import}" (func $probe (result i64)))"#),
+            "(call $probe)".to_string(),
+        )
+    } else {
+        (
+            format!(r#"(import "josh" "{import}" (func $probe (param i32 i32) (result i64)))"#),
+            format!("(call $probe (i32.const 32) (i32.const {path_len}))"),
+        )
+    };
+    let wat = module(
+        &format!(
+            r#"(import "josh" "nop" (func $nop (result i32)))
+  (import "josh" "with_meta" (func $with_meta (param i32 i32 i32 i32 i32) (result i32)))
+  {probe_import}"#
+        ),
+        &format!(
+            r#"(data (i32.const 16) "r")
+  (data (i32.const 32) "{path}")"#
+        ),
+        &format!(
+            r#"(local $s i64)
+    (local.set $s {probe_call})
+    (call $with_meta (call $nop)
+      (i32.const 16) (i32.const 1)
+      (i32.wrap_i64 (i64.shr_u (local.get $s) (i64.const 32)))
+      (i32.wrap_i64 (local.get $s)))"#
+        ),
+    );
+    Ok(eval(repo, &wat, args, tree_oid)?.get_meta("r"))
+}
+
+/// Tree used by the tree-access tests:
+/// README.md, hello.txt ("sub1"), bin.dat (binary), odd.txt (non-UTF-8),
+/// src/{main.rs, lib/{utils.rs}}.
+fn tree_fixture(repo: &git2::Repository) -> anyhow::Result<git2::Oid> {
+    let lib_tree = {
+        let utils = repo.blob(b"pub fn helper() {}")?;
+        let mut b = repo.treebuilder(None)?;
+        b.insert("utils.rs", utils, 0o100644)?;
+        b.write()?
+    };
+    let src_tree = {
+        let main = repo.blob(b"fn main() {}")?;
+        let mut b = repo.treebuilder(None)?;
+        b.insert("main.rs", main, 0o100644)?;
+        b.insert("lib", lib_tree, 0o040000)?;
+        b.write()?
+    };
+    let readme = repo.blob(b"# Project")?;
+    let hello = repo.blob(b"sub1")?;
+    let binary = repo.blob(&[0u8, 159, 146, 150])?;
+    let non_utf8 = repo.blob(&[0xff, 0xfe, 0xfd])?;
+    let mut b = repo.treebuilder(None)?;
+    b.insert("README.md", readme, 0o100644)?;
+    b.insert("hello.txt", hello, 0o100644)?;
+    b.insert("bin.dat", binary, 0o100644)?;
+    b.insert("odd.txt", non_utf8, 0o100644)?;
+    b.insert("src", src_tree, 0o040000)?;
+    Ok(b.write()?)
+}
+
+#[test]
+fn test_nop_module() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))"#,
+        "",
+        "(call $nop)",
+    );
+    let filter = eval(&repo, &wat, &[], tree)?;
+    assert!(filter.is_nop());
+    Ok(())
+}
+
+#[test]
+fn test_subdir_from_data_section() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = r#"(module
+  (import "josh" "nop" (func $nop (result i32)))
+  (import "josh" "subdir" (func $subdir (param i32 i32 i32) (result i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 16) "sub1")
+  (func (export "josh_abi_version") (result i32) (i32.const 1))
+  (func (export "josh_alloc") (param i32) (result i32) (i32.const 1024))
+  (func (export "josh_run") (result i32)
+    (call $subdir (call $nop) (i32.const 16) (i32.const 4))))"#;
+    let filter = eval(&repo, wat, &[], tree)?;
+    assert_eq!(spec(filter), ":/sub1");
+    Ok(())
+}
+
+#[test]
+fn test_chain_and_prefix() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))
+  (import "josh" "subdir" (func $subdir (param i32 i32 i32) (result i32)))
+  (import "josh" "prefix" (func $prefix (param i32 i32 i32) (result i32)))
+  (import "josh" "chain" (func $chain (param i32 i32) (result i32)))"#,
+        r#"(data (i32.const 16) "src") (data (i32.const 24) "lib")"#,
+        r#"(call $chain
+      (call $subdir (call $nop) (i32.const 16) (i32.const 3))
+      (call $prefix (call $nop) (i32.const 24) (i32.const 3)))"#,
+    );
+    let filter = eval(&repo, &wat, &[], tree)?;
+    assert_eq!(spec(filter), ":/src:prefix=lib");
+    Ok(())
+}
+
+#[test]
+fn test_compose() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))
+  (import "josh" "subdir" (func $subdir (param i32 i32 i32) (result i32)))
+  (import "josh" "compose" (func $compose (param i32 i32) (result i32)))"#,
+        r#"(data (i32.const 16) "ab")"#,
+        r#"(i32.store (i32.const 64) (call $subdir (call $nop) (i32.const 16) (i32.const 1)))
+    (i32.store (i32.const 68) (call $subdir (call $nop) (i32.const 17) (i32.const 1)))
+    (call $compose (i32.const 64) (i32.const 2))"#,
+    );
+    let filter = eval(&repo, &wat, &[], tree)?;
+    assert_eq!(spec(filter), ":[:/a,:/b]");
+    Ok(())
+}
+
+#[test]
+fn test_rename_dst_first() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))
+  (import "josh" "rename" (func $rename (param i32 i32 i32 i32 i32) (result i32)))"#,
+        r#"(data (i32.const 16) "dstsrc")"#,
+        r#"(call $rename (call $nop) (i32.const 16) (i32.const 3) (i32.const 19) (i32.const 3))"#,
+    );
+    let filter = eval(&repo, &wat, &[], tree)?;
+    // Destination comes first in the builder and in the spec.
+    assert_eq!(spec(filter), "::dst=src");
+    Ok(())
+}
+
+#[test]
+fn test_tree_file() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = tree_fixture(&repo)?;
+    assert_eq!(
+        probe_string(&repo, tree, "tree_file", "hello.txt", &[])?,
+        Some("sub1".to_string())
+    );
+    assert_eq!(
+        probe_string(&repo, tree, "tree_file", "missing.txt", &[])?,
+        Some("".to_string())
+    );
+    assert_eq!(
+        probe_string(&repo, tree, "tree_file", "bin.dat", &[])?,
+        Some("".to_string())
+    );
+    assert_eq!(
+        probe_string(&repo, tree, "tree_file", "odd.txt", &[])?,
+        Some("".to_string())
+    );
+    // A tree entry is not a blob.
+    assert_eq!(
+        probe_string(&repo, tree, "tree_file", "src", &[])?,
+        Some("".to_string())
+    );
+    Ok(())
+}
+
+#[test]
+fn test_tree_files_and_dirs() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = tree_fixture(&repo)?;
+    // Immediate child blobs only, full paths, git tree entry order.
+    assert_eq!(
+        probe_string(&repo, tree, "tree_files", "", &[])?,
+        Some("README.md\nbin.dat\nhello.txt\nodd.txt".to_string())
+    );
+    assert_eq!(
+        probe_string(&repo, tree, "tree_files", "src", &[])?,
+        Some("src/main.rs".to_string())
+    );
+    assert_eq!(
+        probe_string(&repo, tree, "tree_dirs", "", &[])?,
+        Some("src".to_string())
+    );
+    assert_eq!(
+        probe_string(&repo, tree, "tree_dirs", "src", &[])?,
+        Some("src/lib".to_string())
+    );
+    // Bad paths yield empty results.
+    assert_eq!(
+        probe_string(&repo, tree, "tree_files", "nope", &[])?,
+        Some("".to_string())
+    );
+    assert_eq!(
+        probe_string(&repo, tree, "tree_dirs", "hello.txt", &[])?,
+        Some("".to_string())
+    );
+    Ok(())
+}
+
+#[test]
+fn test_tree_entry_oid() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = tree_fixture(&repo)?;
+    let expected = repo.blob(b"sub1")?.to_string();
+    assert_eq!(
+        probe_string(&repo, tree, "tree_entry_oid", "hello.txt", &[])?,
+        Some(expected)
+    );
+    assert_eq!(
+        probe_string(&repo, tree, "tree_entry_oid", "missing.txt", &[])?,
+        Some("".to_string())
+    );
+    // The empty path names the context tree itself.
+    assert_eq!(
+        probe_string(&repo, tree, "tree_entry_oid", "", &[])?,
+        Some(tree.to_string())
+    );
+    Ok(())
+}
+
+#[test]
+fn test_invocation_args() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    assert_eq!(
+        probe_string(&repo, tree, "invocation_args", "", &[])?,
+        Some("".to_string())
+    );
+    assert_eq!(
+        probe_string(&repo, tree, "invocation_args", "", &["a", "b"])?,
+        Some("a\nb".to_string())
+    );
+    Ok(())
+}
+
+#[test]
+fn test_invalid_handle_traps() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = module(
+        r#"(import "josh" "subdir" (func $subdir (param i32 i32 i32) (result i32)))"#,
+        r#"(data (i32.const 16) "x")"#,
+        r#"(call $subdir (i32.const 99) (i32.const 16) (i32.const 1))"#,
+    );
+    let result = eval(&repo, &wat, &[], tree);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("invalid filter handle")
+    );
+    Ok(())
+}
+
+#[test]
+fn test_bad_abi_version() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = r#"(module
+  (memory (export "memory") 1)
+  (func (export "josh_abi_version") (result i32) (i32.const 2))
+  (func (export "josh_alloc") (param i32) (result i32) (i32.const 1024))
+  (func (export "josh_run") (result i32) (i32.const 0)))"#;
+    let result = eval(&repo, wat, &[], tree);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("ABI version"));
+    Ok(())
+}
+
+#[test]
+fn test_out_of_fuel() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = module("", "", r#"(loop $l (br $l)) (i32.const 0)"#);
+    let result = eval(&repo, &wat, &[], tree);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .to_lowercase()
+            .contains("fuel")
+    );
+    Ok(())
+}
+
+#[test]
+fn test_memory_limit() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    // 4096 pages = 256 MiB, over the default 64 MiB limit.
+    let wat = module(
+        "",
+        "",
+        r#"(drop (memory.grow (i32.const 4096))) (i32.const 0)"#,
+    );
+    let result = eval(&repo, &wat, &[], tree);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn test_table_allocation_limit() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    // A tiny module declaring a huge table minimum: wasmi commits the declared
+    // minimum eagerly at instantiation (before any fuel is consumed), so the
+    // store limits must reject it -- the memory limit alone does not apply to
+    // tables.
+    let wat = r#"(module
+  (table 50000000 funcref)
+  (memory (export "memory") 1)
+  (func (export "josh_abi_version") (result i32) (i32.const 1))
+  (func (export "josh_alloc") (param i32) (result i32) (i32.const 1024))
+  (func (export "josh_run") (result i32) (i32.const 0)))"#;
+    let result = eval(&repo, wat, &[], tree);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn test_multiple_memories_rejected() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    // wasmi's default config enables multi-memory; the store limits cap the
+    // instance at one memory so per-memory limits cannot be stacked.
+    let wat = r#"(module
+  (memory (export "memory") 1)
+  (memory 1)
+  (func (export "josh_abi_version") (result i32) (i32.const 1))
+  (func (export "josh_alloc") (param i32) (result i32) (i32.const 1024))
+  (func (export "josh_run") (result i32) (i32.const 0)))"#;
+    let result = eval(&repo, wat, &[], tree);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn test_handle_limit() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    // One handle over the limit: constructed filters are interned for the
+    // process lifetime, so unbounded construction must trap.
+    let count = *crate::JOSH_WASM_MAX_HANDLES + 1;
+    let body = format!(
+        r#"(local $i i32)
+    (block $done
+      (loop $l
+        (br_if $done (i32.ge_u (local.get $i) (i32.const {count})))
+        (drop (call $nop))
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $l)))
+    (i32.const 0)"#
+    );
+    let wat = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))"#,
+        "",
+        &body,
+    );
+    let result = eval(&repo, &wat, &[], tree);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("filter handle limit")
+    );
+    Ok(())
+}
+
+#[test]
+fn test_tree_file_size_cap() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let content = "a".repeat(100);
+    let blob = repo.blob(content.as_bytes())?;
+    let mut builder = repo.treebuilder(None)?;
+    builder.insert("big.txt", blob, 0o100644)?;
+    let tree = builder.write()?;
+    // Oversized blobs are never materialized host-side; within the cap the
+    // content is returned as usual.
+    assert_eq!(
+        crate::host::tree_file_content(&repo, tree, "big.txt", 10),
+        ""
+    );
+    assert_eq!(
+        crate::host::tree_file_content(&repo, tree, "big.txt", 100),
+        content
+    );
+    Ok(())
+}
+
+#[test]
+fn test_module_size_limit() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let oversized = vec![0u8; *crate::JOSH_WASM_MODULE_SIZE_LIMIT + 1];
+    let module_oid = repo.blob(&oversized)?;
+    let result = crate::evaluate(&repo, module_oid, &[], tree);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("size limit"));
+    Ok(())
+}
+
+#[test]
+fn test_binary_wasm_and_garbage_text() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    // A binary module (with the \0asm magic) runs without WAT assembly.
+    let wat = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))"#,
+        "",
+        "(call $nop)",
+    );
+    let binary = wat::parse_str(&wat)?;
+    assert!(binary.starts_with(b"\0asm"));
+    let module_oid = repo.blob(&binary)?;
+    let filter = crate::evaluate(&repo, module_oid, &[], tree)?;
+    assert!(filter.is_nop());
+    // Garbage text is neither a binary nor valid WAT.
+    let result = eval(&repo, "this is not a wasm module", &[], tree);
+    assert!(result.is_err());
+    Ok(())
+}
+
+#[test]
+fn test_memoization() -> anyhow::Result<()> {
+    let _guard = cache_lock();
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    // Unique data string so this test's module OID is not shared with any
+    // other test (the caches are global and tests run in parallel).
+    let wat = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))"#,
+        r#"(data (i32.const 900) "memoization-test-unique")"#,
+        "(call $nop)",
+    );
+    let module_oid = repo.blob(wat.as_bytes())?;
+    let f1 = crate::evaluate(&repo, module_oid, &[], tree)?;
+    let f2 = crate::evaluate(&repo, module_oid, &[], tree)?;
+    // Filter equality is interned-pointer equality.
+    assert!(f1 == f2);
+    assert_eq!(cache::eval_memo_entries_for(module_oid), 1);
+    // Different args are a different memo key.
+    let _ = crate::evaluate(&repo, module_oid, &["x".to_string()], tree)?;
+    assert_eq!(cache::eval_memo_entries_for(module_oid), 2);
+    Ok(())
+}
+
+#[test]
+fn test_clear_caches() -> anyhow::Result<()> {
+    let _guard = cache_lock();
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))"#,
+        r#"(data (i32.const 900) "clear-caches-test-unique")"#,
+        "(call $nop)",
+    );
+    let module_oid = repo.blob(wat.as_bytes())?;
+    crate::evaluate(&repo, module_oid, &[], tree)?;
+    assert_eq!(cache::eval_memo_entries_for(module_oid), 1);
+    assert!(cache::module_cache().lock().unwrap().contains(&module_oid));
+    crate::clear_caches();
+    assert_eq!(cache::eval_memo_entries_for(module_oid), 0);
+    assert!(!cache::module_cache().lock().unwrap().contains(&module_oid));
+    // Evaluation still works after clearing (recompiles).
+    assert!(crate::evaluate(&repo, module_oid, &[], tree)?.is_nop());
+    Ok(())
+}
+
+#[test]
+fn test_module_lru_eviction() -> anyhow::Result<()> {
+    // Exercised on a local `ModuleLru` with capacity 2 instead of overriding
+    // the global cache's capacity: the global caches are shared across
+    // parallel tests, so shrinking them here would race.
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let engine = crate::wasmi_engine::WasmiEngine::new();
+    let limits = crate::limits();
+    let mut lru = cache::ModuleLru::new(2);
+    let mut oids = Vec::new();
+    for name in ["lru-a", "lru-b", "lru-c"] {
+        let wat = module(
+            r#"(import "josh" "nop" (func $nop (result i32)))"#,
+            &format!(r#"(data (i32.const 900) "{name}")"#),
+            "(call $nop)",
+        );
+        let oid = repo.blob(wat.as_bytes())?;
+        let compiled = engine.load(wat.as_bytes(), &limits)?;
+        lru.insert(oid, compiled);
+        oids.push((oid, wat));
+    }
+    // Capacity 2: the least recently used entry (lru-a) was evicted.
+    assert_eq!(lru.len(), 2);
+    assert!(!lru.contains(&oids[0].0));
+    assert!(lru.contains(&oids[1].0));
+    assert!(lru.contains(&oids[2].0));
+    // A get refreshes recency: after touching lru-b, inserting a fourth
+    // module evicts lru-c instead.
+    assert!(lru.get(&oids[1].0).is_some());
+    let wat_d = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))"#,
+        r#"(data (i32.const 900) "lru-d")"#,
+        "(call $nop)",
+    );
+    let oid_d = repo.blob(wat_d.as_bytes())?;
+    lru.insert(oid_d, engine.load(wat_d.as_bytes(), &limits)?);
+    assert!(lru.contains(&oids[1].0));
+    assert!(!lru.contains(&oids[2].0));
+    // The evicted module still evaluates: it is simply recompiled.
+    let recompiled = engine.load(oids[0].1.as_bytes(), &limits)?;
+    let filter = recompiled.evaluate(
+        EvalContext {
+            repo: &repo,
+            tree_oid: tree,
+            args: &[],
+        },
+        &limits,
+    )?;
+    assert!(filter.is_nop());
+    Ok(())
+}
+
+#[test]
+fn test_wasm_import_traps() -> anyhow::Result<()> {
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))
+  (import "josh" "wasm" (func $wasm (param i32 i32 i32 i32 i32 i32) (result i32)))"#,
+        r#"(data (i32.const 16) "mod")"#,
+        r#"(call $wasm (call $nop) (i32.const 16) (i32.const 3) (i32.const 16) (i32.const 0) (call $nop))"#,
+    );
+    let result = eval(&repo, &wat, &[], tree);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("not wired yet"));
+    Ok(())
+}
+
+#[test]
+fn test_nan_bit_determinism() -> anyhow::Result<()> {
+    // Engine-swap regression guard: 0.0 / 0.0 must produce the canonical
+    // quiet-NaN bit pattern deterministically. An engine that does not
+    // canonicalize NaNs (e.g. wasmtime without nan_canonicalization) fails
+    // this test instead of silently producing nondeterministic filters.
+    let _guard = cache_lock();
+    let repo = temp_repo()?;
+    let tree = empty_tree(&repo)?;
+    let wat = module(
+        r#"(import "josh" "nop" (func $nop (result i32)))
+  (import "josh" "subdir" (func $subdir (param i32 i32 i32) (result i32)))"#,
+        r#"(data (i32.const 16) "ab")"#,
+        r#"(if (result i32)
+      (i64.eq
+        (i64.reinterpret_f64 (f64.div (f64.const 0) (f64.const 0)))
+        (i64.const 0x7ff8000000000000))
+      (then (call $subdir (call $nop) (i32.const 16) (i32.const 1)))
+      (else (call $subdir (call $nop) (i32.const 17) (i32.const 1))))"#,
+    );
+    let first = eval(&repo, &wat, &[], tree)?;
+    assert_eq!(spec(first), ":/a");
+    crate::clear_caches();
+    let second = eval(&repo, &wat, &[], tree)?;
+    assert_eq!(spec(second), ":/a");
+    assert!(first == second);
+    Ok(())
+}

--- a/josh-wasm/src/wasmi_engine.rs
+++ b/josh-wasm/src/wasmi_engine.rs
@@ -1,0 +1,66 @@
+//! The wasmi implementation of the engine traits: a fuel- and memory-limited
+//! store per evaluation, all `"josh"` imports linked, then
+//! `josh_abi_version` (must be 1) followed by `josh_run`.
+
+use crate::engine::{CompiledModule, Engine, EvalContext, Limits};
+use crate::host::{self, HostState};
+use std::sync::Arc;
+
+pub(crate) struct WasmiEngine {
+    engine: wasmi::Engine,
+}
+
+impl WasmiEngine {
+    pub(crate) fn new() -> WasmiEngine {
+        let mut config = wasmi::Config::default();
+        config.consume_fuel(true);
+        WasmiEngine {
+            engine: wasmi::Engine::new(&config),
+        }
+    }
+}
+
+impl Engine for WasmiEngine {
+    fn load(&self, bytes: &[u8], _limits: &Limits) -> anyhow::Result<Arc<dyn CompiledModule>> {
+        let module = wasmi::Module::new(&self.engine, bytes)?;
+        Ok(Arc::new(WasmiModule {
+            engine: self.engine.clone(),
+            module,
+        }))
+    }
+}
+
+struct WasmiModule {
+    engine: wasmi::Engine,
+    module: wasmi::Module,
+}
+
+impl CompiledModule for WasmiModule {
+    fn evaluate(
+        &self,
+        ctx: EvalContext<'_>,
+        limits: &Limits,
+    ) -> anyhow::Result<josh_filter::Filter> {
+        let state = HostState::new(&ctx, limits);
+        let mut store = wasmi::Store::new(&self.engine, state);
+        store.set_fuel(limits.fuel)?;
+        store.limiter(|state| state.limiter());
+        let mut linker = wasmi::Linker::new(&self.engine);
+        host::add_to_linker(&mut linker)?;
+        let instance = linker.instantiate_and_start(&mut store, &self.module)?;
+        let abi_version = instance
+            .get_typed_func::<(), u32>(&store, "josh_abi_version")?
+            .call(&mut store, ())?;
+        anyhow::ensure!(
+            abi_version == 1,
+            "unsupported josh ABI version: {}",
+            abi_version
+        );
+        let handle = instance
+            .get_typed_func::<(), u32>(&store, "josh_run")?
+            .call(&mut store, ())?;
+        store.data().handle(handle).ok_or_else(|| {
+            anyhow::anyhow!("josh_run returned an invalid filter handle: {}", handle)
+        })
+    }
+}


### PR DESCRIPTION
Add josh-wasm crate with a wasmi-backed filter evaluation runtime

New native workspace member implementing Stage 1 of rfcs/wasm-filter.md:
a sandboxed, deterministic runtime that evaluates a wasm filter module
(blob OID) against a context-filtered tree and returns the
josh_filter::Filter the guest constructs through the "josh" host
imports. Nothing references the crate yet; wiring into josh-core lands
with the Op::Wasm rename.

- ABI v1: guest exports memory/josh_abi_version/josh_alloc/josh_run;
  the full builder import set delegating 1:1 to josh_filter::Filter,
  tree_file/tree_files/tree_dirs/tree_entry_oid replicating the Starlark
  tree semantics with git2 only, and invocation_args. Host-to-guest
  strings are written into buffers obtained by re-entrantly calling the
  guest's josh_alloc and returned as packed i64 (ptr<<32|len).
- wasmi 1.1 behind internal Engine/CompiledModule traits as insurance
  for a later engine swap, guarded by a NaN-bit determinism test.
- Resource limits via env vars: JOSH_WASM_FUEL, JOSH_WASM_MEMORY_LIMIT
  (StoreLimits with trap-on-grow), JOSH_WASM_MODULE_SIZE_LIMIT,
  JOSH_WASM_MODULE_CACHE_SIZE, JOSH_WASM_MAX_DEPTH (consumed by
  josh-core later).
- Caching: bounded hand-rolled LRU of compiled modules keyed by blob
  OID plus an unbounded evaluation memo keyed by (module OID, args,
  filtered tree OID), both behind josh_wasm::clear_caches().
- Blobs without the wasm magic that are valid UTF-8 are assembled as
  WAT, keeping simple filters human-readable in the repo.
- The 'wasm' builder import is registered with its final signature but
  traps until Filter::wasm exists after the op rename.

Change: josh-wasm-runtime
Assisted-By: anthropic/claude-fable-5