### PR TITLE
Disable DNS on internal sidecar network; symlink aadvark binaries to avoid base drift

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ env:
   # for any branch and the binary is not rebuilt for every PR / merge-queue
   # run). Bump when a backward-incompatible change to `josh compose` requires
   # it; the new SHA must also already be on `origin/master`.
-  JOSH_BOOTSTRAP_SHA: 078254e1a68d3dd3db52f32268c10e7eee53c987
+  JOSH_BOOTSTRAP_SHA: bd0d646709ea1c88f1a596e254a1eceef30f7d71
 
 jobs:
   test:

--- a/.github/workflows/scripts/install-podman.sh
+++ b/.github/workflows/scripts/install-podman.sh
@@ -28,6 +28,11 @@ for bin in podman crun runc pasta fuse-overlayfs fusermount3; do
     sudo ln -sf "${PREFIX}/usr/local/bin/${bin}" "/usr/local/bin/${bin}"
 done
 
+sudo mkdir -p /usr/local/libexec/podman
+for helper in "${PREFIX}"/usr/local/lib/podman/*; do
+    sudo ln -sf "${helper}" "/usr/local/libexec/podman/$(basename "${helper}")"
+done
+
 sudo mkdir -p /etc/containers
 sudo install -m 0644 "${PODMAN_DIR}/containers.conf" /etc/containers/containers.conf
 

--- a/josh-compose-podman/src/sidecars.rs
+++ b/josh-compose-podman/src/sidecars.rs
@@ -25,10 +25,14 @@ pub(super) fn start_sidecar(args: SidecarArgs) -> anyhow::Result<SidecarHandle> 
     let bytes: [u8; 4] = rand::random();
     let container_name = format!("josh-sidecar-{}-{}", args.name, hex::encode(bytes));
 
+    // "bridge" must come first: podman treats it as a network *mode* selector,
+    // which is only accepted in the first --network value; in later positions
+    // it is rejected with "can only set extra network names, selected mode
+    // bridge conflicts with bridge".
     run_detached(
         &args.env,
         &container_name,
-        &[SIDECAR_NETWORK, "bridge"],
+        &["bridge", SIDECAR_NETWORK],
         &args.env_vars,
         args.port,
     )?;
@@ -93,8 +97,13 @@ fn network_exists(name: &str) -> anyhow::Result<bool> {
 }
 
 fn network_create_internal(name: &str) -> anyhow::Result<()> {
+    // Disable DNS on the internal network: steps reach sidecars by raw IP, and
+    // without this flag podman puts the internal network's aardvark-dns into
+    // resolv.conf alongside the bridge one (in nondeterministic order), which
+    // makes external name resolution in the sidecar fail whenever the internal
+    // resolver — NXDOMAIN-only by design — is consulted first.
     let output = Command::new("podman")
-        .args(["network", "create", "--internal", name])
+        .args(["network", "create", "--internal", "--disable-dns", name])
         .output()
         .context("failed to run podman network create")?;
     if !output.status.success() {


### PR DESCRIPTION
Disable DNS on internal sidecar network; symlink aadvark binaries to avoid base drift

Three fixes for podman CI executor:

1) The sidecar attaches to both the internal sidecar network and the
   default bridge, so podman writes both networks' aardvark-dns addresses
   into resolv.conf in nondeterministic order (Go map iteration over
   NetworkStatus). The internal network's aardvark-dns refuses to forward
   external names and answers NXDOMAIN, and Go's resolver treats NXDOMAIN
   as terminal without trying the second nameserver. Whenever the internal
   resolver landed first, the sccache proxy could not resolve the upstream
   endpoint and sccache's startup storage check failed the build.
   Steps reach sidecars by raw IP, so the internal network does not need
   DNS; disabling it makes resolution deterministic via the bridge network.

2) install-podman.sh symlinked the podman binary and OCI runtimes from the
   pinned static bundle, but not the helpers (netavark, aardvark-dns,
   conmon, ...), so podman resolved them from the runner image's distro
   packages. Those drift as ubuntu-latest moves, changing container
   networking/DNS behavior underneath a pinned podman.
   Link the bundle's helpers into /usr/local/libexec/podman, which is first
   in podman's default helper search path, ahead of the distro locations.

3) The sidecar container must list "bridge" first in its --network
   flags: podman accepts the "bridge" mode selector only as the first
   --network value and rejects it in later positions ("can only set
   extra network names, selected mode bridge conflicts with bridge").
   The pre-port code passed "bridge" first; restore that order.

JOSH_BOOTSTRAP_SHA points at the content of this change (kept fetchable
on vlad/temp-branch-to-keep-sha-alive-2) so this PR's CI exercises the
fixed bootstrap binary together with the helper pinning.

Change: sidecar-net-disable-dns
Assisted-By: moonshotai/kimi-k3