### PR TITLE
Port josh-cli onto the Transaction ref API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,6 +3203,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "git2",
+ "glob",
  "josh-changes",
  "josh-compose",
  "josh-compose-podman",

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -11,6 +11,7 @@ version = "26.7.28"
 
 [dependencies]
 anyhow.workspace = true
+glob = "0.3.4"
 env_logger.workspace = true
 log.workspace = true
 serde_json.workspace = true

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -5,14 +5,17 @@ use std::fs::read_to_string;
 use std::io::Write;
 
 fn resolve_input_ref(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     input_ref: &str,
 ) -> anyhow::Result<(String, git2::Oid)> {
+    let repo = transaction.repo();
     let oid = josh_core::git::resolve_snapshot_input(repo, input_ref)?;
     let ref_string = if input_ref == "+" || input_ref == "." {
         oid.to_string()
     } else if git2::Oid::from_str(input_ref).is_ok() {
         input_ref.to_string()
+    // PORT: DWIM short-name resolution stays on the git2 handle until flag day (gix
+    // partial-name find_reference then).
     } else if let Ok(reference) = repo.resolve_reference_from_short_name(input_ref) {
         reference.name().unwrap().to_string()
     } else {
@@ -230,7 +233,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     let mut refs = vec![];
     let mut ids: Vec<(git2::Oid, josh_core::filter::Filter)> = vec![];
 
-    let (input_ref, oid) = resolve_input_ref(repo, input_ref)?;
+    let (input_ref, oid) = resolve_input_ref(&transaction, input_ref)?;
     refs.push((input_ref.clone(), oid));
 
     if args.get_flag("single") {
@@ -240,16 +243,19 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     }
 
     if let Some(pattern) = args.get_one::<String>("squash-pattern") {
-        let pattern = pattern.to_string();
-        for reference in repo.references_glob(&pattern).unwrap() {
-            let reference = reference?;
-            let target = reference.peel_to_commit()?.id();
-            ids.push((
-                target,
-                josh_core::filter::Filter::new().message(reference.name().unwrap()),
-            ));
-            refs.push((reference.name().unwrap().to_string(), target));
-        }
+        // Iterate over the pattern's literal prefix before its first metacharacter.
+        // `glob`'s default `MatchOptions` let `*` and `?` match across `/`.
+        let matcher = glob::Pattern::new(pattern)?;
+        let literal_len = pattern.find(['*', '?', '[', '\\']).unwrap_or(pattern.len());
+        transaction.for_each_ref_prefixed(&pattern[..literal_len], |name, oid| {
+            if !matcher.matches(name) {
+                return Ok(());
+            }
+            let target = repo.find_object(oid, None)?.peel_to_commit()?.id();
+            ids.push((target, josh_core::filter::Filter::new().message(name)));
+            refs.push((name.to_string(), target));
+            Ok(())
+        })?;
         filterobj = josh_core::filter::Filter::new()
             .squash(Some(&ids))
             .chain(filterobj);
@@ -321,6 +327,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     });
 
     if args.get_flag("discover") {
+        // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
         let r = repo.revparse_single(&input_ref)?;
         let hs =
             josh_core::housekeeping::find_all_workspaces_and_subdirectories(&r.peel_to_tree()?)?;
@@ -341,11 +348,9 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
 
     let reverse = args.get_flag("reverse");
 
-    let old_oid = if let Ok(id) = transaction.repo().refname_to_id(target) {
-        id
-    } else {
-        git2::Oid::ZERO_SHA1
-    };
+    let old_oid = transaction
+        .resolve_ref(target)?
+        .unwrap_or(git2::Oid::ZERO_SHA1);
 
     let (mut updated_refs, errors) = josh_core::filter_refs(&transaction, filterobj, &refs);
 
@@ -367,6 +372,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     josh_core::update_refs(&transaction, updated_refs.clone());
 
     if let Some(searchstring) = args.get_one::<String>("search") {
+        // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
         let commit = repo.revparse_single(&input_ref)?.peel_to_commit()?;
 
         let tree = repo
@@ -409,6 +415,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     }
 
     if reverse {
+        // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
         let new = repo.revparse_single(target).unwrap().id();
         let old = repo.revparse_single("JOSH_TMP").unwrap().id();
         let unfiltered_old = repo.revparse_single(&input_ref).unwrap().id();
@@ -437,7 +444,12 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
                         input_ref
                     ));
                 }
