### PR TITLE
Migrate starlark filter tests to wasm guests with a blob helper

### DIFF
--- a/josh-wasm/tests/starlark_guest.rs
+++ b/josh-wasm/tests/starlark_guest.rs
@@ -1,0 +1,213 @@
+//! Integration tests for the josh-starlark-guest interpreter blob.
+//!
+//! These run the built interpreter through `josh_wasm::evaluate`, replicating
+//! the spec assertions of the old native josh-starlark test suite. The blob
+//! is multi-MiB and not committed, so every test skips with a note on stderr
+//! when it is absent — a plain `cargo test --workspace` stays green without a
+//! wasm toolchain. Build it with `sh scripts/build-starlark-guest.sh`, or
+//! point `JOSH_STARLARK_GUEST_WASM` at a pre-built blob.
+
+use josh_filter::spec;
+
+fn blob_bytes() -> Option<Vec<u8>> {
+    let path = match std::env::var_os("JOSH_STARLARK_GUEST_WASM") {
+        Some(p) => std::path::PathBuf::from(p),
+        None => std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../josh-guest/target/wasm32-unknown-unknown/release/josh_starlark_guest.wasm"),
+    };
+    match std::fs::read(&path) {
+        Ok(bytes) => Some(bytes),
+        Err(_) => {
+            eprintln!(
+                "skipping: starlark interpreter blob not found at {} \
+                 (build with `sh scripts/build-starlark-guest.sh`)",
+                path.display()
+            );
+            None
+        }
+    }
+}
+
+/// A fresh bare repository in a unique temp directory.
+fn temp_repo() -> anyhow::Result<git2::Repository> {
+    static DIR_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let temp_dir = std::env::temp_dir().join(format!(
+        "josh_wasm_starlark_guest_test_{}_{}_{}",
+        std::process::id(),
+        DIR_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    Ok(git2::Repository::init_bare(&temp_dir)?)
+}
+
+/// Evaluate `script` through the interpreter blob: the script is committed as
+/// `config.star` on top of `base_tree` (the context tree the script may
+/// inspect) and its path passed as the first invocation argument.
+fn eval_script(
+    repo: &git2::Repository,
+    blob: &[u8],
+    script: &str,
+    base_tree: Option<git2::Oid>,
+) -> anyhow::Result<josh_filter::Filter> {
+    let module_oid = repo.blob(blob)?;
+    let script_oid = repo.blob(script.as_bytes())?;
+    let base = match base_tree {
+        Some(oid) => Some(repo.find_tree(oid)?),
+        None => None,
+    };
+    let mut builder = repo.treebuilder(base.as_ref())?;
+    builder.insert("config.star", script_oid, 0o100644)?;
+    let tree_oid = builder.write()?;
+    josh_wasm::evaluate(repo, module_oid, &["config.star".to_string()], tree_oid)
+}
+
+/// The tree the old native tree-access tests used:
+/// README.md, src/{main.rs, lib/{utils.rs}}.
+fn tree_fixture(repo: &git2::Repository) -> anyhow::Result<git2::Oid> {
+    let lib_tree = {
+        let utils = repo.blob(b"pub fn helper() {}")?;
+        let mut b = repo.treebuilder(None)?;
+        b.insert("utils.rs", utils, 0o100644)?;
+        b.write()?
+    };
+    let src_tree = {
+        let main = repo.blob(b"fn main() {}")?;
+        let mut b = repo.treebuilder(None)?;
+        b.insert("main.rs", main, 0o100644)?;
+        b.insert("lib", lib_tree, 0o040000)?;
+        b.write()?
+    };
+    let readme = repo.blob(b"# Project")?;
+    let mut b = repo.treebuilder(None)?;
+    b.insert("README.md", readme, 0o100644)?;
+    b.insert("src", src_tree, 0o040000)?;
+    Ok(b.write()?)
+}
+
+#[test]
+fn test_simple_filter() -> anyhow::Result<()> {
+    let Some(blob) = blob_bytes() else {
+        return Ok(());
+    };
+    let repo = temp_repo()?;
+    let filter = eval_script(&repo, &blob, r#"filter = filter.subdir("src")"#, None)?;
+    assert_eq!(spec(filter), ":/src");
+    Ok(())
+}
+
+#[test]
+fn test_chain_filter() -> anyhow::Result<()> {
+    let Some(blob) = blob_bytes() else {
+        return Ok(());
+    };
+    let repo = temp_repo()?;
+    let filter = eval_script(
+        &repo,
+        &blob,
+        r#"filter = filter.subdir("src").prefix("lib")"#,
+        None,
+    )?;
+    assert_eq!(spec(filter), ":/src:prefix=lib");
+    Ok(())
+}
+
+#[test]
+fn test_file_filter() -> anyhow::Result<()> {
+    let Some(blob) = blob_bytes() else {
+        return Ok(());
+    };
+    let repo = temp_repo()?;
+    let filter = eval_script(&repo, &blob, r#"filter = filter.file("README.md")"#, None)?;
+    // file() creates a rename from the same path to itself: ::README.md
+    assert_eq!(spec(filter), "::README.md");
+    Ok(())
+}
+
+#[test]
+fn test_compose() -> anyhow::Result<()> {
+    let Some(blob) = blob_bytes() else {
+        return Ok(());
+    };
+    let repo = temp_repo()?;
+    let script = r#"
+f1 = filter.subdir("src")
+f2 = filter.subdir("lib")
+filter = compose([f1, f2])
+"#;
+    let filter = eval_script(&repo, &blob, script, None)?;
+    assert_eq!(spec(filter), ":[:/src,:/lib]");
+    Ok(())
+}
+
+#[test]
+fn test_tree_build_filter_from_all_files() -> anyhow::Result<()> {
+    let Some(blob) = blob_bytes() else {
+        return Ok(());
+    };
+    let repo = temp_repo()?;
+    let base = tree_fixture(&repo)?;
+    // Unlike the old native test, the script itself is part of the tree it
+    // walks (it must be in the context to be runnable), so it skips .star
+    // files to reproduce the historical expected spec.
+    let script = r#"
+def collect_all_files(dir_path=""):
+    """Recursively collect all files and build filters"""
+    filters = []
+    for file_path in tree.files(dir_path):
+        if not file_path.endswith(".star"):
+            filters.append(filter.file(file_path))
+    for subdir_path in tree.dirs(dir_path):
+        filters.extend(collect_all_files(subdir_path))
+    return filters
+
+all_file_filters = collect_all_files("")
+filter = compose(all_file_filters)
+"#;
+    let filter = eval_script(&repo, &blob, script, Some(base))?;
+    // File filters with multi-component paths decompose into Subdir + File +
+    // Prefix chains; common Subdir/Prefix layers get factored out.
+    assert_eq!(
+        spec(filter),
+        ":[::README.md,:/src:[:/lib::utils.rs:prefix=lib,::main.rs]:prefix=src]"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_determinism_across_cache_clear() -> anyhow::Result<()> {
+    let Some(blob) = blob_bytes() else {
+        return Ok(());
+    };
+    let repo = temp_repo()?;
+    // Iterates a dynamically built dict to smoke iteration-order stability in
+    // the interpreter internals (wasm has no entropy imports, so hash seeds
+    // are fixed; this guards against order nondeterminism regardless). The
+    // loops live inside a def: Dialect::Standard forbids top-level `for`.
+    let script = r#"
+def build():
+    d = {}
+    for i in range(20):
+        d["k" + str(i)] = "sub" + str(i)
+    parts = []
+    for k in d:
+        parts.append(filter.subdir(d[k]).prefix(k))
+    for k in sorted(d.keys(), reverse = True):
+        parts.append(filter.subdir(d[k]))
+    return parts
+
+filter = compose(build())
+"#;
+    let first = eval_script(&repo, &blob, script, None)?;
+    let first_spec = spec(first);
+    josh_wasm::clear_caches();
+    let second = eval_script(&repo, &blob, script, None)?;
+    // Filters are interned: equality is node identity, so an identical spec
+    // AND an identical handle prove the two evaluations produced the same
+    // filter even though the second one fully re-ran (caches were cleared).
+    assert_eq!(first, second);
+    assert_eq!(first_spec, spec(second));
+    Ok(())
+}

--- a/scripts/wasm-guest-blob.sh
+++ b/scripts/wasm-guest-blob.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Print the absolute path of a built guest wasm blob, building it on demand.
+#
+# Usage: wasm-guest-blob.sh starlark|example
+#
+# The build is skipped when the artifact already exists; set JOSH_GUEST_REBUILD
+# to force a rebuild. For containerized runs without a cargo toolchain,
+# JOSH_STARLARK_GUEST_WASM overrides the starlark blob location with a
+# pre-built file. run-tests.sh prepends scripts/ to PATH, so scrut test
+# fixtures call this helper by name.
+set -e
+
+kind="${1:?usage: wasm-guest-blob.sh starlark|example}"
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+release_dir="${root}/josh-guest/target/wasm32-unknown-unknown/release"
+
+case "${kind}" in
+starlark)
+    if [ -n "${JOSH_STARLARK_GUEST_WASM}" ]; then
+        echo "${JOSH_STARLARK_GUEST_WASM}"
+        exit 0
+    fi
+    blob="${release_dir}/josh_starlark_guest.wasm"
+    if [ ! -f "${blob}" ] || [ -n "${JOSH_GUEST_REBUILD}" ]; then
+        sh "${root}/scripts/build-starlark-guest.sh" 1>&2
+    fi
+    ;;
+example)
+    blob="${release_dir}/subdirs_prefixed.wasm"
+    if [ ! -f "${blob}" ] || [ -n "${JOSH_GUEST_REBUILD}" ]; then
+        (
+            cd "${root}/josh-guest" &&
+                cargo build --release --target wasm32-unknown-unknown \
+                    -p subdirs-prefixed 1>&2
+        )
+    fi
+    ;;
+*)
+    echo "unknown guest blob: ${kind}" >&2
+    exit 1
+    ;;
+esac
+
+echo "${blob}"

--- a/tests/experimental/wasm_args.t
+++ b/tests/experimental/wasm_args.t
@@ -1,0 +1,149 @@
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1 sub2 st
+  $ echo contents1 > sub1/file1
+  $ echo contents2 > sub2/file2
+
+This module selects ':/sub1' if the entry named by its first invocation
+argument exists in the CONTEXT tree (checked via tree_entry_oid), and the
+empty filter otherwise. It needs a real bump allocator: the argument string
+must survive the allocation made for tree_entry_oid's result.
+
+  $ cat > st/exists.wasm <<'EOF'
+  > (module
+  >   (import "josh" "nop" (func $nop (result i32)))
+  >   (import "josh" "empty" (func $empty (result i32)))
+  >   (import "josh" "subdir" (func $subdir (param i32 i32 i32) (result i32)))
+  >   (import "josh" "invocation_args" (func $args (result i64)))
+  >   (import "josh" "tree_entry_oid" (func $entry (param i32 i32) (result i64)))
+  >   (memory (export "memory") 1)
+  >   (data (i32.const 16) "sub1")
+  >   (global $next (mut i32) (i32.const 4096))
+  >   (func (export "josh_abi_version") (result i32) (i32.const 1))
+  >   (func (export "josh_alloc") (param i32) (result i32)
+  >     (local $p i32)
+  >     (local.set $p (global.get $next))
+  >     (global.set $next (i32.add (global.get $next) (local.get 0)))
+  >     (local.get $p))
+  >   (func $ptr (param i64) (result i32)
+  >     (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 32))))
+  >   (func $len (param i64) (result i32)
+  >     (i32.wrap_i64 (local.get 0)))
+  >   (func (export "josh_run") (result i32)
+  >     (local $a i64)
+  >     (local.set $a (call $args))
+  >     (if (result i32)
+  >       (call $len (call $entry (call $ptr (local.get $a)) (call $len (local.get $a))))
+  >       (then (call $subdir (call $nop) (i32.const 16) (i32.const 4)))
+  >       (else (call $empty)))))
+  > EOF
+
+This module writes the hex OID of the entry named by its first argument into
+a new file "oid.txt" via insert.
+
+  $ cat > st/oid.wasm <<'EOF'
+  > (module
+  >   (import "josh" "nop" (func $nop (result i32)))
+  >   (import "josh" "insert" (func $insert (param i32 i32 i32 i32 i32) (result i32)))
+  >   (import "josh" "invocation_args" (func $args (result i64)))
+  >   (import "josh" "tree_entry_oid" (func $entry (param i32 i32) (result i64)))
+  >   (memory (export "memory") 1)
+  >   (data (i32.const 16) "oid.txt")
+  >   (global $next (mut i32) (i32.const 4096))
+  >   (func (export "josh_abi_version") (result i32) (i32.const 1))
+  >   (func (export "josh_alloc") (param i32) (result i32)
+  >     (local $p i32)
+  >     (local.set $p (global.get $next))
+  >     (global.set $next (i32.add (global.get $next) (local.get 0)))
+  >     (local.get $p))
+  >   (func $ptr (param i64) (result i32)
+  >     (i32.wrap_i64 (i64.shr_u (local.get 0) (i64.const 32))))
+  >   (func $len (param i64) (result i32)
+  >     (i32.wrap_i64 (local.get 0)))
+  >   (func (export "josh_run") (result i32)
+  >     (local $a i64)
+  >     (local $o i64)
+  >     (local.set $a (call $args))
+  >     (local.set $o (call $entry (call $ptr (local.get $a)) (call $len (local.get $a))))
+  >     (call $insert (call $nop)
+  >       (i32.const 16) (i32.const 7)
+  >       (call $ptr (local.get $o)) (call $len (local.get $o)))))
+  > EOF
+  $ git add sub1 sub2 st
+  $ git commit -m "add tree" 1> /dev/null
+
+The argument names an entry inside the context (::st/ contains the module
+blob itself), so the module returns ':/sub1' and file1 shows up at the root
+of the projection, composed over the context.
+
+  $ josh-filter -s ':!st/exists=st/exists.wasm[::st/]' master --update refs/josh/picked
+  9ab25e932ebb76c1b376002b4ccbce86f7d97b97
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/exists=st/exists.wasm[::st/]
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+
+  $ git ls-tree -r refs/josh/picked --name-only
+  file1
+  st/exists.wasm
+  st/oid.wasm
+
+The argument names an entry that exists in the repository but NOT in the
+context tree: tree_entry_oid operates on the context-filtered tree, returns
+"", and the module returns the empty filter — the projection is just the
+context.
+
+  $ josh-filter -s ':!st/exists=sub1[::st/]' master --update refs/josh/missed
+  3c325aba0dab30d1b3a48898fe2df57ce3c3041c
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/exists=st/exists.wasm[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/exists=sub1[::st/]
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+
+  $ git ls-tree -r refs/josh/missed --name-only
+  st/exists.wasm
+  st/oid.wasm
+
+The oid module surfaces tree_entry_oid's result as file content: oid.txt must
+contain exactly the blob OID of sub1/file1.
+
+  $ josh-filter -s ':!st/oid=sub1/file1[:[::st/,::sub1/]]' master --update refs/josh/oid
+  b92d3dcc359720f8a4a7dc3bf9f2e30752b860dd
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/exists=st/exists.wasm[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/exists=sub1[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/oid=sub1/file1[:[::st/,::sub1/]]
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+
+  $ git show refs/josh/oid:oid.txt
+  a024003ee1acc6bf70318a46e7b6df651b9dc246 (no-eol)
+
+  $ git rev-parse master:sub1/file1
+  a024003ee1acc6bf70318a46e7b6df651b9dc246

--- a/tests/experimental/wasm_starlark_basic.t
+++ b/tests/experimental/wasm_starlark_basic.t
@@ -1,0 +1,76 @@
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1 sub2
+  $ echo contents1 > sub1/file1
+  $ echo contents2 > sub2/file2
+  $ git add sub1 sub2
+  $ git commit -m "add subs" 1> /dev/null
+
+Starlark scripts run through the interpreter guest blob, committed once as
+tools/starlark.wasm and invoked with the script path as its argument.
+
+  $ mkdir -p tools st
+  $ cp "$(wasm-guest-blob.sh starlark)" tools/starlark.wasm
+  $ cat > st/config.star <<'EOF'
+  > # Simple starlark filter: keep only sub1
+  > filter = filter.subdir("sub1")
+  > EOF
+  $ git add tools st
+  $ git commit -m "add starlark config" 1> /dev/null
+
+A later commit switches the script to select sub2 instead: the filter change
+mid-history goes through the splicing machinery.
+
+  $ cat > st/config.star <<'EOF'
+  > filter = filter.subdir("sub2")
+  > EOF
+  $ git add st
+  $ git commit -m "switch script to sub2" 1> /dev/null
+
+  $ echo changed > sub2/file2
+  $ git add sub2
+  $ git commit -m "change file2" 1> /dev/null
+
+The interpreter module comes from the input tree; the script comes from the
+context tree (::st/ includes it). Commits predating the interpreter and
+script filter to empty, and the script change splices in the history of the
+newly selected sub2 as a synthetic merge — the projection graph stays
+connected.
+
+  $ josh-filter -s ':!tools/starlark=st/config.star[::st/]' master --update refs/josh/master
+  f9a93f625cd211de2da73963f3cd2fdaa1359687
+  [1] :[
+      ::st/
+      :/sub1
+  ]
+  [1] :subtract[
+          :/sub2
+          :/sub1
+      ]
+  [4] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!tools/starlark=st/config.star[::st/]
+  ]
+  [4] reachable_roots
+  [4] sequence_number
+
+  $ git log --graph --pretty=%s refs/josh/master
+  * change file2
+  *   switch script to sub2
+  |\  
+  | * add subs
+  * add starlark config
+  * add subs
+
+  $ git ls-tree -r refs/josh/master --name-only
+  file2
+  st/config.star
+
+  $ git ls-tree -r refs/josh/master~2 --name-only
+  file1
+  st/config.star

--- a/tests/experimental/wasm_starlark_errors.t
+++ b/tests/experimental/wasm_starlark_errors.t
@@ -1,0 +1,79 @@
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1 other
+  $ echo contents1 > sub1/file1
+  $ echo contents2 > other/file2
+  $ mkdir -p tools st
+  $ cp "$(wasm-guest-blob.sh starlark)" tools/starlark.wasm
+  $ cat > st/config.star <<'EOF'
+  > filter = filter.subdir("sub1")
+  > EOF
+  $ git add sub1 other tools st
+  $ git commit -m "add tree" 1> /dev/null
+
+A missing or out-of-context script is a deterministic evaluation error, not a
+nop: the interpreter checks the script's presence in the context tree via
+tree_entry_oid and traps when it is absent. Every case below degrades to the
+empty projection — zero OID, ref not written.
+
+The script exists in the repository but the context excludes it:
+
+  $ josh-filter -s ':!tools/starlark=st/config.star[::other/]' master --update refs/josh/outofcontext
+  Warning: reference refs/josh/outofcontext wasn't updated
+  0000000000000000000000000000000000000000
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!tools/starlark=st/config.star[::other/]
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+
+The script does not exist at all:
+
+  $ josh-filter -s ':!tools/starlark=st/missing.star[::st/]' master --update refs/josh/missing
+  Warning: reference refs/josh/missing wasn't updated
+  0000000000000000000000000000000000000000
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!tools/starlark=st/config.star[::other/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!tools/starlark=st/missing.star[::st/]
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+
+No script argument given at all:
+
+  $ josh-filter -s ':!tools/starlark[::st/]' master --update refs/josh/noarg
+  Warning: reference refs/josh/noarg wasn't updated
+  0000000000000000000000000000000000000000
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!tools/starlark=st/config.star[::other/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!tools/starlark=st/missing.star[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!tools/starlark[::st/]
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+
+  $ git ls-tree -r refs/josh/outofcontext --name-only
+  fatal: Not a valid object name refs/josh/outofcontext
+  [128]

--- a/tests/experimental/wasm_starlark_mempack.t
+++ b/tests/experimental/wasm_starlark_mempack.t
@@ -1,0 +1,39 @@
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1
+  $ echo contents1 > sub1/file1
+  $ echo contents2 > sub1/file2
+  $ git add sub1
+  $ git commit -m "add sub1" 1> /dev/null
+
+  $ mkdir tools
+  $ cp "$(wasm-guest-blob.sh starlark)" tools/starlark.wasm
+  $ cat > config.star <<'EOF'
+  > # The context (:/sub1::file1:prefix=lib) produces a tree that is written to
+  > # the mempack backend when running with --pack. This test verifies that the
+  > # wasm evaluation can access that mempack tree (the transaction repo must be
+  > # used directly, not reopened).
+  > content = tree.file("lib/file1")
+  > filter = filter.insert("foobar", content)
+  > EOF
+
+Apply with --pack: the script must see the mempack tree to return the correct
+filter.
+
+  $ josh-filter --pack ':!tools/starlark=config.star[:[::config.star,:/sub1::file1:prefix=lib]]' . --update refs/josh/master
+  30527e47358a1b726b5d9bec51f906709b2c65a7
+
+  $ git ls-tree -r refs/josh/master --name-only
+  config.star
+  foobar
+  lib/file1
+
+The script read "lib/file1" from the mempack tree and inserted its content as
+"foobar" at the root of the result.
+
+  $ git show refs/josh/master:foobar
+  contents1

--- a/tests/experimental/wasm_starlark_subfilter.t
+++ b/tests/experimental/wasm_starlark_subfilter.t
@@ -1,0 +1,49 @@
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1 sub2
+  $ echo contents1 > sub1/file1
+  $ echo contents2 > sub2/file2
+  $ git add sub1 sub2
+  $ git commit -m "add subs" 1> /dev/null
+
+The script inspects the CONTEXT-filtered tree: sub2 exists in the repository
+but is outside the context, so tree.files() cannot see it and no sub2 content
+can end up in the result.
+
+  $ mkdir -p tools st
+  $ cp "$(wasm-guest-blob.sh starlark)" tools/starlark.wasm
+  $ cat > st/config.star <<'EOF'
+  > fs = [filter.file(f) for f in tree.files("sub1") + tree.files("sub2")]
+  > filter = compose(fs)
+  > EOF
+  $ git add tools st
+  $ git commit -m "add starlark config" 1> /dev/null
+
+  $ josh-filter -s ':!tools/starlark=st/config.star[:[::st/,::sub1/]]' master --update refs/josh/master
+  6f06692764a14121345345cefc8858ec449717af
+  [1] :[
+      ::st/
+      sub1 = :/sub1:[
+          :/
+          ::file1
+      ]
+  ]
+  [2] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!tools/starlark=st/config.star[:[::st/,::sub1/]]
+  ]
+  [2] reachable_roots
+  [2] sequence_number
+
+  $ git log --graph --pretty=%s refs/josh/master
+  * add starlark config
+  * add subs
+
+  $ git ls-tree -r refs/josh/master --name-only
+  st/config.star
+  sub1/file1

--- a/tests/experimental/wasm_wat_errors.t
+++ b/tests/experimental/wasm_wat_errors.t
@@ -1,0 +1,157 @@
+  $ export TERM=dumb
+  $ export RUST_LOG_STYLE=never
+
+  $ git init -q real_repo 1> /dev/null
+  $ cd real_repo
+
+  $ mkdir sub1 st
+  $ echo contents1 > sub1/file1
+
+A blob that is neither wasm nor valid WAT text.
+
+  $ cat > st/broken.wasm <<'EOF'
+  > (module this is not a valid module (((
+  > EOF
+
+A module that burns fuel forever: an infinite loop in josh_run. The fuel
+limit turns it into a deterministic evaluation error instead of a hang.
+
+  $ cat > st/fuel.wasm <<'EOF'
+  > (module
+  >   (memory (export "memory") 1)
+  >   (func (export "josh_abi_version") (result i32) (i32.const 1))
+  >   (func (export "josh_alloc") (param i32) (result i32) (i32.const 1024))
+  >   (func (export "josh_run") (result i32)
+  >     (loop $l (br $l))
+  >     (i32.const 0)))
+  > EOF
+  $ git add sub1 st
+  $ git commit -m "add tree" 1> /dev/null
+
+Any evaluation failure degrades to the empty projection: the ref is not
+written and the resulting OID is zero.
+
+A broken module:
+
+  $ josh-filter -s ':!st/broken[::st/]' master --update refs/josh/broken
+  Warning: reference refs/josh/broken wasn't updated
+  0000000000000000000000000000000000000000
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/broken[::st/]
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+
+A missing module blob:
+
+  $ josh-filter -s ':!st/missing[::st/]' master --update refs/josh/missing
+  Warning: reference refs/josh/missing wasn't updated
+  0000000000000000000000000000000000000000
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/broken[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/missing[::st/]
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+
+The fuel bomb (terminates promptly by running out of fuel):
+
+  $ josh-filter -s ':!st/fuel[::st/]' master --update refs/josh/fuel
+  Warning: reference refs/josh/fuel wasn't updated
+  0000000000000000000000000000000000000000
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/broken[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/fuel[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/missing[::st/]
+  ]
+  [1] reachable_roots
+  [1] sequence_number
+
+  $ git ls-tree -r refs/josh/broken --name-only
+  fatal: Not a valid object name refs/josh/broken
+  [128]
+
+A wasm filter cannot be written directly inside a compose group: compose
+requires statically invertible parts and the wasm op has no static inverse,
+so this fails deterministically instead of degrading. A valid module makes
+no difference.
+
+  $ cat > st/valid.wasm <<'EOF2'
+  > (module
+  >   (import "josh" "nop" (func $nop (result i32)))
+  >   (import "josh" "subdir" (func $subdir (param i32 i32 i32) (result i32)))
+  >   (memory (export "memory") 1)
+  >   (data (i32.const 16) "sub1")
+  >   (func (export "josh_abi_version") (result i32) (i32.const 1))
+  >   (func (export "josh_alloc") (param i32) (result i32) (i32.const 1024))
+  >   (func (export "josh_run") (result i32)
+  >     (call $subdir (call $nop) (i32.const 16) (i32.const 4))))
+  > EOF2
+  $ git add st
+  $ git commit -m "add valid module" 1> /dev/null
+
+  $ josh-filter -s ':[::sub1/,:!st/valid[::st/]]' master --update refs/josh/compose
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/broken[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/fuel[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/missing[::st/]
+  ]
+  [2] reachable_roots
+  [2] sequence_number
+  ERROR: no invert Wasm("st/valid", [], Chain([Subdir("st"), Prefix("st")]))
+  [1]
+
+The same op inside an exclude subfilter is supported.
+
+  $ josh-filter -s ':exclude[:!st/valid[::st/]]' master --update refs/josh/exclude
+  73959a47b0dffea09d8c55ac0c95133a12981335
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/broken[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/fuel[::st/]
+  ]
+  [1] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :!st/missing[::st/]
+  ]
+  [2] :~(
+      josh-wasm-limits="fuel=100000000,memory=67108864,module_size=16777216,handles=100000,depth=10"
+  )[
+      :exclude[:!st/valid[::st/]]
+  ]
+  [2] reachable_roots
+  [2] sequence_number


### PR DESCRIPTION
Migrate starlark filter tests to wasm guests with a blob helper

Replace the deleted starlark scrut tests with wasm-guest equivalents and add
the helper that makes interpreter-blob fixtures possible without committing
multi-MiB binaries:

- scripts/wasm-guest-blob.sh prints the absolute path of a built guest blob
  ("starlark" or "example"), building it on demand via
  scripts/build-starlark-guest.sh (skipped when the artifact exists;
  JOSH_GUEST_REBUILD forces a rebuild, JOSH_STARLARK_GUEST_WASM overrides the
  starlark blob location for runs without a cargo toolchain). run-tests.sh
  prepends scripts/ to PATH, so .t files call it by name.
- tests/experimental/wasm_args.t exercises invocation_args and tree_entry_oid
  end-to-end with WAT-text modules (no toolchain needed), including that
  tree_entry_oid operates on the context-filtered tree.
- tests/experimental/wasm_wat_errors.t shows the empty-projection degradation
  for a broken module, a missing module blob, and a fuel bomb.
- tests/experimental/wasm_starlark_{basic,subfilter,mempack}.t port the old
  starlark tests onto the interpreter guest blob injected as
  tools/starlark.wasm. basic additionally covers script-changes-mid-history
  splicing; mempack keeps its mem-odb purpose (evaluation must read trees
  that exist only in the transaction's mempack backend).
- tests/experimental/wasm_starlark_errors.t asserts that a missing or
  out-of-context script is a deterministic evaluation error yielding the
  empty projection (deliberate change from starlark's missing-script nop).
- josh-wasm/tests/starlark_guest.rs runs the interpreter blob through
  josh_wasm::evaluate replicating the old josh-starlark spec assertions plus
  a determinism check across clear_caches; it skips with a note when the
  blob is absent so plain `cargo test --workspace` stays green.

Run everything with:
  sh scripts/build-starlark-guest.sh && \
    JOSH_EXPERIMENTAL_FEATURES=1 sh run-tests.sh tests/experimental

Change: wasm-test-migration
Assisted-By: anthropic/claude-fable-5