### PR TITLE
Add AdmissionState polling APIs

### DIFF
--- a/forges/josh-github-changes/src/admission.rs
+++ b/forges/josh-github-changes/src/admission.rs
@@ -4,6 +4,7 @@ use josh_github_webhooks::webhook_types::{
     PullRequestReviewEventDetails, PullRequestReviewState,
 };
 
+#[derive(Debug, Clone, Default)]
 pub struct AdmissionState {
     pub required_checks: std::collections::BTreeMap<RequiredStatusCheck, bool>,
     pub maintainer_reviews: std::collections::BTreeMap<String, PullRequestReviewState>,
@@ -46,6 +47,34 @@ impl AdmissionState {
                     PullRequestReviewEventDetails::Edited => {}
                 }
             });
+    }
+
+    /// Directly set review states from fetched reviews (non-webhook path).
+    pub fn apply_review_states(&mut self, reviews: &[(String, PullRequestReviewState)]) {
+        for (login, state) in reviews {
+            if self.maintainers.contains(login.as_str()) {
+                match state {
+                    PullRequestReviewState::Dismissed => {
+                        self.maintainer_reviews.remove(login.as_str());
+                    }
+                    _ => {
+                        self.maintainer_reviews.insert(login.clone(), state.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    /// Directly set check run results (non-webhook path).
+    pub fn apply_check_results(&mut self, results: &[(String, Option<i64>, bool)]) {
+        for (context, integration_id, passed) in results {
+            if let Some(entry) = self.required_checks.get_mut(&RequiredStatusCheck {
+                context: context.clone(),
+                integration_id: *integration_id,
+            }) {
+                *entry = *passed;
+            }
+        }
     }
 
     pub fn admissible(&self) -> bool {

--- a/forges/josh-github-graphql/src/operations/repo.rs
+++ b/forges/josh-github-graphql/src/operations/repo.rs
@@ -21,7 +21,7 @@ pub struct RepositoryRuleset {
 }
 
 /// A required status check from a ruleset.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RequiredStatusCheck {
     pub context: String,
     pub integration_id: Option<i64>,


### PR DESCRIPTION
Add AdmissionState polling APIs

Add Debug/Clone/Default derives plus apply_review_states and
apply_check_results, which set admission inputs directly from polled
GitHub data (non-webhook path). RequiredStatusCheck gains Clone so
AdmissionState can be cloned.

Change: cq-admission-polling
Assisted-By: kimi-code/k3