### PR TITLE
Add get_prs_by_sha query and find_open_prs_by_head_sha

### DIFF
--- a/forges/josh-github-codegen-graphql/src/get_prs_by_sha.graphql
+++ b/forges/josh-github-codegen-graphql/src/get_prs_by_sha.graphql
@@ -1,0 +1,15 @@
+query GetPrsBySha($owner: String!, $name: String!, $sha: GitObjectID!) {
+  repository(owner: $owner, name: $name) {
+    object(oid: $sha) {
+      __typename
+      ... on Commit {
+        associatedPullRequests(first: 10, states: [OPEN]) {
+          nodes {
+            id
+            number
+          }
+        }
+      }
+    }
+  }
+}

--- a/forges/josh-github-codegen-graphql/src/manifest.toml
+++ b/forges/josh-github-codegen-graphql/src/manifest.toml
@@ -15,6 +15,8 @@ fragments = ["check_run_info"]
 
 [queries.get_pr_by_head]
 
+[queries.get_prs_by_sha]
+
 [queries.get_pr_comments]
 
 [queries.create_pull_request]

--- a/forges/josh-github-graphql/src/operations/pull_request.rs
+++ b/forges/josh-github-graphql/src/operations/pull_request.rs
@@ -5,11 +5,11 @@ use serde::Serialize;
 use josh_github_codegen_graphql::{
     add_comment, add_pull_request_review, add_pull_request_review_thread,
     add_pull_request_review_thread_reply, close_pull_request, convert_pull_request_to_draft,
-    create_pull_request, get_pr_by_head, get_pr_comments, list_open_p_rs,
+    create_pull_request, get_pr_by_head, get_pr_comments, get_prs_by_sha, list_open_p_rs,
     mark_pull_request_ready_for_review, update_pull_request, AddComment, AddPullRequestReview,
     AddPullRequestReviewThread, AddPullRequestReviewThreadReply, ClosePullRequest,
-    ConvertPullRequestToDraft, CreatePullRequest, GetPrByHead, GetPrComments, ListOpenPRs,
-    MarkPullRequestReadyForReview, UpdatePullRequest,
+    ConvertPullRequestToDraft, CreatePullRequest, GetPrByHead, GetPrComments, GetPrsBySha,
+    ListOpenPRs, MarkPullRequestReadyForReview, UpdatePullRequest,
 };
 
 #[derive(Debug, Serialize)]
@@ -106,6 +106,37 @@ impl GithubApiConnection {
             None => true,
         });
         Ok(pr.map(|n| (n.id, n.number, n.is_draft)))
+    }
+
+    /// Find open PRs whose head commit is the given SHA. Returns `(node_id, number)` for each.
+    pub async fn find_open_prs_by_head_sha(
+        &self,
+        owner: &str,
+        name: &str,
+        sha: &str,
+    ) -> anyhow::Result<Vec<(String, i64)>> {
+        let variables = get_prs_by_sha::Variables {
+            owner: owner.to_string(),
+            name: name.to_string(),
+            sha: sha.to_string(),
+        };
+        let response = self.make_request::<GetPrsBySha>(variables).await?;
+        let prs = response
+            .repository
+            .and_then(|r| r.object)
+            .and_then(|o| match o {
+                get_prs_by_sha::GetPrsByShaRepositoryObject::Commit(c) => {
+                    c.associated_pull_requests
+                }
+                _ => None,
+            })
+            .and_then(|p| p.nodes)
+            .unwrap_or_default()
+            .into_iter()
+            .flatten()
+            .map(|n| (n.id, n.number))
+            .collect();
+        Ok(prs)
     }
 
     /// List all open pull requests with pagination.


### PR DESCRIPTION
Add get_prs_by_sha query and find_open_prs_by_head_sha

New GraphQL query resolving open PRs associated with a commit SHA, and a
GithubApiConnection operation returning (node_id, number) pairs. Needed
by the merge queue to map check-run webhooks back to candidate PRs.

Change: cq-prs-by-sha
Assisted-By: kimi-code/k3