### PR TITLE
Pin the sled cache open in bench setups

### DIFF
--- a/josh-core/benches/deephistory_glob.rs
+++ b/josh-core/benches/deephistory_glob.rs
@@ -140,10 +140,11 @@ impl GlobBench {
             }
         }
 
-        let cache = std::sync::Arc::new(
-            josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-        );
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+        let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // Correctness gates (untimed): confirm every benchmarked pattern filter produces exactly

--- a/josh-core/benches/deephistory_prefix_flush.rs
+++ b/josh-core/benches/deephistory_prefix_flush.rs
@@ -126,10 +126,11 @@ impl PrefixFlushBench {
 
         let filter = Filter::new().prefix(PREFIX);
 
-        let cache = std::sync::Arc::new(
-            josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-        );
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+        let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache)
             .with_mem_odb_limit(MEM_ODB_LIMIT);
 

--- a/josh-core/benches/deephistory_subdir.rs
+++ b/josh-core/benches/deephistory_subdir.rs
@@ -104,10 +104,11 @@ impl SubdirBench {
 
         let filter = Filter::new().subdir(SUBDIR);
 
-        let cache = std::sync::Arc::new(
-            josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-        );
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+        let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // Correctness gate (untimed): confirm the subdir filter produces exactly the SUBDIR subtree of

--- a/josh-core/benches/deephistory_subdir_distributed.rs
+++ b/josh-core/benches/deephistory_subdir_distributed.rs
@@ -100,11 +100,13 @@ impl SubdirBench {
         // -- otherwise this bench would stop measuring the input >> output regime it exists for.
         // Checked on the largest case with a throwaway cache; caches are reset afterwards so nothing
         // here warms the timed runs.
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+
         {
-            let cache = std::sync::Arc::new(
-                josh_core::cache::CacheStack::new()
-                    .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-            );
+            let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
             let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
             let transaction = context.open()?;
             let case = cases.last().expect("at least one case");

--- a/josh-core/benches/deephistory_subdir_sparse.rs
+++ b/josh-core/benches/deephistory_subdir_sparse.rs
@@ -104,10 +104,11 @@ impl SubdirBench {
 
         let filter = Filter::new().subdir(SUBDIR);
 
-        let cache = std::sync::Arc::new(
-            josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-        );
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+        let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // Correctness + shape gate (untimed): confirm the subdir filter produces exactly the SUBDIR

--- a/josh-core/benches/refs_filter_update.rs
+++ b/josh-core/benches/refs_filter_update.rs
@@ -116,10 +116,11 @@ impl RefsBench {
 
         let filter = Filter::new().subdir(SUBDIR);
 
-        let cache = std::sync::Arc::new(
-            josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-        );
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+        let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // Correctness gate (untimed): confirm the subdir filter selects exactly the SUBDIR subtree

--- a/josh-core/benches/ultrawide_pin.rs
+++ b/josh-core/benches/ultrawide_pin.rs
@@ -68,10 +68,11 @@ impl PinBench {
 
         let head = provisioned.head;
 
-        let cache = std::sync::Arc::new(
-            josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-        );
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+        let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
 
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 

--- a/josh-core/benches/ultrawide_pin_hook.rs
+++ b/josh-core/benches/ultrawide_pin_hook.rs
@@ -176,10 +176,11 @@ impl PinBench {
             .hook(HOOK_ARG_ONE_TREE)
             .with_meta("history", "no-splice");
 
-        let cache = std::sync::Arc::new(
-            josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-        );
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+        let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // Sanity + correctness gate (untimed): confirm the `per_path` filter actually holds paths

--- a/josh-core/benches/unapply.rs
+++ b/josh-core/benches/unapply.rs
@@ -85,10 +85,11 @@ impl UnapplyBench {
 
         let filter = Filter::new().subdir(SUBDIR);
 
-        let cache = std::sync::Arc::new(
-            josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-        );
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+        let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // Warm the filter caches for every case head (untimed): the timed sections measure

--- a/josh-core/benches/widetree_glob.rs
+++ b/josh-core/benches/widetree_glob.rs
@@ -124,10 +124,11 @@ impl GlobBench {
             }
         }
 
-        let cache = std::sync::Arc::new(
-            josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-        );
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+        let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // Correctness gates (untimed, per size case, all three patterns): confirm the filters

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -315,10 +315,11 @@ impl TrigramBench {
             },
         )?;
 
-        let cache = std::sync::Arc::new(
-            josh_core::cache::CacheStack::new()
-                .with_backend(josh_core::cache::SledCacheBackend::new(provisioned.path())),
-        );
+        // Pin the sled db open across iterations: per-iteration transaction drops would
+        // otherwise close and reopen it, and the cycle's flush/reopen I/O dominates short cases.
+        let sled = josh_core::cache::SledCacheBackend::new(provisioned.path());
+        sled.pin()?;
+        let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // Per case (untimed): pre-build the tip's index tree for the search group and run the


### PR DESCRIPTION
Pin the sled cache open in bench setups

The refcounted sled lifetime (0993209a) closes the db whenever the last
active transaction drops. Benches open a fresh transaction per iteration,
so every iteration cycled a flush/close/reopen whose I/O dominates short
cases: deephistory_{subdir,rev}/100 regressed from ~2.2ms to ~11ms vs the
pre-gix baseline while longer cases hid it. Pin the db in every sled-using
bench setup, matching the proxy and the load-once semantics the baselines
were recorded under. Restores deephistory_subdir/100 to -24% and
deephistory_rev/100 to -21% vs pre-gix.

The trigram bench edit is untested: that bench already fails to build on
master (pre-existing IndexCache trait mismatch, unrelated).

Change: bench-sled-pin
Assisted-By: anthropic/claude-fable-5