### PR TITLE
Add GithubAuthMiddleware::from_environment

### DIFF
--- a/forges/josh-github-auth/src/lib.rs
+++ b/forges/josh-github-auth/src/lib.rs
@@ -4,6 +4,9 @@ pub mod middleware;
 
 pub const APP_CLIENT_ID: &str = "Ov23lijvAWwDiQDwZGhN";
 
+// Matches official github CLI and other github-adjacent tools
+pub const GITHUB_USER_TOKEN_ENV: &str = "GH_TOKEN";
+
 /// Check if the given URL is a GitHub URL.
 pub fn is_github_url(url: &str) -> bool {
     url::Url::parse(url)

--- a/forges/josh-github-auth/src/middleware.rs
+++ b/forges/josh-github-auth/src/middleware.rs
@@ -66,6 +66,28 @@ pub struct GithubAuthMiddleware {
 }
 
 impl GithubAuthMiddleware {
+    /// Resolve auth credentials from the environment.
+    ///
+    /// Prefers the `GH_TOKEN` env var; otherwise falls back to the supplied
+    /// stored device-flow token (read by the caller to prevent circular deps).
+    /// Returns `None` if neither is available.
+    pub fn from_environment(stored_token: Option<AccessTokenResponse>) -> Option<Self> {
+        if let Ok(token) = std::env::var(crate::GITHUB_USER_TOKEN_ENV)
+            && !token.is_empty()
+        {
+            tracing::info!("using GH_TOKEN for GitHub authentication");
+            return Some(Self::from_token(token));
+        }
+
+        let stored = stored_token?;
+        tracing::info!("using stored device-flow token for GitHub authentication");
+
+        Some(Self::from_app_flow(
+            stored,
+            crate::APP_CLIENT_ID.to_string(),
+        ))
+    }
+
     pub fn from_app_flow(token: AccessTokenResponse, client_id: String) -> Self {
         let (sender, receiver) = mpsc::unbounded_channel();
 

--- a/josh-cli/src/forge/github.rs
+++ b/josh-cli/src/forge/github.rs
@@ -1,8 +1,8 @@
 use anyhow::Context;
 
-use josh_github_auth::APP_CLIENT_ID;
 use josh_github_auth::device_flow::DeviceAuthFlow;
 use josh_github_auth::middleware::GithubAuthMiddleware;
+use josh_github_auth::{APP_CLIENT_ID, GITHUB_USER_TOKEN_ENV};
 use josh_github_graphql::connection::GithubApiConnection;
 use josh_github_graphql::request::GITHUB_GRAPHQL_API_URL;
 
@@ -51,9 +51,6 @@ pub fn logout() -> anyhow::Result<()> {
 
     Ok(())
 }
-
-// Matches official github CLI and other github-adjacent tools
-pub const GITHUB_USER_TOKEN_ENV: &str = "GH_TOKEN";
 
 pub async fn make_api_connection() -> Option<GithubApiConnection> {
     let middleware = if let Ok(token) = std::env::var(GITHUB_USER_TOKEN_ENV) {


### PR DESCRIPTION
Add GithubAuthMiddleware::from_environment

Resolve GitHub auth from the environment: prefer the GH_TOKEN env var,
fall back to a stored device-flow token supplied by the caller. Move the
GITHUB_USER_TOKEN_ENV const from josh-cli into josh-github-auth so forge
consumers (e.g. josh-cq) can share it without depending on josh-cli.

Change: cq-auth-from-environment
Assisted-By: kimi-code/k3