### PR TITLE
Add get_pr_reviews query and operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3429,6 +3429,7 @@ dependencies = [
  "http",
  "josh-github-auth",
  "josh-github-codegen-graphql",
+ "josh-github-webhooks",
  "reqwest",
  "reqwest-middleware",
  "serde",

--- a/forges/josh-github-codegen-graphql/src/get_pr_reviews.graphql
+++ b/forges/josh-github-codegen-graphql/src/get_pr_reviews.graphql
@@ -1,0 +1,19 @@
+query GetPrReviews($owner: String!, $name: String!, $number: Int!, $first: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviews(first: $first, after: $after) {
+        nodes {
+          author {
+            __typename
+            login
+          }
+          state
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}

--- a/forges/josh-github-codegen-graphql/src/manifest.toml
+++ b/forges/josh-github-codegen-graphql/src/manifest.toml
@@ -19,6 +19,8 @@ fragments = ["check_run_info"]
 
 [queries.get_commit_check_runs]
 
+[queries.get_pr_reviews]
+
 [queries.get_pr_comments]
 
 [queries.create_pull_request]

--- a/forges/josh-github-graphql/Cargo.toml
+++ b/forges/josh-github-graphql/Cargo.toml
@@ -25,3 +25,4 @@ graphql_client.workspace = true
 
 josh-github-auth.workspace = true
 josh-github-codegen-graphql.workspace = true
+josh-github-webhooks.workspace = true

--- a/forges/josh-github-graphql/src/operations/pull_request.rs
+++ b/forges/josh-github-graphql/src/operations/pull_request.rs
@@ -5,11 +5,11 @@ use serde::Serialize;
 use josh_github_codegen_graphql::{
     add_comment, add_pull_request_review, add_pull_request_review_thread,
     add_pull_request_review_thread_reply, close_pull_request, convert_pull_request_to_draft,
-    create_pull_request, get_pr_by_head, get_pr_comments, get_prs_by_sha, list_open_p_rs,
-    mark_pull_request_ready_for_review, update_pull_request, AddComment, AddPullRequestReview,
-    AddPullRequestReviewThread, AddPullRequestReviewThreadReply, ClosePullRequest,
-    ConvertPullRequestToDraft, CreatePullRequest, GetPrByHead, GetPrComments, GetPrsBySha,
-    ListOpenPRs, MarkPullRequestReadyForReview, UpdatePullRequest,
+    create_pull_request, get_pr_by_head, get_pr_comments, get_pr_reviews, get_prs_by_sha,
+    list_open_p_rs, mark_pull_request_ready_for_review, update_pull_request, AddComment,
+    AddPullRequestReview, AddPullRequestReviewThread, AddPullRequestReviewThreadReply,
+    ClosePullRequest, ConvertPullRequestToDraft, CreatePullRequest, GetPrByHead, GetPrComments,
+    GetPrReviews, GetPrsBySha, ListOpenPRs, MarkPullRequestReadyForReview, UpdatePullRequest,
 };
 
 #[derive(Debug, Serialize)]
@@ -555,5 +555,82 @@ impl GithubApiConnection {
             .pull_request_review
             .ok_or_else(|| anyhow!("addPullRequestReview pullRequestReview is null"))?;
         Ok(review.id)
+    }
+
+    /// Returns the latest review state for each reviewer on a PR.
+    pub async fn get_pr_reviews(
+        &self,
+        owner: &str,
+        name: &str,
+        pr_number: i64,
+    ) -> anyhow::Result<
+        Vec<(
+            String,
+            josh_github_webhooks::webhook_types::PullRequestReviewState,
+        )>,
+    > {
+        let mut reviews: std::collections::HashMap<
+            String,
+            josh_github_webhooks::webhook_types::PullRequestReviewState,
+        > = std::collections::HashMap::new();
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let variables = get_pr_reviews::Variables {
+                owner: owner.to_string(),
+                name: name.to_string(),
+                number: pr_number,
+                first: 100,
+                after: cursor,
+            };
+
+            let response = self.make_request::<GetPrReviews>(variables).await?;
+
+            let repo = match response.repository {
+                Some(r) => r,
+                None => break,
+            };
+            let pr = match repo.pull_request {
+                Some(p) => p,
+                None => break,
+            };
+            let reviews_conn = match pr.reviews {
+                Some(r) => r,
+                None => break,
+            };
+
+            if let Some(nodes) = reviews_conn.nodes {
+                for node in nodes.into_iter().flatten() {
+                    let login = node
+                        .author
+                        .map(|a| a.login)
+                        .unwrap_or_else(|| "unknown".to_string());
+                    let state = match node.state {
+                        get_pr_reviews::PullRequestReviewState::Approved => {
+                            josh_github_webhooks::webhook_types::PullRequestReviewState::Approved
+                        }
+                        get_pr_reviews::PullRequestReviewState::ChangesRequested => {
+                            josh_github_webhooks::webhook_types::PullRequestReviewState::ChangesRequested
+                        }
+                        get_pr_reviews::PullRequestReviewState::Commented => {
+                            josh_github_webhooks::webhook_types::PullRequestReviewState::Commented
+                        }
+                        get_pr_reviews::PullRequestReviewState::Dismissed => {
+                            josh_github_webhooks::webhook_types::PullRequestReviewState::Dismissed
+                        }
+                        _ => continue,
+                    };
+                    reviews.insert(login, state);
+                }
+            }
+
+            if reviews_conn.page_info.has_next_page {
+                cursor = reviews_conn.page_info.end_cursor;
+            } else {
+                break;
+            }
+        }
+
+        Ok(reviews.into_iter().collect())
     }
 }


### PR DESCRIPTION
Add get_pr_reviews query and operation

New GraphQL query paging through a PR's reviews, and an operation
returning the latest PullRequestReviewState per reviewer (from
josh-github-webhooks webhook types). The merge queue polls this to
evaluate review-based admission rules.

Change: cq-pr-reviews
Assisted-By: kimi-code/k3