### PR TITLE
Add GithubApiConnection::from_middleware

### DIFF
--- a/forges/josh-github-graphql/src/connection.rs
+++ b/forges/josh-github-graphql/src/connection.rs
@@ -1,6 +1,29 @@
+use std::sync::Arc;
+
 use url::Url;
+
+use josh_github_auth::middleware::GithubAuthMiddleware;
 
 pub struct GithubApiConnection {
     pub client: reqwest_middleware::ClientWithMiddleware,
     pub api_url: Url,
+}
+
+impl GithubApiConnection {
+    /// Build an authenticated connection from a shared auth middleware, pointed
+    /// at the real GitHub GraphQL API. The same `Arc` can be reused elsewhere
+    /// (e.g. to attach tokens to spawned git commands).
+    pub fn from_middleware(middleware: Arc<GithubAuthMiddleware>, api_url: Option<Url>) -> Self {
+        let api_url = api_url.unwrap_or(
+            crate::request::GITHUB_GRAPHQL_API_URL
+                .parse()
+                .expect("GITHUB_GRAPHQL_API_URL is valid"),
+        );
+
+        let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
+            .with_arc(middleware)
+            .build();
+
+        Self { client, api_url }
+    }
 }

--- a/josh-cli/src/forge/github.rs
+++ b/josh-cli/src/forge/github.rs
@@ -1,10 +1,11 @@
+use std::sync::Arc;
+
 use anyhow::Context;
 
 use josh_github_auth::device_flow::DeviceAuthFlow;
 use josh_github_auth::middleware::GithubAuthMiddleware;
 use josh_github_auth::{APP_CLIENT_ID, GITHUB_USER_TOKEN_ENV};
 use josh_github_graphql::connection::GithubApiConnection;
-use josh_github_graphql::request::GITHUB_GRAPHQL_API_URL;
 
 /// Login to GitHub using device flow and store the token.
 pub async fn login() -> anyhow::Result<()> {
@@ -53,23 +54,13 @@ pub fn logout() -> anyhow::Result<()> {
 }
 
 pub async fn make_api_connection() -> Option<GithubApiConnection> {
-    let middleware = if let Ok(token) = std::env::var(GITHUB_USER_TOKEN_ENV) {
-        GithubAuthMiddleware::from_token(token)
-    } else {
-        let stored = josh_github_keyring::load_stored_token()?;
-        GithubAuthMiddleware::from_app_flow(stored, APP_CLIENT_ID.to_string())
-    };
+    let middleware =
+        GithubAuthMiddleware::from_environment(josh_github_keyring::load_stored_token())?;
 
-    let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
-        .with(middleware)
-        .build();
-
-    Some(GithubApiConnection {
-        client,
-        api_url: GITHUB_GRAPHQL_API_URL
-            .parse()
-            .expect("Failed to parse API URL"),
-    })
+    Some(GithubApiConnection::from_middleware(
+        Arc::new(middleware),
+        None,
+    ))
 }
 
 pub fn api_connection_hint() -> String {


### PR DESCRIPTION
Add GithubApiConnection::from_middleware

Build an authenticated GraphQL connection from a shared auth middleware
Arc, with an optional api_url override defaulting to the real GitHub
API. Reuse it in josh-cli's make_api_connection together with
GithubAuthMiddleware::from_environment.

Change: cq-connection-from-middleware
Assisted-By: kimi-code/k3