### PR TITLE
Release the sled cache lock before the compose container run

### DIFF
--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -58,6 +58,11 @@ pub fn run(
 
     let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
+    // Computing the workspace tree is the only cache-backed work; running the containers below
+    // only reads objects from the repo. Release the cache lock now so its long tail doesn't block
+    // other josh processes from opening the shared sled cache.
+    transaction.release_cache()?;
+
     let mut attempted = std::collections::HashSet::new();
     // Only extract output artifacts into the working tree when running against
     // uncommitted changes (input_ref == "."). For committed refs there is no

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -90,6 +90,7 @@ josh-starlark.workspace = true
 rand = "0.10.2"
 criterion = { version = "5.0.1", package = "codspeed-criterion-compat" }
 tempfile.workspace = true
+git2.workspace = true
 josh-test-support = { path = "../devtools/josh-test-support" }
 
 [[bench]]

--- a/josh-core/src/cache/backend.rs
+++ b/josh-core/src/cache/backend.rs
@@ -19,6 +19,11 @@ pub trait CacheBackend: Send + Sync {
         to: git2::Oid,
         hint: HistoryGraphHint,
     ) -> anyhow::Result<()>;
+
+    /// Drop any cached handles into the underlying store. The default is a no-op; backends holding
+    /// a lock (e.g. the sled tree handles) override this so the lock can be released. Reads and
+    /// writes stay valid afterwards, transparently reacquiring what they need.
+    fn release(&self) {}
 }
 
 /// Per-commit history-graph facts passed along with every cache record.

--- a/josh-core/src/cache/mod.rs
+++ b/josh-core/src/cache/mod.rs
@@ -19,7 +19,10 @@ pub use history_graph::{
     HistoryGraphInfo, collect_history_graph_info, compute_history_hint, compute_sequence_number,
     parents_share_root,
 };
-pub use sled::{SledCacheBackend, sled_clear, sled_load, sled_open_josh_trees, sled_print_stats};
+pub use sled::{
+    SledCacheBackend, sled_clear, sled_flush, sled_load, sled_open_josh_trees, sled_print_stats,
+    sled_unload,
+};
 pub use stack::CacheStack;
 pub use transaction::*;
 pub use tree_cache::TreeBytes;

--- a/josh-core/src/cache/sled.rs
+++ b/josh-core/src/cache/sled.rs
@@ -75,6 +75,21 @@ pub fn sled_open_josh_trees() -> anyhow::Result<(sled::Tree, sled::Tree, sled::T
     Ok((path_tree, invert_tree, trigram_index_tree))
 }
 
+/// Flush any pending writes of the global cache db to disk. No-op if the cache is not loaded.
+pub fn sled_flush() -> anyhow::Result<()> {
+    if let Some(db) = DB.lock().unwrap().as_ref() {
+        db.flush()?;
+    }
+    Ok(())
+}
+
+/// Drop the global cache db, releasing sled's exclusive file lock on the cache directory. Any
+/// remaining `sled::Tree` handles keep the underlying store (and its lock) alive, so callers must
+/// drop those first; see [`crate::cache::Transaction::release_cache`].
+pub fn sled_unload() {
+    *DB.lock().unwrap() = None;
+}
+
 pub fn sled_load(path: &std::path::Path) -> anyhow::Result<()> {
     let db = sled::Config::default()
         .path(path.join(format!("josh/cache/{}/sled/", CACHE_VERSION)))
@@ -134,5 +149,11 @@ impl CacheBackend for SledCacheBackend {
 
         tree.insert(from.as_bytes(), to.as_bytes())?;
         Ok(())
+    }
+
+    /// Drop the cached per-filter tree handles so that, once the global db is unloaded, sled's file
+    /// lock is released. A later read/write transparently reopens the trees.
+    fn release(&self) {
+        self.trees.lock().unwrap().clear();
     }
 }

--- a/josh-core/src/cache/stack.rs
+++ b/josh-core/src/cache/stack.rs
@@ -42,6 +42,13 @@ impl CacheStack {
         Ok(())
     }
 
