### PR TITLE
Drive the sled cache lifetime by active transactions instead of explicit release

### DIFF
--- a/cq/josh-cq/src/bin/josh-cq.rs
+++ b/cq/josh-cq/src/bin/josh-cq.rs
@@ -73,12 +73,9 @@ fn open_repo(
     };
     let repo_path = normalize_repo_path(repo.path());
 
-    josh_core::cache::sled_load(&repo_path.join(".git")).context("Failed to load sled cache")?;
-
-    let cache = std::sync::Arc::new(
-        josh_core::cache::CacheStack::new()
-            .with_backend(josh_core::cache::SledCacheBackend::default()),
-    );
+    let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(
+        josh_core::cache::SledCacheBackend::new(repo_path.join(".git")),
+    ));
 
     let transaction = josh_core::cache::TransactionContext::new(&repo_path, cache.clone())
         .open()

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -196,13 +196,12 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         josh_core::filter::from_tree(&repo, tree_oid)?
     };
 
-    if !args.get_flag("no-cache") {
-        josh_core::cache::sled_load(&repo_path)?;
-    }
-
     let cache = std::sync::Arc::new({
-        let cache = josh_core::cache::CacheStack::new()
-            .with_backend(josh_core::cache::SledCacheBackend::default());
+        let mut cache = josh_core::cache::CacheStack::new();
+
+        if !args.get_flag("no-cache") {
+            cache = cache.with_backend(josh_core::cache::SledCacheBackend::new(&repo_path));
+        }
 
         if args.get_flag("distributed-cache") {
             cache.with_backend(josh_core::cache::DistributedCacheBackend::new(&repo_path)?)

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -235,10 +235,15 @@ fn run_repo(cmd: &RepoCommand, distributed_cache: bool) -> anyhow::Result<()> {
         .commondir()
         .to_path_buf();
 
-    josh_core::cache::sled_load(&git_common_dir).context("Failed to load sled cache")?;
+    let is_compose = matches!(cmd, RepoCommand::Compose(_));
 
-    let mut cache_stack = josh_core::cache::CacheStack::new()
-        .with_backend(josh_core::cache::SledCacheBackend::default());
+    let mut cache_stack = josh_core::cache::CacheStack::new();
+    // Compose does one-shot, throwaway filtering and then hands off to a long container run; the
+    // on-disk sled cache would only take a lock we would have to release again, so skip it.
+    if !is_compose {
+        cache_stack =
+            cache_stack.with_backend(josh_core::cache::SledCacheBackend::new(&git_common_dir));
+    }
     if distributed_cache {
         cache_stack = cache_stack.with_backend(
             josh_core::cache::DistributedCacheBackend::new(&git_common_dir)
@@ -251,7 +256,7 @@ fn run_repo(cmd: &RepoCommand, distributed_cache: bool) -> anyhow::Result<()> {
 
     // For compose, we don't need to flush the objects to disk;
     // everything else gets mem odb setup with an upper flush limit
-    if matches!(cmd, RepoCommand::Compose(_)) {
+    if is_compose {
         ctx = ctx.ephemeral();
     } else {
         ctx = ctx.with_mem_odb_limit(josh_cli::MAX_MEM_PACK_SIZE)

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -58,11 +58,6 @@ pub fn run(
 
     let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
-    // Computing the workspace tree is the only cache-backed work; running the containers below
-    // only reads objects from the repo. Release the cache lock now so its long tail doesn't block
-    // other josh processes from opening the shared sled cache.
-    transaction.release_cache()?;
-
     let mut attempted = std::collections::HashSet::new();
     // Only extract output artifacts into the working tree when running against
     // uncommitted changes (input_ref == "."). For committed refs there is no

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -92,6 +92,8 @@ criterion = { version = "5.0.1", package = "codspeed-criterion-compat" }
 tempfile.workspace = true
 git2.workspace = true
 josh-test-support = { path = "../devtools/josh-test-support" }
+# Used by tests/cache_lock.rs to probe the sled file lock directly.
+sled = "0.34.7"
 
 [[bench]]
 name = "unapply"

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -92,6 +92,8 @@ criterion = "0.5"
 tempfile.workspace = true
 git2.workspace = true
 josh-test-support = { path = "../devtools/josh-test-support" }
+# Used by tests/cache_lock.rs to probe the sled file lock directly.
+sled = "0.34.7"
 
 [[bench]]
 name = "unapply"

--- a/josh-core/benches/deephistory_glob.rs
+++ b/josh-core/benches/deephistory_glob.rs
@@ -140,10 +140,9 @@ impl GlobBench {
             }
         }
 
-        josh_core::cache::sled_load(provisioned.path())?;
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::default()),
+                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
         );
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 

--- a/josh-core/benches/deephistory_prefix_flush.rs
+++ b/josh-core/benches/deephistory_prefix_flush.rs
@@ -126,10 +126,9 @@ impl PrefixFlushBench {
 
         let filter = Filter::new().prefix(PREFIX);
 
-        josh_core::cache::sled_load(provisioned.path())?;
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::default()),
+                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
         );
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache)
             .with_mem_odb_limit(MEM_ODB_LIMIT);

--- a/josh-core/benches/deephistory_subdir.rs
+++ b/josh-core/benches/deephistory_subdir.rs
@@ -104,10 +104,9 @@ impl SubdirBench {
 
         let filter = Filter::new().subdir(SUBDIR);
 
-        josh_core::cache::sled_load(provisioned.path())?;
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::default()),
+                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
         );
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 

--- a/josh-core/benches/deephistory_subdir_distributed.rs
+++ b/josh-core/benches/deephistory_subdir_distributed.rs
@@ -95,8 +95,6 @@ impl SubdirBench {
 
         let filter = Filter::new().subdir(SUBDIR);
 
-        josh_core::cache::sled_load(provisioned.path())?;
-
         // Correctness + shape gate (untimed): confirm the subdir filter produces exactly the SUBDIR
         // subtree of the raw head, and that the filtered history is far shorter than the input history
         // -- otherwise this bench would stop measuring the input >> output regime it exists for.
@@ -105,7 +103,7 @@ impl SubdirBench {
         {
             let cache = std::sync::Arc::new(
                 josh_core::cache::CacheStack::new()
-                    .with_backend(josh_core::cache::SledCacheBackend::default()),
+                    .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
             );
             let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
             let transaction = context.open()?;
@@ -292,7 +290,7 @@ fn deephistory_subdir_distributed(c: &mut Criterion) {
                     clear_cache_refs(&bench.repo.repo).expect("clear cache refs");
                     let cache = std::sync::Arc::new(
                         josh_core::cache::CacheStack::new()
-                            .with_backend(josh_core::cache::SledCacheBackend::default())
+                            .with_backend(josh_core::cache::SledCacheBackend)
                             .with_backend(
                                 josh_core::cache::DistributedCacheBackend::writable(&path)
                                     .expect("open distributed cache"),

--- a/josh-core/benches/deephistory_subdir_sparse.rs
+++ b/josh-core/benches/deephistory_subdir_sparse.rs
@@ -104,10 +104,9 @@ impl SubdirBench {
 
         let filter = Filter::new().subdir(SUBDIR);
 
-        josh_core::cache::sled_load(provisioned.path())?;
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::default()),
+                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
         );
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 

--- a/josh-core/benches/refs_filter_update.rs
+++ b/josh-core/benches/refs_filter_update.rs
@@ -116,10 +116,9 @@ impl RefsBench {
 
         let filter = Filter::new().subdir(SUBDIR);
 
-        josh_core::cache::sled_load(provisioned.path())?;
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::default()),
+                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
         );
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 

--- a/josh-core/benches/ultrawide_pin.rs
+++ b/josh-core/benches/ultrawide_pin.rs
@@ -67,11 +67,10 @@ impl PinBench {
         )?;
 
         let head = provisioned.head;
-        josh_core::cache::sled_load(provisioned.path())?;
 
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::default()),
+                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
         );
 
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);

--- a/josh-core/benches/ultrawide_pin_hook.rs
+++ b/josh-core/benches/ultrawide_pin_hook.rs
@@ -176,10 +176,9 @@ impl PinBench {
             .hook(HOOK_ARG_ONE_TREE)
             .with_meta("history", "no-splice");
 
-        josh_core::cache::sled_load(provisioned.path())?;
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::default()),
+                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
         );
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 

--- a/josh-core/benches/unapply.rs
+++ b/josh-core/benches/unapply.rs
@@ -85,10 +85,9 @@ impl UnapplyBench {
 
         let filter = Filter::new().subdir(SUBDIR);
 
-        josh_core::cache::sled_load(provisioned.path())?;
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::default()),
+                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
         );
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 

--- a/josh-core/benches/widetree_glob.rs
+++ b/josh-core/benches/widetree_glob.rs
@@ -124,10 +124,9 @@ impl GlobBench {
             }
         }
 
-        josh_core::cache::sled_load(provisioned.path())?;
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::default()),
+                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
         );
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 

