### PR TITLE
Move GitHub-specific change tracking out of josh-changes

### DIFF
--- a/forges/josh-github-changes/src/comments.rs
+++ b/forges/josh-github-changes/src/comments.rs
@@ -1,8 +1,10 @@
-//! Posting local comments and votes to GitHub, and converting fetched PR
-//! comments into the forge-neutral shape `josh-changes` stores.
+//! Posting local comments and votes to GitHub, converting fetched PR
+//! comments into the forge-neutral shape `josh-changes` stores, and composing
+//! `josh-changes` storage primitives with the GitHub ID tracking in `ids`.
 
 use std::collections::HashMap;
 
+use josh_core::cache::Transaction;
 use josh_github_graphql::connection::GithubApiConnection;
 use josh_github_graphql::operations::pull_request::PrData;
 
@@ -177,7 +179,7 @@ pub async fn post_votes(
     };
 
     for (user, vote_data) in votes {
-        let event = josh_changes::vote_state_to_github_review(&vote_data.state);
+        let event = vote_state_to_github_review(&vote_data.state);
         let body = format!("josh vote: {}", vote_data.state);
 
         match connection
@@ -193,4 +195,104 @@ pub async fn post_votes(
     }
 
     outcome
+}
+
+/// Map a josh vote state to a GitHub pull request review event.
+fn vote_state_to_github_review(state: &str) -> &'static str {
+    match state {
+        "approve" => "APPROVE",
+        "discuss" => "COMMENT",
+        "revise" => "REQUEST_CHANGES",
+        _ => "COMMENT",
+    }
+}
+
+/// Filter `comments` (as loaded by [`josh_changes::read_comments`]) down to
+/// those not yet posted to GitHub, plus the GitHub node IDs of already-posted
+/// comments so [`post_comments`] can thread replies.
+pub fn pending_comments(
+    transaction: &Transaction,
+    change_id: &str,
+    scope: &josh_changes::ChangesRef,
+    comments: Vec<josh_changes::Comment>,
+) -> anyhow::Result<josh_changes::PendingComments> {
+    // Pending comments live in `outbox/comments/...` on the Remote ref. Anything
+    // already under `comments/...` was either fetched from the remote or has
+    // already been posted; either way it should not be re-posted.
+    let posted_ids = crate::ids::read_github_ids(transaction, change_id, scope)?;
+    let to_post = comments
+        .into_iter()
+        .filter(|c| c.pending && !posted_ids.contains_key(&c.id))
+        .collect();
+
+    Ok(josh_changes::PendingComments {
+        to_post,
+        posted_ids,
+    })
+}
+
+/// Record GitHub metadata for comments just stored by
+/// [`josh_changes::store_fetched_comments`]: track each written comment's
+/// node ID so it is marked as already posted, and drop outbox entries whose
+/// recorded node ID was observed in the fetch (the canonical copy now lives
+/// under `comments/...` on the ref).
+///
+/// `written` is the `(local hash, GitHub node ID)` pair list returned by
+/// `josh_changes::store_fetched_comments`.
+pub fn record_fetched_comments(
+    transaction: &Transaction,
+    change_id: &str,
+    written: &[(String, String)],
+    scope: &josh_changes::ChangesRef,
+) -> anyhow::Result<()> {
+    for (local_hash, github_id) in written {
+        crate::ids::store_github_id(transaction, change_id, local_hash, github_id, scope)?;
+    }
+
+    let fetched: std::collections::HashSet<&str> = written
+        .iter()
+        .map(|(_, github_id)| github_id.as_str())
+        .collect();
+    let gh_ids = crate::ids::read_github_ids(transaction, change_id, scope)?;
+    let to_remove: Vec<String> = gh_ids
+        .into_iter()
+        .filter(|(_, github_id)| fetched.contains(github_id.as_str()))
+        .map(|(local_hash, _)| local_hash)
+        .collect();
+    josh_changes::delete_outbox_comments(transaction, change_id, scope, &to_remove)?;
+
+    Ok(())
+}
+
+/// Votes queued in the outbox that have not been posted to GitHub yet,
+/// i.e. those whose `(state, sha)` is not already recorded in `gh_vote_ids`.
+pub fn pending_votes(
+    transaction: &Transaction,
+    change_id: &str,
+    scope: &josh_changes::ChangesRef,
+) -> anyhow::Result<Vec<(String, josh_changes::VoteData)>> {
+    let votes = josh_changes::list_outbox_votes(transaction, change_id, scope)?;
+    if votes.is_empty() {
+        return Ok(votes);
+    }
+
+    let tracked = crate::ids::read_github_vote_ids(transaction, change_id, scope)?;
+    Ok(votes
+        .into_iter()
+        .filter(|(user, data)| match tracked.get(user) {
+            Some(t) => t.state != data.state || t.sha != data.sha,
+            None => true,
+        })
+        .collect())
+}
+
+/// Remove outbox vote entries whose post is recorded in `gh_vote_ids`.
+/// Safe to call unconditionally -- it's a no-op when nothing needs cleaning.
+pub fn cleanup_posted_outbox_votes(
+    transaction: &Transaction,
+    change_id: &str,
+    scope: &josh_changes::ChangesRef,
+) -> anyhow::Result<usize> {
+    let tracked = crate::ids::read_github_vote_ids(transaction, change_id, scope)?;
+    josh_changes::cleanup_posted_outbox_votes(transaction, change_id, scope, &tracked)
 }

