### PR TITLE
Store distributed cache entries only for merges that skip a sample point

### DIFF
--- a/josh-core/src/cache/backend.rs
+++ b/josh-core/src/cache/backend.rs
@@ -23,13 +23,24 @@ pub trait CacheBackend: Send + Sync {
 
 /// Per-commit history-graph facts passed along with every cache record.
 ///
-/// Both fields come from the cached hint maintained by the history-graph
+/// All fields come from the cached hint maintained by the history-graph
 /// walk, so producing them never requires reading the commit itself.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HistoryGraphHint {
     pub sequence_number: u64,
     /// Number of parents of the commit, capped at 255. Backends only
-    /// distinguish "exactly one parent" from merges (> 1) and orphans (0),
-    /// so the cap is lossless for eligibility purposes.
+    /// distinguish "exactly one parent" from two-parent merges, octopus
+    /// merges (> 2) and orphans (0), so the cap is lossless for eligibility
+    /// purposes.
     pub parent_count: u8,
+    /// Sequence-number distance to the farther of the first two parents,
+    /// saturating at 127 ("at least 127"). The sequence number is
+    /// `max(parents) + 1`, so for single-parent commits this is always 1 and
+    /// for two-parent merges the *other* parent is always at distance exactly
+    /// 1 — this value carries the only non-trivial distance. Parents beyond
+    /// the first two are not covered (octopus merges are handled
+    /// unconditionally by eligibility).
+    pub jump_delta: u8,
+    /// True when the parent measured by `jump_delta` is the second parent.
+    pub jump_is_second: bool,
 }

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -171,11 +171,35 @@ impl DistributedCacheBackend {
 // is used in addition to the sparse cache.
 // The sparse cache is mostly only used for initial "cold starts" or longer "catch up".
 // For incremental filtering it's fine re-filter commits and rely on the local "dense" cache.
-// We store entries for 1% of all commits, and additionally all merges and orphans.
-// The parent count comes from the cached history-graph hint, so this check never
-// reads the commit from the ODB.
+// We store entries for 1% of all commits (sampled by sequence number), and
+// additionally every commit the sampling alone cannot bound: orphans (a walk
+// path ends there with no parent whose entry could terminate it), octopus
+// merges (the hint only covers the first two parents), and two-parent merges
+// whose backward jump skips over a sample point. A single-parent step always
+// decreases the sequence number by exactly 1, so any walk path reaches a
+// stored entry within at most 100 steps: either it takes 100 consecutive
+// unit steps and crosses a multiple of 100, or it hits one of the stored
+// jump/end commits first.
+// Everything needed comes from the cached history-graph hint, so this check
+// never reads the commit from the ODB.
 fn is_eligible(hint: HistoryGraphHint) -> bool {
-    hint.sequence_number % 100 == 0 || hint.parent_count != 1
+    if hint.sequence_number % 100 == 0 {
+        return true;
+    }
+    match hint.parent_count {
+        1 => false,
+        2 => crosses_sample_boundary(hint.sequence_number, hint.jump_delta),
+        _ => true,
+    }
+}
+
+// True when a backward step of `delta` from `seq` skips over a multiple of 100,
+// i.e. the sampled commit that would otherwise bound the walk on this path is
+// jumped over. `delta` saturates at 127, meaning "at least 127": any jump of
+// 100 or more crosses a boundary, so the saturated value still decodes
+// correctly.
+fn crosses_sample_boundary(seq: u64, delta: u8) -> bool {
+    seq.saturating_sub(delta as u64) / 100 < seq / 100
 }
 
 // To additionally limit the size of the trees the cache is also sharded by sequence

--- a/josh-core/src/cache/history_graph.rs
+++ b/josh-core/src/cache/history_graph.rs
@@ -11,8 +11,10 @@
 //! its parent's blob OID — no read or write — so the hot path is cheap.
 //!
 //! The `sequence_number` slot stores a synthetic OID that also carries the
-//! commit's parent count in a spare byte (see `oid_from_hint`), so cache
-//! backends can classify commits as merges/orphans without reading them.
+//! commit's parent count and the sequence distance to its farther first-two
+//! parent in spare bytes (see `oid_from_hint`), so cache backends can classify
+//! commits as merges/orphans and detect sequence-number jumps without reading
+//! them.
 
 use anyhow::anyhow;
 
@@ -37,21 +39,17 @@ pub struct HistoryGraphInfo {
 /// only compare sequence numbers avoid a per-commit `find_blob` + parse that
 /// would otherwise be discarded.
 pub fn compute_sequence_number(transaction: &Transaction, input: git2::Oid) -> anyhow::Result<u64> {
-    Ok(ensure_hint_cached(transaction, input)?.0)
+    Ok(ensure_hint_cached(transaction, input)?.0.sequence_number)
 }
 
-/// Returns the cached `(sequence number, parent count)` for `input` without
-/// reading the roots blob. Both values are decoded from the same cached hint,
-/// so cache backends can make eligibility decisions without any commit read.
+/// Returns the cached hint for `input` without reading the roots blob. All
+/// fields are decoded from the same cached hint, so cache backends can make
+/// eligibility decisions without any commit read.
 pub fn compute_history_hint(
     transaction: &Transaction,
     input: git2::Oid,
 ) -> anyhow::Result<HistoryGraphHint> {
-    let (sequence_number, parent_count, _) = ensure_hint_cached(transaction, input)?;
-    Ok(HistoryGraphHint {
-        sequence_number,
-        parent_count,
-    })
+    Ok(ensure_hint_cached(transaction, input)?.0)
 }
 
 /// Computes sequence number and reachable roots for `input` in a single walk,
@@ -64,10 +62,10 @@ pub fn collect_history_graph_info(
     transaction: &Transaction,
     input: git2::Oid,
 ) -> anyhow::Result<HistoryGraphInfo> {
-    let (seq, _, blob) = ensure_hint_cached(transaction, input)?;
+    let (hint, blob) = ensure_hint_cached(transaction, input)?;
 
     Ok(HistoryGraphInfo {
-        sequence_number: seq,
+        sequence_number: hint.sequence_number,
         reachable_roots: read_roots_blob(transaction.repo(), blob)?,
     })
 }
@@ -91,7 +89,7 @@ pub fn parents_share_root(
     // identical — they trivially share every root without reading any blob.
     let parent_blobs: Vec<git2::Oid> = parent_ids
         .iter()
-        .map(|p| Ok(ensure_hint_cached(transaction, *p)?.2))
+        .map(|p| Ok(ensure_hint_cached(transaction, *p)?.1))
         .collect::<anyhow::Result<Vec<_>>>()?;
 
     let first_blob = parent_blobs[0];
@@ -117,7 +115,7 @@ pub fn parents_share_root(
 }
 
 /// Ensures `(sequence_number, reachable_roots)` are cached for `input` and
-/// returns the cached `(seq, parent_count, roots_blob_oid)`. Performs a
+/// returns the cached `(hint, roots_blob_oid)`. Performs a
 /// topological walk only if neither piece is cached for `input`. Inside the
 /// walk, each commit's roots blob is reused from its parent when parents
 /// agree, so the common case (linear or shared-root merges) avoids ODB reads
@@ -125,7 +123,7 @@ pub fn parents_share_root(
 fn ensure_hint_cached(
     transaction: &Transaction,
     input: git2::Oid,
-) -> anyhow::Result<(u64, u8, git2::Oid)> {
+) -> anyhow::Result<(HistoryGraphHint, git2::Oid)> {
     if let Some(hint) = try_read_cached_hint(transaction, input)? {
         return Ok(hint);
     }
@@ -139,7 +137,10 @@ fn ensure_hint_cached(
     // Fast path: every parent already has both pieces cached.
     let parents_hint: Option<Vec<(u64, git2::Oid)>> = parent_ids
         .iter()
-        .map(|p| Ok(try_read_cached_hint(transaction, *p)?.map(|(seq, _, blob)| (seq, blob))))
+        .map(|p| {
+            Ok(try_read_cached_hint(transaction, *p)?
+                .map(|(hint, blob)| (hint.sequence_number, blob)))
+        })
         .collect::<anyhow::Result<_>>()?;
 
     if let Some(parents_hint) = parents_hint {
@@ -176,7 +177,7 @@ fn ensure_hint_cached(
                 .into_iter()
                 .map(|p| {
                     try_read_cached_hint(transaction, p)?
-                        .map(|(seq, _, blob)| (seq, blob))
+                        .map(|(hint, blob)| (hint.sequence_number, blob))
                         .ok_or_else(|| anyhow!("parent {} hint missing during walk for {}", p, oid))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
@@ -189,17 +190,25 @@ fn ensure_hint_cached(
 }
 
 /// Given that all parents have cached `(seq, roots_blob_oid)`, derive the
-/// `(seq, parent_count, roots_blob_oid)` for `self_oid`. Performs blob I/O
+/// `(hint, roots_blob_oid)` for `self_oid`. Performs blob I/O
 /// only when parents disagree on the blob; otherwise reuses the parent blob
 /// OID (or, for the root case, writes a single-element blob).
 fn derive_from_parents(
     repo: &git2::Repository,
     self_oid: git2::Oid,
     parents_hint: &[(u64, git2::Oid)],
-) -> anyhow::Result<(u64, u8, git2::Oid)> {
+) -> anyhow::Result<(HistoryGraphHint, git2::Oid)> {
     if parents_hint.is_empty() {
         // Parentless: this commit *is* its own only reachable root.
-        return Ok((0, 0, write_roots_blob(repo, &[self_oid])?));
+        return Ok((
+            HistoryGraphHint {
+                sequence_number: 0,
+                parent_count: 0,
+                jump_delta: 0,
+                jump_is_second: false,
+            },
+            write_roots_blob(repo, &[self_oid])?,
+        ));
     }
 
     let parent_count = parents_hint.len().min(255) as u8;
@@ -210,6 +219,15 @@ fn derive_from_parents(
         .max()
         .expect("non-empty")
         + 1;
+
+    // Distance to the farther of the first two parents. The max parent is at
+    // distance exactly 1, so for two-parent merges this captures the only
+    // non-trivial distance; parents beyond the first two are not covered.
+    let d0 = seq - parents_hint[0].0;
+    let (jump_delta, jump_is_second) = match parents_hint.get(1) {
+        Some((s1, _)) if seq - s1 > d0 => ((seq - s1).min(127) as u8, true),
+        _ => (d0.min(127) as u8, false),
+    };
 
     let first_blob = parents_hint[0].1;
     let roots_blob = if parents_hint.iter().all(|(_, b)| *b == first_blob) {
@@ -223,36 +241,40 @@ fn derive_from_parents(
         write_roots_blob(repo, &roots)?
     };
 
-    Ok((seq, parent_count, roots_blob))
+    Ok((
+        HistoryGraphHint {
+            sequence_number: seq,
+            parent_count,
+            jump_delta,
+            jump_is_second,
+        },
+        roots_blob,
+    ))
 }
 
 fn try_read_cached_hint(
     transaction: &Transaction,
     input: git2::Oid,
-) -> anyhow::Result<Option<(u64, u8, git2::Oid)>> {
+) -> anyhow::Result<Option<(HistoryGraphHint, git2::Oid)>> {
     let Some(seq) = transaction.get(crate::filter::sequence_number(), input)? else {
         return Ok(None);
     };
     let Some(roots_blob) = transaction.get(crate::filter::reachable_roots(), input)? else {
         return Ok(None);
     };
-    Ok(Some((
-        u64_from_oid(seq),
-        parent_count_from_oid(seq),
-        roots_blob,
-    )))
+    Ok(Some((hint_from_oid(seq), roots_blob)))
 }
 
 fn store_hint(
     transaction: &Transaction,
     input: git2::Oid,
-    hint: (u64, u8, git2::Oid),
+    hint: (HistoryGraphHint, git2::Oid),
 ) -> anyhow::Result<()> {
-    let (seq, parent_count, roots_blob) = hint;
+    let (hint, roots_blob) = hint;
     transaction.insert(
         crate::filter::sequence_number(),
         input,
-        oid_from_hint(seq, parent_count),
+        oid_from_hint(hint),
         true,
     )?;
     transaction.insert(crate::filter::reachable_roots(), input, roots_blob, true)?;
@@ -284,46 +306,53 @@ fn read_roots_blob(repo: &git2::Repository, oid: git2::Oid) -> anyhow::Result<Ve
     Ok(out)
 }
 
-/// Encode a `(sequence number, parent count)` hint into a 20-byte git OID
-/// (SHA-1 sized). Bytes 0-10 of the OID are zero, byte 11 holds the parent
-/// count (capped at 255), and bytes 12-19 contain the big-endian sequence
-/// number.
-pub(crate) fn oid_from_hint(seq: u64, parent_count: u8) -> git2::Oid {
+/// Encode a [`HistoryGraphHint`] into a 20-byte git OID (SHA-1 sized). Bytes
+/// 0-9 of the OID are zero, byte 10 packs the jump: bit 7 set when the jump
+/// parent is the second parent, bits 0-6 the jump delta (saturated at 127).
+/// Byte 11 holds the parent count (capped at 255) and bytes 12-19 the
+/// big-endian sequence number.
+pub(crate) fn oid_from_hint(hint: HistoryGraphHint) -> git2::Oid {
     let mut bytes = [0u8; 20];
-    bytes[11] = parent_count;
+    bytes[10] = ((hint.jump_is_second as u8) << 7) | hint.jump_delta;
+    bytes[11] = hint.parent_count;
     // place the 8 integer bytes at the end (big-endian)
-    bytes[20 - 8..].copy_from_slice(&seq.to_be_bytes());
+    bytes[20 - 8..].copy_from_slice(&hint.sequence_number.to_be_bytes());
     // Safe: length is exactly 20
     git2::Oid::from_bytes(&bytes).expect("20-byte OID construction cannot fail")
 }
 
-/// Decode the sequence number from an OID encoded by `oid_from_hint`.
-pub(crate) fn u64_from_oid(oid: git2::Oid) -> u64 {
+/// Decode a hint from an OID encoded by `oid_from_hint`.
+pub(crate) fn hint_from_oid(oid: git2::Oid) -> HistoryGraphHint {
     let b = oid.as_bytes();
     let mut n = [0u8; 8];
     n.copy_from_slice(&b[20 - 8..]); // take the last 8 bytes
-    u64::from_be_bytes(n)
-}
-
-/// Decode the parent count from an OID encoded by `oid_from_hint`.
-pub(crate) fn parent_count_from_oid(oid: git2::Oid) -> u8 {
-    oid.as_bytes()[11]
+    HistoryGraphHint {
+        sequence_number: u64::from_be_bytes(n),
+        parent_count: b[11],
+        jump_delta: b[10] & 0x7f,
+        jump_is_second: b[10] & 0x80 != 0,
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{oid_from_hint, parent_count_from_oid, u64_from_oid};
+    use super::{HistoryGraphHint, hint_from_oid, oid_from_hint};
 
     #[test]
-    fn oid_hint_roundtrip_uses_last_9_bytes() {
-        let value = 0x0123_4567_89ab_cdef_u64;
-        let oid = oid_from_hint(value, 7);
+    fn oid_hint_roundtrip_uses_last_10_bytes() {
+        let hint = HistoryGraphHint {
+            sequence_number: 0x0123_4567_89ab_cdef_u64,
+            parent_count: 7,
+            jump_delta: 42,
+            jump_is_second: true,
+        };
+        let oid = oid_from_hint(hint);
         let bytes = oid.as_bytes();
 
-        assert!(bytes[..11].iter().all(|byte| *byte == 0));
+        assert!(bytes[..10].iter().all(|byte| *byte == 0));
+        assert_eq!(bytes[10], 0x80 | 42);
         assert_eq!(bytes[11], 7);
-        assert_eq!(&bytes[12..], &value.to_be_bytes());
-        assert_eq!(u64_from_oid(oid), value);
-        assert_eq!(parent_count_from_oid(oid), 7);
+        assert_eq!(&bytes[12..], &hint.sequence_number.to_be_bytes());
+        assert_eq!(hint_from_oid(oid), hint);
     }
 }

--- a/josh-core/src/cache/mod.rs
+++ b/josh-core/src/cache/mod.rs
@@ -8,7 +8,10 @@ mod tree_cache;
 
 /// Schema version for on-disk cache structures. Bump when the layout of the
 /// sled trees or distributed cache refs changes incompatibly.
-pub const CACHE_VERSION: u64 = 32;
+/// Version 33: history hints gained the jump-delta byte and jump-parent flag;
+/// old hints would decode as jump_delta 0 and never classify as a boundary
+/// crossing.
+pub const CACHE_VERSION: u64 = 33;
 
 pub use backend::{CacheBackend, HistoryGraphHint};
 pub use distributed::DistributedCacheBackend;

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -542,6 +542,8 @@ impl Transaction {
             HistoryGraphHint {
                 sequence_number: 0,
                 parent_count: 1,
+                jump_delta: 1,
+                jump_is_second: false,
             }
         };
         let mut t2 = self.t2.borrow_mut();
@@ -610,6 +612,8 @@ impl Transaction {
             HistoryGraphHint {
                 sequence_number: 0,
                 parent_count: 1,
+                jump_delta: 1,
+                jump_is_second: false,
             }
         };
         let t2 = self.t2.borrow_mut();

--- a/tests/cli/cache.t
+++ b/tests/cli/cache.t
@@ -45,13 +45,13 @@ Build the distributed cache (applies the filter to already-fetched refs)
 Verify local cache refs were created
 
   $ git for-each-ref --format='%(refname)' 'refs/josh/cache/'
-  refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+  refs/josh/cache/33/0/bf567e0faf634a663d6cef48145a035e1974ab1d
 
 Push the distributed cache and filtered ref to the backing remote
 
   $ josh cache push
   To file://${TESTTMP}/remote/libs
-   * [new reference]   refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d -> refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+   * [new reference]   refs/josh/cache/33/0/bf567e0faf634a663d6cef48145a035e1974ab1d -> refs/josh/cache/33/0/bf567e0faf634a663d6cef48145a035e1974ab1d
   
   To file://${TESTTMP}/remote/libs
    * [new reference]   refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master -> refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master
@@ -84,7 +84,7 @@ Fetch the distributed cache and filtered objects from the remote
 
   $ josh cache fetch
   From file://${TESTTMP}/remote/libs
-   * [new ref]         refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d -> refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+   * [new ref]         refs/josh/cache/33/0/bf567e0faf634a663d6cef48145a035e1974ab1d -> refs/josh/cache/33/0/bf567e0faf634a663d6cef48145a035e1974ab1d
   
   From file://${TESTTMP}/remote/libs
    * [new ref]         refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master -> refs/josh/filtered/bf567e0faf634a663d6cef48145a035e1974ab1d/heads/master
@@ -94,7 +94,7 @@ Fetch the distributed cache and filtered objects from the remote
 Verify cache refs are now present locally
 
   $ git for-each-ref --format='%(refname)' 'refs/josh/cache/'
-  refs/josh/cache/32/0/bf567e0faf634a663d6cef48145a035e1974ab1d
+  refs/josh/cache/33/0/bf567e0faf634a663d6cef48145a035e1974ab1d
 
   $ cd ${TESTTMP}
 

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -125,7 +125,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/authentication.t
+++ b/tests/proxy/authentication.t
@@ -125,7 +125,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/caching.t
+++ b/tests/proxy/caching.t
@@ -52,7 +52,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf
@@ -162,7 +162,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_absent_head.t
+++ b/tests/proxy/clone_absent_head.t
@@ -86,7 +86,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_all.t
+++ b/tests/proxy/clone_all.t
@@ -54,7 +54,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_invalid_url.t
+++ b/tests/proxy/clone_invalid_url.t
@@ -31,7 +31,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -75,7 +75,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_sha.t
+++ b/tests/proxy/clone_sha.t
@@ -94,7 +94,7 @@ Check (2) and (3) but with a branch ref
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -88,7 +88,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -86,7 +86,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_subtree_no_master.t
+++ b/tests/proxy/clone_subtree_no_master.t
@@ -79,7 +79,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -118,7 +118,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/empty_commit.t
+++ b/tests/proxy/empty_commit.t
@@ -84,7 +84,7 @@ should still be included.
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/get_version.t
+++ b/tests/proxy/get_version.t
@@ -8,7 +8,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -302,7 +302,7 @@ Flushed credential cache
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -60,7 +60,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -341,7 +341,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/no_proxy.t
+++ b/tests/proxy/no_proxy.t
@@ -36,7 +36,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/no_proxy_lfs.t
+++ b/tests/proxy/no_proxy_lfs.t
@@ -51,7 +51,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_graphql.t
+++ b/tests/proxy/push_graphql.t
@@ -70,7 +70,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -115,7 +115,7 @@ Check the branch again
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_new_orphan_branch.t
+++ b/tests/proxy/push_new_orphan_branch.t
@@ -126,7 +126,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -57,7 +57,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -88,7 +88,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_review_already_in.t
+++ b/tests/proxy/push_review_already_in.t
@@ -49,7 +49,7 @@ test for that.
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_review_nop_behind.t
+++ b/tests/proxy/push_review_nop_behind.t
@@ -56,7 +56,7 @@ This is a regression test for that problem.
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -86,7 +86,7 @@ Flushed credential cache
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -43,7 +43,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -168,7 +168,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_stacked_gerrit.t
+++ b/tests/proxy/push_stacked_gerrit.t
@@ -110,7 +110,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_stacked_split.t
+++ b/tests/proxy/push_stacked_split.t
@@ -86,7 +86,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -151,7 +151,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -49,7 +49,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -91,7 +91,7 @@ Make sure all temporary namespace got removed
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -119,7 +119,7 @@ Put a double slash in the URL to see that it also works
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/unrelated_leak.t
+++ b/tests/proxy/unrelated_leak.t
@@ -134,7 +134,7 @@ Flushed credential cache
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -226,7 +226,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -443,7 +443,7 @@ Note that ws/d/ is now present in the ws
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -103,7 +103,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -197,7 +197,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -246,7 +246,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -185,7 +185,7 @@ Flushed credential cache
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -442,7 +442,7 @@ Note that ws/d/ is now present in the ws
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -250,7 +250,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -305,7 +305,7 @@ Note that ws/d/ is now present in the ws
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -89,7 +89,7 @@ file was created
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -126,7 +126,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -232,7 +232,7 @@
   .
   |-- josh
   |   `-- cache
-  |       `-- 32
+  |       `-- 33
   |           `-- sled
   |               |-- blobs
   |               |-- conf


### PR DESCRIPTION
Store distributed cache entries only for merges that skip a sample point

The distributed cache stored an entry for every merge and orphan on top of the
1% sequence-number sampling. The merge rule exists because sequence numbers are
generation numbers (max over parents + 1): a single-parent step always decreases
the sequence by exactly 1, so any linear run of 100 commits crosses a multiple
of 100 and hits a sampled entry, but stepping back through a merge to its
non-max parent jumps the sequence down arbitrarily and can hop over sample
points indefinitely. Storing every merge patched that, at the cost of making
the "sparse" cache effectively dense on bors-style repos where nearly every
mainline commit is a merge.

Only the merges whose jump actually crosses a sample boundary are needed to
preserve the walk bound. The history hint now carries that jump: one spare byte
of the synthetic hint OID packs the sequence distance to the farther of the
first two parents (7 bits, saturating at 127, i.e. "at least 127" -- lossless
for any sampling modulus up to 127) and a bit for which parent it is. The
distance is derived in derive_from_parents where the parent sequence numbers
are already in hand, so eligibility stays pure arithmetic on the hint with no
ODB read on either the read or write path.

is_eligible keeps sampled commits, orphans and octopus merges (the hint only
covers two parents; they are rare) unconditionally, and stores a two-parent
merge only when its jump skips over a multiple of 100. Every walk path still
reaches a stored entry within at most 100 steps: it either takes 100 unit
steps and crosses a sample point, or ends at a stored jump/orphan first. The
cost is bounded re-filtering on cold starts: side branches behind unstored
in-block merges are re-filtered locally instead of being cut off by a stored
merge entry.

Bump CACHE_VERSION to 33: old hints have zeros in the jump byte and would
never classify as a boundary crossing.

Change: sparse-cache-jump-delta
Assisted-By: anthropic/claude-fable-5