### PR TITLE
Add get_commit_check_runs query and operation

### DIFF
--- a/forges/josh-github-codegen-graphql/src/get_commit_check_runs.graphql
+++ b/forges/josh-github-codegen-graphql/src/get_commit_check_runs.graphql
@@ -1,0 +1,22 @@
+query GetCommitCheckRuns($owner: String!, $name: String!, $sha: GitObjectID!) {
+  repository(owner: $owner, name: $name) {
+    object(oid: $sha) {
+      __typename
+      ... on Commit {
+        checkSuites(first: 100) {
+          nodes {
+            app {
+              databaseId
+            }
+            checkRuns(first: 100) {
+              nodes {
+                name
+                conclusion
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/forges/josh-github-codegen-graphql/src/manifest.toml
+++ b/forges/josh-github-codegen-graphql/src/manifest.toml
@@ -17,6 +17,8 @@ fragments = ["check_run_info"]
 
 [queries.get_prs_by_sha]
 
+[queries.get_commit_check_runs]
+
 [queries.get_pr_comments]
 
 [queries.create_pull_request]

--- a/forges/josh-github-graphql/src/operations/get_commit_check_runs.rs
+++ b/forges/josh-github-graphql/src/operations/get_commit_check_runs.rs
@@ -1,0 +1,67 @@
+use crate::connection::GithubApiConnection;
+use josh_github_codegen_graphql::{get_commit_check_runs, GetCommitCheckRuns};
+
+impl GithubApiConnection {
+    /// Fetch check run conclusions for a commit, returning `(name, integration_id, passed)`
+    /// for each check run found.
+    pub async fn get_commit_check_runs(
+        &self,
+        owner: &str,
+        name: &str,
+        sha: &str,
+    ) -> anyhow::Result<Vec<(String, Option<i64>, bool)>> {
+        let variables = get_commit_check_runs::Variables {
+            owner: owner.to_string(),
+            name: name.to_string(),
+            sha: sha.to_string(),
+        };
+
+        let response = self.make_request::<GetCommitCheckRuns>(variables).await?;
+
+        let mut results = Vec::new();
+
+        let Some(repo) = response.repository else {
+            return Ok(results);
+        };
+
+        let Some(object) = repo.object else {
+            return Ok(results);
+        };
+
+        let commit = match object {
+            get_commit_check_runs::GetCommitCheckRunsRepositoryObject::Commit(c) => c,
+            _ => return Ok(results),
+        };
+
+        let Some(check_suites) = commit.check_suites else {
+            return Ok(results);
+        };
+
+        let Some(suite_nodes) = check_suites.nodes else {
+            return Ok(results);
+        };
+
+        for suite_node in suite_nodes.into_iter().flatten() {
+            let integration_id = suite_node
+                .app
+                .and_then(|app| app.database_id)
+                .map(|id| id as i64);
+
+            let Some(check_runs_conn) = suite_node.check_runs else {
+                continue;
+            };
+            let Some(run_nodes) = check_runs_conn.nodes else {
+                continue;
+            };
+            for run_node in run_nodes.into_iter().flatten() {
+                let passed = matches!(
+                    run_node.conclusion,
+                    Some(get_commit_check_runs::CheckConclusionState::Success)
+                );
+                results.push((run_node.name, integration_id, passed));
+            }
+        }
+
+        Ok(results)
+    }
+}

--- a/forges/josh-github-graphql/src/operations/mod.rs
+++ b/forges/josh-github-graphql/src/operations/mod.rs
@@ -1,6 +1,7 @@
 pub mod check_runs;
 pub mod collaborators;
 pub mod create_check_run;
+pub mod get_commit_check_runs;
 pub mod get_repo_id;
 pub mod pull_request;
 pub mod repo;


### PR DESCRIPTION
Add get_commit_check_runs query and operation

New GraphQL query fetching check runs across a commit's check suites,
and an operation returning (name, integration_id, passed) triples. The
merge queue uses this to refresh required-check status for candidate
PRs.

Change: cq-commit-check-runs
Assisted-By: kimi-code/k3