### PR TITLE
Disable DNS on internal sidecar network; symlink aadvark binaries to avoid base drift

### DIFF
--- a/.github/workflows/scripts/install-podman.sh
+++ b/.github/workflows/scripts/install-podman.sh
@@ -28,6 +28,15 @@ for bin in podman crun runc pasta fuse-overlayfs fusermount3; do
     sudo ln -sf "${PREFIX}/usr/local/bin/${bin}" "/usr/local/bin/${bin}"
 done
 
+# Pin the helper binaries from the bundle too (netavark, aardvark-dns, conmon,
+# ...). /usr/local/libexec/podman is first in podman's default helper search
+# path, so without this podman silently falls back to the runner image's
+# distro-packaged helpers, which drift as `ubuntu-latest` moves.
+sudo mkdir -p /usr/local/libexec/podman
+for helper in "${PREFIX}"/usr/local/lib/podman/*; do
+    sudo ln -sf "${helper}" "/usr/local/libexec/podman/$(basename "${helper}")"
+done
+
 sudo mkdir -p /etc/containers
 sudo install -m 0644 "${PODMAN_DIR}/containers.conf" /etc/containers/containers.conf
 

--- a/josh-compose-podman/src/sidecars.rs
+++ b/josh-compose-podman/src/sidecars.rs
@@ -93,8 +93,13 @@ fn network_exists(name: &str) -> anyhow::Result<bool> {
 }
 
 fn network_create_internal(name: &str) -> anyhow::Result<()> {
+    // Disable DNS on the internal network: steps reach sidecars by raw IP, and
+    // without this flag podman puts the internal network's aardvark-dns into
+    // resolv.conf alongside the bridge one (in nondeterministic order), which
+    // makes external name resolution in the sidecar fail whenever the internal
+    // resolver — NXDOMAIN-only by design — is consulted first.
     let output = Command::new("podman")
-        .args(["network", "create", "--internal", name])
+        .args(["network", "create", "--internal", "--disable-dns", name])
         .output()
         .context("failed to run podman network create")?;
     if !output.status.success() {


### PR DESCRIPTION
Disable DNS on internal sidecar network; symlink aadvark binaries to avoid base drift

The sidecar attaches to both the internal sidecar network and the
default bridge, so podman writes both networks' aardvark-dns addresses
into resolv.conf in nondeterministic order (Go map iteration over
NetworkStatus). The internal network's aardvark-dns refuses to forward
external names and answers NXDOMAIN, and Go's resolver treats NXDOMAIN
as terminal without trying the second nameserver. Whenever the internal
resolver landed first, the sccache proxy could not resolve the upstream
endpoint and sccache's startup storage check failed the build.

Steps reach sidecars by raw IP, so the internal network does not need
DNS; disabling it makes resolution deterministic via the bridge network.

install-podman.sh symlinked the podman binary and OCI runtimes from the
pinned static bundle, but not the helpers (netavark, aardvark-dns,
conmon, ...), so podman resolved them from the runner image's distro
packages. Those drift as ubuntu-latest moves, changing container
networking/DNS behavior underneath a pinned podman.

Link the bundle's helpers into /usr/local/libexec/podman, which is first
in podman's default helper search path, ahead of the distro locations.

Change: pin-podman-helpers
Assisted-By: moonshotai/kimi-k3