### PR TITLE
Fix stale .dockerignore entries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,11 +15,13 @@
 !josh-templates
 !josh-graphql
 !josh-link
-!josh-cq
+!cq/josh-cq
+!cq/josh-cq-test-components
 !forges/josh-github-changes
 !forges/josh-github-auth
 !forges/josh-github-codegen-graphql
 !forges/josh-github-graphql
+!forges/josh-github-keyring
 !forges/josh-github-webhooks
 !josh-ui/*.json
 !josh-ui/*.rs
@@ -31,6 +33,7 @@
 !josh-ui/src
 !deployment/josh-test-webhook-client
 !deployment/josh-test-webhook-service
+!deployment/josh-command-middleware
 !lfs-test-server
 !run-josh.sh
 # Runtime scripts needed by the run image


### PR DESCRIPTION
Fix stale .dockerignore entries

josh-cq moved under cq/, so the old root-path whitelist entry excluded
the crate from the build context. Also whitelist josh-github-keyring
(josh-cli path-depends on it) and josh-command-middleware (dependency of
josh-github-auth), both required by crates already in the context.

Change: cq-dockerignore-fix
Assisted-By: kimi-code/k3