### PR TITLE
Move outbox vote loading to the sync call site

### DIFF
--- a/forges/josh-github-changes/src/comments.rs
+++ b/forges/josh-github-changes/src/comments.rs
@@ -264,35 +264,56 @@ pub fn record_fetched_comments(
     Ok(())
 }
 
-/// Votes queued in the outbox that have not been posted to GitHub yet,
-/// i.e. those whose `(state, sha)` is not already recorded in `gh_vote_ids`.
+/// Filter `votes` (as loaded by [`josh_changes::list_outbox_votes`]) down to
+/// those not yet posted to GitHub, i.e. whose `(state, sha)` is not already
+/// recorded in `gh_vote_ids`.
 pub fn pending_votes(
     transaction: &Transaction,
     change_id: &str,
     scope: &josh_changes::ChangesRef,
+    votes: &[(String, josh_changes::VoteData)],
 ) -> anyhow::Result<Vec<(String, josh_changes::VoteData)>> {
-    let votes = josh_changes::list_outbox_votes(transaction, change_id, scope)?;
     if votes.is_empty() {
-        return Ok(votes);
+        return Ok(Vec::new());
     }
 
     let tracked = crate::ids::read_github_vote_ids(transaction, change_id, scope)?;
     Ok(votes
-        .into_iter()
+        .iter()
         .filter(|(user, data)| match tracked.get(user) {
             Some(t) => t.state != data.state || t.sha != data.sha,
             None => true,
         })
+        .cloned()
         .collect())
 }
 
-/// Remove outbox vote entries whose post is recorded in `gh_vote_ids`.
-/// Safe to call unconditionally -- it's a no-op when nothing needs cleaning.
+/// Remove outbox vote entries from `votes` (as loaded by
+/// [`josh_changes::list_outbox_votes`]) whose `(state, sha)` is recorded in
+/// `gh_vote_ids`, i.e. votes already posted to GitHub. Safe to call
+/// unconditionally -- it's a no-op when nothing needs cleaning.
 pub fn cleanup_posted_outbox_votes(
     transaction: &Transaction,
     change_id: &str,
     scope: &josh_changes::ChangesRef,
+    votes: &[(String, josh_changes::VoteData)],
 ) -> anyhow::Result<usize> {
+    if votes.is_empty() {
+        return Ok(0);
+    }
+
     let tracked = crate::ids::read_github_vote_ids(transaction, change_id, scope)?;
-    josh_changes::cleanup_posted_outbox_votes(transaction, change_id, scope, &tracked)
+    if tracked.is_empty() {
+        return Ok(0);
+    }
+
+    let users: Vec<String> = votes
+        .iter()
+        .filter(|(user, data)| match tracked.get(user) {
+            Some(t) => t.state == data.state && t.sha == data.sha,
+            None => false,
+        })
+        .map(|(user, _)| user.clone())
+        .collect();
+    josh_changes::delete_outbox_votes(transaction, change_id, scope, &users)
 }

--- a/josh-changes/src/comments.rs
+++ b/josh-changes/src/comments.rs
@@ -433,10 +433,9 @@ fn collect_comments_under_into(
     Ok(())
 }
 
