### PR TITLE
Persist the trigram index cache through the cache backend

### DIFF
--- a/josh-core/src/cache/backend.rs
+++ b/josh-core/src/cache/backend.rs
@@ -1,15 +1,21 @@
-/// Pluggable storage layer for josh's per-filter, per-commit cache.
+/// Pluggable storage layer for josh's `(filter, from_oid) → to_oid` cache.
 ///
-/// Each backend maps `(filter, from_oid) → to_oid`. The [`HistoryGraphHint`]
-/// passed with every record lets backends like the distributed one shard or
-/// skip records based on commit ordering and topology without reading the
-/// commit from the object database.
+/// The [`HistoryGraphHint`] passed with every record lets backends like the
+/// distributed one shard or skip records based on commit ordering and topology
+/// without reading the commit from the object database.
+///
+/// Most records are keyed by commit, with the hint describing that commit's own
+/// history position. Tree-keyed records (the trigram index) key on a tree oid
+/// shared across many commits; the hint then describes the commit being indexed,
+/// so backends must not gate reads on the reading commit's eligibility -- see
+/// [`crate::cache::distributed::DistributedCacheBackend`].
 pub trait CacheBackend: Send + Sync {
     fn read(
         &self,
         filter: crate::filter::Filter,
         from: git2::Oid,
         hint: HistoryGraphHint,
+        tree_keyed: bool,
     ) -> anyhow::Result<Option<git2::Oid>>;
 
     fn write(
@@ -18,6 +24,7 @@ pub trait CacheBackend: Send + Sync {
         from: git2::Oid,
         to: git2::Oid,
         hint: HistoryGraphHint,
+        tree_keyed: bool,
     ) -> anyhow::Result<()>;
 
     /// Drop any cached handles into the underlying store. The default is a no-op; backends holding

--- a/josh-core/src/cache/backend.rs
+++ b/josh-core/src/cache/backend.rs
@@ -1,15 +1,24 @@
-/// Pluggable storage layer for josh's per-filter, per-commit cache.
+/// Pluggable storage layer for josh's per-filter cache.
 ///
 /// Each backend maps `(filter, from_oid) → to_oid`. The [`HistoryGraphHint`]
 /// passed with every record lets backends like the distributed one shard or
 /// skip records based on commit ordering and topology without reading the
 /// commit from the object database.
+///
+/// Most records are per-commit: `from` is a commit and the hint describes that
+/// commit's own position in history. Records with `tree_keyed == true` (the
+/// trigram index) instead key on a *tree* oid shared across many commits, and
+/// the hint describes the commit currently being indexed rather than the key.
+/// Because the key is content-shared, the writing and reading commits differ,
+/// so a backend must not gate reads on the reading commit's eligibility -- see
+/// [`crate::cache::distributed::DistributedCacheBackend`].
 pub trait CacheBackend: Send + Sync {
     fn read(
         &self,
         filter: crate::filter::Filter,
         from: git2::Oid,
         hint: HistoryGraphHint,
+        tree_keyed: bool,
     ) -> anyhow::Result<Option<git2::Oid>>;
 
     fn write(
@@ -18,6 +27,7 @@ pub trait CacheBackend: Send + Sync {
         from: git2::Oid,
         to: git2::Oid,
         hint: HistoryGraphHint,
+        tree_keyed: bool,
     ) -> anyhow::Result<()>;
 
     /// Drop any cached handles into the underlying store. The default is a no-op; backends holding

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -230,11 +230,18 @@ impl CacheBackend for DistributedCacheBackend {
         filter: Filter,
         from: git2::Oid,
         hint: HistoryGraphHint,
+        tree_keyed: bool,
     ) -> anyhow::Result<Option<git2::Oid>> {
         if filter == filter::sequence_number() || filter == filter::reachable_roots() {
             return Ok(None);
         }
-        if !is_eligible(hint) {
+        // Commit-keyed records are only ever stored for eligible (sampled) commits, so a read at a
+        // non-eligible commit can skip the store entirely. Tree-keyed records (the trigram index)
+        // are stored for whichever *indexing* commit was eligible, which is unrelated to the commit
+        // now doing the lookup -- so the read must not gate on the reader's eligibility, or shared
+        // subtrees written at a sampled commit would never be found from the (usually non-sampled)
+        // commits that reuse them. The shard, derived from the hint below, still applies to both.
+        if !tree_keyed && !is_eligible(hint) {
             return Ok(None);
         }
         let repo = self.repo.lock().unwrap();
@@ -287,6 +294,10 @@ impl CacheBackend for DistributedCacheBackend {
         from: git2::Oid,
         to: git2::Oid,
         hint: HistoryGraphHint,
+        // Writes stay gated by eligibility for tree-keyed records too: the store stays sparse, and
+        // because subtrees recur across commits a stable subtree is still caught at whichever
+        // sampled commit indexes it (and re-stored, per shard, in each window it survives into).
+        _tree_keyed: bool,
     ) -> anyhow::Result<()> {
         if !self.writable {
             return Ok(());

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -230,11 +230,15 @@ impl CacheBackend for DistributedCacheBackend {
         filter: Filter,
         from: git2::Oid,
         hint: HistoryGraphHint,
+        tree_keyed: bool,
     ) -> anyhow::Result<Option<git2::Oid>> {
         if filter == filter::sequence_number() || filter == filter::reachable_roots() {
             return Ok(None);
         }
-        if !is_eligible(hint) {
+        // Tree-keyed records were written by whichever indexing commit was eligible,
+        // so gating reads on the reader's eligibility would hide them from the
+        // (usually non-sampled) commits that reuse them.
+        if !tree_keyed && !is_eligible(hint) {
             return Ok(None);
         }
         let repo = self.repo.lock().unwrap();
@@ -287,6 +291,9 @@ impl CacheBackend for DistributedCacheBackend {
         from: git2::Oid,
         to: git2::Oid,
         hint: HistoryGraphHint,
+        // Writes stay eligibility-gated for tree-keyed records too: subtrees recur
+        // across commits, so a stable subtree is still caught at some sampled commit.
+        _tree_keyed: bool,
     ) -> anyhow::Result<()> {
         if !self.writable {
             return Ok(());

--- a/josh-core/src/cache/sled.rs
+++ b/josh-core/src/cache/sled.rs
@@ -107,6 +107,9 @@ impl CacheBackend for SledCacheBackend {
         filter: Filter,
         from: git2::Oid,
         _hint: HistoryGraphHint,
+        // The dense on-disk cache stores every record under its per-filter tree regardless of
+        // whether the key is a commit or a tree, so tree-keyed records need no special handling.
+        _tree_keyed: bool,
     ) -> anyhow::Result<Option<git2::Oid>> {
         let mut trees = self.trees.lock().unwrap();
         let tree = trees
@@ -127,6 +130,7 @@ impl CacheBackend for SledCacheBackend {
         from: git2::Oid,
         to: git2::Oid,
         _hint: HistoryGraphHint,
+        _tree_keyed: bool,
     ) -> anyhow::Result<()> {
         let mut trees = self.trees.lock().unwrap();
         let tree = trees

--- a/josh-core/src/cache/sled.rs
+++ b/josh-core/src/cache/sled.rs
@@ -107,6 +107,8 @@ impl CacheBackend for SledCacheBackend {
         filter: Filter,
         from: git2::Oid,
         _hint: HistoryGraphHint,
+        // Sled stores records by filter alone, so the key kind needs no special handling.
+        _tree_keyed: bool,
     ) -> anyhow::Result<Option<git2::Oid>> {
         let mut trees = self.trees.lock().unwrap();
         let tree = trees
@@ -127,6 +129,7 @@ impl CacheBackend for SledCacheBackend {
         from: git2::Oid,
         to: git2::Oid,
         _hint: HistoryGraphHint,
+        _tree_keyed: bool,
     ) -> anyhow::Result<()> {
         let mut trees = self.trees.lock().unwrap();
         let tree = trees

--- a/josh-core/src/cache/stack.rs
+++ b/josh-core/src/cache/stack.rs
@@ -34,9 +34,10 @@ impl CacheStack {
         from: git2::Oid,
         to: git2::Oid,
         hint: HistoryGraphHint,
+        tree_keyed: bool,
     ) -> anyhow::Result<()> {
         for backend in &self.backends {
-            backend.write(filter, from, to, hint)?;
+            backend.write(filter, from, to, hint, tree_keyed)?;
         }
 
         Ok(())
@@ -60,16 +61,19 @@ impl CacheStack {
         filter: filter::Filter,
         from: git2::Oid,
         hint: HistoryGraphHint,
+        tree_keyed: bool,
     ) -> anyhow::Result<Option<git2::Oid>> {
         let values = self
             .backends
             .iter()
             .enumerate()
-            .find_map(|(index, backend)| match backend.read(filter, from, hint) {
-                Ok(None) => None,
-                Ok(Some(oid)) => Some(Ok((index, oid))),
-                Err(e) => Some(Err(e)),
-            });
+            .find_map(
+                |(index, backend)| match backend.read(filter, from, hint, tree_keyed) {
+                    Ok(None) => None,
+                    Ok(Some(oid)) => Some(Ok((index, oid))),
+                    Err(e) => Some(Err(e)),
+                },
+            );
 
         let (index, oid) = match values {
             // None of the backends had the value
@@ -83,7 +87,7 @@ impl CacheStack {
         self.backends
             .iter()
             .take(index)
-            .try_for_each(|backend| backend.write(filter, from, oid, hint))?;
+            .try_for_each(|backend| backend.write(filter, from, oid, hint, tree_keyed))?;
 
         Ok(Some(oid))
     }

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -27,30 +27,31 @@ static POPULATE_MAP: LazyLock<RwLock<HashMap<(git2::Oid, git2::Oid), git2::Oid>>
 static GLOB_MAP: LazyLock<RwLock<HashMap<(git2::Oid, git2::Oid, u64), git2::Oid>>> =
     LazyLock::new(Default::default);
 
-// Trigram index memoization, keyed by source tree oid -> index tree oid. The index is a pure
-// function of the source tree, and `:INDEX` walks commits parent-first, so when a child commit is
-// indexed the subtrees it shares with its parent are already memoized here from the parent's run --
-// which is where reuse almost always comes from. An in-process map captures that without the
-// persistence (and file lock) of an on-disk cache.
-static TRIGRAM_INDEX_MAP: LazyLock<RwLock<HashMap<git2::Oid, git2::Oid>>> =
-    LazyLock::new(Default::default);
-
 // Path-projection memoization for `:PATHS` and its inverse, keyed by (input tree oid, root path).
 // Both are pure functions of the input tree, and workspace filters walk commits parent-first, so a
-// child commit reuses the projections its parent just computed for the subtrees they share -- the
-// same parent-reuse the trigram index relies on, so an in-process map suffices here too.
+// child commit reuses the projections its parent just computed for the subtrees they share, which
+// an in-process map captures.
 static PATHS_MAP: LazyLock<RwLock<HashMap<(git2::Oid, String), git2::Oid>>> =
     LazyLock::new(Default::default);
 
 static INVERT_MAP: LazyLock<RwLock<HashMap<(git2::Oid, String), git2::Oid>>> =
     LazyLock::new(Default::default);
 
+/// Placeholder hint for tree-keyed records with no commit context. Sequence 0 is
+/// eligible and lands in shard 0 of the distributed backend; the local backend
+/// ignores the hint.
+const TREE_KEYED_FALLBACK_HINT: HistoryGraphHint = HistoryGraphHint {
+    sequence_number: 0,
+    parent_count: 1,
+    jump_delta: 1,
+    jump_is_second: false,
+};
+
 /// Clear the process-global in-memory caches shared across all transactions.
 pub fn clear_global_caches() {
     REF_CACHE.write().unwrap().clear();
     POPULATE_MAP.write().unwrap().clear();
     GLOB_MAP.write().unwrap().clear();
-    TRIGRAM_INDEX_MAP.write().unwrap().clear();
     PATHS_MAP.write().unwrap().clear();
     INVERT_MAP.write().unwrap().clear();
 }
@@ -137,6 +138,9 @@ struct Transaction2 {
     tree_cache: TreeCache,
 
     cache: std::sync::Arc<CacheStack>,
+    // In-transaction memoization of the trigram index (source tree -> index tree); the
+    // cache backend behind it holds the durable, cross-transaction copy.
+    index_map: HashMap<git2::Oid, git2::Oid>,
     missing: Vec<(usize, crate::filter::Filter, git2::Oid)>,
     misses: usize,
     nesting_level: usize,
@@ -210,6 +214,7 @@ impl Transaction {
                 last_written_commit: None,
                 tree_cache: Default::default(),
                 cache,
+                index_map: HashMap::new(),
                 missing: vec![],
                 misses: 0,
                 nesting_level: 0,
@@ -508,16 +513,49 @@ impl Transaction {
         INVERT_MAP.read().unwrap().get(&tree).cloned()
     }
 
-    pub fn insert_trigram_index(&self, tree: git2::Oid, result: git2::Oid) {
-        TRIGRAM_INDEX_MAP
-            .write()
-            .unwrap()
-            .entry(tree)
-            .or_insert(result);
+    /// Build a josh-search index cache that shards records by `commit`'s history-graph
+    /// position. Pass [`git2::Oid::ZERO_SHA1`] for a bare tree with no commit context.
+    pub fn trigram_index_cache(&self, commit: git2::Oid) -> TrigramIndexCache<'_> {
+        TrigramIndexCache {
+            transaction: self,
+            hint: self.tree_keyed_hint(commit),
+        }
     }
 
-    pub fn get_trigram_index(&self, tree: git2::Oid) -> Option<git2::Oid> {
-        TRIGRAM_INDEX_MAP.read().unwrap().get(&tree).cloned()
+    /// Trees carry no history position of their own, so tree-keyed records use the hint
+    /// of the commit being indexed. Falls back to the placeholder when there is no commit
+    /// context or the hint cannot be computed.
+    fn tree_keyed_hint(&self, commit: git2::Oid) -> HistoryGraphHint {
+        if commit == git2::Oid::ZERO_SHA1 {
+            return TREE_KEYED_FALLBACK_HINT;
+        }
+        compute_history_hint(self, commit).unwrap_or(TREE_KEYED_FALLBACK_HINT)
+    }
+
+    fn insert_trigram_index(&self, tree: git2::Oid, result: git2::Oid, hint: HistoryGraphHint) {
+        let filter = crate::filter::index();
+        let mut t2 = self.t2.borrow_mut();
+        t2.index_map.entry(tree).or_insert(result);
+        if let Err(e) = t2.cache.write_all(filter, tree, result, hint, true) {
+            log::warn!("trigram index cache write failed: {e}");
+        }
+    }
+
+    fn get_trigram_index(&self, tree: git2::Oid, hint: HistoryGraphHint) -> Option<git2::Oid> {
+        let filter = crate::filter::index();
+        let t2 = self.t2.borrow_mut();
+        if let Some(oid) = t2.index_map.get(&tree).cloned() {
+            // Written this transaction, so the index tree is live in the mem odb -- no odb check.
+            return Some(oid);
+        }
+        let oid = t2.cache.read_propagate(filter, tree, hint, true).ok()??;
+        // Per-subtree index trees are anchored by no ref, so gc may have pruned a
+        // cached one; treat a dangling hit as a miss and reindex.
+        if self.repo.odb().ok()?.exists(oid) {
+            Some(oid)
+        } else {
+            None
+        }
     }
 
     pub fn insert_populate(&self, tree: (git2::Oid, git2::Oid), result: git2::Oid) {
@@ -608,7 +646,7 @@ impl Transaction {
         // random extra commits (probability 1/256) to avoid long searches for filters that reduce
         // the history length by a very large factor.
         if store || from.as_bytes()[0] == 0 {
-            t2.cache.write_all(filter, from, to, hint)?;
+            t2.cache.write_all(filter, from, to, hint, false)?;
         }
         Ok(())
     }
@@ -675,7 +713,7 @@ impl Transaction {
             return Ok(Some(oid));
         }
 
-        let oid = t2.cache.read_propagate(filter, from, hint)?;
+        let oid = t2.cache.read_propagate(filter, from, hint, false)?;
 
         if let Some(oid) = oid {
             if oid == git2::Oid::ZERO_SHA1 {
@@ -696,16 +734,23 @@ impl Transaction {
     }
 }
 
-/// Back josh-search's index memoization with the process-global trigram map, so `:INDEX` (and any
-/// other in-transaction indexing) stays incremental across transactions within a process -- keyed
-/// by source tree oid, so a child commit reuses the subtrees its parent just indexed.
-impl josh_search::IndexCache for Transaction {
+/// josh-search index memoization backed by the cache backend under the `:INDEX`
+/// filter: durable (sled) and shareable (distributed) across processes, keyed by
+/// source tree oid. The bound `hint` is the indexed commit's history position,
+/// resolved once per commit and reused for every per-subtree lookup of its walk.
+pub struct TrigramIndexCache<'a> {
+    transaction: &'a Transaction,
+    hint: HistoryGraphHint,
+}
+
+impl josh_search::IndexCache for TrigramIndexCache<'_> {
     fn get_index(&self, tree: git2::Oid) -> Option<git2::Oid> {
-        self.get_trigram_index(tree)
+        self.transaction.get_trigram_index(tree, self.hint)
     }
 
     fn set_index(&self, tree: git2::Oid, index: git2::Oid) {
-        self.insert_trigram_index(tree, index)
+        self.transaction
+            .insert_trigram_index(tree, index, self.hint)
     }
 }
 

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -27,14 +27,6 @@ static POPULATE_MAP: LazyLock<RwLock<HashMap<(git2::Oid, git2::Oid), git2::Oid>>
 static GLOB_MAP: LazyLock<RwLock<HashMap<(git2::Oid, git2::Oid, u64), git2::Oid>>> =
     LazyLock::new(Default::default);
 
-// Trigram index memoization, keyed by source tree oid -> index tree oid. The index is a pure
-// function of the source tree, and `:INDEX` walks commits parent-first, so when a child commit is
-// indexed the subtrees it shares with its parent are already memoized here from the parent's run --
-// which is where reuse almost always comes from. An in-process map captures that without the
-// persistence (and file lock) of an on-disk cache.
-static TRIGRAM_INDEX_MAP: LazyLock<RwLock<HashMap<git2::Oid, git2::Oid>>> =
-    LazyLock::new(Default::default);
-
 // Path-projection memoization for `:PATHS` and its inverse, keyed by (input tree oid, root path).
 // Both are pure functions of the input tree, and workspace filters walk commits parent-first, so a
 // child commit reuses the projections its parent just computed for the subtrees they share -- the
@@ -45,12 +37,21 @@ static PATHS_MAP: LazyLock<RwLock<HashMap<(git2::Oid, String), git2::Oid>>> =
 static INVERT_MAP: LazyLock<RwLock<HashMap<(git2::Oid, String), git2::Oid>>> =
     LazyLock::new(Default::default);
 
+/// Placeholder hint for tree-keyed records with no active commit context. Sequence 0 keeps the
+/// distributed backend consistent (`0 % 100 == 0` -> eligible, shard 0); the local backend ignores
+/// the hint entirely.
+const TREE_KEYED_FALLBACK_HINT: HistoryGraphHint = HistoryGraphHint {
+    sequence_number: 0,
+    parent_count: 1,
+    jump_delta: 1,
+    jump_is_second: false,
+};
+
 /// Clear the process-global in-memory caches shared across all transactions.
 pub fn clear_global_caches() {
     REF_CACHE.write().unwrap().clear();
     POPULATE_MAP.write().unwrap().clear();
     GLOB_MAP.write().unwrap().clear();
-    TRIGRAM_INDEX_MAP.write().unwrap().clear();
     PATHS_MAP.write().unwrap().clear();
     INVERT_MAP.write().unwrap().clear();
 }
@@ -137,6 +138,10 @@ struct Transaction2 {
     tree_cache: TreeCache,
 
     cache: std::sync::Arc<CacheStack>,
+    // In-memory front for the tree-keyed trigram index (source tree oid -> index tree oid), so
+    // repeated subtree lookups within a transaction stay off disk. The backend stack (sled +
+    // optional distributed) is the cross-transaction/cross-process layer behind it.
+    index_map: HashMap<git2::Oid, git2::Oid>,
     missing: Vec<(usize, crate::filter::Filter, git2::Oid)>,
     misses: usize,
     nesting_level: usize,
@@ -210,6 +215,7 @@ impl Transaction {
                 last_written_commit: None,
                 tree_cache: Default::default(),
                 cache,
+                index_map: HashMap::new(),
                 missing: vec![],
                 misses: 0,
                 nesting_level: 0,
@@ -508,16 +514,55 @@ impl Transaction {
         INVERT_MAP.read().unwrap().get(&tree).cloned()
     }
 
-    pub fn insert_trigram_index(&self, tree: git2::Oid, result: git2::Oid) {
-        TRIGRAM_INDEX_MAP
-            .write()
-            .unwrap()
-            .entry(tree)
-            .or_insert(result);
+    /// Build a josh-search index cache that shards tree-keyed records by `commit`'s history-graph
+    /// position. `commit` comes from the [`crate::filter::Rewrite`] being filtered, so the index
+    /// path threads its history context explicitly instead of the transaction carrying an ambient
+    /// "current commit". Pass [`git2::Oid::ZERO_SHA1`] when indexing a bare tree with no commit
+    /// context; the hint then falls back to the sequence-0 placeholder.
+    pub fn trigram_index_cache(&self, commit: git2::Oid) -> TrigramIndexCache<'_> {
+        TrigramIndexCache {
+            transaction: self,
+            hint: self.tree_keyed_hint(commit),
+        }
     }
 
-    pub fn get_trigram_index(&self, tree: git2::Oid) -> Option<git2::Oid> {
-        TRIGRAM_INDEX_MAP.read().unwrap().get(&tree).cloned()
+    /// Hint used to shard tree-keyed cache records: the history-graph hint of `commit`. Trees carry
+    /// no history position of their own, so the indexed commit's hint stands in. Falls back to a
+    /// sequence-0 placeholder when there is no commit context (`commit` is the zero oid, i.e. a bare
+    /// tree) or the hint cannot be computed; the local backend ignores the hint and the distributed
+    /// one then treats the record as shard 0.
+    fn tree_keyed_hint(&self, commit: git2::Oid) -> HistoryGraphHint {
+        if commit == git2::Oid::ZERO_SHA1 {
+            return TREE_KEYED_FALLBACK_HINT;
+        }
+        compute_history_hint(self, commit).unwrap_or(TREE_KEYED_FALLBACK_HINT)
+    }
+
+    fn insert_trigram_index(&self, tree: git2::Oid, result: git2::Oid, hint: HistoryGraphHint) {
+        let filter = crate::filter::index();
+        let mut t2 = self.t2.borrow_mut();
+        t2.index_map.entry(tree).or_insert(result);
+        if let Err(e) = t2.cache.write_all(filter, tree, result, hint, true) {
+            log::warn!("trigram index cache write failed: {e}");
+        }
+    }
+
+    fn get_trigram_index(&self, tree: git2::Oid, hint: HistoryGraphHint) -> Option<git2::Oid> {
+        let filter = crate::filter::index();
+        let t2 = self.t2.borrow_mut();
+        if let Some(oid) = t2.index_map.get(&tree).cloned() {
+            // Written this transaction, so the index tree is live in the mem odb -- no odb check.
+            return Some(oid);
+        }
+        let oid = t2.cache.read_propagate(filter, tree, hint, true).ok()??;
+        // Honor a cached index only if it still exists in the object database: per-subtree index
+        // trees are anchored by no ref, so gc/repack can prune them and a dangling hit must
+        // reindex on demand instead of erroring.
+        if self.repo.odb().ok()?.exists(oid) {
+            Some(oid)
+        } else {
+            None
+        }
     }
 
     pub fn insert_populate(&self, tree: (git2::Oid, git2::Oid), result: git2::Oid) {
@@ -608,7 +653,7 @@ impl Transaction {
         // random extra commits (probability 1/256) to avoid long searches for filters that reduce
         // the history length by a very large factor.
         if store || from.as_bytes()[0] == 0 {
-            t2.cache.write_all(filter, from, to, hint)?;
+            t2.cache.write_all(filter, from, to, hint, false)?;
         }
         Ok(())
     }
@@ -675,7 +720,7 @@ impl Transaction {
             return Ok(Some(oid));
         }
 
-        let oid = t2.cache.read_propagate(filter, from, hint)?;
+        let oid = t2.cache.read_propagate(filter, from, hint, false)?;
 
         if let Some(oid) = oid {
             if oid == git2::Oid::ZERO_SHA1 {
@@ -696,16 +741,27 @@ impl Transaction {
     }
 }
 
-/// Back josh-search's index memoization with the process-global trigram map, so `:INDEX` (and any
-/// other in-transaction indexing) stays incremental across transactions within a process -- keyed
-/// by source tree oid, so a child commit reuses the subtrees its parent just indexed.
-impl josh_search::IndexCache for Transaction {
+/// Backs josh-search's index memoization with the per-filter cache backend under the `:INDEX`
+/// filter, keyed by source tree oid. An in-transaction map fronts it for speed; the sled backend
+/// makes it durable across transactions and process restarts, and the distributed backend (when
+/// present) shares it across machines.
+///
+/// The bound `hint` shards those tree-keyed records by the indexed commit's history position: it is
+/// constant for a single indexed commit, so [`Transaction::trigram_index_cache`] resolves it once
+/// and every per-subtree `get`/`set` during the recursive index walk reuses it.
+pub struct TrigramIndexCache<'a> {
+    transaction: &'a Transaction,
+    hint: HistoryGraphHint,
+}
+
+impl josh_search::IndexCache for TrigramIndexCache<'_> {
     fn get_index(&self, tree: git2::Oid) -> Option<git2::Oid> {
-        self.get_trigram_index(tree)
+        self.transaction.get_trigram_index(tree, self.hint)
     }
 
     fn set_index(&self, tree: git2::Oid, index: git2::Oid) {
-        self.insert_trigram_index(tree, index)
+        self.transaction
+            .insert_trigram_index(tree, index, self.hint)
     }
 }
 

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -10,6 +10,7 @@ use std::sync::LazyLock;
 // Re-export from josh-filter
 pub use josh_filter::LinkMode;
 pub use josh_filter::filter::MESSAGE_MATCH_ALL_REGEX;
+pub use josh_filter::filter::index;
 pub use josh_filter::filter::reachable_roots;
 pub use josh_filter::filter::sequence_number;
 pub use josh_filter::flang::parse::{get_comments, parse};
@@ -1509,11 +1510,17 @@ pub fn apply<'a>(
         Op::Paths => Ok(x
             .clone()
             .with_tree(tree::pathstree("", x.tree().id(), transaction)?)),
-        Op::Index => Ok(x.clone().with_tree(josh_search::trigram_index(
-            transaction.repo(),
-            transaction,
-            x.tree().clone(),
-        )?)),
+        Op::Index => {
+            // Shard the tree-keyed index cache by the history position of the commit being
+            // filtered. `x.commit` is the zero oid when indexing a bare tree (no commit context),
+            // which resolves to the sequence-0 fallback hint.
+            let index_cache = transaction.trigram_index_cache(x.commit);
+            Ok(x.clone().with_tree(josh_search::trigram_index(
+                transaction.repo(),
+                &index_cache,
+                x.tree().clone(),
+            )?))
+        }
 
         Op::Invert => {
             Ok(x.clone()

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -10,6 +10,7 @@ use std::sync::LazyLock;
 // Re-export from josh-filter
 pub use josh_filter::LinkMode;
 pub use josh_filter::filter::MESSAGE_MATCH_ALL_REGEX;
+pub use josh_filter::filter::index;
 pub use josh_filter::filter::reachable_roots;
 pub use josh_filter::filter::sequence_number;
 pub use josh_filter::flang::parse::{get_comments, parse};
@@ -1509,11 +1510,14 @@ pub fn apply<'a>(
         Op::Paths => Ok(x
             .clone()
             .with_tree(tree::pathstree("", x.tree().id(), transaction)?)),
-        Op::Index => Ok(x.clone().with_tree(josh_search::trigram_index(
-            transaction.repo(),
-            transaction,
-            x.tree().clone(),
-        )?)),
+        Op::Index => {
+            let index_cache = transaction.trigram_index_cache(x.commit);
+            Ok(x.clone().with_tree(josh_search::trigram_index(
+                transaction.repo(),
+                &index_cache,
+                x.tree().clone(),
+            )?))
+        }
 
         Op::Invert => {
             Ok(x.clone()

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -390,3 +390,9 @@ pub fn reachable_roots() -> Filter {
     });
     *F
 }
+
+/// The `:INDEX` trigram-index filter, used as the cache namespace for the
+/// tree-keyed trigram index records.
+pub fn index() -> Filter {
+    to_filter(Op::Index)
+}

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -390,3 +390,10 @@ pub fn reachable_roots() -> Filter {
     });
     *F
 }
+
+/// The `:INDEX` trigram-index filter. Used as the cache namespace (filter identity) for the
+/// tree-keyed trigram index cache, so per-subtree `source tree -> index tree` records live in
+/// their own per-filter cache tree, keyed and sharded like any other filter's records.
+pub fn index() -> Filter {
+    to_filter(Op::Index)
+}

--- a/tests/experimental/indexer.t
+++ b/tests/experimental/indexer.t
@@ -20,9 +20,9 @@
 
   $ josh-filter -s :INDEX --update refs/heads/index
   ce00c6cd65dea70a35eeaa9283741bcd3f901991
-  [3] :INDEX
   [3] reachable_roots
   [3] sequence_number
+  [9] :INDEX
 
   $ josh-filter :/ --search "Another"
   sub1/file2:1: Another document with more 


### PR DESCRIPTION
Persist the trigram index cache through the cache backend

The `:INDEX` trigram index memoized source-tree -> index-tree in a
process-global in-memory map, lost on exit, so a fresh process re-indexed
whole trees even though the identical index trees were still in the odb.
Store the mapping in the cache backend stack under the `:INDEX` filter,
making it durable (sled) and shareable (distributed); an in-transaction
map still fronts it for speed.

The index key is a tree oid shared across commits and carries no history
position of its own, so a `tree_keyed` flag on the backend read/write
shards these records by the history-graph hint of the commit being
indexed instead. Distributed reads skip the eligibility gate for them
(writer and reader commits differ) while writes stay gated to keep the
cache sparse; a hit whose index tree was pruned by gc is treated as a
miss.

Change: trigram-index-cache-backend
Assisted-By: anthropic/claude-opus-4-8