-                repo.reference(&input_ref, rewritten, true, "unapply_filter")?;
+                transaction.update_ref(
+                    &input_ref,
+                    josh_core::cache::Expected::At(unfiltered_old),
+                    rewritten,
+                    "unapply_filter",
+                )?;
                 rewritten
             }
             Err(e) => {
@@ -503,7 +515,9 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         let transaction = josh_core::cache::TransactionContext::from_env(cache.clone())?
             .with_mem_odb_limit(josh_cli::MAX_MEM_PACK_SIZE)
             .open()?;
-        let commit_id = transaction.repo().refname_to_id(update_target)?;
+        let commit_id = transaction
+            .resolve_ref(update_target)?
+            .ok_or_else(|| anyhow!("update target '{}' not found", update_target))?;
 
         print!(
             "{}",

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -390,6 +390,9 @@ fn handle_clone(
         // Read the remote HEAD symref to get the default branch
         let head_ref = "refs/remotes/origin/HEAD".to_string();
 
+        // PORT: symbolic-target read needs the target name, not the oid, so it is not
+        // expressible via resolve_ref; stays on the git2 handle until flag day (gix
+        // try_find_reference then).
         let head_reference = repo
             .find_reference(&head_ref)
             .with_context(|| format!("Failed to find remote HEAD reference {}", head_ref))?;
@@ -553,7 +556,7 @@ fn handle_filter(
         filter_str, args.remote
     );
 
-    let default_branch = josh_cli::remote_ops::resolve_default_branch(repo, &args.remote)?;
+    let default_branch = josh_cli::remote_ops::resolve_default_branch(transaction, &args.remote)?;
 
     josh_cli::remote_ops::apply_josh_filtering(transaction, filter, &args.remote, &default_branch)?;
 

--- a/josh-cli/src/commands/cache.rs
+++ b/josh-cli/src/commands/cache.rs
@@ -60,27 +60,18 @@ fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyho
     let repo = transaction.repo();
     let repo_path = normalize_repo_path(repo.path());
 
-    let default_branch = remote_ops::resolve_default_branch(repo, &args.remote)?;
+    let default_branch = remote_ops::resolve_default_branch(transaction, &args.remote)?;
 
     // Discover known filter chains from refs/josh/filtered/ refs.
     let mut chain_prefixes: HashSet<String> = HashSet::new();
-    if let Ok(refs) = repo.references_glob("refs/josh/filtered/*") {
-        for reference in refs {
-            let reference = match reference {
-                Ok(r) => r,
-                Err(_) => continue,
-            };
-            let refname = match reference.name() {
-                Ok(n) => n,
-                Err(_) => continue,
-            };
-            if let Some(rest) = refname.strip_prefix("refs/josh/filtered/") {
-                if let Some(heads_pos) = rest.find("/heads/") {
-                    chain_prefixes.insert(rest[..heads_pos].to_string());
-                }
+    transaction.for_each_ref_prefixed("refs/josh/filtered/", |refname, _| {
+        if let Some(rest) = refname.strip_prefix("refs/josh/filtered/") {
+            if let Some(heads_pos) = rest.find("/heads/") {
+                chain_prefixes.insert(rest[..heads_pos].to_string());
             }
         }
-    }
+        Ok(())
+    })?;
 
     // Keep only the longest prefixes (full chains).
     // A shorter prefix like "B/A" is an intermediate step of "C/B/A".
@@ -162,16 +153,14 @@ fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyho
     let backing_prefix = format!("refs/josh/remotes/{}/", args.remote);
     let default_branch_ref = format!("{}{}", backing_prefix, default_branch);
     let default_branch_oid = build_transaction
-        .repo()
-        .find_reference(&default_branch_ref)
-        .with_context(|| {
-            format!(
+        .resolve_ref(&default_branch_ref)?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
                 "Default branch '{}' not found in refs/josh/remotes/{}/",
-                default_branch, args.remote
+                default_branch,
+                args.remote
             )
-        })?
-        .target()
-        .context("Default branch ref has no target")?;
+        })?;
 
     let seed_commits = vec![(default_branch.clone(), default_branch_oid)];
 
@@ -201,11 +190,18 @@ fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyho
                 }
                 let filtered_ref =
                     format!("refs/josh/filtered/{}/heads/{}", prefix_path, branch_name);
-                // `filtered_oid`'s objects are in `build_transaction`'s in-memory store, so resolve
-                // the ref through its repo, not the outer one.
+                // The filtered objects live only in build_transaction's mem-odb until it
+                // flushes (on drop), so the refs briefly dangle for external readers:
+                // write them through the transaction that owns the objects, and route any
+                // future git subprocess that must see them through build_transaction's
+                // git_command (or run it after the drop, as `josh cache push` does).
                 build_transaction
-                    .repo()
-                    .reference(&filtered_ref, filtered_oid, true, "josh cache build")
+                    .update_ref(
+                        &filtered_ref,
+                        josh_core::cache::Expected::Any,
+                        filtered_oid,
+                        "josh cache build",
+                    )
                     .with_context(|| format!("failed to write filtered ref '{}'", filtered_ref))?;
                 next_commits.push((branch_name, filtered_oid));
             }
@@ -233,7 +229,7 @@ fn handle_cache_push(args: &CachePushArgs, transaction: &Transaction) -> anyhow:
     let RemoteConfig { url, .. } = config;
     let steps = flatten_chain(filter);
 
-    let default_branch = remote_ops::resolve_default_branch(repo, &args.remote)?;
+    let default_branch = remote_ops::resolve_default_branch(transaction, &args.remote)?;
 
     // Push all cache refs for the current cache version
     let cache_refspec = format!(
@@ -253,7 +249,7 @@ fn handle_cache_push(args: &CachePushArgs, transaction: &Transaction) -> anyhow:
             prefix_path, default_branch
         );
 
-        if repo.find_reference(&local_ref).is_err() {
+        if transaction.resolve_ref(&local_ref)?.is_none() {
             eprintln!(
                 "Warning: filtered ref '{}' not found — run 'josh cache build' first",
                 local_ref

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -56,6 +56,8 @@ pub fn handle_comment(
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
+    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
+    // Transaction helper at flag day (gix head_name()).
     let head = repo.head()?.peel_to_commit()?.id();
 
     let (short_file, short_location) = args

--- a/josh-cli/src/commands/fetch.rs
+++ b/josh-cli/src/commands/fetch.rs
@@ -75,11 +75,10 @@ pub fn handle_fetch(
             )
         })?;
 
-    repo.reference_symbolic(&head_ref, &default_branch_ref, true, "josh remote HEAD")?;
-    repo.reference_symbolic(
+    transaction.create_symref(&head_ref, &default_branch_ref, "josh remote HEAD")?;
+    transaction.create_symref(
         &format!("refs/namespaces/josh-{}/{}", args.remote, "HEAD"),
         &format!("refs/heads/{}", default_branch),
-        true,
         "josh remote HEAD",
     )?;
 

--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -99,6 +99,8 @@ fn handle_link_add(
     let target = args.target.as_deref().unwrap_or("HEAD");
 
     // Get the current HEAD commit
+    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
+    // Transaction helper at flag day (gix head_name()).
     let head_ref = repo.head().context("Failed to get HEAD")?;
     let head_commit = head_ref
         .peel_to_commit()
@@ -138,6 +140,8 @@ fn handle_link_add(
             .spawn_git(&["fetch", &args.url, target], &[])
             .context("Failed to execute git fetch")?;
 
+        // PORT: FETCH_HEAD pseudo-ref read stays on the git2 handle until flag day
+        // (gix multi-entry FETCH_HEAD semantics still unresolved).
         let fetched_oid = repo
             .find_reference("FETCH_HEAD")
             .context("Failed to find FETCH_HEAD after fetch")?
@@ -168,7 +172,13 @@ fn handle_link_add(
     let branch_name = "refs/heads/josh-link";
 
     // Create or update the branch reference
-    repo.reference(branch_name, commit_oid, true, "josh link add")
+    transaction
+        .update_ref(
+            branch_name,
+            josh_core::cache::Expected::Any,
+            commit_oid,
+            "josh link add",
+        )
         .with_context(|| format!("Failed to create branch '{}'", branch_name))?;
 
     eprintln!(
@@ -186,6 +196,8 @@ fn handle_link_fetch(
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
 
+    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
+    // Transaction helper at flag day (gix head_name()).
     let head_commit = repo
         .head()
         .context("Failed to get HEAD")?
@@ -267,6 +279,8 @@ fn handle_link_update(
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
 
+    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
+    // Transaction helper at flag day (gix head_name()).
     let head_ref = repo.head().context("Failed to get HEAD")?;
     let head_commit = head_ref
         .peel_to_commit()
@@ -321,6 +335,8 @@ fn handle_link_update(
             .spawn_git(&["fetch", &remote, &branch], &[])
             .with_context(|| format!("git fetch failed for '{}'", path.display()))?;
 
+        // PORT: FETCH_HEAD pseudo-ref read stays on the git2 handle until flag day
+        // (gix multi-entry FETCH_HEAD semantics still unresolved).
         let new_oid = repo
             .find_reference("FETCH_HEAD")
             .context("Failed to find FETCH_HEAD")?
@@ -345,13 +361,14 @@ fn handle_link_update(
     };
 
     let branch_name = "refs/heads/josh-link";
-    repo.reference(
-        branch_name,
-        result.filtered_commit,
-        true,
-        "josh link update",
-    )
-    .with_context(|| format!("Failed to update branch '{}'", branch_name))?;
+    transaction
+        .update_ref(
+            branch_name,
+            josh_core::cache::Expected::Any,
+            result.filtered_commit,
+            "josh link update",
+        )
+        .with_context(|| format!("Failed to update branch '{}'", branch_name))?;
 
     eprintln!("Updated {} link file(s)", link_files.len());
     eprintln!("Updated branch: {}", branch_name);
@@ -366,6 +383,8 @@ fn handle_link_push(
     let repo = transaction.repo();
 
     // Get current HEAD commit
+    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
+    // Transaction helper at flag day (gix head_name()).
     let head_commit = repo
         .head()
         .context("Failed to get HEAD")?

--- a/josh-cli/src/commands/pull.rs
+++ b/josh-cli/src/commands/pull.rs
@@ -197,13 +197,15 @@ pub fn render_fetch_summary(
 /// different remote than the one the branch tracks is an error (mirroring
 /// `git pull <other-remote>` without a branch argument).
 fn resolve_upstream_ref(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     branch_ref: &str,
     remote: &str,
 ) -> anyhow::Result<String> {
     let expected_prefix = format!("refs/remotes/{}/", remote);
 
-    if let Ok(upstream_buf) = repo.branch_upstream_name(branch_ref) {
+    // PORT: config-based upstream resolution stays on the git2 handle until flag day
+    // (gix branch_remote_tracking_ref_name then).
+    if let Ok(upstream_buf) = transaction.repo().branch_upstream_name(branch_ref) {
         if let Ok(upstream) = upstream_buf.as_str() {
             if !upstream.starts_with(&expected_prefix) {
                 return Err(anyhow::anyhow!(
@@ -309,6 +311,8 @@ pub fn integrate(
 ) -> anyhow::Result<IntegrateReport> {
     let repo = transaction.repo();
 
+    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
+    // Transaction helper at flag day (gix head_name()).
     let head = repo.head().context("Failed to resolve HEAD")?;
     if !head.is_branch() {
         anyhow::bail!("HEAD is detached; cannot integrate pull");
@@ -322,16 +326,22 @@ pub fn integrate(
         .unwrap_or(&branch_ref)
         .to_string();
 
-    let upstream_refname = resolve_upstream_ref(repo, &branch_ref, remote)?;
+    let upstream_refname = resolve_upstream_ref(transaction, &branch_ref, remote)?;
+    let new = transaction
+        .resolve_ref(&upstream_refname)?
+        .ok_or_else(|| anyhow::anyhow!("failed to resolve upstream ref '{}'", upstream_refname))?;
     let new = repo
-        .find_reference(&upstream_refname)
-        .and_then(|r| r.peel_to_commit())
+        .find_object(new, None)?
+        .peel_to_commit()
         .with_context(|| format!("failed to resolve upstream ref '{}'", upstream_refname))?
         .id();
     let old = head
         .peel_to_commit()
         .context("failed to resolve HEAD commit")?
         .id();
+    // The ref's stored target, which the CAS guard on the write below compares against;
+    // differs from the peeled `old` only if the branch points at an annotated tag.
+    let old_target = head.target().context("HEAD branch has no direct target")?;
 
     if old == new {
         return Ok(IntegrateReport::UpToDate);
@@ -407,7 +417,12 @@ pub fn integrate(
         Some(git2::build::CheckoutBuilder::new().safe()),
     )
     .context("failed to update working tree; local changes conflict with the pulled state")?;
-    repo.reference(&branch_ref, new_tip, true, "josh changes pull")?;
+    transaction.update_ref(
+        &branch_ref,
+        josh_core::cache::Expected::At(old_target),
+        new_tip,
+        "josh changes pull",
+    )?;
 
     Ok(report)
 }

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -124,6 +124,8 @@ fn prepare_push(
         .strip_prefix("refs/heads/")
         .unwrap_or(&remote_ref);
 
+    // PORT: DWIM short-name resolution stays on the git2 handle until flag day (gix
+    // partial-name find_reference then).
     let local_commit = repo
         .resolve_reference_from_short_name(&local_ref)
         .with_context(|| format!("Failed to resolve local ref '{}'", local_ref))?
@@ -132,9 +134,7 @@ fn prepare_push(
 
     let dest_remote_ref = format!("refs/josh/remotes/{}/{}", remote_name, remote_ref);
     let (dest_oid, old_filtered_oid) =
-        if let Ok(remote_reference) = repo.find_reference(&dest_remote_ref) {
-            let dest_oid = remote_reference.target().unwrap_or(git2::Oid::ZERO_SHA1);
-
+        if let Some(dest_oid) = transaction.resolve_ref(&dest_remote_ref)? {
             let (filtered_oids, errors) =
                 josh_core::filter_refs(transaction, filter, &[(dest_remote_ref.clone(), dest_oid)]);
 
@@ -155,15 +155,15 @@ fn prepare_push(
 
     let original_target = if let Some(base) = base {
         let base_remote_ref = format!("refs/josh/remotes/{}/{}", remote_name, base);
-        repo.find_reference(&base_remote_ref)
+        transaction
+            .resolve_ref(&base_remote_ref)?
+            .ok_or_else(|| anyhow!("no such ref: '{}'", base_remote_ref))
             .with_context(|| {
                 format!(
                     "Failed to resolve --base ref (looked up '{}')",
                     base_remote_ref
                 )
             })?
-            .target()
-            .with_context(|| format!("Base ref '{}' has no target", base_remote_ref))?
     } else {
         dest_oid
     };
@@ -522,6 +522,8 @@ fn orchestrate_push(
     let push_target = push_url.as_deref().unwrap_or(&url);
 
     let refspecs = if refspecs_arg.is_empty() {
+        // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
+        // Transaction helper at flag day (gix head_name()).
         let head = repo.head().context("Failed to get HEAD")?;
         let current_branch = head
             .shorthand()

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -31,18 +31,19 @@ pub fn handle_sync(
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
 
+    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
+    // Transaction helper at flag day (gix head_name()).
     let head = repo.head()?.peel_to_commit()?;
     let branch = repo.head()?.shorthand().ok().map(|s| s.to_string());
 
-    let base_oid = branch
-        .as_ref()
-        .and_then(|b| {
-            repo.find_reference(&format!("refs/remotes/origin/{}", b))
-                .ok()
-                .and_then(|r| r.peel_to_commit().ok())
-                .map(|c| c.id())
-        })
-        .unwrap_or(git2::Oid::ZERO_SHA1);
+    let base_oid = if let Some(b) = &branch {
+        match transaction.resolve_ref(&format!("refs/remotes/origin/{}", b))? {
+            Some(oid) => repo.find_object(oid, None)?.peel_to_commit()?.id(),
+            None => git2::Oid::ZERO_SHA1,
+        }
+    } else {
+        git2::Oid::ZERO_SHA1
+    };
 
     let resolved = args.scope.resolve(transaction)?;
     let remote_name = match &resolved {
@@ -66,9 +67,7 @@ pub fn handle_sync(
             }
         }
         for scope in to_delete {
-            if let Ok(mut r) = repo.find_reference(&scope.ref_name()) {
-                r.delete()?;
-            }
+            transaction.delete_ref(&scope.ref_name(), josh_core::cache::Expected::Any)?;
         }
     }
 
@@ -723,6 +722,8 @@ fn fetch_target_branch_tips(
         transaction
             .spawn_git(&["fetch", &github_url, "--no-tags", &refspec], &[])
             .with_context(|| format!("Failed to fetch target branch {}", target))?;
+        // PORT: FETCH_HEAD pseudo-ref read stays on the git2 handle until flag day
+        // (gix multi-entry FETCH_HEAD semantics still unresolved).
         let oid = repo
             .find_reference("FETCH_HEAD")
             .context("Failed to find FETCH_HEAD after target branch fetch")?

--- a/josh-cli/src/remote_ops.rs
+++ b/josh-cli/src/remote_ops.rs
@@ -45,11 +45,16 @@ pub fn get_head_branch(
 /// Returns an error if the symref cannot be resolved (e.g. the remote
 /// has not been fetched yet or does not advertise HEAD).
 pub fn resolve_default_branch(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     remote_name: &str,
 ) -> anyhow::Result<String> {
     let head_symref = format!("refs/remotes/{}/HEAD", remote_name);
-    repo.find_reference(&head_symref)
+    // PORT: symbolic-target read needs the target name, not the oid, so it is not
+    // expressible via resolve_ref; stays on the git2 handle until flag day (gix
+    // try_find_reference then).
+    transaction
+        .repo()
+        .find_reference(&head_symref)
         .ok()
         .and_then(|r| r.symbolic_target().ok().flatten().map(|s| s.to_string()))
         .and_then(|target| {
@@ -73,17 +78,14 @@ pub fn get_backing_refs(
     transaction: &josh_core::cache::Transaction,
     remote_name: &str,
 ) -> anyhow::Result<Vec<(String, git2::Oid)>> {
-    let repo = transaction.repo();
     let mut input_refs = Vec::new();
-    let josh_remotes = repo.references_glob(&format!("refs/josh/remotes/{}/*", remote_name))?;
-
-    for reference in josh_remotes {
-        let reference = reference?;
-        if let Some(target) = reference.target() {
-            let ref_name = reference.name().unwrap().to_string();
-            input_refs.push((ref_name, target));
-        }
-    }
+    transaction.for_each_ref_prefixed(
+        &format!("refs/josh/remotes/{}/", remote_name),
+        |name, oid| {
+            input_refs.push((name.to_string(), oid));
+            Ok(())
+        },
+    )?;
 
     if input_refs.is_empty() {
         return Err(anyhow::anyhow!(
@@ -163,7 +165,13 @@ pub fn apply_josh_filtering(
             if branch_name == default_branch {
                 let filtered_ref =
                     format!("refs/josh/filtered/{}/heads/{}", prefix_path, branch_name);
-                repo.reference(&filtered_ref, *filtered_oid, true, "josh filter")
+                transaction
+                    .update_ref(
+                        &filtered_ref,
+                        josh_core::cache::Expected::Any,
+                        *filtered_oid,
+                        "josh filter",
+                    )
                     .with_context(|| format!("failed to write filtered ref '{}'", filtered_ref))?;
             }
 
@@ -179,7 +187,13 @@ pub fn apply_josh_filtering(
             "refs/namespaces/josh-{}/refs/heads/{}",
             remote_name, branch_name
         );
-        repo.reference(&ns_ref, *filtered_oid, true, "josh filter")
+        transaction
+            .update_ref(
+                &ns_ref,
+                josh_core::cache::Expected::Any,
+                *filtered_oid,
+                "josh filter",
+            )
             .context("failed to create filtered reference")?;
     }
 

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -369,6 +369,56 @@ impl Transaction {
         Ok(())
     }
 
+    /// Delete the ref `refname`, guarded by `expected`: `Expected::Any` deletes whatever
+    /// is there and treats an absent ref as a no-op; `Expected::At(oid)` asserts the ref
+    /// currently points at `oid` and errors, leaving the ref in place, on mismatch or
+    /// absence. `Expected::Absent` is a contract error. The ref entry itself is deleted
+    /// (a symbolic ref is deleted, not followed); loose and packed entries and the reflog
+    /// are removed. Under git2 an `Any` delete of a ref concurrently modified (not
+    /// deleted) mid-call may error (libgit2 CASes against the value read at find time);
+    /// gix's Any-delete succeeds -- acceptable widening at flag day. (gix mapping: RefEdit
+    /// Change::Delete with PreviousValue::Any / MustExistAndMatch, RefLog::AndReference.)
+    pub fn delete_ref(&self, refname: &str, expected: Expected) -> anyhow::Result<()> {
+        match expected {
+            Expected::Absent => Err(anyhow!("delete_ref: Expected::Absent is not a valid guard")),
+            Expected::Any => match self.repo.find_reference(refname) {
+                Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(()),
+                Err(e) => Err(e.into()),
+                Ok(mut reference) => match reference.delete() {
+                    Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(()),
+                    other => Ok(other?),
+                },
+            },
+            Expected::At(old) => {
+                let mut reference = self.repo.find_reference(refname)?;
+                if reference.target() != Some(old) {
+                    return Err(anyhow!(
+                        "delete_ref: '{}' does not point at {}",
+                        refname,
+                        old
+                    ));
+                }
+                Ok(reference.delete()?)
+            }
+        }
+    }
+
+    /// Force-create or update the symbolic ref `refname` to point at the ref named
+    /// `target`, which is validated for refname format but need not exist (dangling
+    /// symrefs are allowed). Always overwrites, like `Expected::Any`; grow a guard
+    /// parameter only when a consumer needs one (as update_ref did). (gix mapping:
+    /// RefEdit Change::Update with Target::Symbolic, PreviousValue::Any.)
+    pub fn create_symref(
+        &self,
+        refname: &str,
+        target: &str,
+        log_message: &str,
+    ) -> anyhow::Result<()> {
+        self.repo
+            .reference_symbolic(refname, target, true, log_message)?;
+        Ok(())
+    }
+
     /// Run `cb` for every direct ref whose full name starts with `prefix`, byte-sorted by
     /// name. `prefix` must consist of refname-valid characters. Symbolic refs and refs
     /// with non-UTF-8 names are skipped. Errors from `cb` abort the iteration.
@@ -1029,5 +1079,186 @@ mod tests {
         });
         assert!(result.is_err());
         assert_eq!(calls, 1);
+    }
+
+    #[test]
+    fn delete_ref_any_deletes_existing() {
+        let (_dir, transaction) = test_transaction();
+        let oid = commit(&transaction, "a");
+        transaction
+            .update_ref("refs/josh/a", Expected::Any, oid, "test")
+            .unwrap();
+        transaction
+            .delete_ref("refs/josh/a", Expected::Any)
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/josh/a").unwrap(), None);
+    }
+
+    #[test]
+    fn delete_ref_any_absent_is_noop() {
+        let (_dir, transaction) = test_transaction();
+        transaction
+            .delete_ref("refs/josh/missing", Expected::Any)
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/josh/missing").unwrap(), None);
+    }
+
+    #[test]
+    fn delete_ref_at_deletes_on_match() {
+        let (_dir, transaction) = test_transaction();
+        let oid = commit(&transaction, "a");
+        transaction
+            .update_ref("refs/josh/a", Expected::Any, oid, "test")
+            .unwrap();
+        transaction
+            .delete_ref("refs/josh/a", Expected::At(oid))
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/josh/a").unwrap(), None);
+    }
+
+    #[test]
+    fn delete_ref_at_fails_on_mismatch() {
+        let (_dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        let b = commit(&transaction, "b");
+        transaction
+            .update_ref("refs/josh/a", Expected::Any, a, "test")
+            .unwrap();
+        assert!(
+            transaction
+                .delete_ref("refs/josh/a", Expected::At(b))
+                .is_err()
+        );
+        assert_eq!(transaction.resolve_ref("refs/josh/a").unwrap(), Some(a));
+    }
+
+    #[test]
+    fn delete_ref_at_fails_on_missing_ref() {
+        let (_dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        assert!(
+            transaction
+                .delete_ref("refs/josh/missing", Expected::At(a))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn delete_ref_absent_is_contract_error() {
+        let (_dir, transaction) = test_transaction();
+        assert!(
+            transaction
+                .delete_ref("refs/josh/missing", Expected::Absent)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn delete_ref_removes_packed_ref() {
+        let (dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        transaction
+            .update_ref("refs/josh/a", Expected::Any, a, "test")
+            .unwrap();
+        // Pack the ref by hand (git2 exposes no pack-refs API): delete must remove the
+        // packed entry, not conclude the ref is absent.
+        std::fs::write(
+            dir.path().join("packed-refs"),
+            format!(
+                "# pack-refs with: peeled fully-peeled sorted\n{} refs/josh/a\n",
+                a
+            ),
+        )
+        .unwrap();
+        std::fs::remove_file(dir.path().join("refs/josh/a")).unwrap();
+
+        transaction
+            .delete_ref("refs/josh/a", Expected::Any)
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/josh/a").unwrap(), None);
+    }
+
+    #[test]
+    fn create_symref_resolves_through() {
+        let (_dir, transaction) = test_transaction();
+        let oid = commit(&transaction, "a");
+        transaction
+            .update_ref("refs/heads/main", Expected::Any, oid, "test")
+            .unwrap();
+        transaction
+            .create_symref("refs/josh/sym", "refs/heads/main", "test")
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/josh/sym").unwrap(), Some(oid));
+    }
+
+    #[test]
+    fn create_symref_dangling_target_allowed() {
+        let (_dir, transaction) = test_transaction();
+        transaction
+            .create_symref("refs/josh/sym", "refs/heads/missing", "test")
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/josh/sym").unwrap(), None);
+    }
+
+    #[test]
+    fn create_symref_overwrites() {
+        let (_dir, transaction) = test_transaction();
+        let a = commit(&transaction, "a");
+        let b = commit(&transaction, "b");
+        transaction
+            .update_ref("refs/heads/a", Expected::Any, a, "test")
+            .unwrap();
+        transaction
+            .update_ref("refs/heads/b", Expected::Any, b, "test")
+            .unwrap();
+        transaction
+            .create_symref("refs/josh/sym", "refs/heads/a", "test")
+            .unwrap();
+        transaction
+            .create_symref("refs/josh/sym", "refs/heads/b", "test")
+            .unwrap();
+        assert_eq!(transaction.resolve_ref("refs/josh/sym").unwrap(), Some(b));
+    }
+
+    #[test]
+    fn create_symref_skipped_by_for_each_ref_prefixed() {
+        let (_dir, transaction) = test_transaction();
+        let oid = commit(&transaction, "a");
+        transaction
+            .update_ref("refs/josh/a", Expected::Any, oid, "test")
+            .unwrap();
+        transaction
+            .create_symref("refs/josh/sym", "refs/josh/a", "test")
+            .unwrap();
+
+        let mut seen = vec![];
+        transaction
+            .for_each_ref_prefixed("refs/josh/", |name, _| {
+                seen.push(name.to_owned());
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(seen, ["refs/josh/a"]);
+    }
+
+    #[test]
+    fn delete_ref_any_deletes_symref_not_target() {
+        let (_dir, transaction) = test_transaction();
+        let oid = commit(&transaction, "a");
+        transaction
+            .update_ref("refs/heads/main", Expected::Any, oid, "test")
+            .unwrap();
+        transaction
+            .create_symref("refs/josh/sym", "refs/heads/main", "test")
+            .unwrap();
+        transaction
+            .delete_ref("refs/josh/sym", Expected::Any)
+            .unwrap();
+        // The symref entry is gone; the branch it pointed at survives.
+        assert!(transaction.repo().find_reference("refs/josh/sym").is_err());
+        assert_eq!(
+            transaction.resolve_ref("refs/heads/main").unwrap(),
+            Some(oid)
+        );
     }
 }

--- a/tests/filter/squash_same_oid.t
+++ b/tests/filter/squash_same_oid.t
@@ -1,0 +1,26 @@
+  $ export RUST_BACKTRACE=1
+  $ git init -q 1> /dev/null
+
+  $ echo contents1 > file1
+  $ git add .
+  $ git commit -m "add file1" 1> /dev/null
+
+Two tags on one commit: refs are enumerated byte-sorted and a duplicate target oid
+takes the last-inserted message filter, so the byte-greatest refname wins the
+message collision.
+
+  $ git tag tag_a
+  $ git tag tag_b
+
+  $ josh-filter --squash-pattern "refs/tags/*" --update refs/heads/filtered
+  077b2cad7b3fbc393b6320b90c9c0be1255ac309
+
+  $ git log --pretty=%s refs/heads/filtered
+  refs/tags/tag_b
+
+A pattern the glob parser rejects (non-component "**") errors instead of matching
+like "*".
+
+  $ josh-filter --squash-pattern "refs/tags/t**" --update refs/heads/filtered
+  ERROR: Pattern syntax error near position 10: recursive wildcards must form a single path component
+  [1]


### PR DESCRIPTION
Port josh-cli onto the Transaction ref API

All josh-cli ref-store sites move onto the Transaction API: reads via
resolve_ref (push dest/--base refs, cache build/push, pull upstream,
sync base, josh-filter --update old oid and --query target),
enumeration via for_each_ref_prefixed (backing refs, cache chain
discovery, --squash-pattern filtered inline with the vendored glob
crate), and writes via update_ref (filtered/namespace refs, cache
build on the build_transaction that owns the mem-odb overlay,
josh-link branch -- all Expected::Any; the unapply write and the pull
branch move take Expected::At of the ref's stored target read before
deriving the new value). The API gains delete_ref (Expected-guarded,
missing-ok under Any; sync --clean) and create_symref (always-force,
dangling targets allowed; the remote HEAD symrefs in fetch), contracts
and gix mappings in the method doc comments. resolve_default_branch,
resolve_input_ref and resolve_upstream_ref now take &Transaction.

Symbolic-HEAD and symbolic-target reads, DWIM short-name resolution,
branch_upstream_name, FETCH_HEAD reads, rev-parse and all object I/O
stay on transaction.repo() until flag day (PORT markers); the
clone/push/pull/link/cache suites pin the unchanged behavior, and
push.t's --base error keeps its context+cause chain byte-identically.

Deliberate divergences, invisible to the suite: ref enumeration is
byte-sorted (first-error selection over multiple failing refs may pick
a different error); squash-pattern matching uses the vendored glob
crate (mid-string ** errors, symbolic and non-UTF-8 refs skip instead
of failing or panicking); corrupt refs and syntactically invalid
refnames error instead of reading as absent (push dest, sync base,
cache-push warning, --update old oid, cache chain discovery);
resolve_ref follows symrefs where targets were read directly; the
guarded writes error on a concurrent ref move instead of clobbering;
sync --clean deletion is missing-ok instead of racing find/delete.
New unit tests pin the delete_ref/create_symref contracts, and the new
squash_same_oid.t pins the now-deterministic squash-pattern collision
winner (byte-greatest refname).

Change: josh-cli-transaction
Assisted-By: anthropic/claude-fable-5