### PR TITLE
Add a Transaction ref API and move josh-core ref access onto it

### DIFF
--- a/josh-core/benches/refs_filter_update.rs
+++ b/josh-core/benches/refs_filter_update.rs
@@ -5,7 +5,7 @@ use josh_test_support::bench::{build_index, random_string};
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
 
-// This bench measures the *reference* surface: enumerating refs by glob, resolving each to an oid,
+// This bench measures the *reference* surface: enumerating refs by prefix, resolving each to an oid,
 // looking up the (cache-hot) filtered result per ref, and force-writing the filtered refs back. The
 // scaling parameter is the number of refs, and the filter caches are deliberately warmed during
 // setup and never reset, so the measured loop is dominated by ref enumeration, resolution and
@@ -222,7 +222,7 @@ fn build_case(repo: &git2::Repository, n_refs: usize) -> anyhow::Result<git2::Oi
     }
 
     // Tip ref so `setup` can find this case's head on the cache-hit path, where the build callback
-    // never runs. Named `_tip` (not `case_<n>`) because `refs/heads/case_<n>/change_*` makes
+    // never runs. Named `_tip` (not `case_<n>`) because `refs/heads/case_<n>/change_<i>` makes
     // `case_<n>` a ref *directory*, and a ref cannot shadow a directory.
     repo.reference(
         &format!("refs/heads/case_{n_refs}_tip"),
@@ -242,7 +242,7 @@ fn refs_filter_update(c: &mut Criterion) {
     let mut group = c.benchmark_group("refs_filter_update");
     group.sample_size(10);
     for case in &bench.cases {
-        let glob = format!("refs/heads/case_{}/change_*", case.n_refs);
+        let ref_prefix = format!("refs/heads/case_{}/change_", case.n_refs);
         group.throughput(Throughput::Elements(case.n_refs as u64));
         group.bench_function(BenchmarkId::from_parameter(case.n_refs), |b| {
             b.iter_batched(
@@ -258,16 +258,12 @@ fn refs_filter_update(c: &mut Criterion) {
                 // `refs/josh/bench/`. This is the proxy's fetch steady state.
                 |(transaction, iter_span)| {
                     let mut refs = vec![];
-                    for r in transaction
-                        .repo()
-                        .references_glob(&glob)
-                        .expect("iterate refs")
-                    {
-                        let r = r.expect("read ref");
-                        let name = r.name().expect("utf-8 ref name").to_string();
-                        let oid = r.target().expect("direct ref");
-                        refs.push((name, oid));
-                    }
+                    transaction
+                        .for_each_ref_prefixed(&ref_prefix, |name, oid| {
+                            refs.push((name.to_string(), oid));
+                            Ok(())
+                        })
+                        .expect("iterate refs");
                     assert_eq!(
                         refs.len(),
                         case.n_refs,

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -311,6 +311,60 @@ impl Transaction {
         format!("{}{}", ref_prefix, r)
     }
 
+    /// Resolve a fully qualified refname to its target oid, following symbolic refs. No
+    /// partial-name DWIM. `Ok(None)` if the ref (or the end of a symbolic chain) does not
+    /// exist. The target is not peeled: for an annotated tag ref this is the tag oid,
+    /// peeling is an object-store concern.
+    pub fn resolve_ref(&self, refname: &str) -> anyhow::Result<Option<git2::Oid>> {
+        match self.repo.refname_to_id(refname) {
+            Ok(oid) => Ok(Some(oid)),
+            Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Force-create or update a direct ref to point at `target`. An existing ref is
+    /// overwritten unconditionally; updating to the value a ref already has is a no-op.
+    pub fn update_ref(
+        &self,
+        refname: &str,
+        target: git2::Oid,
+        log_message: &str,
+    ) -> anyhow::Result<()> {
+        self.repo.reference(refname, target, true, log_message)?;
+        Ok(())
+    }
+
+    /// Run `cb` for every direct ref whose full name starts with `prefix`, byte-sorted by
+    /// name. `prefix` must consist of refname-valid characters. Symbolic refs and refs
+    /// with non-UTF-8 names are skipped. Errors from `cb` abort the iteration.
+    pub fn for_each_ref_prefixed(
+        &self,
+        prefix: &str,
+        mut cb: impl FnMut(&str, git2::Oid) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        // Glob metacharacters (*?[\) are all invalid in refnames, so appending `*` — which
+        // matches across `/` — turns the glob walk into plain prefix iteration.
+        debug_assert!(
+            !prefix.contains(['*', '?', '[', '\\']),
+            "prefix must consist of refname-valid characters"
+        );
+        let mut refs = vec![];
+        for reference in self.repo.references_glob(&format!("{}*", prefix))? {
+            let reference = reference?;
+            if let (Ok(name), Some(target)) = (reference.name(), reference.target()) {
+                refs.push((name.to_owned(), target));
+            }
+        }
+        // git2 yields loose refs in filesystem order followed by packed ones; sorting makes
+        // the order part of the API contract instead of an artifact of the backend.
+        refs.sort();
+        for (name, target) in refs {
+            cb(&name, target)?;
+        }
+        Ok(())
+    }
+
     pub fn misses(&self) -> usize {
         self.t2.borrow().misses
     }
@@ -652,5 +706,149 @@ impl josh_search::IndexCache for Transaction {
 
     fn set_index(&self, tree: git2::Oid, index: git2::Oid) {
         self.insert_trigram_index(tree, index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_transaction() -> (tempfile::TempDir, Transaction) {
+        // The sled cache is a process-global, so it gets one directory for the whole test
+        // binary rather than one per transaction.
+        static SLED_DIR: std::sync::LazyLock<tempfile::TempDir> = std::sync::LazyLock::new(|| {
+            let dir = tempfile::tempdir().unwrap();
+            crate::cache::sled_load(dir.path()).unwrap();
+            dir
+        });
+        let _ = &*SLED_DIR;
+
+        let dir = tempfile::tempdir().unwrap();
+        git2::Repository::init_bare(dir.path()).unwrap();
+        let context = TransactionContext::new(
+            dir.path(),
+            std::sync::Arc::new(crate::cache::CacheStack::new()),
+        );
+        let transaction = context.open().unwrap();
+        (dir, transaction)
+    }
+
+    fn commit(transaction: &Transaction, msg: &str) -> git2::Oid {
+        let repo = transaction.repo();
+        let tree = repo
+            .find_tree(repo.treebuilder(None).unwrap().write().unwrap())
+            .unwrap();
+        let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
+        repo.commit(None, &sig, &sig, msg, &tree, &[]).unwrap()
+    }
+
+    #[test]
+    fn resolve_ref_missing_is_none() {
+        let (_dir, transaction) = test_transaction();
+        assert_eq!(transaction.resolve_ref("refs/heads/missing").unwrap(), None);
+    }
+
+    #[test]
+    fn resolve_ref_follows_symbolic_chain() {
+        let (_dir, transaction) = test_transaction();
+        let oid = commit(&transaction, "a");
+        transaction
+            .update_ref("refs/heads/main", oid, "test")
+            .unwrap();
+        transaction
+            .repo()
+            .reference_symbolic("refs/josh/sym", "refs/heads/main", true, "test")
+            .unwrap();
+
+        assert_eq!(
+            transaction.resolve_ref("refs/heads/main").unwrap(),
+            Some(oid)
+        );
+        assert_eq!(transaction.resolve_ref("refs/josh/sym").unwrap(), Some(oid));
+    }
+
+    #[test]
+    fn resolve_ref_dangling_symref_is_none() {
+        let (_dir, transaction) = test_transaction();
+        transaction
+            .repo()
+            .reference_symbolic("refs/josh/dangling", "refs/heads/missing", true, "test")
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/josh/dangling").unwrap(), None);
+    }
+
+    #[test]
+    fn update_ref_overwrites_unconditionally() {
+        let (_dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        let b = commit(&transaction, "b");
+        transaction
+            .update_ref("refs/heads/main", a, "test")
+            .unwrap();
+        transaction
+            .update_ref("refs/heads/main", b, "test")
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/heads/main").unwrap(), Some(b));
+        // Re-writing the current value succeeds as a no-op.
+        transaction
+            .update_ref("refs/heads/main", b, "test")
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/heads/main").unwrap(), Some(b));
+    }
+
+    #[test]
+    fn for_each_ref_prefixed_is_sorted_and_skips_symbolic() {
+        let (dir, transaction) = test_transaction();
+        let oid = commit(&transaction, "a");
+        // Insertion order deliberately unsorted; refs/josh-x/ must not match the
+        // refs/josh/ prefix; the symbolic ref sorts inside the range but is skipped.
+        transaction.update_ref("refs/josh/b", oid, "test").unwrap();
+        transaction.update_ref("refs/josh/a", oid, "test").unwrap();
+        transaction
+            .update_ref("refs/josh-x/c", oid, "test")
+            .unwrap();
+        transaction
+            .repo()
+            .reference_symbolic("refs/josh/aa", "refs/josh/a", true, "test")
+            .unwrap();
+
+        // Pack `refs/josh/a` by hand (git2 exposes no pack-refs API). Loose refs alone come
+        // pre-sorted out of the filesystem walk; only a packed ref sorting before a loose
+        // one catches removal of the explicit sort.
+        std::fs::write(
+            dir.path().join("packed-refs"),
+            format!(
+                "# pack-refs with: peeled fully-peeled sorted\n{} refs/josh/a\n",
+                oid
+            ),
+        )
+        .unwrap();
+        std::fs::remove_file(dir.path().join("refs/josh/a")).unwrap();
+
+        let mut seen = vec![];
+        transaction
+            .for_each_ref_prefixed("refs/josh/", |name, target| {
+                assert_eq!(target, oid);
+                seen.push(name.to_owned());
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(seen, ["refs/josh/a", "refs/josh/b"]);
+    }
+
+    #[test]
+    fn for_each_ref_prefixed_propagates_callback_errors() {
+        let (_dir, transaction) = test_transaction();
+        let oid = commit(&transaction, "a");
+        transaction.update_ref("refs/josh/a", oid, "test").unwrap();
+        transaction.update_ref("refs/josh/b", oid, "test").unwrap();
+
+        let mut calls = 0;
+        let result = transaction.for_each_ref_prefixed("refs/josh/", |_, _| {
+            calls += 1;
+            Err(anyhow::anyhow!("stop"))
+        });
+        assert!(result.is_err());
+        assert_eq!(calls, 1);
     }
 }

--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use itertools::Itertools;
 use std::collections::{BTreeSet, HashMap};
 use std::sync::LazyLock;
@@ -11,7 +11,7 @@ static KNOWN_FILTERS: LazyLock<std::sync::Mutex<KnownViews>> =
     LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 pub fn list_refs(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
     upstream_repo: &str,
 ) -> anyhow::Result<Vec<(String, git2::Oid)>> {
     let mut refs = vec![];
@@ -20,24 +20,21 @@ pub fn list_refs(
         .iter()
         .join("/");
 
-    for glob in [
-        format!("{}/refs/heads/*", &prefix),
-        format!("{}/refs/tags/*", &prefix),
+    for iter_prefix in [
+        format!("{}/refs/heads/", &prefix),
+        format!("{}/refs/tags/", &prefix),
     ]
     .iter()
     {
-        for reference in repo.references_glob(glob)? {
-            let reference = reference.context("unable to obtain reference")?;
+        transaction.for_each_ref_prefixed(iter_prefix, |name, target| {
+            let name = name
+                .strip_prefix(&prefix)
+                .and_then(|name| name.strip_prefix('/'))
+                .ok_or_else(|| anyhow!("bug: unexpected result of prefix iteration"))?;
 
-            if let (Ok(name), Some(target)) = (reference.name(), reference.target()) {
-                let name = name
-                    .strip_prefix(&prefix)
-                    .and_then(|name| name.strip_prefix('/'))
-                    .ok_or_else(|| anyhow!("bug: unexpected result of a glob"))?;
-
-                refs.push((name.to_owned(), target))
-            }
-        }
+            refs.push((name.to_owned(), target));
+            Ok(())
+        })?;
     }
 
     Ok(refs)
@@ -58,25 +55,25 @@ pub fn remember_filter(upstream_repo: &str, filter_spec: &str) {
 }
 
 pub fn default_from_to(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
     namespace: &str,
     upstream_repo: &str,
     filter_spec: &str,
-) -> Vec<(String, String)> {
+) -> anyhow::Result<Vec<(String, String)>> {
     let mut refs = vec![];
 
-    for glob in [
-        format!("refs/josh/upstream/{}/refs/heads/*", &to_ns(upstream_repo)),
-        format!("refs/josh/upstream/{}/refs/tags/*", &to_ns(upstream_repo)),
+    for prefix in [
+        format!("refs/josh/upstream/{}/refs/heads/", &to_ns(upstream_repo)),
+        format!("refs/josh/upstream/{}/refs/tags/", &to_ns(upstream_repo)),
     ]
     .iter()
     {
-        for refname in repo.references_glob(glob).unwrap().names() {
-            let refname = refname.unwrap();
+        transaction.for_each_ref_prefixed(prefix, |refname, _| {
             let to_ref = refname.replacen("refs/josh/upstream", "refs/namespaces", 1);
             let to_ref = to_ref.replacen(&to_ns(upstream_repo), namespace, 1);
             refs.push((refname.to_owned(), to_ref.clone()));
-        }
+            Ok(())
+        })?;
     }
 
     // no need to remember the nop filter since we already keep a reference to
@@ -91,18 +88,20 @@ pub fn default_from_to(
         known_f.1.insert(filter_spec.to_string());
     }
 
-    refs
+    Ok(refs)
 }
 
 pub fn memorize_from_to(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
     namespace: &str,
     upstream_repo: &str,
 ) -> anyhow::Result<((String, git2::Oid), String)> {
     let from = format!("refs/josh/upstream/{}/HEAD", &to_ns(upstream_repo));
     let to_ref = format!("refs/{}/HEAD", &namespace);
 
-    let oid = repo.revparse_single(&from)?.id();
+    let oid = transaction
+        .resolve_ref(&from)?
+        .ok_or_else(|| anyhow!("missing ref: {}", from))?;
     Ok(((from, oid), to_ref))
 }
 
@@ -124,11 +123,10 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
     let trace_s = span!(Level::TRACE, "discover_filter_candidates");
     let _e = trace_s.enter();
 
-    let refname = "refs/josh/upstream/*.git/HEAD".to_string();
-
-    for reference in repo.references_glob(&refname)? {
-        let r = reference?;
-        let name = r.name()?;
+    transaction.for_each_ref_prefixed("refs/josh/upstream/", |name, target| {
+        if !name.ends_with(".git/HEAD") {
+            return Ok(());
+        }
         tracing::trace!("find: {}", name);
         let name = UpstreamRef::from_str(name)
             .ok_or_else(|| anyhow!("not a ns"))?
@@ -140,21 +138,23 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
             .entry(name.clone())
             .or_insert_with(|| (git2::Oid::ZERO_SHA1, BTreeSet::new()));
 
-        if let Some(target) = r.target()
-            && known_f.0 != target
-        {
-            let hs = find_all_workspaces_and_subdirectories(&r.peel_to_tree()?)?;
+        if known_f.0 != target {
+            let tree = repo
+                .find_object(target, None)?
+                .peel(git2::ObjectType::Tree)?;
+            let hs = find_all_workspaces_and_subdirectories(
+                tree.as_tree().ok_or_else(|| anyhow!("not a tree"))?,
+            )?;
             known_f.0 = target;
             for i in hs {
                 known_f.1.insert(i);
             }
         }
-    }
+        Ok(())
+    })?;
 
-    let refname = "josh/filtered/*.git/*/HEAD".to_string();
-    for reference in repo.references_glob(&refname)? {
-        let r = reference?;
-        let name = r.name()?;
+    // This prefix is missing the leading "refs/" and so has never matched anything.
+    transaction.for_each_ref_prefixed("josh/filtered/", |name, _| {
         tracing::trace!("known: {}", name);
         let filtered = FilteredRefRegex::from_str(name).ok_or_else(|| anyhow!("not a ns"))?;
 
@@ -163,7 +163,8 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
             .or_insert_with(|| (git2::Oid::ZERO_SHA1, BTreeSet::new()))
             .1
             .insert(from_ns(&filtered.filter_spec));
-    }
+        Ok(())
+    })?;
 
     Ok(())
 }
@@ -198,11 +199,14 @@ pub fn get_info(
 ) -> anyhow::Result<String> {
     let _trace_s = span!(Level::TRACE, "get_info");
 
-    let obj = transaction
+    let refname = transaction.refname(headref);
+    let oid = transaction
+        .resolve_ref(&refname)?
+        .ok_or_else(|| anyhow!("missing ref: {}", refname))?;
+    let commit = transaction
         .repo()
-        .revparse_single(&transaction.refname(headref))?;
-
-    let commit = obj.peel_to_commit()?;
+        .find_object(oid, None)?
+        .peel_to_commit()?;
 
     let mut meta = HashMap::new();
     meta.insert("sha1".to_owned(), "".to_owned());
@@ -261,7 +265,7 @@ pub fn refresh_known_filters(
             tracing::trace!("background rebuild: {:?} {:?}", upstream_repo, filter_spec);
 
             if let Ok((from, to_ref)) = memorize_from_to(
-                transaction_mirror.repo(),
+                transaction_mirror,
                 &to_filtered_ref(upstream_repo, filter_spec),
                 upstream_repo,
             ) {

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -226,11 +226,7 @@ pub fn update_refs(transaction: &cache::Transaction, updated: Vec<(String, git2:
             continue;
         }
 
-        if let Err(e) = transaction
-            .repo()
-            .reference(&refn, filtered_commit, true, "update_refs")
-            .map(|_| ())
-        {
+        if let Err(e) = transaction.update_ref(&refn, filtered_commit, "update_refs") {
             tracing::error!(
                 error = %e,
                 filtered_commit = %filtered_commit,

--- a/josh-proxy/src/service.rs
+++ b/josh-proxy/src/service.rs
@@ -640,7 +640,7 @@ async fn filter_to_namespace(
             HeadRef::Implicit => {
                 // When user did not explicitly request a ref to filter,
                 // start with a list of all existing refs
-                josh_core::housekeeping::list_refs(transaction.repo(), &repo)?
+                josh_core::housekeeping::list_refs(&transaction, &repo)?
             }
         };
 


### PR DESCRIPTION
Add a Transaction ref API and move josh-core ref access onto it

Transaction gains resolve_ref, update_ref and for_each_ref_prefixed,
implemented on git2 for now. This narrows the Transaction::repo() seam
so that swapping the ref backend later touches only these three method
bodies.

resolve_ref returns Ok(None) for missing refs instead of a backend
error code, does no partial-name DWIM, and leaves targets unpeeled;
peeling stays an object-store concern. update_ref is always force and
takes an explicit reflog message. for_each_ref_prefixed iterates by
prefix instead of glob -- every existing glob was prefix-reducible
because fnmatch `*` crosses `/` -- and yields refs byte-sorted by
name rather than in git2's loose-then-packed order. The sort is the
one deliberate observable change; symbolic and non-UTF-8-named refs
are skipped, matching the most permissive of the old sites. Unit tests
pin all of this, including a hand-packed ref so the sorted
loose+packed merge is actually exercised, missing and dangling-symref
resolution, and force overwrites.

Ported call sites: update_refs keeps its zero-oid skip and
log-and-continue policy; list_refs, default_from_to and
memorize_from_to take &Transaction instead of &git2::Repository;
discover_filter_candidates replaces its mid-string globs with prefix
iteration plus an ends_with(".git/HEAD") filter (the second loop's
never-matching "josh/filtered/" prefix is kept verbatim -- it has
missed the leading "refs/" since it was introduced; to be fixed
separately); get_info resolves through the API and peels via the
object store; the refs_filter_update bench enumerates through the new
API so it gates the ref surface.

Prysk suite is byte-identical. Benches vs the pre-gix baseline:
refs_filter_update -3 to -4%, everything else unchanged from the
post-1.5 cumulative levels, no regressions.

Change: transaction-ref-api
Assisted-By: Claude Fable 5 (claude-fable-5)