--- a/forges/josh-github-changes/src/ids.rs
+++ b/forges/josh-github-changes/src/ids.rs
@@ -1,0 +1,74 @@
+//! GitHub ID tracking on changes refs: which local comment or vote maps to
+//! which GitHub node ID. Persisted as blobs under `gh_ids/<change-id>/...` and
+//! `gh_vote_ids/<change-id>/...` inside the changes ref — the paths are part
+//! of the on-disk format and must not change.
+
+use std::collections::HashMap;
+
+use josh_changes::{encode_change_id_path, ChangesRef, VoteData};
+use josh_core::cache::Transaction;
+
+/// Store a GitHub node ID for a local comment, marking it as posted.
+pub fn store_github_id(
+    transaction: &Transaction,
+    change_id: &str,
+    local_hash: &str,
+    github_id: &str,
+    scope: &ChangesRef,
+) -> anyhow::Result<()> {
+    let blob_oid = transaction.repo().blob(github_id.as_bytes())?;
+    let path = std::path::Path::new("gh_ids")
+        .join(encode_change_id_path(change_id))
+        .join(local_hash);
+    josh_changes::write_changes_tree(transaction, &path, blob_oid, None, None, scope)?;
+    Ok(())
+}
+
+/// Read all GitHub node IDs for a change's comments.
+/// Returns a map from local comment hash → GitHub node ID.
+pub fn read_github_ids(
+    transaction: &Transaction,
+    change_id: &str,
+    scope: &ChangesRef,
+) -> anyhow::Result<HashMap<String, String>> {
+    let path = std::path::Path::new("gh_ids").join(encode_change_id_path(change_id));
+    Ok(josh_changes::read_blob_map(transaction, scope, &path)?
+        .into_iter()
+        .map(|(name, id)| (name, id.trim().to_string()))
+        .collect())
+}
+
+/// Record a vote as posted to GitHub for the given user.
+pub fn store_github_vote_id(
+    transaction: &Transaction,
+    change_id: &str,
+    user: &str,
+    vote_data: &VoteData,
+    scope: &ChangesRef,
+) -> anyhow::Result<()> {
+    let json = serde_json::to_string(vote_data)?;
+    let blob_oid = transaction.repo().blob(json.as_bytes())?;
+    let path = std::path::Path::new("gh_vote_ids")
+        .join(encode_change_id_path(change_id))
+        .join(user);
+    josh_changes::write_changes_tree(transaction, &path, blob_oid, None, None, scope)?;
+    Ok(())
+}
+
+/// Read the votes recorded as posted to GitHub for a change.
+/// Returns a map from user → vote data.
+pub fn read_github_vote_ids(
+    transaction: &Transaction,
+    change_id: &str,
+    scope: &ChangesRef,
+) -> anyhow::Result<HashMap<String, VoteData>> {
+    let path = std::path::Path::new("gh_vote_ids").join(encode_change_id_path(change_id));
+    Ok(josh_changes::read_blob_map(transaction, scope, &path)?
+        .into_iter()
+        .filter_map(|(user, json)| {
+            serde_json::from_str::<VoteData>(&json)
+                .ok()
+                .map(|d| (user, d))
+        })
+        .collect())
+}

--- a/forges/josh-github-changes/src/lib.rs
+++ b/forges/josh-github-changes/src/lib.rs
@@ -1,11 +1,13 @@
 pub mod admission;
 mod comments;
 mod display;
