### PR TITLE
Extend the sidecar-free CI path to fork PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,13 +25,13 @@ jobs:
     name: CI
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     env:
-      # Dependabot PRs run with a restricted token and no repository secrets, so
-      # they can't reach R2 or authenticate the sccache-proxy sidecar. Drop the
-      # sidecars overlay for those runs so the build is fully self-contained
-      # (falls back to the local sccache disk cache), and skip the R2 and
-      # remote-cache checks below.
-      IS_DEPENDABOT: ${{ github.actor == 'dependabot[bot]' }}
-      COMPOSE_FILTER: ${{ github.actor == 'dependabot[bot]' && ':+compose' || ':[::sidecars.josh=ci-sidecars.josh,:/]:+compose' }}
+      # Fork PRs and dependabot PRs run with a restricted token and no repository
+      # secrets, so they can't reach R2 or authenticate the sccache-proxy sidecar.
+      # Drop the sidecars overlay for those runs so the build is fully
+      # self-contained (falls back to the local sccache disk cache), and skip the
+      # R2 and remote-cache checks below.
+      SECRETLESS: ${{ github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]' }}
+      COMPOSE_FILTER: ${{ (github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]') && ':+compose' || ':[::sidecars.josh=ci-sidecars.josh,:/]:+compose' }}
     steps:
     - name: Free up disk space
       shell: bash
@@ -70,7 +70,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       run: .github/workflows/scripts/bootstrap-josh.sh
     - name: Pull cached job markers and volumes from R2
-      if: (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]'
+      if: env.SECRETLESS != 'true'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -79,7 +79,7 @@ jobs:
         export JOSH_EXPERIMENTAL_FEATURES=1
         .github/workflows/scripts/pull-jobs.sh HEAD "$COMPOSE_FILTER"
     - name: Pull cached images from R2
-      if: (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]'
+      if: env.SECRETLESS != 'true'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -96,14 +96,14 @@ jobs:
         target/release/josh compose run HEAD \
           "$COMPOSE_FILTER" 2>&1 \
           | tee /tmp/compose-run.log
-        # Dependabot runs have no sidecar-provided remote cache, so the local
-        # fallback is expected there; only enforce the remote cache otherwise.
-        if [ "$IS_DEPENDABOT" != "true" ] && grep -q SCCACHE_REMOTE_CACHE_MISSING /tmp/compose-run.log; then
+        # Secretless runs (forks, dependabot) have no sidecar-provided remote
+        # cache, so the local fallback is expected; only enforce it otherwise.
+        if [ "$SECRETLESS" != "true" ] && grep -q SCCACHE_REMOTE_CACHE_MISSING /tmp/compose-run.log; then
           echo "::error::sccache remote cache was not used during the build"
           exit 1
         fi
     - name: Push job markers and volumes to R2
-      if: success() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]'
+      if: success() && env.SECRETLESS != 'true'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -112,7 +112,7 @@ jobs:
         export JOSH_EXPERIMENTAL_FEATURES=1
         .github/workflows/scripts/push-jobs.sh HEAD "$COMPOSE_FILTER"
     - name: Push built images to R2
-      if: success() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]'
+      if: success() && env.SECRETLESS != 'true'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Extend the sidecar-free CI path to fork PRs

Fork PRs also run with a restricted token and no repository secrets, so
they hit the same sccache-proxy sidecar and R2 authentication failures as
dependabot. Generalize the dependabot-only guard into a single SECRETLESS
flag (fork PR or dependabot) that drives the sidecar-free COMPOSE_FILTER,
the R2 pull/push skips, and the SCCACHE_REMOTE_CACHE_MISSING enforcement.

Assisted-By: anthropic/claude-opus-4-8
Change: secretless-without-sidecars