### PR TITLE
Port josh-proxy and the leaf crates onto the Transaction ref API

### DIFF
--- a/cq/josh-cq/src/cq.rs
+++ b/cq/josh-cq/src/cq.rs
@@ -56,9 +56,8 @@ pub fn handle_track(
     let head_commit = head_ref
         .peel_to_commit()
         .context("Failed to peel HEAD to commit")?;
-    let head_tree = head_commit.tree().context("Failed to get HEAD tree")?;
 
-    let signature = make_signature(repo)?;
+    let signature = make_signature(transaction)?;
 
     let link_mode = josh_core::filter::LinkMode::parse(mode)
         .with_context(|| format!("Invalid link mode: '{}'", mode))?;
@@ -71,7 +70,7 @@ pub fn handle_track(
         None,
         "HEAD",
         fetched_commit,
-        &head_tree,
+        head_commit.tree_id(),
         link_mode,
     )?
     .into_tree_oid();

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -188,17 +188,6 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     let repo = git2::Repository::open_from_env()?;
     let repo_path = repo.path().to_path_buf();
 
-    // If the filter spec doesn't contain a colon and it's not from a file,
-    // treat it as a SHA and read from tree
-    let mut filterobj = if specstr.contains(':') || is_from_file {
-        josh_core::filter::parse(&specstr)?
-    } else {
-        // Try to parse as SHA and read filter from tree
-        let tree_oid = git2::Oid::from_str(specstr.trim())
-            .with_context(|| format!("Invalid filter spec or SHA: {}", specstr))?;
-        josh_core::filter::from_tree(&repo, tree_oid)?
-    };
-
     let cache = std::sync::Arc::new({
         let mut cache = josh_core::cache::CacheStack::new();
 
@@ -228,6 +217,18 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     transaction = transaction.with_filter_hook(std::sync::Arc::new(hook));
 
     let repo = transaction.repo();
+
+    // If the filter spec doesn't contain a colon and it's not from a file,
+    // treat it as a SHA and read from tree
+    let mut filterobj = if specstr.contains(':') || is_from_file {
+        josh_core::filter::parse(&specstr)?
+    } else {
+        // Try to parse as SHA and read filter from tree
+        let tree_oid = git2::Oid::from_str(specstr.trim())
+            .with_context(|| format!("Invalid filter spec or SHA: {}", specstr))?;
+        josh_core::filter::from_tree(&transaction, tree_oid)?
+    };
+
     let input_ref = args.get_one::<String>("input").unwrap();
 
     let mut refs = vec![];
@@ -299,7 +300,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         } else {
             filterobj
         };
-        println!("{}", josh_core::filter::as_tree(repo, filterobj)?);
+        println!("{}", josh_core::filter::as_tree(&transaction, filterobj)?);
         return Ok(0);
     }
 

--- a/josh-cli/src/commands/cache.rs
+++ b/josh-cli/src/commands/cache.rs
@@ -99,7 +99,7 @@ fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyho
         for id_str in ids.iter().rev() {
             match git2::Oid::from_str(id_str)
                 .map_err(anyhow::Error::from)
-                .and_then(|oid| from_tree(repo, oid))
+                .and_then(|oid| from_tree(transaction, oid))
             {
                 Ok(f) => steps.push(f),
                 Err(e) => {

--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -105,7 +105,6 @@ fn handle_link_add(
     let head_commit = head_ref
         .peel_to_commit()
         .context("Failed to get HEAD commit")?;
-    let head_tree = head_commit.tree().context("Failed to get HEAD tree")?;
 
     let mode = josh_core::filter::LinkMode::parse(&args.mode)
         .with_context(|| format!("Invalid link mode: '{}'", args.mode))?;
@@ -154,7 +153,7 @@ fn handle_link_add(
     };
 
     // Create a new commit with the updated tree
-    let signature = make_signature(&repo)?;
+    let signature = make_signature(transaction)?;
 
     let commit_oid = josh_link::prepare_link_add(
         transaction,
@@ -163,10 +162,10 @@ fn handle_link_add(
         args.filter.as_deref(),
         target,
         initial_oid,
-        &head_tree,
+        head_commit.tree_id(),
         mode,
     )?
-    .into_commit(transaction, &head_commit, &signature)?;
+    .into_commit(transaction, head_commit.id(), &signature)?;
 
     // Create the fixed branch name
     let branch_name = "refs/heads/josh-link";
@@ -347,14 +346,9 @@ fn handle_link_update(
         links_to_update.push((path.clone(), new_oid));
     }
 
-    let signature = make_signature(&repo)?;
-    let Some(result) = josh_link::update_links(
-        &repo,
-        transaction,
-        &head_commit,
-        links_to_update,
-        &signature,
-    )?
+    let signature = make_signature(transaction)?;
+    let Some(result) =
+        josh_link::update_links(transaction, head_commit.id(), links_to_update, &signature)?
     else {
         eprintln!("All {} link file(s) already up to date", link_files.len());
         return Ok(());

--- a/josh-cli/src/remote_ops.rs
+++ b/josh-cli/src/remote_ops.rs
@@ -124,7 +124,6 @@ pub fn apply_josh_filtering(
     remote_name: &str,
     default_branch: &str,
 ) -> anyhow::Result<Vec<RefUpdate>> {
-    let repo = transaction.repo();
     let prefix = format!("refs/josh/remotes/{}/", remote_name);
 
     let steps = flatten_chain(filter);
@@ -151,7 +150,7 @@ pub fn apply_josh_filtering(
         }
 
         // Persist the filter tree object to ODB so cache build can reconstruct it
-        filter::as_tree(repo, *step_filter)?;
+        filter::as_tree(transaction, *step_filter)?;
 
         let prefix_path = step_ref_prefix(step_idx, &steps);
         let mut next_commits = Vec::new();

--- a/josh-compose/src/filter.rs
+++ b/josh-compose/src/filter.rs
@@ -32,7 +32,7 @@ pub fn compute_ws_tree(
         .context("filtered result is not a commit")?
         .tree_id();
 
-    let safe_name = josh_core::filter::as_tree(repo, filterobj)
+    let safe_name = josh_core::filter::as_tree(transaction, filterobj)
         .context("failed to compute filter id")?
         .to_string();
 

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -71,7 +71,7 @@ impl DistributedCacheBackend {
         if let Some(oid) = self.tree_ids.lock().unwrap().get(&filter) {
             return Ok(*oid);
         }
-        let oid = filter::as_tree(repo, filter)?;
+        let oid = josh_filter::persist::as_tree(repo, filter)?;
         self.tree_ids.lock().unwrap().insert(filter, oid);
         Ok(oid)
     }

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -16,13 +16,20 @@ pub use josh_filter::filter::sequence_number;
 pub use josh_filter::flang::parse::{get_comments, parse};
 pub use josh_filter::opt;
 pub use josh_filter::opt::invert;
-pub use josh_filter::persist::{as_tree, from_tree};
 pub use josh_filter::persist::{peel_filter, peel_op, to_filter, to_op, to_ops};
 pub use josh_filter::{Filter, InsertContent, LazyRef, Op, RevMatch};
 pub use josh_filter::{as_file, pretty, spec};
 
 pub mod text;
 pub mod tree;
+
+pub fn as_tree(transaction: &cache::Transaction, filter: Filter) -> anyhow::Result<git2::Oid> {
+    josh_filter::persist::as_tree(transaction.repo(), filter)
+}
+
+pub fn from_tree(transaction: &cache::Transaction, tree_oid: git2::Oid) -> anyhow::Result<Filter> {
+    josh_filter::persist::from_tree(transaction.repo(), tree_oid)
+}
 
 static WORKSPACES: LazyLock<std::sync::Mutex<std::collections::HashMap<git2::Oid, Filter>>> =
     LazyLock::new(Default::default);
@@ -2614,8 +2621,8 @@ mod tests {
 
     #[test]
     fn meta_filter_tree_roundtrip_test() {
-        use crate::filter::{as_tree, from_tree};
         use git2::Repository;
+        use josh_filter::persist::{as_tree, from_tree};
         use std::fs;
 
         // Create a temporary directory for the test repository

--- a/josh-link/src/lib.rs
+++ b/josh-link/src/lib.rs
@@ -15,13 +15,16 @@ impl PreparedLinkAdd {
     pub fn into_commit(
         self,
         transaction: &josh_core::cache::Transaction,
-        head_commit: &git2::Commit,
+        head_commit: git2::Oid,
         signature: &git2::Signature,
     ) -> anyhow::Result<git2::Oid> {
         let repo = transaction.repo();
         let tree = repo
             .find_tree(self.tree_oid)
             .context("Failed to find tree")?;
+        let head_commit = repo
+            .find_commit(head_commit)
+            .context("Failed to find commit")?;
 
         repo.commit(
             None,
@@ -29,7 +32,7 @@ impl PreparedLinkAdd {
             signature,
             &format!("Add link: {}", self.path.display()),
             &tree,
-            &[head_commit],
+            &[&head_commit],
         )
         .context("Failed to create commit")
     }
@@ -104,7 +107,9 @@ pub fn collect_all_link_refs(
     Ok(refs)
 }
 
-pub fn make_signature(repo: &git2::Repository) -> anyhow::Result<git2::Signature<'static>> {
+pub fn make_signature(
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<git2::Signature<'static>> {
     if let Ok(time) = std::env::var("JOSH_COMMIT_TIME") {
         git2::Signature::new(
             "JOSH",
@@ -113,7 +118,10 @@ pub fn make_signature(repo: &git2::Repository) -> anyhow::Result<git2::Signature
         )
         .context("Failed to create signature")
     } else {
-        let sig = repo.signature().context("Failed to get signature")?;
+        let sig = transaction
+            .repo()
+            .signature()
+            .context("Failed to get signature")?;
         Ok(sig.to_owned())
     }
 }
@@ -126,10 +134,13 @@ pub fn prepare_link_add(
     filter: Option<&str>,
     target: &str,
     fetched_commit: git2::Oid,
-    head_tree: &git2::Tree,
+    head_tree: git2::Oid,
     mode: josh_core::filter::LinkMode,
 ) -> anyhow::Result<PreparedLinkAdd> {
     let repo = transaction.repo();
+    let head_tree = repo
+        .find_tree(head_tree)
+        .context("Failed to find head tree")?;
 
     // Strip leading slash if present (git tree paths are always relative)
     let path = path.strip_prefix("/").unwrap_or(path);
@@ -160,7 +171,7 @@ pub fn prepare_link_add(
     // Insert the .link.josh file into the tree
     let new_tree = tree::insert(
         repo,
-        head_tree,
+        &head_tree,
         &link_path,
         link_blob,
         git2::FileMode::Blob.into(),
@@ -174,12 +185,15 @@ pub fn prepare_link_add(
 }
 
 pub fn update_links(
-    repo: &git2::Repository,
     transaction: &josh_core::cache::Transaction,
-    head_commit: &git2::Commit,
+    head_commit: git2::Oid,
     links_to_update: Vec<(PathBuf, git2::Oid)>,
     signature: &git2::Signature,
 ) -> anyhow::Result<Option<UpdateLinksResult>> {
+    let repo = transaction.repo();
+    let head_commit = repo
+        .find_commit(head_commit)
+        .context("Failed to find commit")?;
     let head_tree = head_commit.tree().context("Failed to get HEAD tree")?;
     let head_tree_id = head_tree.id();
 
@@ -244,7 +258,7 @@ pub fn update_links(
                     .join(", ")
             ),
             &new_tree,
-            &[head_commit],
+            &[&head_commit],
         )
         .context("Failed to create commit")?;
 

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -299,9 +299,8 @@ pub fn merge_meta(
     }
     let rev = transaction_mirror.refname("refs/josh/meta");
 
-    let r = transaction_mirror.repo().revparse_single(&rev);
-    let (tree, parent) = if let Ok(r) = r {
-        let meta_commit = transaction.repo().find_commit(r.id())?;
+    let (tree, parent) = if let Some(meta_oid) = transaction_mirror.resolve_ref(&rev)? {
+        let meta_commit = transaction.repo().find_commit(meta_oid)?;
         let tree = meta_commit.tree()?;
         (tree, Some(meta_commit))
     } else {

--- a/josh-proxy/src/service.rs
+++ b/josh-proxy/src/service.rs
@@ -499,22 +499,15 @@ fn resolve_upstream_ref(
     repo: &str,
     ref_value: &str,
 ) -> anyhow::Result<git2::Oid> {
-    let josh_name = [
-        "refs",
-        "josh",
-        "upstream",
-        &josh_core::to_ns(repo),
-        ref_value,
-    ]
-    .iter()
-    .collect::<PathBuf>();
+    let josh_name = format!(
+        "refs/josh/upstream/{}/{}",
+        josh_core::to_ns(repo),
+        ref_value
+    );
 
     transaction
-        .repo()
-        .find_reference(josh_name.to_str().unwrap())
-        .context("Could not find ref")?
-        .target()
-        .ok_or(anyhow!("Could not resolve ref"))
+        .resolve_ref(&josh_name)?
+        .ok_or_else(|| anyhow!("Could not find ref {:?}", josh_name))
 }
 
 pub struct NamespacedRefs {
@@ -539,8 +532,7 @@ impl NamespacedRefs {
         let (source, target) = (self.ns.reference(&source), self.ns.reference(&target));
 
         self.transaction
-            .repo()
-            .reference_symbolic(&source, &target, true, "write_to_repo")?;
+            .create_symref(&source, &target, "write_to_repo")?;
 
         // Flush before the `git http-backend` subprocess serves these objects from disk.
         self.transaction.flush_mem_odb()?;
@@ -1354,8 +1346,8 @@ async fn serve_render_template(
             oid
         } else {
             transaction_mirror
-                .repo()
-                .refname_to_id(&transaction_mirror.refname(&head_ref))?
+                .resolve_ref(&transaction_mirror.refname(&head_ref))?
+                .ok_or_else(|| anyhow!("ref not found: {}", head_ref))?
         };
         let commit_id = josh_core::filter_commit(&transaction, filter, commit_id)?;
 

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -106,13 +106,7 @@ async fn fetch_needed(
                 &josh_core::to_ns(&upstream_repo)
             )))?;
 
-            match transaction
-                .repo()
-                .refname_to_id(&transaction.refname(&cache_ref))
-            {
-                Ok(oid) => Ok(Some(oid)),
-                Err(_) => Ok(None),
-            }
+            transaction.resolve_ref(&transaction.refname(&cache_ref))
         })
     };
 
@@ -357,11 +351,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
 
         let old = if old == git2::Oid::ZERO_SHA1 {
             let rev = format!("refs/namespaces/{}/{}", repo_update.git_ns, &baseref);
-            let oid = if let Ok(resolved) = transaction.repo().revparse_single(&rev) {
-                resolved.id()
-            } else {
-                old
-            };
+            let oid = transaction.resolve_ref(&rev)?.unwrap_or(old);
 
             tracing::debug!(
                 old_oid = ?oid,
@@ -385,9 +375,8 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
             let full_path_base_refname =
                 transaction_mirror.refname(&format!("refs/heads/{}", base));
             if transaction_mirror
-                .repo()
-                .refname_to_id(&full_path_base_refname)
-                .is_ok()
+                .resolve_ref(&full_path_base_refname)?
+                .is_some()
             {
                 full_path_base_refname
             } else {
@@ -397,32 +386,30 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
             transaction_mirror.refname(&baseref)
         };
 
-        let original_target = if let Ok(oid) = transaction_mirror
-            .repo()
-            .refname_to_id(&original_target_ref)
-        {
-            tracing::debug!(
-                original_target_oid = ?oid,
-                original_target_ref = %original_target_ref,
-                "resolve_original_target"
-            );
+        let original_target =
+            if let Some(oid) = transaction_mirror.resolve_ref(&original_target_ref)? {
+                tracing::debug!(
+                    original_target_oid = ?oid,
+                    original_target_ref = %original_target_ref,
+                    "resolve_original_target"
+                );
 
-            oid
-        } else {
-            tracing::debug!(
-                original_target_ref = %original_target_ref,
-                "resolve_original_target"
-            );
+                oid
+            } else {
+                tracing::debug!(
+                    original_target_ref = %original_target_ref,
+                    "resolve_original_target"
+                );
 
-            return Err(anyhow!(indoc::formatdoc!(
-                r###"
+                return Err(anyhow!(indoc::formatdoc!(
+                    r###"
                     Reference {:?} does not exist on remote.
                     If you want to create it, pass "-o base=<basebranch>" or "-o base=path/to/ref"
                     to specify a base branch/reference.
                     "###,
-                baseref
-            )));
-        };
+                    baseref
+                )));
+            };
 
         let reparent_orphans = if push_options.create {
             Some(original_target)
@@ -460,11 +447,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
 
         let oid_to_push = if push_options.merge {
             let backward_commit = transaction.repo().find_commit(backward_new_oid)?;
-            if let Ok(base_commit_id) = transaction_mirror
-                .repo()
-                .revparse_single(&original_target_ref)
-                .map(|x| x.id())
-            {
+            if let Some(base_commit_id) = transaction_mirror.resolve_ref(&original_target_ref)? {
                 let signature = josh_core::git::josh_commit_signature()?;
                 let base_commit = transaction.repo().find_commit(base_commit_id)?;
                 let merged_tree = transaction
@@ -539,15 +522,15 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
 
         if new_oid != reapply {
             if std::env::var("JOSH_REWRITE_REFS").is_ok() {
-                transaction.repo().reference(
+                transaction.update_ref(
                     &format!(
                         "refs/josh/rewrites/{}/{:?}/r_{}",
                         repo_update.base_ns,
                         filter.id(),
                         reapply
                     ),
+                    josh_core::cache::Expected::Any,
                     reapply,
-                    true,
                     "reapply",
                 )?;
             }
@@ -591,12 +574,17 @@ pub fn push_head_url(
     cmd.push(url);
     cmd.push(&push_refspec);
 
-    let mut fake_head = repo.reference(&push_temp_ref, oid, true, "push_head_url")?;
+    transaction.update_ref(
+        &push_temp_ref,
+        josh_core::cache::Expected::Any,
+        oid,
+        "push_head_url",
+    )?;
     // Flush before the external `git push` below reads these objects from disk.
     transaction.flush_mem_odb()?;
     let (stdout, stderr, status) =
         run_git_with_auth(repo.path(), &cmd, remote_auth, Some(alternate.to_owned()))?;
-    fake_head.delete()?;
+    transaction.delete_ref(&push_temp_ref, josh_core::cache::Expected::Any)?;
 
     tracing::debug!(
         stdout = %stdout,


### PR DESCRIPTION
Port josh-proxy and the leaf crates onto the Transaction ref API

All josh-proxy ref-store sites move onto resolve_ref, update_ref,
delete_ref and create_symref, preserving the write->flush->subprocess
orderings. josh_core::filter::{as_tree,from_tree} become
&Transaction-taking wrappers, and josh-link takes oids instead of
borrowed git2 objects, dropping its redundant repo parameter.
Suite-invisible divergences: resolve errors propagate instead of
selecting fallback arms, resolve_upstream_ref follows symrefs, and
the push temp-ref delete is missing-ok.

Change: josh-proxy-transaction
Assisted-By: anthropic/claude-fable-5