+mod ids;
 mod prs;
 pub mod repo;
 
 pub use comments::{
-    fetched_comments, post_comments, post_votes, PostCommentsOutcome, PostVotesOutcome,
-    PostedComment,
+    cleanup_posted_outbox_votes, fetched_comments, pending_comments, pending_votes, post_comments,
+    post_votes, record_fetched_comments, PostCommentsOutcome, PostVotesOutcome, PostedComment,
 };
+pub use ids::{read_github_ids, read_github_vote_ids, store_github_id, store_github_vote_id};
 pub use prs::{collect_pr_infos, create_or_update_prs, PrInfo};

--- a/josh-changes/src/change.rs
+++ b/josh-changes/src/change.rs
@@ -82,6 +82,34 @@ pub fn encode_change_id_path(id: &str) -> String {
     id.replace('/', "%2F")
 }
 
+/// Create a real merge commit that has the target branch tip and the change
+/// head as its two parents. The tree is the change head's tree (no content
+/// merge needed). Author and committer are copied from the head commit.
+pub fn create_synthetic_merge_commit(
+    transaction: &josh_core::cache::Transaction,
+    pr_head: git2::Oid,
+    target_branch_tip: git2::Oid,
+    message: &str,
+) -> anyhow::Result<git2::Oid> {
+    let repo = transaction.repo();
+    let pr_head = repo.find_commit(pr_head)?;
+    let target_branch_tip = repo.find_commit(target_branch_tip)?;
+    let tree = pr_head.tree()?;
+    let author = pr_head.author();
+    let committer = pr_head.committer();
+
+    let oid = repo.commit(
+        None,
+        &author,
+        &committer,
+        message,
+        &tree,
+        &[&target_branch_tip, &pr_head],
+    )?;
+
+    Ok(oid)
+}
+
 pub(crate) fn decode_change_id_path(enc: &str) -> String {
     enc.replace("%2F", "/")
 }