+    /// Release cached handles across all backends (see [`CacheBackend::release`]).
+    pub fn release(&self) {
+        for backend in &self.backends {
+            backend.release();
+        }
+    }
+
     /// Try to read from the cache backend stack.
     ///
     /// When a record is found, it's propagated to the backends

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -117,13 +117,33 @@ struct Transaction2 {
     tree_cache: TreeCache,
 
     cache: std::sync::Arc<CacheStack>,
-    path_tree: sled::Tree,
-    invert_tree: sled::Tree,
-    trigram_index_tree: sled::Tree,
+    // Held `Some` for the life of the transaction; `release_cache` drops them (along with the
+    // backend handles and the global db) to free the sled file lock while the transaction's repo
+    // and object store stay usable. Only the cache-populating filter phase touches these, so any
+    // access after release is a bug and panics.
+    path_tree: Option<sled::Tree>,
+    invert_tree: Option<sled::Tree>,
+    trigram_index_tree: Option<sled::Tree>,
     missing: Vec<(usize, crate::filter::Filter, git2::Oid)>,
     misses: usize,
     nesting_level: usize,
 }
+
+impl Transaction2 {
+    fn path_tree(&self) -> &sled::Tree {
+        self.path_tree.as_ref().expect(CACHE_RELEASED)
+    }
+
+    fn invert_tree(&self) -> &sled::Tree {
+        self.invert_tree.as_ref().expect(CACHE_RELEASED)
+    }
+
+    fn trigram_index_tree(&self) -> &sled::Tree {
+        self.trigram_index_tree.as_ref().expect(CACHE_RELEASED)
+    }
+}
+
+const CACHE_RELEASED: &str = "cache tree accessed after release_cache";
 
 pub struct Transaction {
     t2: std::cell::RefCell<Transaction2>,
@@ -196,9 +216,9 @@ impl Transaction {
                 last_written_commit: None,
                 tree_cache: Default::default(),
                 cache,
-                path_tree,
-                invert_tree,
-                trigram_index_tree,
+                path_tree: Some(path_tree),
+                invert_tree: Some(invert_tree),
+                trigram_index_tree: Some(trigram_index_tree),
                 missing: vec![],
                 misses: 0,
                 nesting_level: 0,
@@ -226,6 +246,25 @@ impl Transaction {
 
     pub fn repo(&self) -> &git2::Repository {
         &self.repo
+    }
+
+    /// Close the on-disk cache, releasing sled's exclusive lock on the cache directory so other
+    /// josh processes can open it. This flushes pending writes, then drops every sled handle: this
+    /// transaction's tree handles, the shared backend's, and the process-global database.
+    ///
+    /// Call once no further cache reads or writes will happen. The repo and in-memory object store
+    /// stay usable, so a filtering phase can hand its result to a long, cache-free tail (for
+    /// example running containers) without pinning the lock. Any cache access after this panics.
+    pub fn release_cache(&self) -> anyhow::Result<()> {
+        crate::cache::sled::sled_flush()?;
+        let mut t2 = self.t2.borrow_mut();
+        t2.path_tree = None;
+        t2.invert_tree = None;
+        t2.trigram_index_tree = None;
+        t2.cache.release();
+        drop(t2);
+        crate::cache::sled::sled_unload();
+        Ok(())
     }
 
     /// Read the raw bytes of the tree `oid` through the per-transaction [`TreeCache`]
@@ -416,7 +455,7 @@ impl Transaction {
         let t2 = self.t2.borrow();
         let s = format!("{:?}", tree);
         let x = git2::Oid::hash_object(git2::ObjectType::Blob, s.as_bytes()).expect("hash_object");
-        t2.path_tree
+        t2.path_tree()
             .insert(x.as_bytes(), result.as_bytes())
             .unwrap();
     }
@@ -426,7 +465,7 @@ impl Transaction {
         let s = format!("{:?}", tree);
         let x = git2::Oid::hash_object(git2::ObjectType::Blob, s.as_bytes()).expect("hash_object");
 
-        if let Some(oid) = t2.path_tree.get(x.as_bytes()).unwrap() {
+        if let Some(oid) = t2.path_tree().get(x.as_bytes()).unwrap() {
             return Some(git2::Oid::from_bytes(&oid).unwrap());
         }
         None
@@ -436,7 +475,7 @@ impl Transaction {
         let t2 = self.t2.borrow();
         let s = format!("{:?}", tree);
         let x = git2::Oid::hash_object(git2::ObjectType::Blob, s.as_bytes()).expect("hash_object");
-        t2.invert_tree
+        t2.invert_tree()
             .insert(x.as_bytes(), result.as_bytes())
             .unwrap();
     }
@@ -446,7 +485,7 @@ impl Transaction {
         let s = format!("{:?}", tree);
         let x = git2::Oid::hash_object(git2::ObjectType::Blob, s.as_bytes()).expect("hash_object");
 
-        if let Some(oid) = t2.invert_tree.get(x.as_bytes()).unwrap() {
+        if let Some(oid) = t2.invert_tree().get(x.as_bytes()).unwrap() {
             return Some(git2::Oid::from_bytes(&oid).unwrap());
         }
         None
@@ -454,7 +493,7 @@ impl Transaction {
 
     pub fn insert_trigram_index(&self, tree: git2::Oid, result: git2::Oid) {
         let t2 = self.t2.borrow();
-        t2.trigram_index_tree
+        t2.trigram_index_tree()
             .insert(tree.as_bytes(), result.as_bytes())
             .unwrap();
     }
@@ -462,7 +501,7 @@ impl Transaction {
     pub fn get_trigram_index(&self, tree: git2::Oid) -> Option<git2::Oid> {
         let t2 = self.t2.borrow();
 
-        if let Some(oid) = t2.trigram_index_tree.get(tree.as_bytes()).unwrap() {
+        if let Some(oid) = t2.trigram_index_tree().get(tree.as_bytes()).unwrap() {
             return Some(git2::Oid::from_bytes(&oid).unwrap());
         }
         None

--- a/josh-core/tests/cache_lock.rs
+++ b/josh-core/tests/cache_lock.rs
@@ -1,0 +1,36 @@
+//! `Transaction::release_cache` must free sled's exclusive lock on the cache directory so another
+//! opener can take it. This lives in its own integration binary because it loads and unloads the
+//! process-global cache db; sharing that global with the unit tests (which keep it loaded for the
+//! whole run) would race.
+
+use std::sync::Arc;
+
+use josh_core::cache::{CacheStack, TransactionContext, sled_load, sled_unload};
+
+#[test]
+fn release_cache_frees_the_sled_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path();
+    git2::Repository::init_bare(repo).unwrap();
+
+    sled_load(repo).unwrap();
+    let transaction = TransactionContext::new(repo, Arc::new(CacheStack::default()))
+        .open()
+        .unwrap();
+
+    // Populate a cache tree so the transaction and the backend both hold live sled handles.
+    transaction.insert_paths((git2::Oid::ZERO_SHA1, "x".into()), git2::Oid::ZERO_SHA1);
+
+    // A second open of the same cache dir must fail while the transaction holds the lock: sled_load
+    // opens before swapping the global db in, so it observes the still-held lock and errors.
+    assert!(
+        sled_load(repo).is_err(),
+        "cache should be locked while the transaction holds it"
+    );
+
+    transaction.release_cache().unwrap();
+
+    // With every sled handle dropped, the cache dir opens cleanly again.
+    sled_load(repo).expect("cache still locked after release_cache");
+    sled_unload();
+}


### PR DESCRIPTION
Release the sled cache lock before the compose container run

josh compose held the process-global sled cache open for its whole run,
so its exclusive file lock blocked every other josh command in the repo
for the entire container build -- even though only the initial workspace
filtering touches the cache; running the containers just reads objects
from the repo.

Add Transaction::release_cache, which flushes and drops every sled
handle (the transaction's own trees, the shared backend's cached trees
via a new CacheBackend::release, and the global db) so sled's lock is
freed. The transaction's repo and in-memory object store stay usable, so
josh compose calls it right after computing the workspace tree and before
the container phase. The cache trees become Option so they can be dropped;
any access after release panics, which is correct since the only caller
is done with the cache.

Change: sled-release-compose-lock
Assisted-By: Claude Fable 5 (claude-fable-5)