-/// Remove specific outbox comment entries by content hash. Used by the fetch
-/// path to drop entries whose posted counterparts have just come back from
-/// the remote. Pass the set of local content hashes whose `gh_ids` entry is
-/// known to be reflected in `comments/...` already.
+/// Remove specific outbox comment entries by content hash. Used by forge
+/// sync paths to drop entries whose posted counterparts have been observed
+/// on the forge and stored under `comments/...` already.
 pub fn delete_outbox_comments(
     transaction: &Transaction,
     change_id: &str,
@@ -527,7 +526,7 @@ pub struct FetchedComment {
 ///
 /// Recording which local hash maps to which forge ID (so the comment is
 /// tracked as already posted) and dropping outbox entries observed in the
-/// fetch are the caller's job; see `josh_github_changes::store_fetched_comments`
+/// fetch are the caller's job; see `josh_github_changes::record_fetched_comments`
 /// for the GitHub composition.
 pub fn store_fetched_comments(
     transaction: &Transaction,

--- a/josh-changes/src/votes.rs
+++ b/josh-changes/src/votes.rs
@@ -29,9 +29,9 @@ pub fn write_vote(
 }
 
 /// Write a vote into the outbox subtree of a `Remote` ref. The vote is queued
-/// for the next `sync --push` to post as a PR review, after which the
-/// `gh_vote_ids` mapping records the post and the outbox entry can be
-/// cleaned up.
+/// for the next `sync --push` to post to the forge, after which the forge's
+/// posted-vote tracking records the post and the outbox entry can be cleaned
+/// up.
 pub fn write_outbox_vote(
     transaction: &Transaction,
     change: &Change,
@@ -223,31 +223,19 @@ fn list_votes_at_prefix(
     Ok(votes)
 }
 
-/// Remove outbox vote entries whose `(state, sha)` matches an entry in
-/// `posted` (the forge's record of already-posted votes, keyed by user).
-/// Called by forge sync paths after a successful push so the outbox doesn't
-/// accumulate forever.
-pub fn cleanup_posted_outbox_votes(
+/// Delete the outbox vote entries of the given users from `scope`'s ref.
+/// Returns the number of entries removed.
+pub fn delete_outbox_votes(
     transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
-    posted: &std::collections::HashMap<String, VoteData>,
+    users: &[String],
 ) -> anyhow::Result<usize> {
-    if !matches!(scope, ChangesRef::Remote { .. }) {
-        return Err(anyhow::anyhow!(
-            "cleanup_posted_outbox_votes requires a Remote scope"
-        ));
+    if users.is_empty() {
+        return Ok(0);
     }
 
     let repo = transaction.repo();
-    if posted.is_empty() {
-        return Ok(0);
-    }
-    let outbox = list_outbox_votes(transaction, change_id, scope)?;
-    if outbox.is_empty() {
-        return Ok(0);
-    }
-
     let encoded = encode_change_id_path(change_id);
     let ref_name = scope.ref_name();
     let prev_commit = match transaction.resolve_ref(&ref_name)? {
@@ -257,14 +245,7 @@ pub fn cleanup_posted_outbox_votes(
     let mut tree = prev_commit.tree()?;
 
     let mut removed = 0usize;
-    for (user, data) in &outbox {
-        let posted = match posted.get(user) {
-            Some(p) => p,
-            None => continue,
-        };
-        if posted.state != data.state || posted.sha != data.sha {
-            continue;
-        }
+    for user in users {
         let path = std::path::Path::new("outbox/votes")
             .join(&encoded)
             .join(user);
@@ -279,7 +260,7 @@ pub fn cleanup_posted_outbox_votes(
     }
 
     let sig = repo.signature()?;
-    let msg = format!("cleanup posted outbox votes on {}\n", ref_name);
+    let msg = format!("delete outbox votes on {}\n", ref_name);
     let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &[&prev_commit])?;
     transaction.update_ref(&ref_name, Expected::At(prev_commit.id()), new_oid, &msg)?;
 

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -506,10 +506,22 @@ impl GithubSyncCtx<'_> {
                     }
 
                     'votes: {
+                        let outbox_votes = match josh_changes::list_outbox_votes(
+                            self.transaction,
+                            &change_id,
+                            &remote_scope,
+                        ) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                eprintln!("  PR #{}: failed to load local votes: {}", pr.number, e);
+                                break 'votes;
+                            }
+                        };
                         let pending_votes = match josh_github_changes::pending_votes(
                             self.transaction,
                             &change_id,
                             &remote_scope,
+                            &outbox_votes,
                         ) {
                             Ok(v) => v,
                             Err(e) => {
@@ -547,6 +559,7 @@ impl GithubSyncCtx<'_> {
                             self.transaction,
                             &change_id,
                             &remote_scope,
+                            &outbox_votes,
                         ) {
                             eprintln!(
                                 "  PR #{}: failed to clean up posted votes: {}",


### PR DESCRIPTION
Move outbox vote loading to the sync call site

pending_votes and cleanup_posted_outbox_votes in josh-github-changes now
take the caller-loaded outbox vote list instead of reading it themselves,
matching the pending_comments split: josh-cli loads once via
josh_changes::list_outbox_votes and reuses the list for filtering,
posting, and cleanup. Also sweep stale doc comments in josh-changes that
referenced gh_ids/gh_vote_ids behavior now owned by josh-github-changes.

Change: caller-loaded-outbox-votes
Assisted-By: kimi-code/k3