--- a/josh-core/src/cache/backend.rs
+++ b/josh-core/src/cache/backend.rs
@@ -27,10 +27,15 @@ pub trait CacheBackend: Send + Sync {
         tree_keyed: bool,
     ) -> anyhow::Result<()>;
 
-    /// Drop any cached handles into the underlying store. The default is a no-op; backends holding
-    /// a lock (e.g. the sled tree handles) override this so the lock can be released. Reads and
-    /// writes stay valid afterwards, transparently reacquiring what they need.
-    fn release(&self) {}
+    /// Register the start of a transaction against this backend. The default is a no-op; backends
+    /// whose underlying store holds a process-exclusive lock (the sled backend) use this to open
+    /// lazily and reference-count active transactions.
+    fn begin(&self) {}
+
+    /// Register the end of a transaction. Balances a prior [`CacheBackend::begin`]. When the last
+    /// active transaction ends, a locking backend flushes and drops its handles, releasing the lock
+    /// until the next [`CacheBackend::begin`] transparently reopens what it needs.
+    fn end(&self) {}
 }
 
 /// Per-commit history-graph facts passed along with every cache record.

--- a/josh-core/src/cache/backend.rs
+++ b/josh-core/src/cache/backend.rs
@@ -30,10 +30,15 @@ pub trait CacheBackend: Send + Sync {
         tree_keyed: bool,
     ) -> anyhow::Result<()>;
 
-    /// Drop any cached handles into the underlying store. The default is a no-op; backends holding
-    /// a lock (e.g. the sled tree handles) override this so the lock can be released. Reads and
-    /// writes stay valid afterwards, transparently reacquiring what they need.
-    fn release(&self) {}
+    /// Register the start of a transaction against this backend. The default is a no-op; backends
+    /// whose underlying store holds a process-exclusive lock (the sled backend) use this to open
+    /// lazily and reference-count active transactions.
+    fn begin(&self) {}
+
+    /// Register the end of a transaction. Balances a prior [`CacheBackend::begin`]. When the last
+    /// active transaction ends, a locking backend flushes and drops its handles, releasing the lock
+    /// until the next [`CacheBackend::begin`] transparently reopens what it needs.
+    fn end(&self) {}
 }
 
 /// Per-commit history-graph facts passed along with every cache record.

--- a/josh-core/src/cache/mod.rs
+++ b/josh-core/src/cache/mod.rs
@@ -19,9 +19,7 @@ pub use history_graph::{
     HistoryGraphInfo, collect_history_graph_info, compute_history_hint, compute_sequence_number,
     parents_share_root,
 };
-pub use sled::{
-    SledCacheBackend, sled_clear, sled_flush, sled_load, sled_print_stats, sled_unload,
-};
+pub use sled::{SledCacheBackend, sled_clear, sled_print_stats};
 pub use stack::CacheStack;
 pub use transaction::*;
 pub use tree_cache::TreeBytes;

--- a/josh-core/src/cache/sled.rs
+++ b/josh-core/src/cache/sled.rs
@@ -6,99 +6,98 @@ use super::backend::{CacheBackend, HistoryGraphHint};
 use crate::filter;
 use crate::filter::Filter;
 
-static DB: LazyLock<std::sync::Mutex<Option<sled::Db>>> = LazyLock::new(Default::default);
-
-/// Remove all entries from every tree in the global on-disk cache.
+/// Process-wide state of the on-disk sled cache.
 ///
