### PR TITLE
Port josh-changes onto the Transaction ref API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3396,6 +3396,7 @@ dependencies = [
  "anyhow",
  "git2",
  "josh-changes",
+ "josh-core",
  "josh-github-graphql",
  "josh-github-webhooks",
  "serde_json",

--- a/forges/josh-github-changes/Cargo.toml
+++ b/forges/josh-github-changes/Cargo.toml
@@ -15,5 +15,6 @@ url.workspace = true
 serde_json.workspace = true
 
 josh-changes.workspace = true
+josh-core.workspace = true
 josh-github-graphql.workspace = true
 josh-github-webhooks.workspace = true

--- a/forges/josh-github-changes/src/comments.rs
+++ b/forges/josh-github-changes/src/comments.rs
@@ -6,7 +6,7 @@ use josh_github_graphql::connection::GithubApiConnection;
 
 /// Write PR comments into the given changes ref. Shared by both sync paths.
 fn write_pr_comments(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     change: &josh_changes::Change,
     pr_data: &josh_github_graphql::operations::pull_request::PrData,
     scope: &josh_changes::ChangesRef,
@@ -40,7 +40,7 @@ fn write_pr_comments(
         let blob_commit = comment.commit_oid.clone();
 
         let hash = josh_changes::write_comment_with_commit(
-            repo,
+            transaction,
             change,
             &meta,
             Some(&comment.author),
@@ -50,7 +50,7 @@ fn write_pr_comments(
         )?;
         // Record the GitHub node ID so this comment is tracked as "already posted".
         if let Some(change_id) = change.id() {
-            josh_changes::store_github_id(repo, change_id, &hash, &comment.id, scope)?;
+            josh_changes::store_github_id(transaction, change_id, &hash, &comment.id, scope)?;
         }
         id_map.insert(comment.id.clone(), hash);
     }
@@ -61,13 +61,13 @@ fn write_pr_comments(
     if let Some(change_id) = change.id() {
         let fetched: std::collections::HashSet<&str> =
             pr_data.comments.iter().map(|c| c.id.as_str()).collect();
-        let gh_ids = josh_changes::read_github_ids(repo, change_id, scope)?;
+        let gh_ids = josh_changes::read_github_ids(transaction, change_id, scope)?;
         let to_remove: Vec<String> = gh_ids
             .into_iter()
             .filter(|(_, gh_id)| fetched.contains(gh_id.as_str()))
             .map(|(local_hash, _)| local_hash)
             .collect();
-        josh_changes::delete_outbox_comments(repo, change_id, scope, &to_remove)?;
+        josh_changes::delete_outbox_comments(transaction, change_id, scope, &to_remove)?;
     }
 
     Ok(pr_data.comments.len())
@@ -79,7 +79,7 @@ pub async fn sync_change_comments(
     connection: &GithubApiConnection,
     owner: &str,
     repo_name: &str,
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     change: &josh_changes::Change,
     head_ref: &str,
     scope: &josh_changes::ChangesRef,
@@ -108,9 +108,9 @@ pub async fn sync_change_comments(
 
     let pr_data = connection.get_pr_comments(owner, repo_name, pr).await?;
     let json = serde_json::to_string(&pr_data)?;
-    josh_changes::store_pr_data(repo, change_id, &json, scope)?;
+    josh_changes::store_pr_data(transaction, change_id, &json, scope)?;
 
-    write_pr_comments(repo, change, &pr_data, scope)
+    write_pr_comments(transaction, change, &pr_data, scope)
 }
 
 /// Sync GitHub PR comments for a change identified directly by PR number.
@@ -118,7 +118,7 @@ pub async fn sync_change_comments_by_pr_number(
     connection: &GithubApiConnection,
     owner: &str,
     repo_name: &str,
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     change: &josh_changes::Change,
     pr_number: i64,
     scope: &josh_changes::ChangesRef,
@@ -132,9 +132,9 @@ pub async fn sync_change_comments_by_pr_number(
         .get_pr_comments(owner, repo_name, pr_number)
         .await?;
     let json = serde_json::to_string(&pr_data)?;
-    josh_changes::store_pr_data(repo, change_id, &json, scope)?;
+    josh_changes::store_pr_data(transaction, change_id, &json, scope)?;
 
-    write_pr_comments(repo, change, &pr_data, scope)
+    write_pr_comments(transaction, change, &pr_data, scope)
 }
 
 /// Post local comments (those without a `github_id`) to a GitHub PR.
@@ -143,7 +143,7 @@ pub async fn sync_change_comments_by_pr_number(
 /// Returns the number of comments successfully posted.
 pub async fn post_local_comments(
     connection: &GithubApiConnection,
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     change_id: &str,
     pr_node_id: &str,
     remote_scope: &josh_changes::ChangesRef,
@@ -152,7 +152,7 @@ pub async fn post_local_comments(
     // already under `comments/...` was either fetched from the remote or has
     // already been posted; either way it should not be re-posted.
     let comments: Vec<josh_changes::Comment> =
-        josh_changes::read_comments(repo, change_id, remote_scope)?
+        josh_changes::read_comments(transaction, change_id, remote_scope)?
             .into_iter()
             .filter(|c| c.pending)
             .collect();
@@ -160,7 +160,7 @@ pub async fn post_local_comments(
         return Ok(0);
     }
 
-    let github_ids = josh_changes::read_github_ids(repo, change_id, remote_scope)?;
+    let github_ids = josh_changes::read_github_ids(transaction, change_id, remote_scope)?;
 
     // Collect unposted comments (no github_id mapping yet).
     let mut unposted: Vec<&josh_changes::Comment> = comments
@@ -214,7 +214,13 @@ pub async fn post_local_comments(
                 connection.add_comment(pr_node_id, &comment.message).await?
             };
 
-            josh_changes::store_github_id(repo, change_id, &comment.id, &github_id, remote_scope)?;
+            josh_changes::store_github_id(
+                transaction,
+                change_id,
+                &comment.id,
+                &github_id,
+                remote_scope,
+            )?;
             new_ids.insert(comment.id.clone(), github_id);
             posted_count += 1;
             progressed = true;
@@ -240,7 +246,7 @@ pub async fn post_local_comments(
                     connection.add_comment(pr_node_id, &comment.message).await?
                 };
                 josh_changes::store_github_id(
-                    repo,
+                    transaction,
                     change_id,
                     &comment.id,
                     &github_id,
@@ -263,18 +269,18 @@ pub async fn post_local_comments(
 /// writes the tracking entry into `remote_scope`.
 pub async fn post_local_votes(
     connection: &GithubApiConnection,
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     change_id: &str,
     pr_node_id: &str,
     commit_oid: &str,
     remote_scope: &josh_changes::ChangesRef,
 ) -> anyhow::Result<usize> {
-    let votes = josh_changes::list_outbox_votes(repo, change_id, remote_scope)?;
+    let votes = josh_changes::list_outbox_votes(transaction, change_id, remote_scope)?;
     if votes.is_empty() {
         return Ok(0);
     }
 
-    let tracked = josh_changes::read_github_vote_ids(repo, change_id, remote_scope)?;
+    let tracked = josh_changes::read_github_vote_ids(transaction, change_id, remote_scope)?;
 
     let mut posted = 0usize;
     for (user, vote_data) in &votes {
@@ -291,13 +297,13 @@ pub async fn post_local_votes(
             .add_pull_request_review(pr_node_id, event, Some(&body), Some(commit_oid))
             .await?;
 
-        josh_changes::store_github_vote_id(repo, change_id, user, vote_data, remote_scope)?;
+        josh_changes::store_github_vote_id(transaction, change_id, user, vote_data, remote_scope)?;
         posted += 1;
     }
 
     // Drop outbox entries whose post is now reflected in gh_vote_ids. Safe to
     // call unconditionally -- it's a no-op when nothing needs cleaning.
-    josh_changes::cleanup_posted_outbox_votes(repo, change_id, remote_scope)?;
+    josh_changes::cleanup_posted_outbox_votes(transaction, change_id, remote_scope)?;
 
     Ok(posted)
 }

--- a/forges/josh-github-changes/src/prs.rs
+++ b/forges/josh-github-changes/src/prs.rs
@@ -17,7 +17,10 @@ pub struct PrInfo {
 
 /// Collect PR info from a set of refs to push.
 /// Uses the @base ref for each change as the base branch. Title and body come from the head commit message.
-pub fn collect_pr_infos(repo: &git2::Repository, to_push: &[josh_changes::PushRef]) -> Vec<PrInfo> {
+pub fn collect_pr_infos(
+    transaction: &josh_core::cache::Transaction,
+    to_push: &[josh_changes::PushRef],
+) -> Vec<PrInfo> {
     #[derive(Default)]
     struct ByIdEntry {
         head_branch: Option<String>,
@@ -61,7 +64,7 @@ pub fn collect_pr_infos(repo: &git2::Repository, to_push: &[josh_changes::PushRe
                 entry.head_oid?,
                 entry.base_oid?,
             );
-            let commit = repo.find_commit(head_oid).ok()?;
+            let commit = transaction.repo().find_commit(head_oid).ok()?;
             let raw_message = commit.message().unwrap_or("");
             let message = raw_message.trim_end();
             let title = message.lines().next().unwrap_or("").trim().to_string();

--- a/josh-changes/src/change.rs
+++ b/josh-changes/src/change.rs
@@ -13,7 +13,14 @@ pub struct Change {
 }
 
 impl Change {
-    pub fn new(_repo: &git2::Repository, commit: &git2::Commit) -> Self {
+    pub fn new(
+        transaction: &josh_core::cache::Transaction,
+        commit: git2::Oid,
+    ) -> anyhow::Result<Self> {
+        Ok(Self::from_commit(&transaction.repo().find_commit(commit)?))
+    }
+
+    pub(crate) fn from_commit(commit: &git2::Commit) -> Self {
         let mut change = Self {
             author: commit.author().email().unwrap_or("").to_string(),
             id: None,
@@ -52,8 +59,11 @@ impl Change {
         self.base = base;
     }
 
-    pub fn contributing(&self, repo: &git2::Repository) -> anyhow::Result<Vec<git2::Oid>> {
-        let mut walk = repo.revwalk()?;
+    pub fn contributing(
+        &self,
+        transaction: &josh_core::cache::Transaction,
+    ) -> anyhow::Result<Vec<git2::Oid>> {
+        let mut walk = transaction.repo().revwalk()?;
         walk.simplify_first_parent()?;
         walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
         walk.push(self.commit)?;
@@ -97,10 +107,11 @@ pub(crate) fn split_changes(
 }
 
 pub(crate) fn get_changes(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<std::collections::HashMap<git2::Oid, Change>> {
+    let repo = transaction.repo();
     let mut walk = repo.revwalk()?;
     walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
     walk.simplify_first_parent()?;
@@ -112,7 +123,7 @@ pub(crate) fn get_changes(
     let mut changes = std::collections::HashMap::new();
     for rev in walk {
         let commit = repo.find_commit(rev?)?;
-        let mut change = Change::new(repo, &commit);
+        let mut change = Change::from_commit(&commit);
         if change.id.is_none() {
             continue;
         }
@@ -124,27 +135,30 @@ pub(crate) fn get_changes(
 }
 
 pub fn sync_changes(
-    repo: &git2::Repository,
     transaction: &josh_core::cache::Transaction,
     tip: git2::Oid,
     base: git2::Oid,
     branch: &str,
 ) -> anyhow::Result<Vec<Change>> {
-    let changes = get_changes(repo, tip, base)?;
+    let changes = get_changes(transaction, tip, base)?;
     let changes = split_changes(transaction, changes)?;
     let scope = ChangesRef::Local {
         branch: branch.to_string(),
     };
     for c in &changes {
-        let _ = store_diff_data(repo, c, &scope);
+        let _ = store_diff_data(transaction, c, &scope);
     }
     Ok(changes)
 }
 
-pub fn list_changes(repo: &git2::Repository, scope: &ChangesRef) -> anyhow::Result<Vec<Change>> {
-    let tree = match repo.find_reference(&scope.ref_name()) {
-        Ok(r) => r.peel_to_tree()?,
-        Err(_) => return Ok(Vec::new()),
+pub fn list_changes(
+    transaction: &josh_core::cache::Transaction,
+    scope: &ChangesRef,
+) -> anyhow::Result<Vec<Change>> {
+    let repo = transaction.repo();
+    let tree = match transaction.resolve_ref(&scope.ref_name())? {
+        Some(oid) => repo.find_commit(oid)?.tree()?,
+        None => return Ok(Vec::new()),
     };
 
     let diffs_tree = match tree
@@ -193,7 +207,7 @@ pub fn list_changes(repo: &git2::Repository, scope: &ChangesRef) -> anyhow::Resu
             Ok(c) => c,
             Err(_) => continue,
         };
-        let mut change = Change::new(repo, &commit);
+        let mut change = Change::from_commit(&commit);
         change.base = base_oid;
         if change.id.is_none() {
             change.id = Some(change_id);
@@ -204,21 +218,23 @@ pub fn list_changes(repo: &git2::Repository, scope: &ChangesRef) -> anyhow::Resu
 }
 
 pub fn resolve_change(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     head: git2::Oid,
     spec: &str,
 ) -> anyhow::Result<Change> {
+    let repo = transaction.repo();
     // Try as a full OID first.
     if let Ok(oid) = git2::Oid::from_str(spec) {
         if let Ok(commit) = repo.find_commit(oid) {
-            return Ok(Change::new(repo, &commit));
+            return Ok(Change::from_commit(&commit));
         }
     }
 
     // Try as a revparse (branch, tag, short SHA).
+    // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
     if let Ok(obj) = repo.revparse_single(spec) {
         if let Ok(commit) = obj.peel_to_commit() {
-            return Ok(Change::new(repo, &commit));
+            return Ok(Change::from_commit(&commit));
         }
     }
 
@@ -232,7 +248,7 @@ pub fn resolve_change(
         if let Ok(c) = repo.find_commit(oid) {
             let (id, _) = parse_change_meta(c.message().unwrap_or(""));
             if id.as_deref() == Some(spec) {
-                return Ok(Change::new(repo, &c));
+                return Ok(Change::from_commit(&c));
             }
         }
     }

--- a/josh-changes/src/comments.rs
+++ b/josh-changes/src/comments.rs
@@ -2,6 +2,7 @@ use crate::change::{Change, encode_change_id_path};
 use crate::refs::ChangesRef;
 use crate::store::{get_tree, write_changes_tree};
 use anyhow::anyhow;
+use josh_core::cache::{Expected, Transaction};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Location {
@@ -25,18 +26,18 @@ pub struct CommentMeta {
 }
 
 pub fn write_comment(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change: &Change,
     meta: &CommentMeta,
     author: Option<&str>,
     timestamp: Option<&str>,
     scope: &ChangesRef,
 ) -> anyhow::Result<String> {
-    write_comment_with_commit(repo, change, meta, author, timestamp, None, scope)
+    write_comment_with_commit(transaction, change, meta, author, timestamp, None, scope)
 }
 
 pub fn write_comment_with_commit(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change: &Change,
     meta: &CommentMeta,
     author: Option<&str>,
@@ -45,7 +46,7 @@ pub fn write_comment_with_commit(
     scope: &ChangesRef,
 ) -> anyhow::Result<String> {
     write_comment_inner(
-        repo,
+        transaction,
         change,
         meta,
         author,
@@ -60,7 +61,7 @@ pub fn write_comment_with_commit(
 /// pending posts to the remote; the cleanup runs on the next fetch when the
 /// posted comment is observed coming back from the remote.
 pub fn write_outbox_comment(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change: &Change,
     meta: &CommentMeta,
     author: Option<&str>,
@@ -74,7 +75,7 @@ pub fn write_outbox_comment(
         ));
     }
     write_comment_inner(
-        repo,
+        transaction,
         change,
         meta,
         author,
@@ -87,7 +88,7 @@ pub fn write_outbox_comment(
 
 #[allow(clippy::too_many_arguments)]
 fn write_comment_inner(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change: &Change,
     meta: &CommentMeta,
     author: Option<&str>,
@@ -100,6 +101,7 @@ fn write_comment_inner(
         return Err(anyhow::anyhow!("comment message must not be empty"));
     }
 
+    let repo = transaction.repo();
     let change_id = change
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
@@ -133,7 +135,7 @@ fn write_comment_inner(
             .join(encode_change_id_path(&change_id))
             .join(&content_hash)
     };
-    write_changes_tree(repo, &path, blob_oid, author, timestamp, scope)?;
+    write_changes_tree(transaction, &path, blob_oid, author, timestamp, scope)?;
 
     Ok(content_hash)
 }
@@ -154,21 +156,22 @@ pub struct Comment {
 }
 
 pub fn comment_author(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change: &Change,
     comment_id: &str,
     file: Option<&str>,
     scope: &ChangesRef,
 ) -> anyhow::Result<(String, String)> {
+    let repo = transaction.repo();
     let change_id = match change.id() {
         Some(id) => id,
         None => return Err(anyhow!("change has no Change-Id")),
     };
 
     let ref_name = scope.ref_name();
-    let head = match repo.find_reference(&ref_name) {
-        Ok(r) => r.peel_to_commit()?,
-        Err(_) => return Err(anyhow!("{} not found", ref_name)),
+    let head = match transaction.resolve_ref(&ref_name)? {
+        Some(oid) => repo.find_commit(oid)?,
+        None => return Err(anyhow!("{} not found", ref_name)),
     };
 
     let path = if let Some(f) = file {
@@ -253,15 +256,17 @@ fn parse_comment_blob(
 }
 
 pub fn read_comments(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<Comment>> {
+    let repo = transaction.repo();
     let ref_name = scope.ref_name();
-    let tree = match repo.find_reference(&ref_name) {
-        Ok(r) => r.peel_to_tree()?,
-        Err(_) => return Ok(Vec::new()),
+    let head_commit = match transaction.resolve_ref(&ref_name)? {
+        Some(oid) => repo.find_commit(oid)?,
+        None => return Ok(Vec::new()),
     };
+    let tree = head_commit.tree()?;
 
     let mut comments = Vec::new();
 
@@ -278,34 +283,53 @@ pub fn read_comments(
     )?;
 
     // Walk history once to resolve author/timestamp for all comments.
-    if let Ok(head) = repo.find_reference(&ref_name) {
-        if let Ok(head_commit) = head.peel_to_commit() {
-            let mut walk = repo.revwalk().unwrap_or_else(|_| repo.revwalk().unwrap());
-            let _ = walk.simplify_first_parent();
-            let _ = walk.push(head_commit.id());
-            'outer: for oid in walk.flatten() {
-                if let Ok(commit) = repo.find_commit(oid) {
-                    let tree = commit.tree().unwrap();
-                    let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
-                    for c in &mut comments {
-                        if c.author.is_some() {
-                            continue;
+    let mut walk = repo.revwalk().unwrap_or_else(|_| repo.revwalk().unwrap());
+    let _ = walk.simplify_first_parent();
+    let _ = walk.push(head_commit.id());
+    'outer: for oid in walk.flatten() {
+        if let Ok(commit) = repo.find_commit(oid) {
+            let tree = commit.tree().unwrap();
+            let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
+            for c in &mut comments {
+                if c.author.is_some() {
+                    continue;
+                }
+                let prefix = if c.pending {
+                    "outbox/comments"
+                } else {
+                    "comments"
+                };
+                if c.file.is_none() {
+                    let p = std::path::Path::new(prefix)
+                        .join("C")
+                        .join(encode_change_id_path(change_id))
+                        .join(&c.id);
+                    if let Ok(entry) = tree.get_path(&p) {
+                        let is_new = parent_tree
+                            .as_ref()
+                            .and_then(|pt| pt.get_path(&p).ok())
+                            .map_or(true, |e| e.id() != entry.id());
+                        if is_new {
+                            let time = commit.time();
+                            let ts = time.seconds().to_string();
+                            c.author = Some(commit.author().email().unwrap_or("").to_string());
+                            c.timestamp = Some(ts);
                         }
-                        let prefix = if c.pending {
-                            "outbox/comments"
-                        } else {
-                            "comments"
-                        };
-                        if c.file.is_none() {
-                            let p = std::path::Path::new(prefix)
-                                .join("C")
-                                .join(encode_change_id_path(change_id))
-                                .join(&c.id);
-                            if let Ok(entry) = tree.get_path(&p) {
-                                let is_new = parent_tree
+                    }
+                } else {
+                    let cid_path = std::path::Path::new(prefix)
+                        .join("F")
+                        .join(encode_change_id_path(change_id));
+                    if let Some(cid_tree) = get_tree(repo, &tree, &cid_path) {
+                        for blob_entry in cid_tree.iter() {
+                            let blob_name = blob_entry.name().unwrap_or("");
+                            let sub = std::path::Path::new(c.file.as_ref().unwrap()).join(&c.id);
+                            let full_path = cid_path.join(blob_name).join(&sub);
+                            if let Ok(entry) = tree.get_path(&full_path) {
+                                let parent_entry = parent_tree
                                     .as_ref()
-                                    .and_then(|pt| pt.get_path(&p).ok())
-                                    .map_or(true, |e| e.id() != entry.id());
+                                    .and_then(|pt| pt.get_path(&full_path).ok());
+                                let is_new = parent_entry.map_or(true, |e| e.id() != entry.id());
                                 if is_new {
                                     let time = commit.time();
                                     let ts = time.seconds().to_string();
@@ -314,39 +338,12 @@ pub fn read_comments(
                                     c.timestamp = Some(ts);
                                 }
                             }
-                        } else {
-                            let cid_path = std::path::Path::new(prefix)
-                                .join("F")
-                                .join(encode_change_id_path(change_id));
-                            if let Some(cid_tree) = get_tree(repo, &tree, &cid_path) {
-                                for blob_entry in cid_tree.iter() {
-                                    let blob_name = blob_entry.name().unwrap_or("");
-                                    let sub =
-                                        std::path::Path::new(c.file.as_ref().unwrap()).join(&c.id);
-                                    let full_path = cid_path.join(blob_name).join(&sub);
-                                    if let Ok(entry) = tree.get_path(&full_path) {
-                                        let parent_entry = parent_tree
-                                            .as_ref()
-                                            .and_then(|pt| pt.get_path(&full_path).ok());
-                                        let is_new =
-                                            parent_entry.map_or(true, |e| e.id() != entry.id());
-                                        if is_new {
-                                            let time = commit.time();
-                                            let ts = time.seconds().to_string();
-                                            c.author = Some(
-                                                commit.author().email().unwrap_or("").to_string(),
-                                            );
-                                            c.timestamp = Some(ts);
-                                        }
-                                    }
-                                }
-                            }
                         }
                     }
-                    if comments.iter().all(|c| c.author.is_some()) {
-                        break 'outer;
-                    }
                 }
+            }
+            if comments.iter().all(|c| c.author.is_some()) {
+                break 'outer;
             }
         }
     }
@@ -441,7 +438,7 @@ fn collect_comments_under_into(
 /// the remote. Pass the set of local content hashes whose `gh_ids` entry is
 /// known to be reflected in `comments/...` already.
 pub fn delete_outbox_comments(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
     content_hashes: &[String],
@@ -449,13 +446,15 @@ pub fn delete_outbox_comments(
     if content_hashes.is_empty() {
         return Ok(0);
     }
+    let repo = transaction.repo();
     let want: std::collections::HashSet<&str> = content_hashes.iter().map(|s| s.as_str()).collect();
 
     let ref_name = scope.ref_name();
-    let mut tree = match repo.find_reference(&ref_name) {
-        Ok(r) => r.peel_to_tree()?,
-        Err(_) => return Ok(0),
+    let prev_commit = match transaction.resolve_ref(&ref_name)? {
+        Some(oid) => repo.find_commit(oid)?,
+        None => return Ok(0),
     };
+    let mut tree = prev_commit.tree()?;
 
     let encoded = encode_change_id_path(change_id);
     let mut paths_to_remove: Vec<std::path::PathBuf> = Vec::new();
@@ -489,19 +488,9 @@ pub fn delete_outbox_comments(
     }
 
     let sig = repo.signature()?;
-    let parent_commit = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_commit().ok());
-    let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
-    repo.commit(
-        Some(&ref_name),
-        &sig,
-        &sig,
-        &format!("cleanup posted outbox comments on {}\n", ref_name),
-        &tree,
-        &parents,
-    )?;
+    let msg = format!("cleanup posted outbox comments on {}\n", ref_name);
+    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &[&prev_commit])?;
+    transaction.update_ref(&ref_name, Expected::At(prev_commit.id()), new_oid, &msg)?;
 
     Ok(paths_to_remove.len())
 }

--- a/josh-changes/src/forges/gerrit.rs
+++ b/josh-changes/src/forges/gerrit.rs
@@ -133,7 +133,7 @@ fn rewrite_chain_with_gerrit_ids(
 /// where every change appears once with exactly one parent. Each commit is
 /// rewritten to carry a deterministic Gerrit `Change-Id`.
 pub fn build_gerrit_push(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     branch: &str,
     tip: git2::Oid,
     base: git2::Oid,
@@ -142,7 +142,7 @@ pub fn build_gerrit_push(
         return Ok(vec![]);
     }
 
-    let new_tip = rewrite_chain_with_gerrit_ids(repo, tip, base)?;
+    let new_tip = rewrite_chain_with_gerrit_ids(transaction.repo(), tip, base)?;
     Ok(vec![PushRef {
         ref_name: format!("refs/for/{}", branch),
         oid: new_tip,
@@ -163,13 +163,13 @@ pub fn build_gerrit_push(
 /// The returned `PushRef`s all target the same `refs/for/<branch>` ref with
 /// distinct oids; the caller pushes each in its own `git push` invocation.
 pub fn build_gerrit_independent_push(
-    repo: &git2::Repository,
     transaction: &josh_core::cache::Transaction,
     branch: &str,
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<Vec<PushRef>> {
-    let changes = get_changes(repo, tip, base)?;
+    let repo = transaction.repo();
+    let changes = get_changes(transaction, tip, base)?;
     let changes = split_changes(transaction, changes)?;
 
     // `get_changes` collects into a HashMap, so sort for a deterministic push order.

--- a/josh-changes/src/forges/github.rs
+++ b/josh-changes/src/forges/github.rs
@@ -3,16 +3,20 @@ use crate::refs::{ChangesRef, StackedChangeRef, StackedRef};
 use crate::store::{get_tree, write_changes_tree};
 use crate::votes::VoteData;
 use anyhow::anyhow;
+use josh_core::cache::Transaction;
 
 /// Create a real merge commit that has the target branch tip and PR head as its two parents.
 /// The tree is the PR head's tree (no content merge needed).
 /// Author and committer are copied from the PR head commit.
 pub fn create_synthetic_merge_commit(
-    repo: &git2::Repository,
-    pr_head: &git2::Commit,
-    target_branch_tip: &git2::Commit,
+    transaction: &Transaction,
+    pr_head: git2::Oid,
+    target_branch_tip: git2::Oid,
     message: &str,
 ) -> anyhow::Result<git2::Oid> {
+    let repo = transaction.repo();
+    let pr_head = repo.find_commit(pr_head)?;
+    let target_branch_tip = repo.find_commit(target_branch_tip)?;
     let tree = pr_head.tree()?;
     let author = pr_head.author();
     let committer = pr_head.committer();
@@ -23,7 +27,7 @@ pub fn create_synthetic_merge_commit(
         &committer,
         message,
         &tree,
-        &[target_branch_tip, pr_head],
+        &[&target_branch_tip, &pr_head],
     )?;
 
     Ok(oid)
@@ -72,7 +76,7 @@ pub fn baseref_and_options(
 }
 
 pub(crate) fn changes_to_refs(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     baseref: &str,
     change_author: &str,
     changes: Vec<Change>,
@@ -117,7 +121,12 @@ pub(crate) fn changes_to_refs(
                 oid: change.commit,
                 change_id: change_id.clone(),
             });
-            if let Some(parent_sha) = repo.find_commit(change.commit)?.parent_ids().next() {
+            if let Some(parent_sha) = transaction
+                .repo()
+                .find_commit(change.commit)?
+                .parent_ids()
+                .next()
+            {
                 refs.push(PushRef {
                     ref_name: StackedRef::ChangeRef(change_ref.as_base()).ref_name(),
                     oid: parent_sha,
@@ -130,8 +139,7 @@ pub(crate) fn changes_to_refs(
 }
 
 pub fn build_to_push(
-    repo: &git2::Repository,
-    transaction: &josh_core::cache::Transaction,
+    transaction: &Transaction,
     push_mode: &PushMode,
     baseref: &str,
     ref_with_options: &str,
@@ -140,10 +148,10 @@ pub fn build_to_push(
 ) -> anyhow::Result<Vec<PushRef>> {
     match push_mode {
         PushMode::Publish(author) => {
-            let changes = get_changes(repo, oid_to_push, base_oid)?;
+            let changes = get_changes(transaction, oid_to_push, base_oid)?;
             let changes = split_changes(transaction, changes)?;
 
-            let mut push_refs = changes_to_refs(repo, baseref, author, changes)?;
+            let mut push_refs = changes_to_refs(transaction, baseref, author, changes)?;
 
             let target = baseref.replacen("refs/heads/", "", 1);
             push_refs.push(PushRef {
@@ -173,30 +181,31 @@ pub fn build_to_push(
 
 /// Store a GitHub node ID for a local comment, marking it as posted.
 pub fn store_github_id(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     local_hash: &str,
     github_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let blob_oid = repo.blob(github_id.as_bytes())?;
+    let blob_oid = transaction.repo().blob(github_id.as_bytes())?;
     let path = std::path::Path::new("gh_ids")
         .join(encode_change_id_path(change_id))
         .join(local_hash);
-    write_changes_tree(repo, &path, blob_oid, None, None, scope)?;
+    write_changes_tree(transaction, &path, blob_oid, None, None, scope)?;
     Ok(())
 }
 
 /// Read all GitHub node IDs for a change's comments.
 /// Returns a map from local comment hash → GitHub node ID.
 pub fn read_github_ids(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<std::collections::HashMap<String, String>> {
-    let tree = match repo.find_reference(&scope.ref_name()) {
-        Ok(r) => r.peel_to_tree()?,
-        Err(_) => return Ok(Default::default()),
+    let repo = transaction.repo();
+    let tree = match transaction.resolve_ref(&scope.ref_name())? {
+        Some(oid) => repo.find_commit(oid)?.tree()?,
+        None => return Ok(Default::default()),
     };
     let gh_ids_path = std::path::Path::new("gh_ids").join(encode_change_id_path(change_id));
     let subtree = match get_tree(repo, &tree, &gh_ids_path) {
@@ -216,29 +225,30 @@ pub fn read_github_ids(
 }
 
 pub fn store_github_vote_id(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     user: &str,
     vote_data: &VoteData,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let json = serde_json::to_string(vote_data)?;
-    let blob_oid = repo.blob(json.as_bytes())?;
+    let blob_oid = transaction.repo().blob(json.as_bytes())?;
     let path = std::path::Path::new("gh_vote_ids")
         .join(encode_change_id_path(change_id))
         .join(user);
-    write_changes_tree(repo, &path, blob_oid, None, None, scope)?;
+    write_changes_tree(transaction, &path, blob_oid, None, None, scope)?;
     Ok(())
 }
 
 pub fn read_github_vote_ids(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<std::collections::HashMap<String, VoteData>> {
-    let tree = match repo.find_reference(&scope.ref_name()) {
-        Ok(r) => r.peel_to_tree()?,
-        Err(_) => return Ok(Default::default()),
+    let repo = transaction.repo();
+    let tree = match transaction.resolve_ref(&scope.ref_name())? {
+        Some(oid) => repo.find_commit(oid)?.tree()?,
+        None => return Ok(Default::default()),
     };
     let path = std::path::Path::new("gh_vote_ids").join(encode_change_id_path(change_id));
     let subtree = match get_tree(repo, &tree, &path) {

--- a/josh-changes/src/refs.rs
+++ b/josh-changes/src/refs.rs
@@ -214,13 +214,13 @@ impl ChangesRef {
     /// `remote` selects the `Remote` variant for that remote; `None` selects
     /// the `Local` variant.
     pub fn resolve(
-        repo: &git2::Repository,
+        transaction: &josh_core::cache::Transaction,
         branch: Option<&str>,
         remote: Option<&str>,
     ) -> anyhow::Result<ChangesRef> {
         let branch = match branch {
             Some(b) => b.to_string(),
-            None => head_branch(repo)?,
+            None => head_branch(transaction)?,
         };
         Ok(match remote {
             Some(remote) => ChangesRef::Remote {
@@ -255,10 +255,13 @@ impl ChangesRef {
     }
 }
 
-/// Read `repo.head()` and return the current branch shorthand. Errors on a
+/// Read HEAD and return the current branch shorthand. Errors on a
 /// detached HEAD with a message asking the caller to pass an explicit branch.
-pub fn head_branch(repo: &git2::Repository) -> anyhow::Result<String> {
-    let head = repo
+// PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
+// Transaction helper at flag day (gix head_name()).
+pub fn head_branch(transaction: &josh_core::cache::Transaction) -> anyhow::Result<String> {
+    let head = transaction
+        .repo()
         .head()
         .map_err(|e| anyhow!("failed to read HEAD: {}", e))?;
     if !head.is_branch() {
@@ -272,29 +275,29 @@ pub fn head_branch(repo: &git2::Repository) -> anyhow::Result<String> {
 /// Return every changes ref that currently exists, as `ChangesRef` values.
 /// `(remote, branch)` pairs are sorted for deterministic iteration; Local
 /// entries come first.
-pub fn all_changes_refs(repo: &git2::Repository) -> anyhow::Result<Vec<ChangesRef>> {
+pub fn all_changes_refs(
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<Vec<ChangesRef>> {
     let mut locals: Vec<String> = Vec::new();
     let mut remotes: Vec<(String, String)> = Vec::new();
-    for r in repo.references()? {
-        let r = r?;
-        let name = match r.name() {
-            Ok(n) => n,
-            Err(_) => continue,
-        };
-        if let Some(branch) = name.strip_prefix("refs/josh/changes/") {
-            if !branch.is_empty() {
-                locals.push(branch.to_string());
-            }
-        } else if let Some(rest) = name.strip_prefix("refs/josh/remotes/") {
-            // `<remote>/changes/<branch>` -- branch may contain `/`, so split
-            // on the literal `/changes/` separator.
-            if let Some((remote, branch)) = rest.split_once("/changes/") {
-                if !remote.is_empty() && !branch.is_empty() {
-                    remotes.push((remote.to_string(), branch.to_string()));
-                }
+    transaction.for_each_ref_prefixed("refs/josh/changes/", |name, _| {
+        let branch = &name["refs/josh/changes/".len()..];
+        if !branch.is_empty() {
+            locals.push(branch.to_string());
+        }
+        Ok(())
+    })?;
+    transaction.for_each_ref_prefixed("refs/josh/remotes/", |name, _| {
+        // `<remote>/changes/<branch>` -- branch may contain `/`, so split
+        // on the literal `/changes/` separator.
+        let rest = &name["refs/josh/remotes/".len()..];
+        if let Some((remote, branch)) = rest.split_once("/changes/") {
+            if !remote.is_empty() && !branch.is_empty() {
+                remotes.push((remote.to_string(), branch.to_string()));
             }
         }
-    }
+        Ok(())
+    })?;
     locals.sort();
     locals.dedup();
     remotes.sort();

--- a/josh-changes/src/revisions.rs
+++ b/josh-changes/src/revisions.rs
@@ -9,18 +9,19 @@ pub struct Revision {
 }
 
 pub fn read_revisions(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     change: &Change,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<Revision>> {
+    let repo = transaction.repo();
     let change_id = match change.id() {
         Some(id) => id,
         None => return Ok(Vec::new()),
     };
 
-    let head = match repo.find_reference(&scope.ref_name()) {
-        Ok(r) => r.peel_to_commit()?,
-        Err(_) => return Ok(Vec::new()),
+    let head = match transaction.resolve_ref(&scope.ref_name())? {
+        Some(oid) => repo.find_commit(oid)?,
+        None => return Ok(Vec::new()),
     };
 
     let mut revs: Vec<Revision> = Vec::new();

--- a/josh-changes/src/store.rs
+++ b/josh-changes/src/store.rs
@@ -1,5 +1,6 @@
 use crate::change::{Change, encode_change_id_path};
 use crate::refs::ChangesRef;
+use josh_core::cache::{Expected, Transaction};
 
 pub(crate) fn get_tree<'a>(
     repo: &'a git2::Repository,
@@ -23,18 +24,21 @@ pub(crate) fn parse_timestamp(s: Option<&str>) -> git2::Time {
 }
 
 pub(crate) fn write_changes_tree(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     path: &std::path::Path,
     blob_oid: git2::Oid,
     author: Option<&str>,
     timestamp: Option<&str>,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
+    let repo = transaction.repo();
     let ref_name = scope.ref_name();
-    let base_tree = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_tree().ok())
+    let prev_commit = transaction
+        .resolve_ref(&ref_name)?
+        .and_then(|oid| repo.find_commit(oid).ok());
+    let base_tree = prev_commit
+        .as_ref()
+        .and_then(|c| c.tree().ok())
         .unwrap_or_else(|| repo.find_tree(josh_core::filter::tree::empty_id()).unwrap());
 
     // Skip if the blob already exists at this path.
@@ -64,27 +68,26 @@ pub(crate) fn write_changes_tree(
         }
         None => josh_core::git::user_signature(repo)?,
     };
-    let parent_commit = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_commit().ok());
-    let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
-    repo.commit(
-        Some(&ref_name),
-        &sig,
-        &sig,
-        &format!("update {}\n", ref_name),
-        &tree,
-        &parents,
+    let parents: Vec<&git2::Commit> = prev_commit.iter().collect();
+    let msg = format!("update {}\n", ref_name);
+    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &parents)?;
+    transaction.update_ref(
+        &ref_name,
+        prev_commit
+            .as_ref()
+            .map_or(Expected::Absent, |c| Expected::At(c.id())),
+        new_oid,
+        &msg,
     )?;
     Ok(())
 }
 
 pub fn store_diff_data(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change: &Change,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
+    let repo = transaction.repo();
     let change_id = change
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
@@ -100,10 +103,12 @@ pub fn store_diff_data(
     let tree_oid = tb.write()?;
 
     let ref_name = scope.ref_name();
-    let base_tree = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_tree().ok())
+    let prev_tip = transaction
+        .resolve_ref(&ref_name)?
+        .and_then(|oid| repo.find_commit(oid).ok());
+    let base_tree = prev_tip
+        .as_ref()
+        .and_then(|c| c.tree().ok())
         .unwrap_or_else(|| repo.find_tree(josh_core::filter::tree::empty_id()).unwrap());
 
     let path = std::path::Path::new("diffs").join(encode_change_id_path(&change_id));
@@ -121,10 +126,6 @@ pub fn store_diff_data(
     let tree = josh_core::filter::tree::insert(repo, &base_tree, &path, tree_oid, 0o0040000)?;
 
     let sig = repo.signature()?;
-    let prev_tip = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_commit().ok());
 
     let source_commit = repo.find_commit(change.commit())?;
     let anchor_sig = git2::Signature::new("JOSH", "josh@josh-project.dev", &git2::Time::new(0, 0))?;
@@ -144,24 +145,27 @@ pub fn store_diff_data(
         parents.push(c);
     }
     parents.push(&anchor_commit);
-    repo.commit(
-        Some(&ref_name),
-        &sig,
-        &sig,
-        &format!("update {}\n", ref_name),
-        &tree,
-        &parents,
+    let msg = format!("update {}\n", ref_name);
+    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &parents)?;
+    transaction.update_ref(
+        &ref_name,
+        prev_tip
+            .as_ref()
+            .map_or(Expected::Absent, |c| Expected::At(c.id())),
+        new_oid,
+        &msg,
     )?;
 
     Ok(())
 }
 
 pub fn store_pr_data(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     json: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
+    let repo = transaction.repo();
     let blob_oid = repo.blob(json.as_bytes())?;
 
     let mut tb = repo.treebuilder(None)?;
@@ -169,10 +173,12 @@ pub fn store_pr_data(
     let tree_oid = tb.write()?;
 
     let ref_name = scope.ref_name();
-    let base_tree = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_tree().ok())
+    let prev_tip = transaction
+        .resolve_ref(&ref_name)?
+        .and_then(|oid| repo.find_commit(oid).ok());
+    let base_tree = prev_tip
+        .as_ref()
+        .and_then(|c| c.tree().ok())
         .unwrap_or_else(|| repo.find_tree(josh_core::filter::tree::empty_id()).unwrap());
 
     let path = std::path::Path::new("gh").join(encode_change_id_path(change_id));
@@ -190,18 +196,16 @@ pub fn store_pr_data(
     let tree = josh_core::filter::tree::insert(repo, &base_tree, &path, tree_oid, 0o0040000)?;
 
     let sig = repo.signature()?;
-    let prev_tip = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_commit().ok());
     let parents: Vec<&git2::Commit> = prev_tip.iter().collect();
-    repo.commit(
-        Some(&ref_name),
-        &sig,
-        &sig,
-        &format!("update {}\n", ref_name),
-        &tree,
-        &parents,
+    let msg = format!("update {}\n", ref_name);
+    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &parents)?;
+    transaction.update_ref(
+        &ref_name,
+        prev_tip
+            .as_ref()
+            .map_or(Expected::Absent, |c| Expected::At(c.id())),
+        new_oid,
+        &msg,
     )?;
 
     Ok(())
@@ -209,13 +213,14 @@ pub fn store_pr_data(
 
 /// Read stored GitHub PR data JSON for a change, if it exists.
 pub fn read_pr_data(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Option<String>> {
-    let tree = match repo.find_reference(&scope.ref_name()) {
-        Ok(r) => r.peel_to_tree()?,
-        Err(_) => return Ok(None),
+    let repo = transaction.repo();
+    let tree = match transaction.resolve_ref(&scope.ref_name())? {
+        Some(oid) => repo.find_commit(oid)?.tree()?,
+        None => return Ok(None),
     };
     let gh_path = std::path::Path::new("gh").join(encode_change_id_path(change_id));
     let subtree = match get_tree(repo, &tree, &gh_path) {
@@ -234,17 +239,19 @@ pub fn read_pr_data(
 /// Removes entries from diffs/, comments/{C,F}/, outbox/comments/{C,F}/,
 /// gh/, and gh_ids/ subtrees.
 pub fn delete_change(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
+    let repo = transaction.repo();
     let encoded = encode_change_id_path(change_id);
 
     let ref_name = scope.ref_name();
-    let base_tree = match repo.find_reference(&ref_name) {
-        Ok(r) => r.peel_to_tree()?,
-        Err(_) => return Ok(()),
+    let prev_commit = match transaction.resolve_ref(&ref_name)? {
+        Some(oid) => repo.find_commit(oid)?,
+        None => return Ok(()),
     };
+    let base_tree = prev_commit.tree()?;
 
     let mut tree = base_tree;
     for prefix in &[
@@ -266,19 +273,9 @@ pub fn delete_change(
     }
 
     let sig = repo.signature()?;
-    let parent_commit = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_commit().ok());
-    let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
-    repo.commit(
-        Some(&ref_name),
-        &sig,
-        &sig,
-        &format!("update {}\n", ref_name),
-        &tree,
-        &parents,
-    )?;
+    let msg = format!("update {}\n", ref_name);
+    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &[&prev_commit])?;
+    transaction.update_ref(&ref_name, Expected::At(prev_commit.id()), new_oid, &msg)?;
 
     Ok(())
 }

--- a/josh-changes/src/votes.rs
+++ b/josh-changes/src/votes.rs
@@ -1,6 +1,7 @@
 use crate::change::{Change, encode_change_id_path};
 use crate::refs::ChangesRef;
 use crate::store::{get_tree, parse_timestamp};
+use josh_core::cache::{Expected, Transaction};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct VoteData {
@@ -9,14 +10,22 @@ pub struct VoteData {
 }
 
 pub fn write_vote(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change: &Change,
     state: &str,
     author: Option<&str>,
     timestamp: Option<&str>,
     scope: &ChangesRef,
 ) -> anyhow::Result<String> {
-    write_vote_inner(repo, change, state, author, timestamp, scope, "votes")
+    write_vote_inner(
+        transaction,
+        change,
+        state,
+        author,
+        timestamp,
+        scope,
+        "votes",
+    )
 }
 
 /// Write a vote into the outbox subtree of a `Remote` ref. The vote is queued
@@ -24,7 +33,7 @@ pub fn write_vote(
 /// `gh_vote_ids` mapping records the post and the outbox entry can be
 /// cleaned up.
 pub fn write_outbox_vote(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change: &Change,
     state: &str,
     author: Option<&str>,
@@ -38,7 +47,7 @@ pub fn write_outbox_vote(
         ));
     }
     write_vote_inner(
-        repo,
+        transaction,
         change,
         state,
         author,
@@ -49,7 +58,7 @@ pub fn write_outbox_vote(
 }
 
 fn write_vote_inner(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change: &Change,
     state: &str,
     author: Option<&str>,
@@ -57,6 +66,7 @@ fn write_vote_inner(
     scope: &ChangesRef,
     path_prefix: &str,
 ) -> anyhow::Result<String> {
+    let repo = transaction.repo();
     let change_id = change
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
@@ -81,10 +91,12 @@ fn write_vote_inner(
         .join(&user);
 
     let ref_name = scope.ref_name();
-    let base_tree = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_tree().ok())
+    let prev_commit = transaction
+        .resolve_ref(&ref_name)?
+        .and_then(|oid| repo.find_commit(oid).ok());
+    let base_tree = prev_commit
+        .as_ref()
+        .and_then(|c| c.tree().ok())
         .unwrap_or_else(|| repo.find_tree(josh_core::filter::tree::empty_id()).unwrap());
 
     if let Some(existing) = base_tree
@@ -107,32 +119,31 @@ fn write_vote_inner(
         }
         None => repo.signature()?,
     };
-    let parent_commit = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_commit().ok());
-    let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
-    repo.commit(
-        Some(&ref_name),
-        &sig,
-        &sig,
-        &format!("update {}\n", ref_name),
-        &tree,
-        &parents,
+    let parents: Vec<&git2::Commit> = prev_commit.iter().collect();
+    let msg = format!("update {}\n", ref_name);
+    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &parents)?;
+    transaction.update_ref(
+        &ref_name,
+        prev_commit
+            .as_ref()
+            .map_or(Expected::Absent, |c| Expected::At(c.id())),
+        new_oid,
+        &msg,
     )?;
 
     Ok(content_hash)
 }
 
 pub fn read_vote(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     user: Option<&str>,
     scope: &ChangesRef,
 ) -> anyhow::Result<Option<VoteData>> {
-    let tree = match repo.find_reference(&scope.ref_name()) {
-        Ok(r) => r.peel_to_tree()?,
-        Err(_) => return Ok(None),
+    let repo = transaction.repo();
+    let tree = match transaction.resolve_ref(&scope.ref_name())? {
+        Some(oid) => repo.find_commit(oid)?.tree()?,
+        None => return Ok(None),
     };
 
     let user = match user {
@@ -158,32 +169,33 @@ pub fn read_vote(
 }
 
 pub fn list_votes(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<(String, VoteData)>> {
-    list_votes_at_prefix(repo, change_id, scope, "votes")
+    list_votes_at_prefix(transaction, change_id, scope, "votes")
 }
 
 /// List votes queued in the outbox subtree of `scope` (must be Remote in
 /// practice; this just returns empty for refs that lack `outbox/votes`).
 pub fn list_outbox_votes(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<(String, VoteData)>> {
-    list_votes_at_prefix(repo, change_id, scope, "outbox/votes")
+    list_votes_at_prefix(transaction, change_id, scope, "outbox/votes")
 }
 
 fn list_votes_at_prefix(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
     path_prefix: &str,
 ) -> anyhow::Result<Vec<(String, VoteData)>> {
-    let tree = match repo.find_reference(&scope.ref_name()) {
-        Ok(r) => r.peel_to_tree()?,
-        Err(_) => return Ok(Default::default()),
+    let repo = transaction.repo();
+    let tree = match transaction.resolve_ref(&scope.ref_name())? {
+        Some(oid) => repo.find_commit(oid)?.tree()?,
+        None => return Ok(Default::default()),
     };
     let path = std::path::Path::new(path_prefix).join(encode_change_id_path(change_id));
     let subtree = match get_tree(repo, &tree, &path) {
@@ -215,7 +227,7 @@ fn list_votes_at_prefix(
 /// in the `gh_vote_ids` map for the change. Called by `post_local_votes` after
 /// a successful push so the outbox doesn't accumulate forever.
 pub fn cleanup_posted_outbox_votes(
-    repo: &git2::Repository,
+    transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<usize> {
@@ -225,21 +237,23 @@ pub fn cleanup_posted_outbox_votes(
         ));
     }
 
-    let tracked = crate::forges::github::read_github_vote_ids(repo, change_id, scope)?;
+    let repo = transaction.repo();
+    let tracked = crate::forges::github::read_github_vote_ids(transaction, change_id, scope)?;
     if tracked.is_empty() {
         return Ok(0);
     }
-    let outbox = list_outbox_votes(repo, change_id, scope)?;
+    let outbox = list_outbox_votes(transaction, change_id, scope)?;
     if outbox.is_empty() {
         return Ok(0);
     }
 
     let encoded = encode_change_id_path(change_id);
     let ref_name = scope.ref_name();
-    let mut tree = match repo.find_reference(&ref_name) {
-        Ok(r) => r.peel_to_tree()?,
-        Err(_) => return Ok(0),
+    let prev_commit = match transaction.resolve_ref(&ref_name)? {
+        Some(oid) => repo.find_commit(oid)?,
+        None => return Ok(0),
     };
+    let mut tree = prev_commit.tree()?;
 
     let mut removed = 0usize;
     for (user, data) in &outbox {
@@ -264,19 +278,9 @@ pub fn cleanup_posted_outbox_votes(
     }
 
     let sig = repo.signature()?;
-    let parent_commit = repo
-        .find_reference(&ref_name)
-        .ok()
-        .and_then(|r| r.peel_to_commit().ok());
-    let parents: Vec<&git2::Commit> = parent_commit.iter().collect();
-    repo.commit(
-        Some(&ref_name),
-        &sig,
-        &sig,
-        &format!("cleanup posted outbox votes on {}\n", ref_name),
-        &tree,
-        &parents,
-    )?;
+    let msg = format!("cleanup posted outbox votes on {}\n", ref_name);
+    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &[&prev_commit])?;
+    transaction.update_ref(&ref_name, Expected::At(prev_commit.id()), new_oid, &msg)?;
 
     Ok(removed)
 }

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -14,8 +14,8 @@ pub fn handle_list(
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
-    let scope = args.scope.resolve(repo)?;
-    let changes = josh_changes::list_changes(repo, &scope)?;
+    let scope = args.scope.resolve(transaction)?;
+    let changes = josh_changes::list_changes(transaction, &scope)?;
 
     let scope_label = match &scope {
         josh_changes::ChangesRef::Local { branch } => format!("Local [{}]", branch),
@@ -44,7 +44,7 @@ pub fn handle_list(
 
         println!("{} {}{} ({})", id, subject, series, change.author());
 
-        let contributing = change.contributing(repo)?;
+        let contributing = change.contributing(transaction)?;
         for oid in &contributing {
             if let Ok(c) = repo.find_commit(*oid) {
                 let c_subject = c.message().unwrap_or("").lines().next().unwrap_or("");
@@ -55,7 +55,7 @@ pub fn handle_list(
 
         let comments = change
             .id()
-            .map(|cid| josh_changes::read_comments(repo, cid, &scope).unwrap_or_default())
+            .map(|cid| josh_changes::read_comments(transaction, cid, &scope).unwrap_or_default())
             .unwrap_or_default();
         if !comments.is_empty() {
             println!();

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -110,7 +110,7 @@ pub fn handle_comment(
         (short_file, short_location)
     };
 
-    let change = josh_changes::resolve_change(repo, head, &args.change)?;
+    let change = josh_changes::resolve_change(transaction, head, &args.change)?;
     let meta = josh_changes::CommentMeta {
         message: args.message.clone(),
         file: file.or(args.file.clone()),
@@ -119,14 +119,14 @@ pub fn handle_comment(
         update_of: args.update_of.clone(),
     };
 
-    let scope = args.scope.resolve(repo)?;
+    let scope = args.scope.resolve(transaction)?;
     match &scope {
         josh_changes::ChangesRef::Remote { remote, .. } => {
-            josh_changes::write_outbox_comment(repo, &change, &meta, None, None, &scope)?;
+            josh_changes::write_outbox_comment(transaction, &change, &meta, None, None, &scope)?;
             println!("Comment queued in outbox for remote '{}'.", remote);
         }
         josh_changes::ChangesRef::Local { .. } => {
-            josh_changes::write_comment(repo, &change, &meta, None, None, &scope)?;
+            josh_changes::write_comment(transaction, &change, &meta, None, None, &scope)?;
             println!("Comment saved (private to local ref).");
         }
     }

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -216,20 +216,21 @@ fn prepare_push(
     let to_push = match (forge, push_mode) {
         (Some(Forge::Gerrit), PushMode::Publish(_)) => match gerrit_mode {
             GerritMode::Independent => josh_changes::build_gerrit_independent_push(
-                repo,
                 transaction,
                 remote_ref,
                 unfiltered_oid,
                 original_target,
             )
             .context("Failed to build Gerrit push")?,
-            GerritMode::Stack => {
-                josh_changes::build_gerrit_push(repo, remote_ref, unfiltered_oid, original_target)
-                    .context("Failed to build Gerrit push")?
-            }
+            GerritMode::Stack => josh_changes::build_gerrit_push(
+                transaction,
+                remote_ref,
+                unfiltered_oid,
+                original_target,
+            )
+            .context("Failed to build Gerrit push")?,
         },
         _ => build_to_push(
-            repo,
             transaction,
             push_mode,
             remote_ref,
@@ -244,7 +245,7 @@ fn prepare_push(
 
     let pr_infos =
         if !dry_run && matches!(push_mode, PushMode::Publish(_)) && *forge == Some(Forge::Github) {
-            josh_github_changes::collect_pr_infos(repo, &to_push)
+            josh_github_changes::collect_pr_infos(transaction, &to_push)
         } else {
             vec![]
         };

--- a/josh-cli/src/commands/scope.rs
+++ b/josh-cli/src/commands/scope.rs
@@ -15,7 +15,14 @@ pub struct ScopeArgs {
 }
 
 impl ScopeArgs {
-    pub fn resolve(&self, repo: &git2::Repository) -> anyhow::Result<josh_changes::ChangesRef> {
-        josh_changes::ChangesRef::resolve(repo, self.branch.as_deref(), self.remote.as_deref())
+    pub fn resolve(
+        &self,
+        transaction: &josh_core::cache::Transaction,
+    ) -> anyhow::Result<josh_changes::ChangesRef> {
+        josh_changes::ChangesRef::resolve(
+            transaction,
+            self.branch.as_deref(),
+            self.remote.as_deref(),
+        )
     }
 }

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -43,7 +43,7 @@ pub fn handle_sync(
         })
         .unwrap_or(git2::Oid::ZERO_SHA1);
 
-    let resolved = args.scope.resolve(repo)?;
+    let resolved = args.scope.resolve(transaction)?;
     let remote_name = match &resolved {
         josh_changes::ChangesRef::Remote { remote, .. } => Some(remote.clone()),
         josh_changes::ChangesRef::Local { .. } => None,
@@ -54,7 +54,7 @@ pub fn handle_sync(
         // `refs/josh/changes/<branch>`. For Remote: every
         // `refs/josh/remotes/<remote>/changes/<branch>` for the chosen remote.
         let mut to_delete: Vec<josh_changes::ChangesRef> = Vec::new();
-        for scope in josh_changes::all_changes_refs(repo)? {
+        for scope in josh_changes::all_changes_refs(transaction)? {
             let keep = match (&scope, remote_name.as_deref()) {
                 (josh_changes::ChangesRef::Local { .. }, None) => true,
                 (josh_changes::ChangesRef::Remote { remote, .. }, Some(name)) => remote == name,
@@ -160,7 +160,7 @@ pub fn handle_sync(
 
                 let result = (|| -> anyhow::Result<(josh_changes::Change, i64)> {
                     let change = if existing_change_id.is_some() {
-                        let mut change = josh_changes::Change::new(repo, &pr_head);
+                        let mut change = josh_changes::Change::new(transaction, pr_head.id())?;
                         let base = match parse_changes_target(&pr.head_ref_name)
                             .and_then(|t| target_branch_shas.get(&t))
                         {
@@ -179,16 +179,18 @@ pub fn handle_sync(
                         message.push_str(&format!("\n\nChange-Id: {}\n", change_id));
 
                         let merge_oid = josh_changes::create_synthetic_merge_commit(
-                            repo, &pr_head, &target, &message,
+                            transaction,
+                            pr_head.id(),
+                            target.id(),
+                            &message,
                         )?;
 
-                        let merge = repo.find_commit(merge_oid)?;
-                        let mut change = josh_changes::Change::new(repo, &merge);
+                        let mut change = josh_changes::Change::new(transaction, merge_oid)?;
                         change.set_base(target.id());
                         change
                     };
 
-                    josh_changes::store_diff_data(repo, &change, &remote_scope)?;
+                    josh_changes::store_diff_data(transaction, &change, &remote_scope)?;
                     Ok((change, pr.number))
                 })();
 
@@ -198,7 +200,7 @@ pub fn handle_sync(
                             &api,
                             &owner,
                             &repo_name,
-                            repo,
+                            transaction,
                             &change,
                             pr_number,
                             &remote_scope,
@@ -233,13 +235,13 @@ pub fn handle_sync(
             // Iterate every (change, scope) pair under this remote -- changes may live
             // under multiple target-branch refs.
             let remote_scopes: Vec<josh_changes::ChangesRef> =
-                josh_changes::all_changes_refs(repo)?
+                josh_changes::all_changes_refs(transaction)?
                     .into_iter()
                     .filter(|r| r.remote() == Some(&remote_name))
                     .collect();
             let mut all_changes: Vec<(josh_changes::Change, josh_changes::ChangesRef)> = Vec::new();
             for scope in &remote_scopes {
-                for c in josh_changes::list_changes(repo, scope)? {
+                for c in josh_changes::list_changes(transaction, scope)? {
                     all_changes.push((c, scope.clone()));
                 }
             }
@@ -261,7 +263,7 @@ pub fn handle_sync(
                         Some(n) => n,
                         None => {
                             // Custom Change-Id; try reading stored PR data.
-                            match josh_changes::read_pr_data(repo, change_id, remote_scope) {
+                            match josh_changes::read_pr_data(transaction, change_id, remote_scope) {
                                 Ok(Some(json)) => {
                                     match serde_json::from_str::<serde_json::Value>(&json) {
                                         Ok(v) => match v.get("number").and_then(|n| n.as_i64()) {
@@ -316,7 +318,7 @@ pub fn handle_sync(
                 if pr_data.state == "OPEN" {
                     // Record the current state even if unexpectedly open.
                     let json = serde_json::to_string(&pr_data)?;
-                    josh_changes::store_pr_data(repo, change_id, &json, remote_scope)?;
+                    josh_changes::store_pr_data(transaction, change_id, &json, remote_scope)?;
                     eprintln!(
                         "  Change '{}' (PR #{}): unexpectedly still OPEN on GitHub \
                          -- skipping deletion",
@@ -327,7 +329,9 @@ pub fn handle_sync(
 
                 // Commit 1: store the updated PR data (final CLOSED/MERGED state).
                 let json = serde_json::to_string(&pr_data)?;
-                if let Err(e) = josh_changes::store_pr_data(repo, change_id, &json, remote_scope) {
+                if let Err(e) =
+                    josh_changes::store_pr_data(transaction, change_id, &json, remote_scope)
+                {
                     eprintln!(
                         "  Change '{}' (PR #{}): failed to store updated PR data: {} \
                          -- skipping deletion",
@@ -337,7 +341,7 @@ pub fn handle_sync(
                 }
 
                 // Commit 2: delete the change from the remote changes ref.
-                if let Err(e) = josh_changes::delete_change(repo, change_id, remote_scope) {
+                if let Err(e) = josh_changes::delete_change(transaction, change_id, remote_scope) {
                     eprintln!(
                         "  Change '{}' (PR #{}): failed to delete: {}",
                         change_id, pr_number, e
@@ -370,7 +374,7 @@ pub fn handle_sync(
                         Ok(Some((pr_node_id, _, _))) => {
                             match josh_github_changes::post_local_comments(
                                 &api,
-                                repo,
+                                transaction,
                                 &change_id,
                                 &pr_node_id,
                                 &remote_scope,
@@ -396,7 +400,7 @@ pub fn handle_sync(
 
                             match josh_github_changes::post_local_votes(
                                 &api,
-                                repo,
+                                transaction,
                                 &change_id,
                                 &pr_node_id,
                                 &pr.head_oid,
@@ -445,8 +449,7 @@ pub fn handle_sync(
             josh_changes::ChangesRef::Remote { .. } => unreachable!(),
         };
         let _ = branch;
-        let changes =
-            josh_changes::sync_changes(repo, transaction, head.id(), base_oid, &local_branch)?;
+        let changes = josh_changes::sync_changes(transaction, head.id(), base_oid, &local_branch)?;
         if changes.is_empty() {
             println!("No local changes found.");
             return Ok(());

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -15,6 +15,18 @@ pub trait FilterHook {
     ) -> anyhow::Result<crate::filter::Filter>;
 }
 
+/// What [`Transaction::update_ref`] requires the ref to currently be before it is
+/// repointed at the new target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Expected {
+    /// No requirement: overwrite whatever is there.
+    Any,
+    /// The ref must not exist yet.
+    Absent,
+    /// The ref must currently point at exactly this oid.
+    At(git2::Oid),
+}
+
 static REF_CACHE: LazyLock<RwLock<HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>>> =
     LazyLock::new(Default::default);
 
@@ -321,15 +333,34 @@ impl Transaction {
         }
     }
 
-    /// Force-create or update a direct ref to point at `target`. An existing ref is
-    /// overwritten unconditionally; updating to the value a ref already has is a no-op.
+    /// Create or update the direct ref `refname` to point at `target`, guarded by
+    /// `expected`: with `Expected::Any` an existing ref is overwritten unconditionally
+    /// (updating to the value a ref already has is a no-op); `Expected::At(oid)` asserts
+    /// the ref currently points at `oid`; `Expected::Absent` asserts it does not exist.
+    /// On a failed assertion — including a ref that appeared or disappeared
+    /// concurrently — an error is returned and the ref is unchanged. Writers that derive
+    /// `target` from the ref's old value pass `At`/`Absent` so they never overwrite a
+    /// concurrent update. (gix mapping: `PreviousValue::Any` / `MustExistAndMatch` /
+    /// `MustNotExist`.)
     pub fn update_ref(
         &self,
         refname: &str,
+        expected: Expected,
         target: git2::Oid,
         log_message: &str,
     ) -> anyhow::Result<()> {
-        self.repo.reference(refname, target, true, log_message)?;
+        match expected {
+            Expected::Any => {
+                self.repo.reference(refname, target, true, log_message)?;
+            }
+            Expected::At(old) => {
+                self.repo
+                    .reference_matching(refname, target, true, old, log_message)?;
+            }
+            Expected::Absent => {
+                self.repo.reference(refname, target, false, log_message)?;
+            }
+        }
         Ok(())
     }
 
@@ -784,7 +815,7 @@ mod tests {
         let (_dir, transaction) = test_transaction();
         let oid = commit(&transaction, "a");
         transaction
-            .update_ref("refs/heads/main", oid, "test")
+            .update_ref("refs/heads/main", Expected::Any, oid, "test")
             .unwrap();
         transaction
             .repo()
@@ -814,17 +845,113 @@ mod tests {
         let a = commit(&transaction, "a");
         let b = commit(&transaction, "b");
         transaction
-            .update_ref("refs/heads/main", a, "test")
+            .update_ref("refs/heads/main", Expected::Any, a, "test")
             .unwrap();
         transaction
-            .update_ref("refs/heads/main", b, "test")
+            .update_ref("refs/heads/main", Expected::Any, b, "test")
             .unwrap();
         assert_eq!(transaction.resolve_ref("refs/heads/main").unwrap(), Some(b));
         // Re-writing the current value succeeds as a no-op.
         transaction
-            .update_ref("refs/heads/main", b, "test")
+            .update_ref("refs/heads/main", Expected::Any, b, "test")
             .unwrap();
         assert_eq!(transaction.resolve_ref("refs/heads/main").unwrap(), Some(b));
+    }
+
+    #[test]
+    fn update_ref_absent_creates() {
+        let (_dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        transaction
+            .update_ref("refs/heads/main", Expected::Absent, a, "test")
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/heads/main").unwrap(), Some(a));
+    }
+
+    #[test]
+    fn update_ref_absent_fails_on_existing_ref() {
+        let (_dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        let b = commit(&transaction, "b");
+        transaction
+            .update_ref("refs/heads/main", Expected::Any, a, "test")
+            .unwrap();
+        assert!(
+            transaction
+                .update_ref("refs/heads/main", Expected::Absent, b, "test")
+                .is_err()
+        );
+        assert_eq!(transaction.resolve_ref("refs/heads/main").unwrap(), Some(a));
+    }
+
+    #[test]
+    fn update_ref_at_updates_on_match() {
+        let (_dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        let b = commit(&transaction, "b");
+        transaction
+            .update_ref("refs/heads/main", Expected::Any, a, "test")
+            .unwrap();
+        transaction
+            .update_ref("refs/heads/main", Expected::At(a), b, "test")
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/heads/main").unwrap(), Some(b));
+    }
+
+    #[test]
+    fn update_ref_at_fails_on_mismatch() {
+        let (_dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        let b = commit(&transaction, "b");
+        let c = commit(&transaction, "c");
+        transaction
+            .update_ref("refs/heads/main", Expected::Any, a, "test")
+            .unwrap();
+        assert!(
+            transaction
+                .update_ref("refs/heads/main", Expected::At(b), c, "test")
+                .is_err()
+        );
+        assert_eq!(transaction.resolve_ref("refs/heads/main").unwrap(), Some(a));
+    }
+
+    #[test]
+    fn update_ref_at_fails_on_missing_ref() {
+        let (_dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        let b = commit(&transaction, "b");
+        assert!(
+            transaction
+                .update_ref("refs/heads/missing", Expected::At(a), b, "test")
+                .is_err()
+        );
+        assert_eq!(transaction.resolve_ref("refs/heads/missing").unwrap(), None);
+    }
+
+    #[test]
+    fn update_ref_at_matches_packed_ref() {
+        let (dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        let b = commit(&transaction, "b");
+        transaction
+            .update_ref("refs/josh/a", Expected::Any, a, "test")
+            .unwrap();
+        // Pack the ref by hand (git2 exposes no pack-refs API): the CAS must see the
+        // packed value, not conclude the ref is absent.
+        std::fs::write(
+            dir.path().join("packed-refs"),
+            format!(
+                "# pack-refs with: peeled fully-peeled sorted\n{} refs/josh/a\n",
+                a
+            ),
+        )
+        .unwrap();
+        std::fs::remove_file(dir.path().join("refs/josh/a")).unwrap();
+
+        transaction
+            .update_ref("refs/josh/a", Expected::At(a), b, "test")
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/josh/a").unwrap(), Some(b));
     }
 
     #[test]
@@ -833,10 +960,14 @@ mod tests {
         let oid = commit(&transaction, "a");
         // Insertion order deliberately unsorted; refs/josh-x/ must not match the
         // refs/josh/ prefix; the symbolic ref sorts inside the range but is skipped.
-        transaction.update_ref("refs/josh/b", oid, "test").unwrap();
-        transaction.update_ref("refs/josh/a", oid, "test").unwrap();
         transaction
-            .update_ref("refs/josh-x/c", oid, "test")
+            .update_ref("refs/josh/b", Expected::Any, oid, "test")
+            .unwrap();
+        transaction
+            .update_ref("refs/josh/a", Expected::Any, oid, "test")
+            .unwrap();
+        transaction
+            .update_ref("refs/josh-x/c", Expected::Any, oid, "test")
             .unwrap();
         transaction
             .repo()
@@ -871,8 +1002,12 @@ mod tests {
     fn for_each_ref_prefixed_propagates_callback_errors() {
         let (_dir, transaction) = test_transaction();
         let oid = commit(&transaction, "a");
-        transaction.update_ref("refs/josh/a", oid, "test").unwrap();
-        transaction.update_ref("refs/josh/b", oid, "test").unwrap();
+        transaction
+            .update_ref("refs/josh/a", Expected::Any, oid, "test")
+            .unwrap();
+        transaction
+            .update_ref("refs/josh/b", Expected::Any, oid, "test")
+            .unwrap();
 
         let mut calls = 0;
         let result = transaction.for_each_ref_prefixed("refs/josh/", |_, _| {

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -226,7 +226,9 @@ pub fn update_refs(transaction: &cache::Transaction, updated: Vec<(String, git2:
             continue;
         }
 
-        if let Err(e) = transaction.update_ref(&refn, filtered_commit, "update_refs") {
+        if let Err(e) =
+            transaction.update_ref(&refn, cache::Expected::Any, filtered_commit, "update_refs")
+        {
             tracing::error!(
                 error = %e,
                 filtered_commit = %filtered_commit,

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -3476,6 +3476,7 @@ dependencies = [
  "dioxus",
  "git2",
  "josh-changes",
+ "josh-core",
  "serde_json",
 ]
 

--- a/josh-gui/Cargo.toml
+++ b/josh-gui/Cargo.toml
@@ -16,6 +16,7 @@ clap = { version = "4", features = ["derive"] }
 dioxus = { version = "0.7", features = ["desktop"] }
 serde_json = "1.0"
 josh-changes = { path = "../josh-changes" }
+josh-core = { path = "../josh-core" }
 git2 = { version = "0.21.0", default-features = false, features = ["vendored-libgit2"] }
 
 # Same as the root workspace: use the vendored glob fork, which keeps the

--- a/josh-gui/src/common.rs
+++ b/josh-gui/src/common.rs
@@ -2,6 +2,12 @@ use std::sync::OnceLock;
 
 use dioxus::prelude::*;
 
+pub fn open_transaction() -> anyhow::Result<josh_core::cache::Transaction> {
+    let repo = git2::Repository::discover(".")?;
+    let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new());
+    josh_core::cache::TransactionContext::new(repo.path(), cache).open()
+}
+
 pub fn vote_state_label(state: &str) -> &'static str {
     match state {
         "approve" => "approve",

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -292,8 +292,9 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
 }
 
 pub fn load_detail(sha: &str, scope: &josh_changes::ChangesRef) -> anyhow::Result<DetailData> {
-    let repo = git2::Repository::discover(".")?;
+    let transaction = crate::common::open_transaction()?;
     let oid = git2::Oid::from_str(sha)?;
+    let repo = transaction.repo();
     let commit = repo.find_commit(oid)?;
 
     let msg = commit.message().unwrap_or("");
@@ -329,12 +330,12 @@ pub fn load_detail(sha: &str, scope: &josh_changes::ChangesRef) -> anyhow::Resul
         });
     }
 
-    let mut change = josh_changes::Change::new(&repo, &commit);
+    let mut change = josh_changes::Change::new(&transaction, oid)?;
 
     let mut stack: Vec<StackCommit> = Vec::new();
     let mut pr_info: Option<PrInfo> = None;
     if let Some(ref cid) = change_id {
-        pr_info = josh_changes::read_pr_data(&repo, cid, scope)
+        pr_info = josh_changes::read_pr_data(&transaction, cid, scope)
             .ok()
             .flatten()
             .and_then(|json| serde_json::from_str::<serde_json::Value>(&json).ok())
@@ -346,7 +347,7 @@ pub fn load_detail(sha: &str, scope: &josh_changes::ChangesRef) -> anyhow::Resul
             });
 
         // Adopt the base oid recorded under the selected scope, if present.
-        if let Ok(all) = josh_changes::list_changes(&repo, scope) {
+        if let Ok(all) = josh_changes::list_changes(&transaction, scope) {
             if let Some(c) = all.iter().find(|c| c.id() == Some(cid.as_str())) {
                 let base = c.base();
                 if base != git2::Oid::ZERO_SHA1 {
@@ -354,7 +355,7 @@ pub fn load_detail(sha: &str, scope: &josh_changes::ChangesRef) -> anyhow::Resul
                 }
             }
         }
-        for oid in change.contributing(&repo).unwrap_or_default() {
+        for oid in change.contributing(&transaction).unwrap_or_default() {
             if let Ok(c) = repo.find_commit(oid) {
                 let msg = c.message().unwrap_or("");
                 let c_subject = msg.lines().next().unwrap_or("").to_string();
@@ -372,12 +373,12 @@ pub fn load_detail(sha: &str, scope: &josh_changes::ChangesRef) -> anyhow::Resul
 
     let comments = change_id
         .as_deref()
-        .map(|cid| josh_changes::read_comments(&repo, cid, scope).unwrap_or_default())
+        .map(|cid| josh_changes::read_comments(&transaction, cid, scope).unwrap_or_default())
         .unwrap_or_default();
-    let revisions = josh_changes::read_revisions(&repo, &change, scope).unwrap_or_default();
+    let revisions = josh_changes::read_revisions(&transaction, &change, scope).unwrap_or_default();
     let local_vote = change_id
         .as_ref()
-        .and_then(|cid| josh_changes::read_vote(&repo, cid, None, scope).ok())
+        .and_then(|cid| josh_changes::read_vote(&transaction, cid, None, scope).ok())
         .flatten();
 
     Ok(DetailData {
@@ -404,10 +405,9 @@ pub fn save_comment(
     message: &str,
     scope: &josh_changes::ChangesRef,
 ) -> anyhow::Result<String> {
-    let repo = git2::Repository::discover(".")?;
+    let transaction = crate::common::open_transaction()?;
     let oid = git2::Oid::from_str(sha)?;
-    let commit = repo.find_commit(oid)?;
-    let change = josh_changes::Change::new(&repo, &commit);
+    let change = josh_changes::Change::new(&transaction, oid)?;
 
     let meta = josh_changes::CommentMeta {
         message: message.to_string(),
@@ -422,14 +422,18 @@ pub fn save_comment(
         update_of: None,
     };
 
-    match scope {
+    let content_hash = match scope {
         josh_changes::ChangesRef::Remote { .. } => {
-            josh_changes::write_outbox_comment(&repo, &change, &meta, None, None, scope)
+            josh_changes::write_outbox_comment(&transaction, &change, &meta, None, None, scope)?
         }
         josh_changes::ChangesRef::Local { .. } => {
-            josh_changes::write_comment(&repo, &change, &meta, None, None, scope)
+            josh_changes::write_comment(&transaction, &change, &meta, None, None, scope)?
         }
-    }
+    };
+    // The write went into the transaction's in-memory odb; make it durable (and
+    // surface flush errors) before reporting success.
+    transaction.flush_mem_odb()?;
+    Ok(content_hash)
 }
 
 pub fn save_vote(
@@ -438,10 +442,9 @@ pub fn save_vote(
     body: &str,
     scope: &josh_changes::ChangesRef,
 ) -> anyhow::Result<String> {
-    let repo = git2::Repository::discover(".")?;
+    let transaction = crate::common::open_transaction()?;
     let oid = git2::Oid::from_str(sha)?;
-    let commit = repo.find_commit(oid)?;
-    let change = josh_changes::Change::new(&repo, &commit);
+    let change = josh_changes::Change::new(&transaction, oid)?;
 
     let body_meta = || josh_changes::CommentMeta {
         message: body.to_string(),
@@ -451,11 +454,11 @@ pub fn save_vote(
         update_of: None,
     };
 
-    match scope {
+    let content_hash = match scope {
         josh_changes::ChangesRef::Remote { .. } => {
             if !body.trim().is_empty() {
                 josh_changes::write_outbox_comment(
-                    &repo,
+                    &transaction,
                     &change,
                     &body_meta(),
                     None,
@@ -463,13 +466,24 @@ pub fn save_vote(
                     scope,
                 )?;
             }
-            josh_changes::write_outbox_vote(&repo, &change, state, None, None, scope)
+            josh_changes::write_outbox_vote(&transaction, &change, state, None, None, scope)?
         }
         josh_changes::ChangesRef::Local { .. } => {
             if !body.trim().is_empty() {
-                josh_changes::write_comment(&repo, &change, &body_meta(), None, None, scope)?;
+                josh_changes::write_comment(
+                    &transaction,
+                    &change,
+                    &body_meta(),
+                    None,
+                    None,
+                    scope,
+                )?;
             }
-            josh_changes::write_vote(&repo, &change, state, None, None, scope)
+            josh_changes::write_vote(&transaction, &change, state, None, None, scope)?
         }
-    }
+    };
+    // The write went into the transaction's in-memory odb; make it durable (and
+    // surface flush errors) before reporting success.
+    transaction.flush_mem_odb()?;
+    Ok(content_hash)
 }

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -299,9 +299,9 @@ pub fn ListView(
 }
 
 pub fn load_rows(scope: &josh_changes::ChangesRef) -> anyhow::Result<ListData> {
-    let repo = git2::Repository::discover(".")?;
+    let transaction = crate::common::open_transaction()?;
 
-    let changes = josh_changes::list_changes(&repo, scope)?;
+    let changes = josh_changes::list_changes(&transaction, scope)?;
 
     let mut oid_to_change_id: HashMap<String, String> = HashMap::new();
     for change in &changes {
@@ -315,7 +315,7 @@ pub fn load_rows(scope: &josh_changes::ChangesRef) -> anyhow::Result<ListData> {
     let mut dependencies: HashMap<String, Vec<String>> = HashMap::new();
 
     for change in &changes {
-        let commit = repo.find_commit(change.commit())?;
+        let commit = transaction.repo().find_commit(change.commit())?;
         let subject = commit
             .message()
             .unwrap_or("")
@@ -327,7 +327,7 @@ pub fn load_rows(scope: &josh_changes::ChangesRef) -> anyhow::Result<ListData> {
         let change_id = change.id().unwrap_or("").to_string();
 
         let mut deps: Vec<String> = Vec::new();
-        for oid in change.contributing(&repo)? {
+        for oid in change.contributing(&transaction)? {
             let oid_str = oid.to_string();
             if let Some(dep_id) = oid_to_change_id.get(&oid_str) {
                 if dep_id != &change_id {
@@ -368,11 +368,11 @@ pub fn load_rows(scope: &josh_changes::ChangesRef) -> anyhow::Result<ListData> {
 }
 
 fn load_metadata(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     scope: &josh_changes::ChangesRef,
     change_id: &str,
 ) -> RowMetadata {
-    let (review_decision, check_status) = josh_changes::read_pr_data(repo, change_id, scope)
+    let (review_decision, check_status) = josh_changes::read_pr_data(transaction, change_id, scope)
         .ok()
         .flatten()
         .and_then(|json| {
@@ -392,12 +392,12 @@ fn load_metadata(
         })
         .unwrap_or_default();
 
-    let local_vote = josh_changes::read_vote(repo, change_id, None, scope)
+    let local_vote = josh_changes::read_vote(transaction, change_id, None, scope)
         .ok()
         .flatten()
         .map(|v| v.state);
 
-    let comments_count = josh_changes::read_comments(repo, change_id, scope)
+    let comments_count = josh_changes::read_comments(transaction, change_id, scope)
         .map(|c| c.len())
         .unwrap_or(0);
 
@@ -416,11 +416,11 @@ pub fn load_metadata_batch(
     if change_ids.is_empty() {
         return Vec::new();
     }
-    let Ok(repo) = git2::Repository::discover(".") else {
+    let Ok(transaction) = crate::common::open_transaction() else {
         return Vec::new();
     };
     change_ids
         .iter()
-        .map(|cid| (cid.clone(), load_metadata(&repo, scope, cid)))
+        .map(|cid| (cid.clone(), load_metadata(&transaction, scope, cid)))
         .collect()
 }

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -40,9 +40,9 @@ fn main() {
 
 fn resolve_initial_scope(cli: &Cli) -> josh_changes::ChangesRef {
     let branch = cli.branch.clone().unwrap_or_else(|| {
-        git2::Repository::discover(".")
+        common::open_transaction()
             .ok()
-            .and_then(|r| josh_changes::head_branch(&r).ok())
+            .and_then(|transaction| josh_changes::head_branch(&transaction).ok())
             .unwrap_or_default()
     });
     match &cli.remote {

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -493,7 +493,6 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
         };
 
         let to_push = build_to_push(
-            transaction.repo(),
             &transaction,
             &push_mode,
             &baseref,


### PR DESCRIPTION
Port josh-changes onto the Transaction ref API

Public fns take &cache::Transaction instead of &git2::Repository; the
redundant (repo, transaction) parameter pairs collapse; no git2 object
handles remain in the public API (Change::new and
create_synthetic_merge_commit take oids, Change::new is now fallible).
Ref reads go through resolve_ref, enumeration through
for_each_ref_prefixed, and every commit-with-ref-update splits into a
plain object write plus update_ref, which now takes an Expected guard
(Any / Absent / At(oid), mirroring gix PreviousValue); the At/Absent
guards preserve libgit2's first-parent-must-be-tip check on the
metadata refs (contract pinned by unit tests, incl. packed-ref match
and error-on-vanished). Object I/O, git2 revwalks, symbolic-HEAD and
rev-parse stay on transaction.repo() until the flag day, marked with
PORT comments.

Deliberate divergences, invisible to the suite: corrupt-ref errors now
propagate instead of reading as absent, symbolic refs under the
enumerated refs/josh/ prefixes no longer enumerate, and reflog message
text differs.

Callers updated in josh-cli, josh-proxy, josh-github-changes, and
josh-gui; the latter two gain a josh-core dependency, with josh-gui
opening a per-callback transaction over an empty cache stack and
flushing the mem-odb before reporting a write as saved (its writes
previously went straight to the on-disk odb).

Change: josh-changes-transaction
Assisted-By: anthropic/claude-fable-5