--- a/josh-changes/src/comments.rs
+++ b/josh-changes/src/comments.rs
@@ -498,36 +498,14 @@ pub fn delete_outbox_comments(
 /// Pending (not yet posted to the forge) comments for a change, loaded from
 /// the outbox subtree of `scope`, plus the forge IDs of already-posted
 /// comments so a publisher can thread replies.
+///
+/// Constructed by forge crates (e.g. `josh_github_changes::pending_comments`),
+/// which combine [`read_comments`] with their forge-ID tracking.
 pub struct PendingComments {
     /// Outbox comments with no forge ID mapping yet.
     pub to_post: Vec<Comment>,
     /// local hash -> forge node ID for already-posted comments (reply threading).
     pub posted_ids: std::collections::HashMap<String, String>,
-}
-
-pub fn pending_comments(
-    transaction: &Transaction,
-    change_id: &str,
-    scope: &ChangesRef,
-) -> anyhow::Result<PendingComments> {
-    // Pending comments live in `outbox/comments/...` on the Remote ref. Anything
-    // already under `comments/...` was either fetched from the remote or has
-    // already been posted; either way it should not be re-posted.
-    let comments: Vec<Comment> = read_comments(transaction, change_id, scope)?
-        .into_iter()
-        .filter(|c| c.pending)
-        .collect();
-
-    let posted_ids = crate::forges::github::read_github_ids(transaction, change_id, scope)?;
-    let to_post = comments
-        .into_iter()
-        .filter(|c| !posted_ids.contains_key(&c.id))
-        .collect();
-
-    Ok(PendingComments {
-        to_post,
-        posted_ids,
-    })
 }
 
 /// A comment fetched from a forge, in forge-neutral form. `forge_id` is the
@@ -545,13 +523,19 @@ pub struct FetchedComment {
 }
 
 /// Write comments fetched from a forge into the given changes ref.
-/// Returns the number of comments stored.
+/// Returns the `(local hash, forge ID)` pairs written, in fetch order.
+///
+/// Recording which local hash maps to which forge ID (so the comment is
+/// tracked as already posted) and dropping outbox entries observed in the
+/// fetch are the caller's job; see `josh_github_changes::store_fetched_comments`
+/// for the GitHub composition.
 pub fn store_fetched_comments(
     transaction: &Transaction,
     change: &Change,
     comments: &[FetchedComment],
     scope: &ChangesRef,
-) -> anyhow::Result<usize> {
+) -> anyhow::Result<Vec<(String, String)>> {
+    let mut written = Vec::with_capacity(comments.len());
     let mut id_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     for comment in comments {
         let location = comment
@@ -586,35 +570,11 @@ pub fn store_fetched_comments(
             comment.commit_oid.as_deref(),
             scope,
         )?;
-        // Record the forge ID so this comment is tracked as "already posted".
-        if let Some(change_id) = change.id() {
-            crate::forges::github::store_github_id(
-                transaction,
-                change_id,
-                &hash,
-                &comment.forge_id,
-                scope,
-            )?;
-        }
-        id_map.insert(comment.forge_id.clone(), hash);
+        id_map.insert(comment.forge_id.clone(), hash.clone());
+        written.push((hash, comment.forge_id.clone()));
     }
 
-    // Cleanup: any outbox entry whose `gh_ids[hash]` points at a forge comment
-    // we just observed in the fetch can now be dropped — the canonical copy
-    // lives under `comments/...` on this ref.
-    if let Some(change_id) = change.id() {
-        let fetched: std::collections::HashSet<&str> =
-            comments.iter().map(|c| c.forge_id.as_str()).collect();
-        let gh_ids = crate::forges::github::read_github_ids(transaction, change_id, scope)?;
-        let to_remove: Vec<String> = gh_ids
-            .into_iter()
-            .filter(|(_, forge_id)| fetched.contains(forge_id.as_str()))
-            .map(|(local_hash, _)| local_hash)
-            .collect();
-        delete_outbox_comments(transaction, change_id, scope, &to_remove)?;
-    }
-
-    Ok(comments.len())
+    Ok(written)
 }
 
 fn collect_outbox_file_paths(

--- a/josh-changes/src/forges/gerrit.rs
+++ b/josh-changes/src/forges/gerrit.rs
@@ -1,5 +1,5 @@
-use super::github::PushRef;
 use crate::change::{Change, get_changes, split_changes};
+use crate::stacked::PushRef;
 use anyhow::anyhow;
 
 /// A valid Gerrit Change-Id is the letter `I` followed by 40 hex digits.

--- a/josh-changes/src/forges/mod.rs
+++ b/josh-changes/src/forges/mod.rs
@@ -1,5 +1,3 @@
 pub mod gerrit;
-pub mod github;
 
 pub use gerrit::*;
-pub use github::*;

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1,6 +1,6 @@
 //! Stacked-changes metadata store for josh: change identity, comments, votes,
-//! revisions, and forge-specific publishing (GitHub-style stacked refs and
-//! Gerrit), persisted in `refs/josh/...` refs.
+//! revisions, and stacked-changes push machinery (including Gerrit-style
+//! publishing), persisted in `refs/josh/...` refs.
 //!
 //! The public API is flat: everything is re-exported at the crate root.
 
@@ -11,6 +11,7 @@ mod comments;
 mod forges;
 mod refs;
 mod revisions;
+mod stacked;
 mod store;
 mod votes;
 
@@ -19,5 +20,6 @@ pub use comments::*;
 pub use forges::*;
 pub use refs::*;
 pub use revisions::*;
+pub use stacked::*;
 pub use store::*;
 pub use votes::*;

--- a/josh-changes/src/stacked.rs
+++ b/josh-changes/src/stacked.rs
@@ -1,37 +1,11 @@
-use crate::change::{Change, encode_change_id_path, get_changes, split_changes};
-use crate::refs::{ChangesRef, StackedChangeRef, StackedRef};
-use crate::store::{get_tree, write_changes_tree};
-use crate::votes::VoteData;
+//! Stacked-changes push machinery: deciding which refs a push must create or
+//! update. Handles `refs/for`/`refs/drafts`/`refs/publish/for` ref syntax and
+//! is used by both the GitHub-style stacked-refs flow and the Gerrit flow.
+
+use crate::change::{Change, get_changes, split_changes};
+use crate::refs::{StackedChangeRef, StackedRef};
 use anyhow::anyhow;
 use josh_core::cache::Transaction;
-
-/// Create a real merge commit that has the target branch tip and PR head as its two parents.
-/// The tree is the PR head's tree (no content merge needed).
-/// Author and committer are copied from the PR head commit.
-pub fn create_synthetic_merge_commit(
-    transaction: &Transaction,
-    pr_head: git2::Oid,
-    target_branch_tip: git2::Oid,
-    message: &str,
-) -> anyhow::Result<git2::Oid> {
-    let repo = transaction.repo();
-    let pr_head = repo.find_commit(pr_head)?;
-    let target_branch_tip = repo.find_commit(target_branch_tip)?;
-    let tree = pr_head.tree()?;
-    let author = pr_head.author();
-    let committer = pr_head.committer();
-
-    let oid = repo.commit(
-        None,
-        &author,
-        &committer,
-        message,
-        &tree,
-        &[&target_branch_tip, &pr_head],
-    )?;
-
-    Ok(oid)
-}
 
 #[derive(PartialEq, Clone, Debug)]
 pub enum PushMode {
@@ -176,103 +150,5 @@ pub fn build_to_push(
             oid: oid_to_push,
             change_id: "JOSH_PUSH".to_string(),
         }]),
-    }
-}
-
-/// Store a GitHub node ID for a local comment, marking it as posted.
-pub fn store_github_id(
-    transaction: &Transaction,
-    change_id: &str,
-    local_hash: &str,
-    github_id: &str,
-    scope: &ChangesRef,
-) -> anyhow::Result<()> {
-    let blob_oid = transaction.repo().blob(github_id.as_bytes())?;
-    let path = std::path::Path::new("gh_ids")
-        .join(encode_change_id_path(change_id))
-        .join(local_hash);
-    write_changes_tree(transaction, &path, blob_oid, None, None, scope)?;
-    Ok(())
-}
-
-/// Read all GitHub node IDs for a change's comments.
-/// Returns a map from local comment hash → GitHub node ID.
-pub fn read_github_ids(
-    transaction: &Transaction,
-    change_id: &str,
-    scope: &ChangesRef,
-) -> anyhow::Result<std::collections::HashMap<String, String>> {
-    let repo = transaction.repo();
-    let tree = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => repo.find_commit(oid)?.tree()?,
-        None => return Ok(Default::default()),
-    };
-    let gh_ids_path = std::path::Path::new("gh_ids").join(encode_change_id_path(change_id));
-    let subtree = match get_tree(repo, &tree, &gh_ids_path) {
-        Some(t) => t,
-        None => return Ok(Default::default()),
-    };
-    let mut map = std::collections::HashMap::new();
-    for entry in subtree.iter() {
-        if let Ok(name) = entry.name() {
-            if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
-                let github_id = String::from_utf8_lossy(blob.content()).trim().to_string();
-                map.insert(name.to_string(), github_id);
-            }
-        }
-    }
-    Ok(map)
-}
-
-pub fn store_github_vote_id(
-    transaction: &Transaction,
-    change_id: &str,
-    user: &str,
-    vote_data: &VoteData,
-    scope: &ChangesRef,
-) -> anyhow::Result<()> {
-    let json = serde_json::to_string(vote_data)?;
-    let blob_oid = transaction.repo().blob(json.as_bytes())?;
-    let path = std::path::Path::new("gh_vote_ids")
-        .join(encode_change_id_path(change_id))
-        .join(user);
-    write_changes_tree(transaction, &path, blob_oid, None, None, scope)?;
-    Ok(())
-}
-
-pub fn read_github_vote_ids(
-    transaction: &Transaction,
-    change_id: &str,
-    scope: &ChangesRef,
-) -> anyhow::Result<std::collections::HashMap<String, VoteData>> {
-    let repo = transaction.repo();
-    let tree = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => repo.find_commit(oid)?.tree()?,
-        None => return Ok(Default::default()),
-    };
-    let path = std::path::Path::new("gh_vote_ids").join(encode_change_id_path(change_id));
-    let subtree = match get_tree(repo, &tree, &path) {
-        Some(t) => t,
-        None => return Ok(Default::default()),
-    };
-    let mut map = std::collections::HashMap::new();
-    for entry in subtree.iter() {
-        if let Ok(user) = entry.name() {
-            if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
-                if let Ok(data) = serde_json::from_slice::<VoteData>(blob.content()) {
-                    map.insert(user.to_string(), data);
-                }
-            }
-        }
-    }
-    Ok(map)
-}
-
-pub fn vote_state_to_github_review(state: &str) -> &'static str {
-    match state {
-        "approve" => "APPROVE",
-        "discuss" => "COMMENT",
-        "revise" => "REQUEST_CHANGES",
-        _ => "COMMENT",
     }
 }