-/// This nukes the persistent sled cache. Doing so is safe: the sled cache is
-/// ephemeral and, when configured, backed by a remote cache. Primarily intended
-/// for benchmarks and tests that need a cold cache between runs. Does nothing if
-/// the cache has not been loaded.
-pub fn sled_clear() -> anyhow::Result<()> {
-    let db = DB.lock().unwrap();
-    let Some(db) = db.as_ref() else {
-        return Ok(());
-    };
-
-    for name in db.tree_names() {
-        db.open_tree(&name)?.clear()?;
-    }
-
-    Ok(())
+/// sled takes a process-exclusive file lock on the cache directory and permits only one open handle
+/// per path per process, so the db is a single shared instance rather than per-backend -- every
+/// [`SledCacheBackend`] forwards here. Its lifetime is driven by `active`, the number of live
+/// transactions (plus any [`SledCacheBackend::pin`]): the db is opened lazily on the first
+/// transaction and dropped once the last one ends, releasing the lock. There is no explicit
+/// load/release step.
+struct State {
+    /// Cache directory, set by [`SledCacheBackend::new`]. `None` until the first backend is built.
+    path: Option<std::path::PathBuf>,
+    db: Option<sled::Db>,
+    trees: std::collections::HashMap<git2::Oid, sled::Tree>,
+    active: usize,
 }
 
-pub fn sled_print_stats() -> anyhow::Result<()> {
-    let db = DB.lock().unwrap();
-    let db = match db.as_ref() {
-        Some(db) => db,
-        None => return Err(anyhow!("cache not initialized")),
-    };
+static STATE: LazyLock<std::sync::Mutex<State>> = LazyLock::new(|| {
+    std::sync::Mutex::new(State {
+        path: None,
+        db: None,
+        trees: Default::default(),
+        active: 0,
+    })
+});
 
-    db.flush()?;
-    log::debug!("Trees:");
-
-    let mut v = vec![];
-    for name in db.tree_names() {
-        let name = String::from_utf8(name.to_vec())?;
-        let t = db.open_tree(&name)?;
-
-        if !t.is_empty() {
-            let name = if let Ok(filter) = filter::parse(&name) {
-                filter::pretty(filter, 4)
-            } else {
-                name.clone()
-            };
-            v.push((t.len(), name));
+impl State {
+    /// Ensure the db is open, returning a reference to it. Errors if no cache path has been
+    /// configured (i.e. no [`SledCacheBackend::new`] was ever called).
+    fn ensure_open(&mut self) -> anyhow::Result<&sled::Db> {
+        if self.db.is_none() {
+            let path = self
+                .path
+                .as_ref()
+                .ok_or_else(|| anyhow!("sled cache path not configured"))?;
+            self.db = Some(
+                sled::Config::default()
+                    .path(path.join(format!("josh/cache/{}/sled/", CACHE_VERSION)))
+                    .flush_every_ms(Some(200))
+                    .open()?,
+            );
         }
+        Ok(self.db.as_ref().unwrap())
     }
 
-    v.sort();
-
-    for (len, name) in v.iter() {
-        println!("[{}] {}", len, name);
+    /// Look up (opening and caching if needed) the per-filter tree.
+    fn tree(&mut self, filter: Filter) -> anyhow::Result<sled::Tree> {
+        if let Some(tree) = self.trees.get(&filter.id()) {
+            return Ok(tree.clone());
+        }
+        let tree = self.ensure_open()?.open_tree(filter::spec(filter))?;
+        self.trees.insert(filter.id(), tree.clone());
+        Ok(tree)
     }
 
-    Ok(())
-}
-
-/// Flush any pending writes of the global cache db to disk. No-op if the cache is not loaded.
-pub fn sled_flush() -> anyhow::Result<()> {
-    if let Some(db) = DB.lock().unwrap().as_ref() {
-        db.flush()?;
+    /// Flush pending writes, then drop the cached tree handles and the db, releasing sled's file
+    /// lock on the cache directory.
+    fn close(&mut self) {
+        if let Some(Err(e)) = self.db.as_ref().map(|db| db.flush()) {
+            log::error!("failed to flush sled cache: {e}");
+        }
+        self.trees.clear();
+        self.db = None;
     }
-    Ok(())
 }
 
-/// Drop the global cache db, releasing sled's exclusive file lock on the cache directory. Any
-/// remaining `sled::Tree` handles keep the underlying store (and its lock) alive, so callers must
-/// drop those first; see [`crate::cache::Transaction::release_cache`].
-pub fn sled_unload() {
-    *DB.lock().unwrap() = None;
-}
+/// Per-filter on-disk cache backed by sled.
+///
+/// The backend is a thin handle onto the process-wide sled db (see [`State`]); the db itself is
+/// opened lazily and dropped automatically once no transaction is active. Constructing a backend
+/// with [`SledCacheBackend::new`] configures the cache directory; a long-running process (the proxy)
+/// that wants the cache hot for its whole lifetime additionally calls [`SledCacheBackend::pin`].
+#[derive(Clone, Default)]
+pub struct SledCacheBackend;
 
-pub fn sled_load(path: &std::path::Path) -> anyhow::Result<()> {
-    let db = sled::Config::default()
-        .path(path.join(format!("josh/cache/{}/sled/", CACHE_VERSION)))
-        .flush_every_ms(Some(200))
-        .open()?;
+impl SledCacheBackend {
+    /// Configure the on-disk cache directory and return a backend handle. Must be called before any
+    /// transaction opens; later calls repoint the shared cache path.
+    pub fn new(path: impl AsRef<std::path::Path>) -> Self {
+        STATE.lock().unwrap().path = Some(path.as_ref().to_path_buf());
+        Self
+    }
 
-    *DB.lock().unwrap() = Some(db);
-
-    Ok(())
-}
-
-#[derive(Default)]
-pub struct SledCacheBackend {
-    trees: std::sync::Mutex<std::collections::HashMap<git2::Oid, sled::Tree>>,
-}
-
-fn insert_sled_tree(filter: Filter) -> sled::Tree {
-    DB.lock()
-        .unwrap()
-        .as_ref()
-        .expect("Sled DB not initialized")
-        .open_tree(filter::spec(filter))
-        .expect("Failed to insert Sled tree")
+    /// Keep the db open for the lifetime of the process regardless of transaction activity. This is
+    /// an unbalanced [`CacheBackend::begin`]: it opens the db and bumps the active count once
+    /// without a matching `end`, so the cache stays hot and the lock is held until the process
+    /// exits. Used by the proxy.
+    pub fn pin(&self) -> anyhow::Result<()> {
+        let mut state = STATE.lock().unwrap();
+        state.ensure_open()?;
+        state.active += 1;
+        Ok(())
+    }
 }
 
 impl CacheBackend for SledCacheBackend {
@@ -111,14 +110,9 @@ impl CacheBackend for SledCacheBackend {
         // whether the key is a commit or a tree, so tree-keyed records need no special handling.
         _tree_keyed: bool,
     ) -> anyhow::Result<Option<git2::Oid>> {
-        let mut trees = self.trees.lock().unwrap();
-        let tree = trees
-            .entry(filter.id())
-            .or_insert_with(|| insert_sled_tree(filter));
-
+        let tree = STATE.lock().unwrap().tree(filter)?;
         if let Some(oid) = tree.get(from.as_bytes())? {
-            let oid = git2::Oid::from_bytes(&oid)?;
-            Ok(Some(oid))
+            Ok(Some(git2::Oid::from_bytes(&oid)?))
         } else {
             Ok(None)
         }
@@ -132,18 +126,99 @@ impl CacheBackend for SledCacheBackend {
         _hint: HistoryGraphHint,
         _tree_keyed: bool,
     ) -> anyhow::Result<()> {
-        let mut trees = self.trees.lock().unwrap();
-        let tree = trees
-            .entry(filter.id())
-            .or_insert_with(|| insert_sled_tree(filter));
-
+        let tree = STATE.lock().unwrap().tree(filter)?;
         tree.insert(from.as_bytes(), to.as_bytes())?;
         Ok(())
     }
 
-    /// Drop the cached per-filter tree handles so that, once the global db is unloaded, sled's file
-    /// lock is released. A later read/write transparently reopens the trees.
-    fn release(&self) {
-        self.trees.lock().unwrap().clear();
+    /// Open the db (if needed) and count this transaction as active.
+    fn begin(&self) {
+        let mut state = STATE.lock().unwrap();
+        if let Err(e) = state.ensure_open() {
+            log::error!("failed to open sled cache: {e}");
+            return;
+        }
+        state.active += 1;
     }
+
+    /// Drop this transaction from the active count; when the last one ends, flush and close the db,
+    /// releasing sled's exclusive lock. A later [`CacheBackend::begin`] reopens it transparently.
+    fn end(&self) {
+        let mut state = STATE.lock().unwrap();
+        state.active = state.active.saturating_sub(1);
+        if state.active == 0 {
+            state.close();
+        }
+    }
+}
+
+/// Run a maintenance closure against the shared db, opening it temporarily if no transaction is
+/// holding it open and closing it again afterwards. Returns `None` if no cache path is configured.
+fn with_maintenance_db<T>(
+    f: impl FnOnce(&sled::Db) -> anyhow::Result<T>,
+) -> anyhow::Result<Option<T>> {
+    let mut state = STATE.lock().unwrap();
+    if state.path.is_none() {
+        return Ok(None);
+    }
+    let opened_here = state.db.is_none();
+    let result = f(state.ensure_open()?);
+    // If we opened the db just for this maintenance op, close it again to keep the "open only while
+    // a transaction is active" invariant.
+    if opened_here && state.active == 0 {
+        state.close();
+    }
+    result.map(Some)
+}
+
+/// Remove all entries from every tree in the on-disk cache.
+///
+/// This nukes the persistent sled cache. Doing so is safe: the sled cache is
+/// ephemeral and, when configured, backed by a remote cache. Primarily intended
+/// for benchmarks and tests that need a cold cache between runs. Does nothing if
+/// no cache directory has been configured.
+pub fn sled_clear() -> anyhow::Result<()> {
+    with_maintenance_db(|db| {
+        for name in db.tree_names() {
+            db.open_tree(&name)?.clear()?;
+        }
+        Ok(())
+    })?;
+    Ok(())
+}
+
+pub fn sled_print_stats() -> anyhow::Result<()> {
+    let printed = with_maintenance_db(|db| {
+        db.flush()?;
+        log::debug!("Trees:");
+
+        let mut v = vec![];
+        for name in db.tree_names() {
+            let name = String::from_utf8(name.to_vec())?;
+            let t = db.open_tree(&name)?;
+
+            if !t.is_empty() {
+                let name = if let Ok(filter) = filter::parse(&name) {
+                    filter::pretty(filter, 4)
+                } else {
+                    name.clone()
+                };
+                v.push((t.len(), name));
+            }
+        }
+
+        v.sort();
+
+        for (len, name) in v.iter() {
+            println!("[{}] {}", len, name);
+        }
+
+        Ok(())
+    })?;
+
+    if printed.is_none() {
+        return Err(anyhow!("cache not initialized"));
+    }
+
+    Ok(())
 }

--- a/josh-core/src/cache/sled.rs
+++ b/josh-core/src/cache/sled.rs
@@ -6,99 +6,96 @@ use super::backend::{CacheBackend, HistoryGraphHint};
 use crate::filter;
 use crate::filter::Filter;
 
-static DB: LazyLock<std::sync::Mutex<Option<sled::Db>>> = LazyLock::new(Default::default);
-
-/// Remove all entries from every tree in the global on-disk cache.
+/// Process-wide state of the on-disk sled cache.
 ///
-/// This nukes the persistent sled cache. Doing so is safe: the sled cache is
-/// ephemeral and, when configured, backed by a remote cache. Primarily intended
-/// for benchmarks and tests that need a cold cache between runs. Does nothing if
-/// the cache has not been loaded.
-pub fn sled_clear() -> anyhow::Result<()> {
-    let db = DB.lock().unwrap();
-    let Some(db) = db.as_ref() else {
-        return Ok(());
-    };
-
-    for name in db.tree_names() {
-        db.open_tree(&name)?.clear()?;
-    }
-
-    Ok(())
+/// sled takes a process-exclusive file lock on the cache directory and permits only one open handle
+/// per path per process, so the db is a single shared instance rather than per-backend -- every
+/// [`SledCacheBackend`] forwards here. Its lifetime is driven by `active`, the number of live
+/// transactions (plus any [`SledCacheBackend::pin`]): the db is opened lazily on the first
+/// transaction and dropped once the last one ends, releasing the lock.
+struct State {
+    /// Cache directory, set by [`SledCacheBackend::new`]. `None` until the first backend is built.
+    path: Option<std::path::PathBuf>,
+    db: Option<sled::Db>,
+    trees: std::collections::HashMap<git2::Oid, sled::Tree>,
+    active: usize,
 }
 
-pub fn sled_print_stats() -> anyhow::Result<()> {
-    let db = DB.lock().unwrap();
-    let db = match db.as_ref() {
-        Some(db) => db,
-        None => return Err(anyhow!("cache not initialized")),
-    };
+static STATE: LazyLock<std::sync::Mutex<State>> = LazyLock::new(|| {
+    std::sync::Mutex::new(State {
+        path: None,
+        db: None,
+        trees: Default::default(),
+        active: 0,
+    })
+});
 
-    db.flush()?;
-    log::debug!("Trees:");
-
-    let mut v = vec![];
-    for name in db.tree_names() {
-        let name = String::from_utf8(name.to_vec())?;
-        let t = db.open_tree(&name)?;
-
-        if !t.is_empty() {
-            let name = if let Ok(filter) = filter::parse(&name) {
-                filter::pretty(filter, 4)
-            } else {
-                name.clone()
-            };
-            v.push((t.len(), name));
+impl State {
+    /// Open the db if it isn't already. Errors if no [`SledCacheBackend::new`] ever configured a
+    /// cache path.
+    fn ensure_open(&mut self) -> anyhow::Result<&sled::Db> {
+        if self.db.is_none() {
+            let path = self
+                .path
+                .as_ref()
+                .ok_or_else(|| anyhow!("sled cache path not configured"))?;
+            self.db = Some(
+                sled::Config::default()
+                    .path(path.join(format!("josh/cache/{}/sled/", CACHE_VERSION)))
+                    .flush_every_ms(Some(200))
+                    .open()?,
+            );
         }
+        Ok(self.db.as_ref().unwrap())
     }
 
-    v.sort();
-
-    for (len, name) in v.iter() {
-        println!("[{}] {}", len, name);
+    fn tree(&mut self, filter: Filter) -> anyhow::Result<sled::Tree> {
+        if let Some(tree) = self.trees.get(&filter.id()) {
+            return Ok(tree.clone());
+        }
+        let tree = self.ensure_open()?.open_tree(filter::spec(filter))?;
+        self.trees.insert(filter.id(), tree.clone());
+        Ok(tree)
     }
 
-    Ok(())
-}
-
-/// Flush any pending writes of the global cache db to disk. No-op if the cache is not loaded.
-pub fn sled_flush() -> anyhow::Result<()> {
-    if let Some(db) = DB.lock().unwrap().as_ref() {
-        db.flush()?;
+    /// Flush pending writes, then drop the cached tree handles and the db, releasing sled's file
+    /// lock on the cache directory.
+    fn close(&mut self) {
+        if let Some(Err(e)) = self.db.as_ref().map(|db| db.flush()) {
+            log::error!("failed to flush sled cache: {e}");
+        }
+        self.trees.clear();
+        self.db = None;
     }
-    Ok(())
 }
 
-/// Drop the global cache db, releasing sled's exclusive file lock on the cache directory. Any
-/// remaining `sled::Tree` handles keep the underlying store (and its lock) alive, so callers must
-/// drop those first; see [`crate::cache::Transaction::release_cache`].
-pub fn sled_unload() {
-    *DB.lock().unwrap() = None;
-}
+/// Per-filter on-disk cache backed by sled.
+///
+/// The backend is a thin handle onto the process-wide sled db (see [`State`]); the db itself is
+/// opened lazily and dropped automatically once no transaction is active. Constructing a backend
+/// with [`SledCacheBackend::new`] configures the cache directory; a long-running process (the proxy)
+/// that wants the cache hot for its whole lifetime additionally calls [`SledCacheBackend::pin`].
+#[derive(Clone, Default)]
+pub struct SledCacheBackend;
 
-pub fn sled_load(path: &std::path::Path) -> anyhow::Result<()> {
-    let db = sled::Config::default()
-        .path(path.join(format!("josh/cache/{}/sled/", CACHE_VERSION)))
-        .flush_every_ms(Some(200))
-        .open()?;
+impl SledCacheBackend {
+    /// Configure the on-disk cache directory and return a backend handle. Must be called before any
+    /// transaction opens; later calls repoint the shared cache path.
+    pub fn new(path: impl AsRef<std::path::Path>) -> Self {
+        STATE.lock().unwrap().path = Some(path.as_ref().to_path_buf());
+        Self
+    }
 
-    *DB.lock().unwrap() = Some(db);
-
-    Ok(())
-}
-
-#[derive(Default)]
-pub struct SledCacheBackend {
-    trees: std::sync::Mutex<std::collections::HashMap<git2::Oid, sled::Tree>>,
-}
-
-fn insert_sled_tree(filter: Filter) -> sled::Tree {
-    DB.lock()
-        .unwrap()
-        .as_ref()
-        .expect("Sled DB not initialized")
-        .open_tree(filter::spec(filter))
-        .expect("Failed to insert Sled tree")
+    /// Keep the db open for the lifetime of the process regardless of transaction activity. This is
+    /// an unbalanced [`CacheBackend::begin`]: it opens the db and bumps the active count once
+    /// without a matching `end`, so the cache stays hot and the lock is held until the process
+    /// exits.
+    pub fn pin(&self) -> anyhow::Result<()> {
+        let mut state = STATE.lock().unwrap();
+        state.ensure_open()?;
+        state.active += 1;
+        Ok(())
+    }
 }
 
 impl CacheBackend for SledCacheBackend {
@@ -110,14 +107,9 @@ impl CacheBackend for SledCacheBackend {
         // Sled stores records by filter alone, so the key kind needs no special handling.
         _tree_keyed: bool,
     ) -> anyhow::Result<Option<git2::Oid>> {
-        let mut trees = self.trees.lock().unwrap();
-        let tree = trees
-            .entry(filter.id())
-            .or_insert_with(|| insert_sled_tree(filter));
-
+        let tree = STATE.lock().unwrap().tree(filter)?;
         if let Some(oid) = tree.get(from.as_bytes())? {
-            let oid = git2::Oid::from_bytes(&oid)?;
-            Ok(Some(oid))
+            Ok(Some(git2::Oid::from_bytes(&oid)?))
         } else {
             Ok(None)
         }
@@ -131,18 +123,99 @@ impl CacheBackend for SledCacheBackend {
         _hint: HistoryGraphHint,
         _tree_keyed: bool,
     ) -> anyhow::Result<()> {
-        let mut trees = self.trees.lock().unwrap();
-        let tree = trees
-            .entry(filter.id())
-            .or_insert_with(|| insert_sled_tree(filter));
-
+        let tree = STATE.lock().unwrap().tree(filter)?;
         tree.insert(from.as_bytes(), to.as_bytes())?;
         Ok(())
     }
 
-    /// Drop the cached per-filter tree handles so that, once the global db is unloaded, sled's file
-    /// lock is released. A later read/write transparently reopens the trees.
-    fn release(&self) {
-        self.trees.lock().unwrap().clear();
+    /// Open the db (if needed) and count this transaction as active.
+    fn begin(&self) {
+        let mut state = STATE.lock().unwrap();
+        if let Err(e) = state.ensure_open() {
+            log::error!("failed to open sled cache: {e}");
+            return;
+        }
+        state.active += 1;
     }
+
+    /// Drop this transaction from the active count; when the last one ends, flush and close the db,
+    /// releasing sled's exclusive lock. A later [`CacheBackend::begin`] reopens it transparently.
+    fn end(&self) {
+        let mut state = STATE.lock().unwrap();
+        state.active = state.active.saturating_sub(1);
+        if state.active == 0 {
+            state.close();
+        }
+    }
+}
+
+/// Run a maintenance closure against the shared db, opening it temporarily if no transaction is
+/// holding it open and closing it again afterwards. Returns `None` if no cache path is configured.
+fn with_maintenance_db<T>(
+    f: impl FnOnce(&sled::Db) -> anyhow::Result<T>,
+) -> anyhow::Result<Option<T>> {
+    let mut state = STATE.lock().unwrap();
+    if state.path.is_none() {
+        return Ok(None);
+    }
+    let opened_here = state.db.is_none();
+    let result = f(state.ensure_open()?);
+    // If we opened the db just for this maintenance op, close it again to keep the "open only while
+    // a transaction is active" invariant.
+    if opened_here && state.active == 0 {
+        state.close();
+    }
+    result.map(Some)
+}
+
+/// Remove all entries from every tree in the on-disk cache.
+///
+/// This nukes the persistent sled cache. Doing so is safe: the sled cache is
+/// ephemeral and, when configured, backed by a remote cache. Primarily intended
+/// for benchmarks and tests that need a cold cache between runs. Does nothing if
+/// no cache directory has been configured.
+pub fn sled_clear() -> anyhow::Result<()> {
+    with_maintenance_db(|db| {
+        for name in db.tree_names() {
+            db.open_tree(&name)?.clear()?;
+        }
+        Ok(())
+    })?;
+    Ok(())
+}
+
+pub fn sled_print_stats() -> anyhow::Result<()> {
+    let printed = with_maintenance_db(|db| {
+        db.flush()?;
+        log::debug!("Trees:");
+
+        let mut v = vec![];
+        for name in db.tree_names() {
+            let name = String::from_utf8(name.to_vec())?;
+            let t = db.open_tree(&name)?;
+
+            if !t.is_empty() {
+                let name = if let Ok(filter) = filter::parse(&name) {
+                    filter::pretty(filter, 4)
+                } else {
+                    name.clone()
+                };
+                v.push((t.len(), name));
+            }
+        }
+
+        v.sort();
+
+        for (len, name) in v.iter() {
+            println!("[{}] {}", len, name);
+        }
+
+        Ok(())
+    })?;
+
+    if printed.is_none() {
+        return Err(anyhow!("cache not initialized"));
+    }
+
+    Ok(())
 }

--- a/josh-core/src/cache/stack.rs
+++ b/josh-core/src/cache/stack.rs
@@ -8,7 +8,7 @@ pub struct CacheStack {
 
 impl Default for CacheStack {
     fn default() -> Self {
-        CacheStack::new().with_backend(SledCacheBackend::default())
+        CacheStack::new().with_backend(SledCacheBackend)
     }
 }
 
@@ -43,10 +43,17 @@ impl CacheStack {
         Ok(())
     }
 
-    /// Release cached handles across all backends (see [`CacheBackend::release`]).
-    pub fn release(&self) {
+    /// Register the start of a transaction across all backends (see [`CacheBackend::begin`]).
+    pub fn begin(&self) {
         for backend in &self.backends {
-            backend.release();
+            backend.begin();
+        }
+    }
+
+    /// Register the end of a transaction across all backends (see [`CacheBackend::end`]).
+    pub fn end(&self) {
+        for backend in &self.backends {
+            backend.end();
         }
     }
 

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -162,6 +162,11 @@ pub struct Transaction {
 
 impl Drop for Transaction {
     fn drop(&mut self) {
+        // Balance the `begin` from `Transaction::new`. Unconditional (even for ephemeral
+        // transactions) so the sled backend's active-transaction count stays balanced and the
+        // on-disk cache lock is released once the last transaction ends.
+        self.t2.borrow().cache.end();
+
         // Skip flushing to disk, the mem odb will be lost, as requested.
         if self.ephemeral {
             return;
@@ -198,6 +203,10 @@ impl Transaction {
 
         let mem_odb = josh_memodb::MemOdb::new(mem_odb_limit, repo.path().to_owned());
         mem_odb.register(&repo);
+
+        // Register this transaction with the cache backends so a locking backend (sled) opens
+        // lazily and holds its lock only while a transaction is live. Balanced in `Drop`.
+        cache.begin();
 
         log::debug!("new transaction");
 
@@ -243,21 +252,6 @@ impl Transaction {
 
     pub fn repo(&self) -> &git2::Repository {
         &self.repo
-    }
-
-    /// Close the on-disk cache, releasing sled's exclusive lock on the cache directory so other
-    /// josh processes can open it. This flushes pending writes, then drops the remaining sled
-    /// handles: the shared backend's per-filter trees and the process-global database.
-    ///
-    /// Call once no further cache reads or writes will happen. The repo and in-memory object store
-    /// stay usable, so a filtering phase can hand its result to a long, cache-free tail (for
-    /// example running containers) without pinning the lock. A later cache read or write reopens
-    /// what it needs.
-    pub fn release_cache(&self) -> anyhow::Result<()> {
-        crate::cache::sled::sled_flush()?;
-        self.t2.borrow().cache.release();
-        crate::cache::sled::sled_unload();
-        Ok(())
     }
 
     /// Read the raw bytes of the tree `oid` through the per-transaction [`TreeCache`]
@@ -770,15 +764,8 @@ mod tests {
     use super::*;
 
     fn test_transaction() -> (tempfile::TempDir, Transaction) {
-        // The sled cache is a process-global, so it gets one directory for the whole test
-        // binary rather than one per transaction.
-        static SLED_DIR: std::sync::LazyLock<tempfile::TempDir> = std::sync::LazyLock::new(|| {
-            let dir = tempfile::tempdir().unwrap();
-            crate::cache::sled_load(dir.path()).unwrap();
-            dir
-        });
-        let _ = &*SLED_DIR;
-
+        // These tests exercise ref/commit machinery, not the on-disk cache, so an empty cache
+        // stack (no sled backend) is enough.
         let dir = tempfile::tempdir().unwrap();
         git2::Repository::init_bare(dir.path()).unwrap();
         let context = TransactionContext::new(

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -161,6 +161,10 @@ pub struct Transaction {
 
 impl Drop for Transaction {
     fn drop(&mut self) {
+        // Balance the `begin` from `Transaction::new`, even for ephemeral transactions, so a
+        // locking backend can release once the last transaction ends.
+        self.t2.borrow().cache.end();
+
         // Skip flushing to disk, the mem odb will be lost, as requested.
         if self.ephemeral {
             return;
@@ -197,6 +201,10 @@ impl Transaction {
 
         let mem_odb = josh_memodb::MemOdb::new(mem_odb_limit, repo.path().to_owned());
         mem_odb.register(&repo);
+
+        // Balanced in `Drop`; lets a locking backend (sled) hold its lock only while a
+        // transaction is live.
+        cache.begin();
 
         log::debug!("new transaction");
 
@@ -242,21 +250,6 @@ impl Transaction {
 
     pub fn repo(&self) -> &git2::Repository {
         &self.repo
-    }
-
-    /// Close the on-disk cache, releasing sled's exclusive lock on the cache directory so other
-    /// josh processes can open it. This flushes pending writes, then drops the remaining sled
-    /// handles: the shared backend's per-filter trees and the process-global database.
-    ///
-    /// Call once no further cache reads or writes will happen. The repo and in-memory object store
-    /// stay usable, so a filtering phase can hand its result to a long, cache-free tail (for
-    /// example running containers) without pinning the lock. A later cache read or write reopens
-    /// what it needs.
-    pub fn release_cache(&self) -> anyhow::Result<()> {
-        crate::cache::sled::sled_flush()?;
-        self.t2.borrow().cache.release();
-        crate::cache::sled::sled_unload();
-        Ok(())
     }
 
     /// Read the raw bytes of the tree `oid` through the per-transaction [`TreeCache`]
@@ -759,15 +752,8 @@ mod tests {
     use super::*;
 
     fn test_transaction() -> (tempfile::TempDir, Transaction) {
-        // The sled cache is a process-global, so it gets one directory for the whole test
-        // binary rather than one per transaction.
-        static SLED_DIR: std::sync::LazyLock<tempfile::TempDir> = std::sync::LazyLock::new(|| {
-            let dir = tempfile::tempdir().unwrap();
-            crate::cache::sled_load(dir.path()).unwrap();
-            dir
-        });
-        let _ = &*SLED_DIR;
-
+        // These tests exercise ref/commit machinery, not the on-disk cache, so an empty cache
+        // stack (no sled backend) is enough.
         let dir = tempfile::tempdir().unwrap();
         git2::Repository::init_bare(dir.path()).unwrap();
         let context = TransactionContext::new(

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2690,9 +2690,8 @@ mod tests {
             .unwrap();
         let tree = repo.find_tree(tree).unwrap();
 
-        cache::sled_load(td.path()).unwrap();
         let cachestack = std::sync::Arc::new(
-            cache::CacheStack::new().with_backend(cache::SledCacheBackend::default()),
+            cache::CacheStack::new().with_backend(cache::SledCacheBackend::new(td.path())),
         );
         let ctx = cache::TransactionContext::new(td.path(), cachestack);
         let t = ctx.open().unwrap();
@@ -2838,9 +2837,8 @@ mod tests {
             "merge change",
         );
 
-        cache::sled_load(td.path()).unwrap();
         let cachestack = std::sync::Arc::new(
-            cache::CacheStack::new().with_backend(cache::SledCacheBackend::default()),
+            cache::CacheStack::new().with_backend(cache::SledCacheBackend::new(td.path())),
         );
         let ctx = cache::TransactionContext::new(td.path(), cachestack);
         let t = ctx.open().unwrap();

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2687,9 +2687,8 @@ mod tests {
             .unwrap();
         let tree = repo.find_tree(tree).unwrap();
 
-        cache::sled_load(td.path()).unwrap();
         let cachestack = std::sync::Arc::new(
-            cache::CacheStack::new().with_backend(cache::SledCacheBackend::default()),
+            cache::CacheStack::new().with_backend(cache::SledCacheBackend::new(td.path())),
         );
         let ctx = cache::TransactionContext::new(td.path(), cachestack);
         let t = ctx.open().unwrap();
@@ -2835,9 +2834,8 @@ mod tests {
             "merge change",
         );
 
-        cache::sled_load(td.path()).unwrap();
         let cachestack = std::sync::Arc::new(
-            cache::CacheStack::new().with_backend(cache::SledCacheBackend::default()),
+            cache::CacheStack::new().with_backend(cache::SledCacheBackend::new(td.path())),
         );
         let ctx = cache::TransactionContext::new(td.path(), cachestack);
         let t = ctx.open().unwrap();

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -1167,8 +1167,9 @@ mod tests {
     }
 
     fn open_transaction(td: &tempfile::TempDir) -> cache::Transaction {
-        cache::sled_load(td.path()).unwrap();
-        let ctx = cache::TransactionContext::new(td.path(), cache::CacheStack::default().into());
+        let cachestack =
+            cache::CacheStack::new().with_backend(cache::SledCacheBackend::new(td.path()));
+        let ctx = cache::TransactionContext::new(td.path(), cachestack.into());
         ctx.open().unwrap()
     }
 

--- a/josh-core/tests/cache_lock.rs
+++ b/josh-core/tests/cache_lock.rs
@@ -1,46 +1,60 @@
-//! `Transaction::release_cache` must free sled's exclusive lock on the cache directory so another
-//! opener can take it. This lives in its own integration binary because it loads and unloads the
-//! process-global cache db; sharing that global with the unit tests (which keep it loaded for the
-//! whole run) would race.
+//! The sled cache holds a process-exclusive lock on the cache directory only while a transaction is
+//! active: it is opened lazily on the first transaction and dropped once the last one ends. This
+//! lives in its own integration binary because it exercises that process-global lifetime; sharing
+//! it with the unit tests (which configure a cache for the whole run) would race.
 
 use std::sync::Arc;
 
-use josh_core::cache::{CacheStack, TransactionContext, sled_load, sled_unload};
+use josh_core::cache::{CACHE_VERSION, CacheStack, SledCacheBackend, TransactionContext};
 use josh_core::filter;
 
+/// The directory sled locks for a cache rooted at `repo` (mirrors the backend's own layout).
+fn sled_dir(repo: &std::path::Path) -> std::path::PathBuf {
+    repo.join(format!("josh/cache/{}/sled/", CACHE_VERSION))
+}
+
+/// Try to open the sled db directly. `Err` means the cache directory is still locked by someone
+/// else; the db opened here is closed again immediately.
+fn open_is_locked(repo: &std::path::Path) -> bool {
+    sled::Config::default().path(sled_dir(repo)).open().is_err()
+}
+
 #[test]
-fn release_cache_frees_the_sled_lock() {
+fn sled_lock_follows_transaction_lifetime() {
     let dir = tempfile::tempdir().unwrap();
     let repo = dir.path();
     git2::Repository::init_bare(repo).unwrap();
 
-    sled_load(repo).unwrap();
-    let transaction = TransactionContext::new(repo, Arc::new(CacheStack::default()))
-        .open()
-        .unwrap();
+    let cache = Arc::new(CacheStack::new().with_backend(SledCacheBackend::new(repo)));
+    let transaction = TransactionContext::new(repo, cache).open().unwrap();
 
-    // Force a backend cache write so the SledCacheBackend opens a per-filter tree -- that handle,
-    // plus the global db, is what release_cache has to drop to free the lock.
-    let git = transaction.repo();
-    let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
-    let tree = git
-        .find_tree(git.treebuilder(None).unwrap().write().unwrap())
-        .unwrap();
-    let commit = git.commit(None, &sig, &sig, "c", &tree, &[]).unwrap();
-    transaction
-        .insert(filter::parse(":/").unwrap(), commit, commit, true)
-        .unwrap();
+    // Force a backend cache write so the sled db (and a per-filter tree) is open -- that is what
+    // holds the exclusive lock on the cache directory. Scoped so the git borrows of `transaction`
+    // end before it is dropped below.
+    {
+        let git = transaction.repo();
+        let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
+        let tree = git
+            .find_tree(git.treebuilder(None).unwrap().write().unwrap())
+            .unwrap();
+        let commit = git.commit(None, &sig, &sig, "c", &tree, &[]).unwrap();
+        transaction
+            .insert(filter::parse(":/").unwrap(), commit, commit, true)
+            .unwrap();
+    }
 
-    // A second open of the same cache dir must fail while those handles are live: sled_load opens
-    // before swapping the global db in, so it observes the still-held lock and errors.
+    // While the transaction is alive the cache directory is locked: a direct open must fail.
     assert!(
-        sled_load(repo).is_err(),
-        "cache should be locked while the transaction holds it"
+        open_is_locked(repo),
+        "cache should be locked while a transaction is active"
     );
 
-    transaction.release_cache().unwrap();
+    drop(transaction);
 
-    // With every sled handle dropped, the cache dir opens cleanly again.
-    sled_load(repo).expect("cache still locked after release_cache");
-    sled_unload();
+    // Dropping the last transaction closes the sled db and releases the lock, so a fresh open
+    // succeeds again.
+    assert!(
+        !open_is_locked(repo),
+        "cache still locked after the transaction was dropped"
+    );
 }

--- a/josh-core/tests/cache_lock.rs
+++ b/josh-core/tests/cache_lock.rs
@@ -1,46 +1,60 @@
-//! `Transaction::release_cache` must free sled's exclusive lock on the cache directory so another
-//! opener can take it. This lives in its own integration binary because it loads and unloads the
-//! process-global cache db; sharing that global with the unit tests (which keep it loaded for the
-//! whole run) would race.
+//! The sled cache holds a process-exclusive lock on the cache directory only while a transaction is
+//! active: it is opened lazily on the first transaction and dropped once the last one ends. This
+//! lives in its own integration binary because it exercises that process-global lifetime; sharing
+//! it with the unit tests (which configure a cache for the whole run) would race.
 
 use std::sync::Arc;
 
-use josh_core::cache::{CacheStack, TransactionContext, sled_load, sled_unload};
+use josh_core::cache::{CACHE_VERSION, CacheStack, SledCacheBackend, TransactionContext};
 use josh_core::filter;
 
+/// The directory sled locks for a cache rooted at `repo` (mirrors the backend's own layout).
+fn sled_dir(repo: &std::path::Path) -> std::path::PathBuf {
+    repo.join(format!("josh/cache/{}/sled/", CACHE_VERSION))
+}
+
+/// Try to open the sled db directly. `Err` means the cache directory is still locked by someone
+/// else; the db opened here is closed again immediately.
+fn open_is_locked(repo: &std::path::Path) -> bool {
+    sled::Config::default().path(sled_dir(repo)).open().is_err()
+}
+
 #[test]
-fn release_cache_frees_the_sled_lock() {
+fn sled_lock_follows_transaction_lifetime() {
     let dir = tempfile::tempdir().unwrap();
     let repo = dir.path();
     git2::Repository::init_bare(repo).unwrap();
 
-    sled_load(repo).unwrap();
-    let transaction = TransactionContext::new(repo, Arc::new(CacheStack::default()))
-        .open()
-        .unwrap();
+    let cache = Arc::new(CacheStack::new().with_backend(SledCacheBackend::new(repo)));
+    let transaction = TransactionContext::new(repo, cache).open().unwrap();
 
-    // Force a backend cache write so the SledCacheBackend opens a per-filter tree -- that handle,
-    // plus the global db, is what release_cache has to drop to free the lock.
-    let git = transaction.repo();
-    let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
-    let tree = git
-        .find_tree(git.treebuilder(None).unwrap().write().unwrap())
-        .unwrap();
-    let commit = git.commit(None, &sig, &sig, "c", &tree, &[]).unwrap();
-    transaction
-        .insert(filter::parse(":/").unwrap(), commit, commit, true)
-        .unwrap();
+    // Force a backend cache write so the sled db (and a per-filter tree) is open -- that is what
+    // holds the exclusive lock on the cache directory. Scoped so the git borrows of `transaction`
+    // end before it is dropped below.
+    {
+        let git = transaction.repo();
+        let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
+        let tree = git
+            .find_tree(git.treebuilder(None).unwrap().write().unwrap())
+            .unwrap();
+        let commit = git.commit(None, &sig, &sig, "c", &tree, &[]).unwrap();
+        transaction
+            .insert(filter::parse(":/").unwrap(), commit, commit, true)
+            .unwrap();
+    }
 
-    // A second open of the same cache dir must fail while those handles are live: sled_load opens
-    // before swapping the global db in, so it observes the still-held lock and errors.
+    // While the transaction is alive the cache directory is locked: a direct open must fail.
     assert!(
-        sled_load(repo).is_err(),
-        "cache should be locked while the transaction holds it"
+        open_is_locked(repo),
+        "cache should be locked while a transaction is active"
     );
 
-    transaction.release_cache().unwrap();
+    drop(transaction);
 
-    // With every sled handle dropped, the cache dir opens cleanly again.
-    sled_load(repo).expect("cache still locked after release_cache");
-    sled_unload();
+    // Dropping the last transaction closes the sled db and releases the lock, so a fresh open
+    // succeeds again -- no explicit release step required.
+    assert!(
+        !open_is_locked(repo),
+        "cache still locked after the transaction was dropped"
+    );
 }

--- a/josh-proxy/benches/push_upstream.rs
+++ b/josh-proxy/benches/push_upstream.rs
@@ -87,7 +87,9 @@ async fn main() -> anyhow::Result<()> {
 
     josh_proxy::service::create_repo(&repo_path, Some(&args.josh_proxy_path))
         .expect("Failed to create repo");
-    josh_core::cache::sled_load(&repo_path).expect("Failed to load cache");
+    josh_core::cache::SledCacheBackend::new(&repo_path)
+        .pin()
+        .expect("Failed to load cache");
 
     let git_server_task = start_git_server(&args.upstream_dir).await;
     let (io_tx, mut io_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -155,7 +155,9 @@ async fn run_proxy(args: josh_proxy::cli::Args) -> anyhow::Result<i32> {
     let io_thread = tokio::task::spawn_blocking(move || io_thread(io_thread_rx));
 
     josh_proxy::service::create_repo(&local, None)?;
-    josh_core::cache::sled_load(&local)?;
+    // The proxy serves many concurrent transactions and should keep the cache hot rather than
+    // reopen it in the gaps between them, so pin the sled db open for the whole process.
+    josh_core::cache::SledCacheBackend::new(&local).pin()?;
 
     let proxy_service = make_service()
         .port(args.port)

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -155,7 +155,10 @@ async fn run_proxy(args: josh_proxy::cli::Args) -> anyhow::Result<i32> {
     let io_thread = tokio::task::spawn_blocking(move || io_thread(io_thread_rx));
 
     josh_proxy::service::create_repo(&local, None)?;
-    josh_core::cache::sled_load(&local)?;
+    // Configure the cache directory and pin the sled db open for the whole process: the proxy
+    // serves many concurrent transactions and should keep the cache hot rather than reopen it in
+    // the gaps between them.
+    josh_core::cache::SledCacheBackend::new(&local).pin()?;
 
     let proxy_service = make_service()
         .port(args.port)

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -310,10 +310,9 @@ impl TrigramBench {
             },
         )?;
 
-        josh_core::cache::sled_load(provisioned.path())?;
         let cache = std::sync::Arc::new(
             josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::default()),
+                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
         );
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 

--- a/tests/filter/compose_shadow_dir_same_name.t
+++ b/tests/filter/compose_shadow_dir_same_name.t
@@ -89,6 +89,14 @@
 
   $ josh-filter -s ":[:/sub/xx::file3,:/sub1,:/xx,:/sub/xx]"
   f9da6dcfc582a60447a9870b596eb9f28a7e03ec
+  [2] :[
+      :/sub1
+      :/xx
+  ]
+  [2] :[
+      :/xx
+      :/sub1
+  ]
   [3] :[
       :/sub/xx::file3
       :/sub1

--- a/tests/filter/gpgsig.t
+++ b/tests/filter/gpgsig.t
@@ -41,25 +41,29 @@ If 0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb shows up then the signature was lost
 Remove the signature, the shas are different.
   $ josh-filter :unsign refs/heads/master --update refs/heads/filtered -s
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+  [1] :/extra
+  [1] :prefix=extra
   [1] :~(
       gpgsig="remove"
   )[
       :/
   ]
-  [1] reachable_roots
-  [1] sequence_number
+  [2] reachable_roots
+  [2] sequence_number
   $ git rev-parse master filtered
   cb22ebb8e47b109f7add68b1043e561e0db09802
   0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb
   $ josh-filter --reverse :unsign refs/heads/double-filtered --update refs/heads/filtered -s
   cb22ebb8e47b109f7add68b1043e561e0db09802
+  [1] :/extra
+  [1] :prefix=extra
   [1] :~(
       gpgsig="remove"
   )[
       :/
   ]
-  [1] reachable_roots
-  [1] sequence_number
+  [2] reachable_roots
+  [2] sequence_number
   $ git rev-parse master double-filtered
   cb22ebb8e47b109f7add68b1043e561e0db09802
   cb22ebb8e47b109f7add68b1043e561e0db09802


### PR DESCRIPTION
Drive the sled cache lifetime by active transactions instead of explicit release

Replace the process-global `sled_load`/`release_cache` lifetime with reference
counting in the sled backend: `CacheBackend` gains `begin`/`end`, called from
`Transaction::new`/`Drop`, so the db opens lazily on the first transaction and
closes (releasing sled's exclusive lock) once the last one ends. sled allows
only one handle per path per process, so the db stays a single module-held
instance; `SledCacheBackend::new` configures the directory and `pin` keeps the
db open for a long-running process like the proxy. Compose drops the sled
backend entirely. Removes `release_cache`, `sled_load`, `sled_unload`,
`sled_flush` and `CacheBackend::release`.

Change: sled-cache-refcount-lifetime
Assisted-By: anthropic/claude-opus-4-8
Assisted-By: anthropic/claude-fable-5