### PR TITLE
Bump CI bootstrap josh to sidecar DNS fix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ env:
   # for any branch and the binary is not rebuilt for every PR / merge-queue
   # run). Bump when a backward-incompatible change to `josh compose` requires
   # it; the new SHA must also already be on `origin/master`.
-  JOSH_BOOTSTRAP_SHA: 1471ea656cc52eecd43010d58989bb946186cf28
+  JOSH_BOOTSTRAP_SHA: 078254e1a68d3dd3db52f32268c10e7eee53c987
 
 jobs:
   test:


### PR DESCRIPTION
Bump CI bootstrap josh to sidecar DNS fix

Point JOSH_BOOTSTRAP_SHA at the commit that creates the internal sidecar
network with --disable-dns, so CI builds use a josh binary that no longer
lets the internal network's aardvark-dns shadow the bridge resolver in
the sccache proxy sidecar.

Change: bump-bootstrap-josh
Assisted-By: moonshotai/kimi-k3