### PR TITLE
Port josh-graphql onto the Transaction ref API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3488,6 +3488,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "git2",
+ "glob",
  "josh-core",
  "josh-search",
  "juniper",

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -59,6 +59,14 @@ pub fn git2_oid(oid: &gix_hash::oid) -> git2::Oid {
     git2::Oid::from_bytes(oid.as_bytes()).expect("oid sizes match")
 }
 
+/// Hash `data` as a blob without writing it anywhere.
+pub fn hash_blob(data: &[u8]) -> git2::Oid {
+    git2_oid(
+        &gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Blob, data)
+            .expect("failed to compute hash"),
+    )
+}
+
 /// Serialize `entries` as a git tree in exactly the order given and write it straight to `odb`.
 /// Used on hot paths while git2 still owns all I/O: the write is immediately visible to every
 /// reader of the repository (and lands in the in-memory memodb store when one is registered),
@@ -325,5 +333,22 @@ impl gix_object::Exists for StagingOdb<'_> {
                 .odb
                 .as_ref()
                 .is_some_and(|odb| odb.exists(git2_oid(id)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn hash_blob_matches_git2() {
+        for data in [&b""[..], b"x", b"1:{\"a\":1}\n"] {
+            assert_eq!(
+                super::hash_blob(data),
+                git2::Oid::hash_object(git2::ObjectType::Blob, data).unwrap()
+            );
+        }
+        assert_eq!(
+            super::hash_blob(b"").to_string(),
+            "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+        );
     }
 }

--- a/josh-graphql/Cargo.toml
+++ b/josh-graphql/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/josh-project/josh"
 keywords = ["git", "monorepo", "workflow", "scm"]
 
 [dependencies]
+glob = "0.3.4"
 strfmt = "0.2.5"
 
 anyhow.workspace = true

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -102,8 +102,8 @@ impl Revision {
 
     fn hash(&self, context: &Context) -> FieldResult<String> {
         let transaction = context.transaction.lock().unwrap();
-        // Existence/type probe: a bogus id (e.g. the zero oid from a target-less symbolic
-        // ref) must error here, not filter to a bogus hash under a nop filter.
+        // Existence/type probe: a bogus id (e.g. the zero oid `parents` substitutes when
+        // find_original fails) must error here, not filter to a bogus hash under a nop filter.
         transaction.repo().find_commit(self.commit_id)?;
         let filter_commit = filter::apply_to_commit(self.filter, self.commit_id, &transaction)?;
         Ok(format!("{}", filter_commit))
@@ -559,9 +559,10 @@ impl Markers {
 
         let refname = transaction_mirror.refname("refs/josh/meta");
 
-        let r = transaction_mirror.repo().revparse_single(&refname);
-        let tree = if let Ok(r) = r {
-            let commit = transaction.repo().find_commit(r.id())?;
+        // Resolve on the mirror, read objects on the overlay: the overlay repo sees the
+        // mirror's objects through a disk alternate.
+        let tree = if let Some(id) = transaction_mirror.resolve_ref(&refname)? {
+            let commit = transaction.repo().find_commit(id)?;
             commit.tree()?
         } else {
             filter::tree::empty(transaction.repo())
@@ -611,9 +612,8 @@ impl Markers {
 
         let refname = transaction_mirror.refname("refs/josh/meta");
 
-        let r = transaction_mirror.repo().revparse_single(&refname);
-        let mtree = if let Ok(r) = r {
-            let commit = transaction.repo().find_commit(r.id())?;
+        let mtree = if let Some(id) = transaction_mirror.resolve_ref(&refname)? {
+            let commit = transaction.repo().find_commit(id)?;
             commit.tree()?
         } else {
             filter::tree::empty(transaction.repo())
@@ -835,10 +835,8 @@ impl Reference {
     fn rev(&self, context: &Context, filter: Option<String>) -> FieldResult<Revision> {
         let transaction_mirror = context.transaction_mirror.lock().unwrap();
         let commit_id = transaction_mirror
-            .repo()
-            .find_reference(&self.refname)?
-            .target()
-            .unwrap_or(git2::Oid::ZERO_SHA1);
+            .resolve_ref(&self.refname)?
+            .ok_or_else(|| anyhow!("missing ref: {}", self.refname))?;
 
         Ok(Revision {
             filter: filter::parse(&filter.unwrap_or_else(|| ":/".to_string()))?,
@@ -917,7 +915,7 @@ struct MarkersInput {
 fn format_marker(input: &str) -> anyhow::Result<String> {
     let value = serde_json::from_str::<serde_json::Value>(input)?;
     let line = serde_json::to_string(&value)?;
-    let hash = git2::Oid::hash_object(git2::ObjectType::Blob, line.as_bytes())?;
+    let hash = josh_core::objects::hash_blob(line.as_bytes());
     Ok(format!("{}:{}", &hash, &line))
 }
 
@@ -1009,24 +1007,28 @@ impl Repository {
         }
 
         let transaction_mirror = context.transaction_mirror.lock().unwrap();
-        let refname = format!(
-            "{}{}",
-            self.ns,
-            pattern.unwrap_or_else(|| "refs/heads/*".to_string())
-        );
+        let pattern = pattern.unwrap_or_else(|| "refs/heads/*".to_string());
 
-        tracing::debug!(refname = refname, "refs");
+        tracing::debug!(pattern = pattern, "refs");
+
+        // The namespace stays out of glob matching: it extends the iteration prefix --
+        // together with the pattern's literal part before its first metacharacter -- and
+        // is stripped off the names matched against the pattern. `glob`'s default
+        // `MatchOptions` let `*` and `?` match across `/`.
+        let matcher = glob::Pattern::new(&pattern)?;
+        let literal_len = pattern.find(['*', '?', '[', '\\']).unwrap_or(pattern.len());
+        let prefix = format!("{}{}", self.ns, &pattern[..literal_len]);
 
         let mut refs = vec![];
 
-        for reference in transaction_mirror.repo().references_glob(&refname)? {
-            let r = reference?;
-            let name = r.name()?;
-
-            refs.push(Reference {
-                refname: name.to_string(),
-            });
-        }
+        transaction_mirror.for_each_ref_prefixed(&prefix, |name, _| {
+            if matcher.matches(&name[self.ns.len()..]) {
+                refs.push(Reference {
+                    refname: name.to_string(),
+                });
+            }
+            Ok(())
+        })?;
 
         Ok(refs)
     }
@@ -1056,6 +1058,7 @@ impl Repository {
             if let Some((oid, _)) = oid {
                 oid
             } else {
+                // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
                 transaction_mirror.repo().revparse_single(&rev)?.id()
             }
         };

--- a/tests/filter/graphql_refs.t
+++ b/tests/filter/graphql_refs.t
@@ -1,0 +1,79 @@
+  $ export TESTTMP=${PWD}
+
+  $ cd ${TESTTMP}
+  $ git init -q repo 1> /dev/null
+  $ cd repo
+
+  $ echo contents0 > file1
+  $ git add .
+  $ git commit -m "initial" 1> /dev/null
+
+  $ git branch a/b
+  $ git branch a-b
+  $ git branch release-1.0
+  $ git tag v1
+  $ git symbolic-ref refs/heads/sym refs/heads/master
+
+Default pattern "refs/heads/*": byte-sorted ("a-b" before "a/b"), symbolic "sym" skipped.
+
+  $ josh-filter -g 'query { refs { name } }'
+  35394071cd3b979e976016e08cddfc6fe16ca49b
+  {
+    "refs": [
+      {
+        "name": "refs/heads/a-b"
+      },
+      {
+        "name": "refs/heads/a/b"
+      },
+      {
+        "name": "refs/heads/master"
+      },
+      {
+        "name": "refs/heads/release-1.0"
+      }
+    ]
+  }
+
+"*" matches across "/", like libgit2's wildmatch.
+
+  $ josh-filter -g 'query { refs(pattern: "refs/heads/a*") { name } }'
+  35394071cd3b979e976016e08cddfc6fe16ca49b
+  {
+    "refs": [
+      {
+        "name": "refs/heads/a-b"
+      },
+      {
+        "name": "refs/heads/a/b"
+      }
+    ]
+  }
+
+A metacharacter mid-pattern: the part before it is the iteration prefix.
+
+  $ josh-filter -g 'query { refs(pattern: "refs/heads/release-*.0") { name } }'
+  35394071cd3b979e976016e08cddfc6fe16ca49b
+  {
+    "refs": [
+      {
+        "name": "refs/heads/release-1.0"
+      }
+    ]
+  }
+
+  $ josh-filter -g 'query { refs(pattern: "refs/tags/*") { name } }'
+  35394071cd3b979e976016e08cddfc6fe16ca49b
+  {
+    "refs": [
+      {
+        "name": "refs/tags/v1"
+      }
+    ]
+  }
+
+A pattern the glob parser rejects (non-component "**") errors the field.
+
+  $ josh-filter -g 'query { refs(pattern: "refs/h**") { name } }'
+  35394071cd3b979e976016e08cddfc6fe16ca49b
+  null


### PR DESCRIPTION
Port josh-graphql onto the Transaction ref API

Markers and Reference::rev resolve via resolve_ref, Repository::refs
enumerates via for_each_ref_prefixed filtered with the vendored glob
crate (the namespace extends the iteration prefix and is stripped
before matching, so it never enters glob syntax), and format_marker
hashes through josh_gix_ext::hash_blob. Rev-parse and all object I/O
stay on the git2 handle until flag day (PORT markers).

Divergences, invisible to the suite: the refs listing is byte-sorted;
symbolic, non-UTF-8 and corrupt refs are skipped; glob edge patterns
differ from libgit2's wildmatch. New prysk test graphql_refs.t pins
the matcher semantics and sorted order; a unit test pins hash_blob.

Change: josh-graphql-transaction
Assisted-By: anthropic/claude-fable-5