--- a/josh-changes/src/store.rs
+++ b/josh-changes/src/store.rs
@@ -23,7 +23,12 @@ pub(crate) fn parse_timestamp(s: Option<&str>) -> git2::Time {
     git2::Time::new(dt.timestamp(), dt.offset().local_minus_utc() / 60)
 }
 
-pub(crate) fn write_changes_tree(
+/// Write `blob_oid` at `path` inside `scope`'s ref, committing the updated
+/// tree onto the ref. No-op when the same blob is already present at `path`.
+///
+/// This is the generic write primitive for path-keyed metadata on changes
+/// refs; forge crates build their on-ref layouts on top of it.
+pub fn write_changes_tree(
     transaction: &Transaction,
     path: &std::path::Path,
     blob_oid: git2::Oid,
@@ -80,6 +85,37 @@ pub(crate) fn write_changes_tree(
         &msg,
     )?;
     Ok(())
+}
+
+/// Read a flat subtree of `scope`'s ref at `path` as a map of entry name to
+/// blob contents (UTF-8, lossy). Entries that are not blobs are skipped.
+/// Returns an empty map when the ref or the subtree does not exist.
+pub fn read_blob_map(
+    transaction: &Transaction,
+    scope: &ChangesRef,
+    path: &std::path::Path,
+) -> anyhow::Result<std::collections::HashMap<String, String>> {
+    let repo = transaction.repo();
+    let tree = match transaction.resolve_ref(&scope.ref_name())? {
+        Some(oid) => repo.find_commit(oid)?.tree()?,
+        None => return Ok(Default::default()),
+    };
+    let subtree = match get_tree(repo, &tree, path) {
+        Some(t) => t,
+        None => return Ok(Default::default()),
+    };
+    let mut map = std::collections::HashMap::new();
+    for entry in subtree.iter() {
+        if let Ok(name) = entry.name() {
+            if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
+                map.insert(
+                    name.to_string(),
+                    String::from_utf8_lossy(blob.content()).to_string(),
+                );
+            }
+        }
+    }
+    Ok(map)
 }
 
 pub fn store_diff_data(

--- a/josh-changes/src/votes.rs
+++ b/josh-changes/src/votes.rs
@@ -186,28 +186,6 @@ pub fn list_outbox_votes(
     list_votes_at_prefix(transaction, change_id, scope, "outbox/votes")
 }
 
-/// Votes queued in the outbox that have not been posted to the forge yet,
-/// i.e. those whose `(state, sha)` is not already recorded in `gh_vote_ids`.
-pub fn pending_votes(
-    transaction: &Transaction,
-    change_id: &str,
-    scope: &ChangesRef,
-) -> anyhow::Result<Vec<(String, VoteData)>> {
-    let votes = list_outbox_votes(transaction, change_id, scope)?;
-    if votes.is_empty() {
-        return Ok(votes);
-    }
-
-    let tracked = crate::forges::github::read_github_vote_ids(transaction, change_id, scope)?;
-    Ok(votes
-        .into_iter()
-        .filter(|(user, data)| match tracked.get(user) {
-            Some(t) => t.state != data.state || t.sha != data.sha,
-            None => true,
-        })
-        .collect())
-}
-
 fn list_votes_at_prefix(
     transaction: &Transaction,
     change_id: &str,
@@ -245,13 +223,15 @@ fn list_votes_at_prefix(
     Ok(votes)
 }
 
-/// Remove outbox vote entries whose `(state, sha)` has already been recorded
-/// in the `gh_vote_ids` map for the change. Called by the sync push path after
-/// a successful push so the outbox doesn't accumulate forever.
+/// Remove outbox vote entries whose `(state, sha)` matches an entry in
+/// `posted` (the forge's record of already-posted votes, keyed by user).
+/// Called by forge sync paths after a successful push so the outbox doesn't
+/// accumulate forever.
 pub fn cleanup_posted_outbox_votes(
     transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
+    posted: &std::collections::HashMap<String, VoteData>,
 ) -> anyhow::Result<usize> {
     if !matches!(scope, ChangesRef::Remote { .. }) {
         return Err(anyhow::anyhow!(
@@ -260,8 +240,7 @@ pub fn cleanup_posted_outbox_votes(
     }
 
     let repo = transaction.repo();
-    let tracked = crate::forges::github::read_github_vote_ids(transaction, change_id, scope)?;
-    if tracked.is_empty() {
+    if posted.is_empty() {
         return Ok(0);
     }
     let outbox = list_outbox_votes(transaction, change_id, scope)?;
@@ -279,7 +258,7 @@ pub fn cleanup_posted_outbox_votes(
 
     let mut removed = 0usize;
     for (user, data) in &outbox {
-        let posted = match tracked.get(user) {
+        let posted = match posted.get(user) {
             Some(p) => p,
             None => continue,
         };

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -227,7 +227,19 @@ impl GithubSyncCtx<'_> {
         josh_changes::store_pr_data(self.transaction, change_id, &json, &remote_scope)?;
 
         let fetched = josh_github_changes::fetched_comments(&pr_data);
-        josh_changes::store_fetched_comments(self.transaction, &change, &fetched, &remote_scope)
+        let written = josh_changes::store_fetched_comments(
+            self.transaction,
+            &change,
+            &fetched,
+            &remote_scope,
+        )?;
+        josh_github_changes::record_fetched_comments(
+            self.transaction,
+            change_id,
+            &written,
+            &remote_scope,
+        )?;
+        Ok(written.len())
     }
 
     /// Delete local changes whose PRs are no longer open on GitHub, after
@@ -435,10 +447,25 @@ impl GithubSyncCtx<'_> {
             {
                 Ok(Some((pr_node_id, _, _))) => {
                     'comments: {
-                        let pending = match josh_changes::pending_comments(
+                        let comments = match josh_changes::read_comments(
                             self.transaction,
                             &change_id,
                             &remote_scope,
+                        ) {
+                            Ok(c) => c,
+                            Err(e) => {
+                                eprintln!(
+                                    "  PR #{}: failed to load local comments: {}",
+                                    pr.number, e
+                                );
+                                break 'comments;
+                            }
+                        };
+                        let pending = match josh_github_changes::pending_comments(
+                            self.transaction,
+                            &change_id,
+                            &remote_scope,
+                            comments,
                         ) {
                             Ok(p) => p,
                             Err(e) => {
@@ -454,7 +481,7 @@ impl GithubSyncCtx<'_> {
                                 .await;
                         let mut recorded = 0usize;
                         for p in &outcome.posted {
-                            if let Err(e) = josh_changes::store_github_id(
+                            if let Err(e) = josh_github_changes::store_github_id(
                                 self.transaction,
                                 &change_id,
                                 &p.local_id,
@@ -479,7 +506,7 @@ impl GithubSyncCtx<'_> {
                     }
 
                     'votes: {
-                        let pending_votes = match josh_changes::pending_votes(
+                        let pending_votes = match josh_github_changes::pending_votes(
                             self.transaction,
                             &change_id,
                             &remote_scope,
@@ -499,7 +526,7 @@ impl GithubSyncCtx<'_> {
                         .await;
                         let mut recorded_votes = 0usize;
                         for (user, data) in &outcome.posted {
-                            if let Err(e) = josh_changes::store_github_vote_id(
+                            if let Err(e) = josh_github_changes::store_github_vote_id(
                                 self.transaction,
                                 &change_id,
                                 user,
@@ -516,7 +543,7 @@ impl GithubSyncCtx<'_> {
                         }
                         // Drop outbox entries whose post is now reflected in gh_vote_ids.
                         // Safe to call unconditionally -- it's a no-op when nothing needs cleaning.
-                        if let Err(e) = josh_changes::cleanup_posted_outbox_votes(
+                        if let Err(e) = josh_github_changes::cleanup_posted_outbox_votes(
                             self.transaction,
                             &change_id,
                             &remote_scope,


### PR DESCRIPTION
Move GitHub-specific change tracking out of josh-changes

josh-changes is now forge-neutral: the gh_ids/gh_vote_ids storage,
pending comment/vote filtering against posted-ID maps, and the
vote-state to review-event mapping all live in josh-github-changes,
which composes josh-changes' raw storage primitives (write_changes_tree,
read_blob_map, list_outbox_votes, delete_outbox_comments) with its own
GitHub ID tracking. On-disk paths under gh_ids/ and gh_vote_ids/ are
unchanged.

The generic stacked-changes push machinery (PushMode, PushRef,
baseref_and_options, build_to_push, changes_to_refs) moves from
forges/github.rs to a new stacked module, and
create_synthetic_merge_commit to change.rs; josh-changes' flat
re-exports keep downstream call sites unchanged.

Change: forge-split-github-ids
Assisted-By: kimi-code/k3