### PR TITLE
Port the memodb flusher onto gix-pack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,14 +2154,18 @@ checksum = "6d5446127b269706e85998065267ddd2ccc3550179da6780b22fe496175ccb20"
 dependencies = [
  "clru",
  "gix-chunk",
+ "gix-diff",
  "gix-error",
  "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
  "gix-path",
+ "gix-tempfile",
+ "gix-traverse",
  "gix-zlib",
  "memmap2",
+ "parking_lot 0.12.5",
  "smallvec",
  "thiserror 2.0.19",
 ]
@@ -3515,6 +3519,13 @@ name = "josh-memodb"
 version = "26.7.28"
 dependencies = [
  "git2",
+ "gix-features",
+ "gix-hash",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-zlib",
+ "josh-gix-ext",
  "libgit2-sys",
  "log",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,12 @@ form_urlencoded = "1.2.2"
 futures = "0.3.33"
 gix = { version = "0.86.0", default-features = false, features = ["sha1"] }
 gix-actor = "^0.41"
+gix-features = { version = "0.49", features = ["progress"] }
 gix-hash = { version = "^0.26", features = ["sha1"] }
 gix-object = "0.63.0"
+gix-odb = "0.83"
+gix-pack = { version = "0.73", features = ["sha1"] }
+gix-zlib = "0.1"
 gix-config = "0.59.0"
 gix-submodule = "0.33.0"
 libc = "0.2.189"

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -55,7 +55,7 @@ impl DistributedCacheBackend {
 
     fn open(repo_path: impl AsRef<std::path::Path>, writable: bool) -> anyhow::Result<Self> {
         let repo = git2::Repository::open(repo_path.as_ref())?;
-        let mem_odb = josh_memodb::MemOdb::new(None, repo.path().to_owned());
+        let mem_odb = josh_memodb::MemOdb::new(None, josh_memodb::objects_dir(&repo));
         mem_odb.register(&repo);
         Ok(Self {
             repo: std::sync::Mutex::new(repo),

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -215,7 +215,7 @@ impl Transaction {
             git2::opts::strict_hash_verification(false);
         });
 
-        let mem_odb = josh_memodb::MemOdb::new(mem_odb_limit, repo.path().to_owned());
+        let mem_odb = josh_memodb::MemOdb::new(mem_odb_limit, josh_memodb::objects_dir(&repo));
         mem_odb.register(&repo);
 
         // Balanced in `Drop`; lets a locking backend (sled) hold its lock only while a

--- a/josh-memodb/Cargo.toml
+++ b/josh-memodb/Cargo.toml
@@ -12,7 +12,12 @@ edition = "2024"
 [dependencies]
 libgit2-sys = "0.18"
 git2.workspace = true
+gix-features.workspace = true
+gix-hash.workspace = true
+gix-object.workspace = true
+gix-odb.workspace = true
+gix-pack.workspace = true
+gix-zlib.workspace = true
+josh-gix-ext.workspace = true
 log.workspace = true
-
-[dev-dependencies]
 tempfile.workspace = true

--- a/josh-memodb/src/flusher.rs
+++ b/josh-memodb/src/flusher.rs
@@ -1,6 +1,6 @@
 //! Background packfile writer for [`MemOdb`](crate::mem_odb::MemOdb).
 //!
-//! Writing a packfile (zlib-compressing every buffered object and fsyncing the result) is the
+//! Writing a packfile (zlib-compressing every buffered object and indexing the result) is the
 //! expensive tail of a flush. Running it inline would block the filter hot path — the mid-run
 //! overflow flush most of all, which fires repeatedly during a large rewrite. So all packing is
 //! funnelled to one process-global worker thread:
@@ -12,9 +12,10 @@
 //!   caller proceeds.
 //!
 //! A single worker processes jobs FIFO, so a store's queued overflow chunks always complete before
-//! its drain — and no two packbuilders ever run against the same store concurrently. Stores are
-//! per-operation, so a job carries the store's `Arc` and its repo path (a `git2::Repository` is not
-//! `Send`); the worker opens its own repository handle to run the packbuilder.
+//! its drain — and no two packs are ever written from the same store concurrently. A job carries
+//! the store's `Arc`; the worker snapshots the buffered objects and packs them with gix-pack
+//! straight into the store's object directory (see [`crate::pack`]) — no repository handle
+//! involved.
 
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -22,8 +23,8 @@ use std::sync::mpsc::{Sender, SyncSender, channel, sync_channel};
 
 use crate::mem_odb::MemOdb;
 
-/// A unit of packing work for the background worker. Each carries the store's `Arc` (the packbuilder
-/// reads objects back out of it) rather than a repository handle, which is not `Send`.
+/// A unit of packing work for the background worker. Each carries the store's `Arc`; the worker
+/// snapshots and packs its buffered objects.
 enum Job {
     /// Pack the store's currently-buffered objects and evict them. Best-effort; no acknowledgement.
     Chunk { store: Arc<MemOdb> },

--- a/josh-memodb/src/lib.rs
+++ b/josh-memodb/src/lib.rs
@@ -15,3 +15,4 @@ pub mod pack;
 pub use hash::PassthroughHasher;
 pub use mem_odb::MemOdb;
 pub use odb_backend::{OdbBackend, register};
+pub use pack::objects_dir;

--- a/josh-memodb/src/mem_odb.rs
+++ b/josh-memodb/src/mem_odb.rs
@@ -7,8 +7,8 @@
 //! Packing itself runs on a background thread (see [`crate::flusher`]): the write path enqueues the
 //! work and keeps filtering, and a boundary flush blocks only until the pack is durable. The store's
 //! `Mutex` therefore guards concurrent access from the filter thread (writes/reads through the
-//! backend) and the flusher thread (which reads objects to pack them, then evicts them); it is
-//! `Send + Sync` so its `Arc` can cross to the flusher.
+//! backend) and the flusher thread (which snapshots the buffered objects to pack them, then evicts
+//! them); it is `Send + Sync` so its `Arc` can cross to the flusher.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
@@ -20,7 +20,14 @@ use libgit2_sys as raw;
 
 use crate::odb_backend::{self, OdbBackend};
 
-type ObjectMap = BTreeMap<Oid, (raw::git_object_t, Box<[u8]>)>;
+/// Object bytes are held behind an `Arc` so a flush can snapshot them without copying: the store
+/// must keep serving reads while the flusher packs (eviction only happens once the pack is
+/// durable), so the snapshot shares the buffers instead of draining or cloning them.
+type ObjectMap = BTreeMap<Oid, (raw::git_object_t, Arc<[u8]>)>;
+
+/// A `Send` snapshot of buffered objects in sorted-oid order (the `ObjectMap` iteration order),
+/// which keeps the resulting packfile — and hence its checksum-derived name — deterministic.
+pub(crate) type Snapshot = Vec<(Oid, raw::git_object_t, Arc<[u8]>)>;
 
 /// The buffered objects plus a running total of their data size, guarded by one lock so that an
 /// insert and the overflow check following it are observed atomically.
@@ -36,9 +43,10 @@ struct Inner {
 pub struct MemOdb {
     inner: Mutex<Inner>,
     limit: Option<usize>,
-    /// Repository the store is registered on, re-opened by the background flusher to run the
-    /// packbuilder (a `git2::Repository` is not `Send`).
-    repo_path: PathBuf,
+    /// The registered repository's resolved object directory (`<commondir>/objects`, see
+    /// [`crate::pack::objects_dir`]), captured at construction while the caller holds a repository
+    /// handle; the background flusher packs straight into it without opening one.
+    objects_dir: PathBuf,
     /// Set while an overflow chunk is queued on or running in the background flusher, so the write
     /// path does not pile up redundant chunk requests every time the store crosses its limit.
     /// Cleared by the flusher once the chunk has packed and evicted.
@@ -49,14 +57,16 @@ impl MemOdb {
     /// Create an empty store. Returned as an [`Arc`] because the store is shared between the owning
     /// transaction and the libgit2 backend registered on its repository. `limit` bounds the total
     /// buffered object data: once exceeded the store flushes itself to a packfile (`None` = unbounded).
-    pub fn new(limit: Option<usize>, repo_path: PathBuf) -> Arc<MemOdb> {
+    /// `objects_dir` is where flushes land; pass [`crate::pack::objects_dir`] of the repository the
+    /// store is about to be registered on.
+    pub fn new(limit: Option<usize>, objects_dir: PathBuf) -> Arc<MemOdb> {
         Arc::new(MemOdb {
             inner: Mutex::new(Inner {
                 map: Default::default(),
                 size: 0,
             }),
             limit,
-            repo_path,
+            objects_dir,
             chunk_in_flight: AtomicBool::new(false),
         })
     }
@@ -75,7 +85,7 @@ impl MemOdb {
 
     /// Buffer `oid` (a no-op for a content-addressed duplicate) and return whether the store has now
     /// exceeded its size limit, so the caller can flush.
-    fn insert(&self, oid: Oid, kind: raw::git_object_t, data: Box<[u8]>) -> bool {
+    fn insert(&self, oid: Oid, kind: raw::git_object_t, data: Arc<[u8]>) -> bool {
         let len = data.len();
         let mut inner = self.inner.lock().unwrap();
         if inner.map.insert(oid, (kind, data)).is_none() {
@@ -117,47 +127,38 @@ impl MemOdb {
         self.chunk_in_flight.store(false, Ordering::Release);
     }
 
-    /// Pack this store's currently-buffered objects into a packfile and evict them. Runs only on the
-    /// background flusher, which owns no repository handle (`git2::Repository` is not `Send`), so it
-    /// re-opens the repository and registers a backend sharing this store — the packbuilder reads
-    /// each object back through that backend.
+    /// Pack this store's currently-buffered objects into a packfile and evict them. Runs only on
+    /// the background flusher, which packs a snapshot of the buffers straight into the object
+    /// directory captured at construction (see [`crate::pack::write_snapshot`]) — no repository
+    /// handle involved. The snapshot shares the object buffers (`Arc`), and the objects stay in the
+    /// map while the pack is written, so concurrent reads through the backend keep resolving until
+    /// eviction — which happens only once the pack is on disk.
     pub(crate) fn pack_to_disk(self: &Arc<Self>) -> Result<(), git2::Error> {
-        // Snapshot the oids under the lock, then release it. The objects must stay in the store
-        // across the packbuilder below: `pb.write` reads each one back through the odb -> this
-        // backend -> `self.inner.lock()`, so we can neither hold the lock here (self-deadlock) nor
-        // drain the map before the pack is on disk. A BTreeMap iterates in sorted oid order, so the
-        // packbuilder produces a deterministic packfile (hence a deterministic pack name).
-        let oids: Vec<Oid> = {
+        // Snapshot under the lock, then release it: `write_snapshot` filters against the on-disk
+        // store and compresses every object, which must not stall the filter thread's reads and
+        // writes. Objects already on disk may have been re-buffered (the memory-only freshen does
+        // not deduplicate against disk, see `odb_backend`); `write_snapshot` packs only the
+        // genuinely-new ones, in the map's sorted oid order, keeping the packfile — and its
+        // checksum-derived name — deterministic.
+        let snapshot: Snapshot = {
             let inner = self.inner.lock().unwrap();
             if inner.map.is_empty() {
                 return Ok(());
             }
-            inner.map.keys().copied().collect()
+            inner
+                .map
+                .iter()
+                .map(|(oid, (kind, data))| (*oid, *kind, data.clone()))
+                .collect()
         };
 
-        let repo = git2::Repository::open(&self.repo_path)?;
-        self.register(&repo);
-
-        // The memory-only freshen (see `odb_backend`) no longer deduplicates writes against disk,
-        // so objects already present on disk may have been re-buffered into the store. Pack only the
-        // genuinely-new ones — `filter_absent_on_disk` preserves the sorted oid order, so the
-        // packfile (and its name) stays deterministic.
-        let to_pack = odb_backend::filter_absent_on_disk(&repo, &oids);
-        if !to_pack.is_empty() {
-            let mut pb = repo.packbuilder()?;
-            for oid in &to_pack {
-                pb.insert_object(*oid, None)?;
-            }
-            // `packfile_path` resolves the common object directory, so this is correct for linked
-            // worktrees (whose gitdir has no `objects/` of its own) as well as normal repos.
-            pb.write(&crate::pack::packfile_path(&repo), 0)?;
-        }
+        crate::pack::write_snapshot(&self.objects_dir, &snapshot)?;
 
         // Evict exactly the snapshotted oids (now durable: packed just above, or already on disk).
         // Writes that landed after the snapshot stay buffered for the next chunk or the drain, so a
         // background chunk running concurrently with the write path never drops a live object.
         let mut inner = self.inner.lock().unwrap();
-        for oid in &oids {
+        for (oid, _, _) in &snapshot {
             if let Some((_, data)) = inner.map.remove(oid) {
                 inner.size = inner.size.saturating_sub(data.len());
             }
@@ -206,7 +207,7 @@ impl OdbBackend for MemBackend {
     }
 
     fn write(&mut self, oid: Oid, data: Vec<u8>, kind: ObjectType) -> Result<(), git2::Error> {
-        let overflow = self.store.insert(oid, kind.raw(), data.into_boxed_slice());
+        let overflow = self.store.insert(oid, kind.raw(), data.into());
         if overflow {
             self.store.enqueue_chunk();
         }
@@ -239,7 +240,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init(dir.path()).unwrap();
 
-        let store = MemOdb::new(None, repo.path().to_owned());
+        let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
         store.register(&repo);
 
         let ids: Vec<Oid> = (0..4)
@@ -264,9 +265,9 @@ mod tests {
         store.flush().unwrap();
     }
 
-    /// A linked worktree's gitdir has no `objects/` of its own, so the flush must write into the
-    /// common object directory rather than `repo.path()/objects/pack` (which does not exist and
-    /// previously failed with "No such file or directory").
+    /// A linked worktree's gitdir has no `objects/` of its own, so [`crate::pack::objects_dir`]
+    /// must resolve the common object directory rather than `repo.path()/objects` (which does not
+    /// exist and previously failed with "No such file or directory").
     #[test]
     fn flush_writes_to_common_dir_for_worktree() {
         let tmp = tempfile::tempdir().unwrap();
@@ -288,7 +289,7 @@ mod tests {
         // The worktree's gitdir differs from its common dir (the main gitdir).
         assert_ne!(wt_repo.path(), wt_repo.commondir());
 
-        let store = MemOdb::new(None, wt_repo.path().to_owned());
+        let store = MemOdb::new(None, crate::pack::objects_dir(&wt_repo));
         store.register(&wt_repo);
         let id = wt_repo.blob(b"worktree blob").unwrap();
 
@@ -309,7 +310,7 @@ mod tests {
         let repo = git2::Repository::init(dir.path()).unwrap();
 
         // A 16-byte limit: each 100-byte blob overflows it, so every write enqueues a pack.
-        let store = MemOdb::new(Some(16), repo.path().to_owned());
+        let store = MemOdb::new(Some(16), crate::pack::objects_dir(&repo));
         store.register(&repo);
 
         // The write overflowed and enqueued a background pack; it lands on the flusher thread, so
@@ -326,6 +327,87 @@ mod tests {
             wait_on_disk(dir.path(), id2),
             "second overflow pack never reached disk"
         );
+    }
+
+    /// A flush leaves exactly a `pack-<hash>.pack`/`.idx` pair behind — in particular no `.keep`
+    /// file, which gix-pack creates for its caller to remove and which would otherwise exempt the
+    /// pack from `git repack -d` (and churn test dir listings).
+    #[test]
+    fn flush_leaves_only_pack_and_idx() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
+        store.register(&repo);
+
+        repo.blob(b"some blob").unwrap();
+        store.flush().unwrap();
+
+        let mut exts: Vec<String> = std::fs::read_dir(crate::pack::objects_dir(&repo).join("pack"))
+            .unwrap()
+            .map(|e| {
+                let name = e.unwrap().file_name().into_string().unwrap();
+                assert!(name.starts_with("pack-"), "unexpected file {name}");
+                name.rsplit('.').next().unwrap().to_string()
+            })
+            .collect();
+        exts.sort();
+        assert_eq!(exts, ["idx", "pack"]);
+    }
+
+    /// Identical store contents produce an identical packfile, and hence an identical
+    /// checksum-derived pack name: the snapshot is taken in sorted oid order and entries are
+    /// compressed at a fixed level and serialized single-threaded.
+    #[test]
+    fn identical_content_yields_identical_pack_name() {
+        let pack_names = || {
+            let dir = tempfile::tempdir().unwrap();
+            let repo = git2::Repository::init(dir.path()).unwrap();
+            let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
+            store.register(&repo);
+            for i in 0..4 {
+                repo.blob(format!("blob {i}").repeat(100).as_bytes())
+                    .unwrap();
+            }
+            store.flush().unwrap();
+            let mut names: Vec<String> =
+                std::fs::read_dir(crate::pack::objects_dir(&repo).join("pack"))
+                    .unwrap()
+                    .map(|e| e.unwrap().file_name().into_string().unwrap())
+                    .collect();
+            names.sort();
+            names
+        };
+        assert_eq!(pack_names(), pack_names());
+    }
+
+    /// Commits and trees written through the store keep their kinds across a flush: a fresh
+    /// backend-less repository must read them back from the pack with the right object types.
+    #[test]
+    fn flush_preserves_object_kinds() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
+        store.register(&repo);
+
+        let blob_id = repo.blob(b"contents").unwrap();
+        let mut tb = repo.treebuilder(None).unwrap();
+        tb.insert("file", blob_id, 0o100644).unwrap();
+        let tree_id = tb.write().unwrap();
+        let sig = git2::Signature::new("t", "t@t", &git2::Time::new(0, 0)).unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let commit_id = repo.commit(None, &sig, &sig, "msg", &tree, &[]).unwrap();
+        drop(tree);
+
+        store.flush().unwrap();
+
+        let on_disk = git2::Repository::open(dir.path()).unwrap();
+        let commit = on_disk.find_commit(commit_id).unwrap();
+        assert_eq!(commit.tree_id(), tree_id);
+        assert_eq!(
+            on_disk.find_tree(tree_id).unwrap().get(0).unwrap().id(),
+            blob_id
+        );
+        assert_eq!(on_disk.find_blob(blob_id).unwrap().content(), b"contents");
     }
 
     /// Poll a freshly-opened (backend-less) view of the repository until `id` is readable from disk,

--- a/josh-memodb/src/odb_backend.rs
+++ b/josh-memodb/src/odb_backend.rs
@@ -182,7 +182,8 @@ impl RawOdbBackend {
     }
 
     /// Object enumeration is delegated to the on-disk ODB only; in-memory objects are not enumerated
-    /// (the filter path inserts objects into the packbuilder by OID, not via `foreach`).
+    /// (nothing enumerates the store: flushes pack a snapshot of it, see
+    /// [`crate::pack::write_snapshot`]).
     extern "C" fn backend_foreach(
         backend: *mut raw::git_odb_backend,
         cb: raw::git_odb_foreach_cb,
@@ -200,7 +201,7 @@ impl RawOdbBackend {
     /// `GIT_ENOTFOUND` otherwise (so the write proceeds to `backend_write`). It deliberately never
     /// consults the on-disk delegate: avoiding that per-object filesystem stat/touch is the whole
     /// point of the ODB swap. Objects already on disk are deduplicated at the flush boundary instead
-    /// (see [`filter_absent_on_disk`]).
+    /// (see [`crate::pack::write_snapshot`]).
     extern "C" fn backend_freshen(
         backend: *mut raw::git_odb_backend,
         oid: *const raw::git_oid,
@@ -319,50 +320,6 @@ where
         // the backend's `delegate` field until the repo (and thus `new`) is freed.
         raw::git_odb_free(new);
         Ok(())
-    }
-}
-
-/// The on-disk ODB that `repo`'s swapped in-memory backend delegates reads to, or null if the
-/// backend is not installed. Reaches the backend at index 0 of the (swapped) repo ODB, which is
-/// always the single backend added by [`register`].
-unsafe fn delegate_of(repo: &git2::Repository) -> *mut raw::git_odb {
-    unsafe {
-        let repo_raw = *(repo as *const git2::Repository as *const *mut raw::git_repository);
-        let mut odb: *mut raw::git_odb = ptr::null_mut();
-        if raw::git_repository_odb(&mut odb, repo_raw) != raw::GIT_OK {
-            return ptr::null_mut();
-        }
-        let mut backend: *mut raw::git_odb_backend = ptr::null_mut();
-        let rc = raw::git_odb_get_backend(&mut backend, odb, 0);
-        raw::git_odb_free(odb);
-        if rc != raw::GIT_OK || backend.is_null() {
-            return ptr::null_mut();
-        }
-        (*(backend as *const RawOdbBackend)).delegate
-    }
-}
-
-/// Return the subset of `oids` that are NOT already present in the on-disk ODB that `repo`'s swapped
-/// backend delegates to, using `NO_REFRESH` (matching the non-refreshing semantics of the write-time
-/// freshen that the memory-only [`RawOdbBackend::backend_freshen`] replaced). The memory-only
-/// freshen no longer deduplicates writes against disk, so a flush uses this to pack only
-/// genuinely-new objects and keep the on-disk layout deterministic. If the backend is not installed
-/// (no delegate), every oid is returned.
-pub fn filter_absent_on_disk(repo: &git2::Repository, oids: &[Oid]) -> Vec<Oid> {
-    unsafe {
-        let disk = delegate_of(repo);
-        if disk.is_null() {
-            return oids.to_vec();
-        }
-        oids.iter()
-            .copied()
-            .filter(|oid| {
-                let mut goid: raw::git_oid = std::mem::zeroed();
-                goid.id.copy_from_slice(oid.as_bytes());
-                let flags = raw::GIT_ODB_LOOKUP_NO_REFRESH as std::os::raw::c_uint;
-                raw::git_odb_exists_ext(disk, &goid, flags) == 0
-            })
-            .collect()
     }
 }
 

--- a/josh-memodb/src/pack.rs
+++ b/josh-memodb/src/pack.rs
@@ -1,12 +1,129 @@
-//! Helpers for locating on-disk packfile storage within a repository.
+//! Writing a snapshot of in-memory objects to an on-disk packfile with gix-pack.
+//!
+//! This is the flusher-side half of [`MemOdb`](crate::mem_odb::MemOdb): it takes a `Send` snapshot
+//! of `(oid, kind, bytes)` tuples and produces a `pack-<checksum>.pack`/`.idx` pair in the
+//! repository's pack directory, without ever opening a repository handle. Objects already present
+//! on disk are filtered out first, so a pack contains only genuinely-new objects and the on-disk
+//! layout stays deterministic.
 
-use std::path::PathBuf;
+use std::io::{Seek, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 
-/// The directory where `repo`'s packfiles live (`objects/pack`).
+use gix_object::Exists;
+use gix_pack::data::output;
+
+use crate::mem_odb::Snapshot;
+
+/// The directory where `repo`'s objects live (`<commondir>/objects`), captured at
+/// [`MemOdb::new`](crate::mem_odb::MemOdb::new) time while a repository handle exists.
 ///
 /// Resolved from the repository's *common* directory rather than its gitdir: a linked worktree has
-/// no `objects/` of its own, so its packs live under the common dir. For a non-worktree repo the two
-/// are the same.
-pub fn packfile_path(repo: &git2::Repository) -> PathBuf {
-    repo.commondir().join("objects").join("pack")
+/// no `objects/` of its own, so its objects live under the common dir. For a non-worktree repo the
+/// two are the same.
+pub fn objects_dir(repo: &git2::Repository) -> PathBuf {
+    repo.commondir().join("objects")
+}
+
+fn pack_error(e: impl std::fmt::Display) -> git2::Error {
+    git2::Error::from_str(&format!("mem-odb pack write failed: {e}"))
+}
+
+/// Compress and write the objects of `snapshot` that are not already present in `objects_dir`
+/// (loose, packed, or via alternates) as a single packfile-plus-index pair in
+/// `objects_dir/pack`. A no-op if every object is already on disk.
+///
+/// The pack is deterministic for a given snapshot: entries are compressed at a fixed level and
+/// serialized single-threaded in snapshot order, and the file pair is named after the pack
+/// trailer checksum (the same rule libgit2 and modern git use), so identical snapshots produce
+/// identical packs. Files are written via tempfile-and-rename, index last, so a concurrent
+/// reader scanning for `.idx` files never sees a torn pair.
+pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> Result<(), git2::Error> {
+    // A fresh store handle per flush observes every pack written by previous flushes. Misses are
+    // the expected case below, and the default refresh mode re-lists the pack directory on every
+    // miss — disable it; the first lookup still loads all indices present now, and loose-object
+    // probes stat the filesystem directly either way.
+    let mut odb = gix_odb::at(objects_dir.to_owned()).map_err(pack_error)?;
+    odb.refresh = gix_odb::store::RefreshMode::Never;
+
+    let to_pack = snapshot
+        .iter()
+        .filter(|(oid, _, _)| !odb.exists(&josh_gix_ext::gix_oid(*oid)))
+        .map(|(oid, kind, data)| {
+            let kind = git2::ObjectType::from_raw(*kind)
+                .and_then(josh_gix_ext::gix_kind)
+                .ok_or_else(|| pack_error(format!("object {oid} has no packable kind")))?;
+            Ok((josh_gix_ext::gix_oid(*oid), kind, data))
+        })
+        .collect::<Result<Vec<_>, git2::Error>>()?;
+    if to_pack.is_empty() {
+        return Ok(());
+    }
+    let num_entries = u32::try_from(to_pack.len())
+        .map_err(|_| pack_error("more objects in one flush than a pack header can count"))?;
+
+    let pack_dir = objects_dir.join("pack");
+    std::fs::create_dir_all(&pack_dir).map_err(pack_error)?;
+
+    // Serialize the pack byte stream (header, compressed entries, checksum trailer) through an
+    // anonymous spool file in the pack directory: objects are compressed one at a time as the
+    // serializer pulls them, so no more than one compressed object is ever held in memory —
+    // a snapshot's size is only *typically* bounded by the store's chunk limit (unbounded stores
+    // exist, and the limit is an overflow trigger, not a cap).
+    let mut spool = std::io::BufWriter::new(tempfile::tempfile_in(&pack_dir).map_err(pack_error)?);
+    let mut iter = output::bytes::FromEntriesIter::new(
+        to_pack.iter().map(|(oid, kind, data)| {
+            output::Entry::from_data(
+                &output::Count::from_data(*oid, None),
+                // Fixed level 6, the zlib/libgit2/git `pack.compression` default.
+                &gix_object::Data::new(data, *kind, gix_hash::Kind::Sha1),
+                gix_zlib::Compression::DEFAULT,
+            )
+            .map(|entry| vec![entry])
+        }),
+        &mut spool,
+        num_entries,
+        gix_pack::data::Version::V2,
+        gix_hash::Kind::Sha1,
+    );
+    for written in &mut iter {
+        written.map_err(pack_error)?;
+    }
+    drop(iter);
+    spool.flush().map_err(pack_error)?;
+    let mut spool = spool.into_inner().map_err(pack_error)?;
+    spool.rewind().map_err(pack_error)?;
+
+    let outcome = gix_pack::Bundle::write_to_directory(
+        &mut std::io::BufReader::new(spool),
+        Some(&pack_dir),
+        &mut gix_features::progress::Discard,
+        &AtomicBool::new(false),
+        None::<gix_object::find::Never>,
+        gix_pack::bundle::write::Options {
+            thread_limit: Some(1),
+            iteration_mode: gix_pack::data::input::Mode::Verify,
+            index_version: gix_pack::index::Version::V2,
+            object_hash: gix_hash::Kind::Sha1,
+            alloc_limit_bytes: None,
+            // Only used to complete thin packs, which this never writes.
+            compression: gix_zlib::Compression::DEFAULT,
+        },
+    )
+    .map_err(pack_error)?;
+    // gix marks the freshly-landed pack with a `.keep` file for the caller to remove once its
+    // referencing refs exist. josh's flushes carry no such handshake (libgit2's packbuilder wrote
+    // no `.keep` either), and a leftover one would exempt the pack from `git repack -d` forever.
+    // Derived from `data_path` rather than taking `outcome.keep_path`: when an earlier attempt
+    // persisted the pack but failed before completing (missing idx, crash), the retry finds the
+    // pack already present and gets `keep_path: None` — deriving the name still heals the marker
+    // the earlier attempt left behind (missing-ok, since that branch usually has none to remove).
+    if let Some(data_path) = &outcome.data_path {
+        if let Err(e) = std::fs::remove_file(data_path.with_extension("keep")) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                return Err(pack_error(e));
+            }
+        }
+    }
+    Ok(())
 }

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -200,12 +200,12 @@
       |   |   `-- 4ad756a74e200f89b43b0d6f21b41eb284b454
       |   |-- info
       |   `-- pack
-      |       |-- pack-9f1d5b705f285451a89d8e75d2e3ed95ba8cc998.idx
-      |       |-- pack-9f1d5b705f285451a89d8e75d2e3ed95ba8cc998.pack
-      |       |-- pack-a0d4d7da863ed9bcde8d55093ccc35b5c0e7fd27.idx
-      |       |-- pack-a0d4d7da863ed9bcde8d55093ccc35b5c0e7fd27.pack
-      |       |-- pack-b1bafc32ba8e81e4a1a2f5a5d465d9bc1eab7ee1.idx
-      |       `-- pack-b1bafc32ba8e81e4a1a2f5a5d465d9bc1eab7ee1.pack
+      |       |-- pack-40095ca152b59e2e5b75f9a5ce06bcf88a3eed59.idx
+      |       |-- pack-40095ca152b59e2e5b75f9a5ce06bcf88a3eed59.pack
+      |       |-- pack-8e855a558d184842f61c9b98788ee35e6a1f2fb0.idx
+      |       |-- pack-8e855a558d184842f61c9b98788ee35e6a1f2fb0.pack
+      |       |-- pack-c9d173f1861d5fda8d1751fef4702b539ef510ef.idx
+      |       `-- pack-c9d173f1861d5fda8d1751fef4702b539ef510ef.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/caching.t
+++ b/tests/proxy/caching.t
@@ -100,10 +100,10 @@
       |   |   `-- c926c483c4dfa77e84105c6967e74d8ff9bf5f
       |   |-- info
       |   `-- pack
-      |       |-- pack-a44287650558d5610fb771360d8e3ee97671557c.idx
-      |       |-- pack-a44287650558d5610fb771360d8e3ee97671557c.pack
-      |       |-- pack-e6ea08342a6fbc40312444de4552434e4dbf41a9.idx
-      |       `-- pack-e6ea08342a6fbc40312444de4552434e4dbf41a9.pack
+      |       |-- pack-17bda029e2f8a7cae69293dbd5cfd54be1783480.idx
+      |       |-- pack-17bda029e2f8a7cae69293dbd5cfd54be1783480.pack
+      |       |-- pack-42e8065677055f029442f4dfb1f8b930ba3a29a9.idx
+      |       `-- pack-42e8065677055f029442f4dfb1f8b930ba3a29a9.pack
       `-- refs
           |-- heads
           |-- namespaces
@@ -218,12 +218,12 @@
       |   |   `-- c926c483c4dfa77e84105c6967e74d8ff9bf5f
       |   |-- info
       |   `-- pack
+      |       |-- pack-17bda029e2f8a7cae69293dbd5cfd54be1783480.idx
+      |       |-- pack-17bda029e2f8a7cae69293dbd5cfd54be1783480.pack
       |       |-- pack-320458e5ec491f521fae67b51436d535dc9ecb49.idx
       |       |-- pack-320458e5ec491f521fae67b51436d535dc9ecb49.pack
-      |       |-- pack-a44287650558d5610fb771360d8e3ee97671557c.idx
-      |       |-- pack-a44287650558d5610fb771360d8e3ee97671557c.pack
-      |       |-- pack-e6ea08342a6fbc40312444de4552434e4dbf41a9.idx
-      |       `-- pack-e6ea08342a6fbc40312444de4552434e4dbf41a9.pack
+      |       |-- pack-42e8065677055f029442f4dfb1f8b930ba3a29a9.idx
+      |       `-- pack-42e8065677055f029442f4dfb1f8b930ba3a29a9.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -123,8 +123,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-99ecd3f961c673728c44c77b13523f71980ac569.idx
-      |       `-- pack-99ecd3f961c673728c44c77b13523f71980ac569.pack
+      |       |-- pack-5a34d6972372a5df1225da7b3458665b96be8d30.idx
+      |       `-- pack-5a34d6972372a5df1225da7b3458665b96be8d30.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -138,10 +138,10 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-442b8fb8b28a9e4db96c2918ac2b58a1f786beb1.idx
-      |       |-- pack-442b8fb8b28a9e4db96c2918ac2b58a1f786beb1.pack
-      |       |-- pack-dc6413149cc84a39b1f6795b6f032a4d391a2e9e.idx
-      |       `-- pack-dc6413149cc84a39b1f6795b6f032a4d391a2e9e.pack
+      |       |-- pack-5c8a6b6168fe8012756c4278585b1852f9a0cbcb.idx
+      |       |-- pack-5c8a6b6168fe8012756c4278585b1852f9a0cbcb.pack
+      |       |-- pack-f2883c7d8701eb14a51b3a87f0f25c77ac3669db.idx
+      |       `-- pack-f2883c7d8701eb14a51b3a87f0f25c77ac3669db.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -134,8 +134,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
-      |       `-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
+      |       `-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/clone_subtree_no_master.t
+++ b/tests/proxy/clone_subtree_no_master.t
@@ -126,8 +126,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
-      |       `-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
+      |       `-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
       `-- refs
           |-- heads
           `-- tags

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -175,8 +175,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-520761ba67cf670cd00b18237d9f65bab639d94b.idx
-      |       `-- pack-520761ba67cf670cd00b18237d9f65bab639d94b.pack
+      |       |-- pack-17827226c5c0c01f693d535b0ee03ce6b1279d8f.idx
+      |       `-- pack-17827226c5c0c01f693d535b0ee03ce6b1279d8f.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -397,20 +397,20 @@ Flushed credential cache
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-57aa405783926aecf0c4757c6c3a5705b9dcd606.idx
-      |       |-- pack-57aa405783926aecf0c4757c6c3a5705b9dcd606.pack
-      |       |-- pack-b3d0761cbb7d1687ce01bf427a8ee074404d8ad4.idx
-      |       |-- pack-b3d0761cbb7d1687ce01bf427a8ee074404d8ad4.pack
-      |       |-- pack-bd386714b9845c1d6f993b21c968c3189cb6c55f.idx
-      |       |-- pack-bd386714b9845c1d6f993b21c968c3189cb6c55f.pack
-      |       |-- pack-c3e5e7fe561eafbfd5bf726f4fe20f4e2b9966f1.idx
-      |       |-- pack-c3e5e7fe561eafbfd5bf726f4fe20f4e2b9966f1.pack
-      |       |-- pack-e32a11fa9491d13e1eef03a02a01717ffb893017.idx
-      |       |-- pack-e32a11fa9491d13e1eef03a02a01717ffb893017.pack
-      |       |-- pack-e8f089f082f050a67498a1702a9ef72c15b32be7.idx
-      |       |-- pack-e8f089f082f050a67498a1702a9ef72c15b32be7.pack
-      |       |-- pack-ed8851c038e9b9a76ee1cb84a7c6b1a23d6b4f26.idx
-      |       `-- pack-ed8851c038e9b9a76ee1cb84a7c6b1a23d6b4f26.pack
+      |       |-- pack-275baec11277b940c391c584112a244532b28efb.idx
+      |       |-- pack-275baec11277b940c391c584112a244532b28efb.pack
+      |       |-- pack-375d25e0c6596d9401a4d7eb7e2871d759b08277.idx
+      |       |-- pack-375d25e0c6596d9401a4d7eb7e2871d759b08277.pack
+      |       |-- pack-38e63719299466e26e7897867e7c75b859bd172c.idx
+      |       |-- pack-38e63719299466e26e7897867e7c75b859bd172c.pack
+      |       |-- pack-8810340c36e5ff2458af0bc5d9cc189e5a1192db.idx
+      |       |-- pack-8810340c36e5ff2458af0bc5d9cc189e5a1192db.pack
+      |       |-- pack-ba7b17bd156a8fc4d784351b007214e40bcd4978.idx
+      |       |-- pack-ba7b17bd156a8fc4d784351b007214e40bcd4978.pack
+      |       |-- pack-da1db865c308ca71393595171805d9ca66b37bfa.idx
+      |       |-- pack-da1db865c308ca71393595171805d9ca66b37bfa.pack
+      |       |-- pack-edbcd821de41e8484ccca7b9007453a147e16b08.idx
+      |       `-- pack-edbcd821de41e8484ccca7b9007453a147e16b08.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -112,8 +112,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-dfd9843a38e8a4c7ec7231382409474c2cbd5981.idx
-      |       `-- pack-dfd9843a38e8a4c7ec7231382409474c2cbd5981.pack
+      |       |-- pack-22a5f4914ed052ea4eea2873846d2591ddf38cfa.idx
+      |       `-- pack-22a5f4914ed052ea4eea2873846d2591ddf38cfa.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -458,14 +458,14 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-1a631b5bbd2b05937baaaa4ddeaa4c1b500cb2a7.idx
-      |       |-- pack-1a631b5bbd2b05937baaaa4ddeaa4c1b500cb2a7.pack
-      |       |-- pack-4ee9e150f10f6cd4ae11c19ac760d7e412da64e6.idx
-      |       |-- pack-4ee9e150f10f6cd4ae11c19ac760d7e412da64e6.pack
-      |       |-- pack-6de58fb128833690095d24aea26698bddf4b092e.idx
-      |       |-- pack-6de58fb128833690095d24aea26698bddf4b092e.pack
-      |       |-- pack-e429893378822d8bd667854bb44a9481094ddf8e.idx
-      |       `-- pack-e429893378822d8bd667854bb44a9481094ddf8e.pack
+      |       |-- pack-46be1f3792f935f94f7d7180cae3a269e0a41a05.idx
+      |       |-- pack-46be1f3792f935f94f7d7180cae3a269e0a41a05.pack
+      |       |-- pack-8c2f206b69cd9e00d53669fdb645f62ad8786ffa.idx
+      |       |-- pack-8c2f206b69cd9e00d53669fdb645f62ad8786ffa.pack
+      |       |-- pack-f54dc3f7d049d03172f1a116b7ec24c8daf36394.idx
+      |       |-- pack-f54dc3f7d049d03172f1a116b7ec24c8daf36394.pack
+      |       |-- pack-fe9df806f2b505fce1b94000b21fcdfb8ef27f17.idx
+      |       `-- pack-fe9df806f2b505fce1b94000b21fcdfb8ef27f17.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_graphql.t
+++ b/tests/proxy/push_graphql.t
@@ -113,8 +113,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-f365fdaf48fb6dfec6ed88c79867abe37a55162b.idx
-      |       `-- pack-f365fdaf48fb6dfec6ed88c79867abe37a55162b.pack
+      |       |-- pack-5af10d5b0a5c3a1f5ec6910ec2d1c430496a79cd.idx
+      |       `-- pack-5af10d5b0a5c3a1f5ec6910ec2d1c430496a79cd.pack
       `-- refs
           |-- heads
           `-- tags

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -184,12 +184,12 @@ Check the branch again
       |   |   `-- 35f3fecaba02ae9cc9d462b1bd0d396fdf352f
       |   |-- info
       |   `-- pack
-      |       |-- pack-506f77be639c56f3124b09bc6c74ca46083eb416.idx
-      |       |-- pack-506f77be639c56f3124b09bc6c74ca46083eb416.pack
-      |       |-- pack-6f373fdfd68f130303e51d70f84843bbb3b9933d.idx
-      |       |-- pack-6f373fdfd68f130303e51d70f84843bbb3b9933d.pack
-      |       |-- pack-9284b8b46944ee6adfb791d61fa9faf125784a91.idx
-      |       `-- pack-9284b8b46944ee6adfb791d61fa9faf125784a91.pack
+      |       |-- pack-2893a00b7ba37075bd59cbf84d3e300ca17afecd.idx
+      |       |-- pack-2893a00b7ba37075bd59cbf84d3e300ca17afecd.pack
+      |       |-- pack-ca72748ef4386cec74f87862434f7c982edd66fa.idx
+      |       |-- pack-ca72748ef4386cec74f87862434f7c982edd66fa.pack
+      |       |-- pack-e54bf06bfc3b3596e93261dc699bccb21d0f5adb.idx
+      |       `-- pack-e54bf06bfc3b3596e93261dc699bccb21d0f5adb.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_new_orphan_branch.t
+++ b/tests/proxy/push_new_orphan_branch.t
@@ -201,12 +201,12 @@ Make sure all temporary namespace got removed
       |   |   `-- b06d7748772bdd407c5911c0ba02b0f5fb31a4
       |   |-- info
       |   `-- pack
-      |       |-- pack-24ce4c1953f799fe03bab1d9c04cf7ec9f96814d.idx
-      |       |-- pack-24ce4c1953f799fe03bab1d9c04cf7ec9f96814d.pack
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
       |       |-- pack-ed1b2e1285c87d628ed4fedf2e84338a0fa698e1.idx
-      |       `-- pack-ed1b2e1285c87d628ed4fedf2e84338a0fa698e1.pack
+      |       |-- pack-ed1b2e1285c87d628ed4fedf2e84338a0fa698e1.pack
+      |       |-- pack-f77bd2bf44561fe0f2030d424730624a36a8feea.idx
+      |       `-- pack-f77bd2bf44561fe0f2030d424730624a36a8feea.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -107,10 +107,10 @@
       |   |   `-- 9a2dde698e6d3fc31cbeedea6d0204399f90ce
       |   |-- info
       |   `-- pack
-      |       |-- pack-a279587d75bc5b34c2c0e6a68a19e7f155e1eb54.idx
-      |       |-- pack-a279587d75bc5b34c2c0e6a68a19e7f155e1eb54.pack
-      |       |-- pack-e9cffc2f019d87d49415e5fc30cb50630fe29846.idx
-      |       `-- pack-e9cffc2f019d87d49415e5fc30cb50630fe29846.pack
+      |       |-- pack-4bdf7423c6b0c22e388bf62ed53c1a12ca3d0d0d.idx
+      |       |-- pack-4bdf7423c6b0c22e388bf62ed53c1a12ca3d0d0d.pack
+      |       |-- pack-5776a40aaa25ae1ea80b5e471fca2e11c985c47d.idx
+      |       `-- pack-5776a40aaa25ae1ea80b5e471fca2e11c985c47d.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -136,10 +136,10 @@ Make sure all temporary namespace got removed
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
-      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.idx
-      |       `-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.pack
+      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.idx
+      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.pack
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
+      |       `-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -142,12 +142,12 @@ Flushed credential cache
       |   |   `-- 6a812a71a431e71d30949f25013ca63f8493c3
       |   |-- info
       |   `-- pack
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
-      |       |-- pack-a724713a58e1918b9032aed364764a0a4cece84b.idx
-      |       |-- pack-a724713a58e1918b9032aed364764a0a4cece84b.pack
-      |       |-- pack-d30dedde21210b124782caf6ef83f7cf4c11a181.idx
-      |       `-- pack-d30dedde21210b124782caf6ef83f7cf4c11a181.pack
+      |       |-- pack-4bd58ee63975a927d6f412d722859a6d5aebbbe2.idx
+      |       |-- pack-4bd58ee63975a927d6f412d722859a6d5aebbbe2.pack
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
+      |       |-- pack-84bf2195a0e00629f813ae535a24bb7fca071fa2.idx
+      |       `-- pack-84bf2195a0e00629f813ae535a24bb7fca071fa2.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -91,10 +91,10 @@ Make sure all temporary namespace got removed
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
-      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.idx
-      |       `-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.pack
+      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.idx
+      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.pack
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
+      |       `-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -258,14 +258,14 @@ Make sure all temporary namespace got removed
       |   |   `-- b2a5b9c65fae1d20c1b1fb777d1ea025456faa
       |   |-- info
       |   `-- pack
-      |       |-- pack-78ffbd7e7c8abf2dbcfc09867596c326c91d05c3.idx
-      |       |-- pack-78ffbd7e7c8abf2dbcfc09867596c326c91d05c3.pack
-      |       |-- pack-8b21babdbe4d8b1392439429880860d8cf698332.idx
-      |       |-- pack-8b21babdbe4d8b1392439429880860d8cf698332.pack
-      |       |-- pack-9afe2a05aace90b45bcd9486b9fc09e71480633c.idx
-      |       |-- pack-9afe2a05aace90b45bcd9486b9fc09e71480633c.pack
-      |       |-- pack-f084b3cbab8aecd03fa3cd68e6aa79382657e69b.idx
-      |       `-- pack-f084b3cbab8aecd03fa3cd68e6aa79382657e69b.pack
+      |       |-- pack-3a57e9cdc95400944f3e385ef9f2dd3e34214850.idx
+      |       |-- pack-3a57e9cdc95400944f3e385ef9f2dd3e34214850.pack
+      |       |-- pack-63a0eba9c29d8be4a080b31f7ae988c86dcf4f40.idx
+      |       |-- pack-63a0eba9c29d8be4a080b31f7ae988c86dcf4f40.pack
+      |       |-- pack-73ff0b391af4bb8dff50f6070f8e6bd258d3d562.idx
+      |       |-- pack-73ff0b391af4bb8dff50f6070f8e6bd258d3d562.pack
+      |       |-- pack-e56807bf90b581321239e94899e9a2bad8ea715c.idx
+      |       `-- pack-e56807bf90b581321239e94899e9a2bad8ea715c.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_stacked_split.t
+++ b/tests/proxy/push_stacked_split.t
@@ -185,8 +185,8 @@ Make sure all temporary namespace got removed
       |   |   `-- b2a5b9c65fae1d20c1b1fb777d1ea025456faa
       |   |-- info
       |   `-- pack
-      |       |-- pack-d787933d12fa80e0118646c0aa4a83139c02e4cb.idx
-      |       `-- pack-d787933d12fa80e0118646c0aa4a83139c02e4cb.pack
+      |       |-- pack-7a3bcd23cf0d9c3f433e71e7885b8ff12c31d912.idx
+      |       `-- pack-7a3bcd23cf0d9c3f433e71e7885b8ff12c31d912.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -255,14 +255,14 @@ Make sure all temporary namespace got removed
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
       |   |-- info
       |   `-- pack
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
-      |       |-- pack-718676b296aa09fce4d6d811a3d7543ec8803d1e.idx
-      |       |-- pack-718676b296aa09fce4d6d811a3d7543ec8803d1e.pack
-      |       |-- pack-8ba16953737b1eddb48842059c6fea9cae77170f.idx
-      |       |-- pack-8ba16953737b1eddb48842059c6fea9cae77170f.pack
-      |       |-- pack-e64aa37e31e3b3b41104754707ae8b326ce1b30b.idx
-      |       `-- pack-e64aa37e31e3b3b41104754707ae8b326ce1b30b.pack
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
+      |       |-- pack-85062c8051be8d1cc8c3f2bb59d2c43955b713b5.idx
+      |       |-- pack-85062c8051be8d1cc8c3f2bb59d2c43955b713b5.pack
+      |       |-- pack-8e3400a243c06eadce222b7e3fc003f3ec51d8e7.idx
+      |       |-- pack-8e3400a243c06eadce222b7e3fc003f3ec51d8e7.pack
+      |       |-- pack-a19b84c20a0ea82ae2c5184e6056e9a9a8f628ad.idx
+      |       `-- pack-a19b84c20a0ea82ae2c5184e6056e9a9a8f628ad.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -99,12 +99,12 @@
       |   |   `-- 2cc0b3d612792395dd9ac2ca649da0e6e54620
       |   |-- info
       |   `-- pack
-      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.idx
-      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.pack
-      |       |-- pack-9fb50b1e4c13a30e0da1720d8b22f58af0535d63.idx
-      |       |-- pack-9fb50b1e4c13a30e0da1720d8b22f58af0535d63.pack
-      |       |-- pack-a724713a58e1918b9032aed364764a0a4cece84b.idx
-      |       `-- pack-a724713a58e1918b9032aed364764a0a4cece84b.pack
+      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.idx
+      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.pack
+      |       |-- pack-84bf2195a0e00629f813ae535a24bb7fca071fa2.idx
+      |       |-- pack-84bf2195a0e00629f813ae535a24bb7fca071fa2.pack
+      |       |-- pack-92ff53f1be3ade3375cb4bc4382ab90aa392c290.idx
+      |       `-- pack-92ff53f1be3ade3375cb4bc4382ab90aa392c290.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -148,10 +148,10 @@ Make sure all temporary namespace got removed
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
-      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.idx
-      |       `-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.pack
+      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.idx
+      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.pack
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
+      |       `-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -186,14 +186,14 @@ Put a double slash in the URL to see that it also works
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
-      |       |-- pack-0d4b38b140b6e8e4cae7dbc5e5ae6e12b11d2d52.idx
-      |       |-- pack-0d4b38b140b6e8e4cae7dbc5e5ae6e12b11d2d52.pack
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.idx
-      |       |-- pack-2f3daab2c2bc0fa3c2cb94022cd73dbeb79fba8b.pack
-      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.idx
-      |       |-- pack-9bd28ba2926c418d23678c7b9960f5577e09896b.pack
-      |       |-- pack-f445d148fd9a82f820ea90fe67d7f3a794e393a4.idx
-      |       `-- pack-f445d148fd9a82f820ea90fe67d7f3a794e393a4.pack
+      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.idx
+      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.pack
+      |       |-- pack-3870f7c23e56f421fca42ddb98af629a74027df3.idx
+      |       |-- pack-3870f7c23e56f421fca42ddb98af629a74027df3.pack
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
+      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
+      |       |-- pack-cb303098d881b2cc9c72fe2d5958c4108e1dfc5f.idx
+      |       `-- pack-cb303098d881b2cc9c72fe2d5958c4108e1dfc5f.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/unrelated_leak.t
+++ b/tests/proxy/unrelated_leak.t
@@ -216,12 +216,12 @@ Flushed credential cache
       |   |   `-- 184bf11ece7fbeb99395ab7676b80e7d98631a
       |   |-- info
       |   `-- pack
-      |       |-- pack-365bafb594d0b05b03a3c90ea320df4fe4021f9e.idx
-      |       |-- pack-365bafb594d0b05b03a3c90ea320df4fe4021f9e.pack
-      |       |-- pack-749ce45681f8e4fe8c7b114878930d43b1828c50.idx
-      |       |-- pack-749ce45681f8e4fe8c7b114878930d43b1828c50.pack
-      |       |-- pack-e314ce900fa86c59aa7128e98b5cb3ec9520949a.idx
-      |       `-- pack-e314ce900fa86c59aa7128e98b5cb3ec9520949a.pack
+      |       |-- pack-3580c0a0c9c7beb59e4498be2a8e11209cf88985.idx
+      |       |-- pack-3580c0a0c9c7beb59e4498be2a8e11209cf88985.pack
+      |       |-- pack-5181289169f3bdc2ccab261ef101d1e3ba47a6c6.idx
+      |       |-- pack-5181289169f3bdc2ccab261ef101d1e3ba47a6c6.pack
+      |       |-- pack-84987279b748d1e02ab5af4ec82c39812b3bf9d9.idx
+      |       `-- pack-84987279b748d1e02ab5af4ec82c39812b3bf9d9.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -326,12 +326,12 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-5d11ca698a761cfb0102d4d44599349077fbafb5.idx
-      |       |-- pack-5d11ca698a761cfb0102d4d44599349077fbafb5.pack
-      |       |-- pack-cf634696f53f4ca2e6072988b224113252440145.idx
-      |       |-- pack-cf634696f53f4ca2e6072988b224113252440145.pack
-      |       |-- pack-e5529b295aa82690ce40a2abeefb9ae9bdfe2288.idx
-      |       `-- pack-e5529b295aa82690ce40a2abeefb9ae9bdfe2288.pack
+      |       |-- pack-0618668c300df49932c864a4be615ce1411207b2.idx
+      |       |-- pack-0618668c300df49932c864a4be615ce1411207b2.pack
+      |       |-- pack-34c90511b5a8b771ac547f9b72395fdc5036cd52.idx
+      |       |-- pack-34c90511b5a8b771ac547f9b72395fdc5036cd52.pack
+      |       |-- pack-a7c1da3ed4de712808b5b180ebdd5f4fedec0e0f.idx
+      |       `-- pack-a7c1da3ed4de712808b5b180ebdd5f4fedec0e0f.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -591,22 +591,22 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
       |   |-- info
       |   `-- pack
-      |       |-- pack-0a5087aa14c50693a3d73b25e94466c4b21c7d30.idx
-      |       |-- pack-0a5087aa14c50693a3d73b25e94466c4b21c7d30.pack
-      |       |-- pack-132b596594e7cf7bc3af1b2c7a24fdf62d759469.idx
-      |       |-- pack-132b596594e7cf7bc3af1b2c7a24fdf62d759469.pack
-      |       |-- pack-369060c82a79aba08c50857e8818b02e9fb2578f.idx
-      |       |-- pack-369060c82a79aba08c50857e8818b02e9fb2578f.pack
-      |       |-- pack-56434dd1073324f0c25f881a1c87eff63af5c27e.idx
-      |       |-- pack-56434dd1073324f0c25f881a1c87eff63af5c27e.pack
+      |       |-- pack-54fef233f76a8e6e43153db0cfb036c950efabb0.idx
+      |       |-- pack-54fef233f76a8e6e43153db0cfb036c950efabb0.pack
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
-      |       |-- pack-78f8060245d0cbe6e14e9baffbd43827973328cd.idx
-      |       |-- pack-78f8060245d0cbe6e14e9baffbd43827973328cd.pack
-      |       |-- pack-ac69f084a822e26e92fcd950197630c5d06a5ddf.idx
-      |       |-- pack-ac69f084a822e26e92fcd950197630c5d06a5ddf.pack
-      |       |-- pack-f856631ca92126724726c23f44d834967dbcc5de.idx
-      |       `-- pack-f856631ca92126724726c23f44d834967dbcc5de.pack
+      |       |-- pack-8739d0708434a80a1f35dea255c7fa677209221b.idx
+      |       |-- pack-8739d0708434a80a1f35dea255c7fa677209221b.pack
+      |       |-- pack-97f12e7b2b70cbd63c3daf19e953b1ab655cf1d9.idx
+      |       |-- pack-97f12e7b2b70cbd63c3daf19e953b1ab655cf1d9.pack
+      |       |-- pack-9d2d72a65a2c561c6e5f082b16dfd953a1e4da84.idx
+      |       |-- pack-9d2d72a65a2c561c6e5f082b16dfd953a1e4da84.pack
+      |       |-- pack-bb1014a1ce8fc26d5d310e021152caa61aba740d.idx
+      |       |-- pack-bb1014a1ce8fc26d5d310e021152caa61aba740d.pack
+      |       |-- pack-c15bd674d709da5f3e68e7147f93bfcffc88215a.idx
+      |       |-- pack-c15bd674d709da5f3e68e7147f93bfcffc88215a.pack
+      |       |-- pack-c803d5f49a80510bd56b22fcf31e45238f5c8778.idx
+      |       `-- pack-c803d5f49a80510bd56b22fcf31e45238f5c8778.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -187,8 +187,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-bc2bd46c4c017717f7584aad0c1f3b80cdb1fee6.idx
-      |       `-- pack-bc2bd46c4c017717f7584aad0c1f3b80cdb1fee6.pack
+      |       |-- pack-344f101b5d72f5ef8bb927db14289ba3c44692aa.idx
+      |       `-- pack-344f101b5d72f5ef8bb927db14289ba3c44692aa.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -311,18 +311,18 @@
       |   |   `-- 3efb2615e1c17f0d0b6e610da85da09438cd29
       |   |-- info
       |   `-- pack
-      |       |-- pack-020a9c25afd039b7908829ed180c3c5b5c2aeb43.idx
-      |       |-- pack-020a9c25afd039b7908829ed180c3c5b5c2aeb43.pack
-      |       |-- pack-5e1711c1c8fd3c58e9ecf87c44dda797a57b4d09.idx
-      |       |-- pack-5e1711c1c8fd3c58e9ecf87c44dda797a57b4d09.pack
-      |       |-- pack-810042fcc342c573b7d491be291eac8697326115.idx
-      |       |-- pack-810042fcc342c573b7d491be291eac8697326115.pack
-      |       |-- pack-8f2ab97436b3ff8e62f3dce0c1093ce4832bca89.idx
-      |       |-- pack-8f2ab97436b3ff8e62f3dce0c1093ce4832bca89.pack
-      |       |-- pack-a242cae1552f7e295b006c0963abdf9f3d89b7d7.idx
-      |       |-- pack-a242cae1552f7e295b006c0963abdf9f3d89b7d7.pack
-      |       |-- pack-f3754114f5e623d4b9710175aed17f8bd2ce1f30.idx
-      |       `-- pack-f3754114f5e623d4b9710175aed17f8bd2ce1f30.pack
+      |       |-- pack-1045e0215955d0d17455f662d87e9e9e9f525f61.idx
+      |       |-- pack-1045e0215955d0d17455f662d87e9e9e9f525f61.pack
+      |       |-- pack-424d13ce1705b756e4096bc480ccf751cc269fdf.idx
+      |       |-- pack-424d13ce1705b756e4096bc480ccf751cc269fdf.pack
+      |       |-- pack-7c542c70d0d9425967b64d48abb92c8437cd3e12.idx
+      |       |-- pack-7c542c70d0d9425967b64d48abb92c8437cd3e12.pack
+      |       |-- pack-8faf89e68dac787f61976cda504ca21ac1b452b3.idx
+      |       |-- pack-8faf89e68dac787f61976cda504ca21ac1b452b3.pack
+      |       |-- pack-9c4b2c03aaf94e1c174c7c5853d105a952d83199.idx
+      |       |-- pack-9c4b2c03aaf94e1c174c7c5853d105a952d83199.pack
+      |       |-- pack-a9d3e9f7de4bdd92d422c446d9d5c491beff94f6.idx
+      |       `-- pack-a9d3e9f7de4bdd92d422c446d9d5c491beff94f6.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -380,16 +380,16 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-61cee1ce849190d88cdfb51f8fd8aea0bcfd8e63.idx
-      |       |-- pack-61cee1ce849190d88cdfb51f8fd8aea0bcfd8e63.pack
-      |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.idx
-      |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.pack
-      |       |-- pack-7aa46131845bcb33ada5dd9264a54f6bda553621.idx
-      |       |-- pack-7aa46131845bcb33ada5dd9264a54f6bda553621.pack
-      |       |-- pack-969240cacd518199eb056a306b470700114f2177.idx
-      |       |-- pack-969240cacd518199eb056a306b470700114f2177.pack
-      |       |-- pack-b0339b769beb47ea5c28c0a4f4379ab2d18a4b29.idx
-      |       `-- pack-b0339b769beb47ea5c28c0a4f4379ab2d18a4b29.pack
+      |       |-- pack-8ff00f1e1d6cae0d9a353341bcabe039c2695bcf.idx
+      |       |-- pack-8ff00f1e1d6cae0d9a353341bcabe039c2695bcf.pack
+      |       |-- pack-98fe2fcc1ca8d493770a9fe52ae4d50e96793a27.idx
+      |       |-- pack-98fe2fcc1ca8d493770a9fe52ae4d50e96793a27.pack
+      |       |-- pack-c105a3cf9958469daa4b7c9bcb22c21025fdc83b.idx
+      |       |-- pack-c105a3cf9958469daa4b7c9bcb22c21025fdc83b.pack
+      |       |-- pack-d2f1121a06a53dbc7c35b23f77a1edf526503745.idx
+      |       |-- pack-d2f1121a06a53dbc7c35b23f77a1edf526503745.pack
+      |       |-- pack-f7abe9eb33a28f534dd36b4772fec65a411fc901.idx
+      |       `-- pack-f7abe9eb33a28f534dd36b4772fec65a411fc901.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -264,12 +264,12 @@ Flushed credential cache
       |   |   `-- 8eb888451be077531b50794384c2faec025765
       |   |-- info
       |   `-- pack
-      |       |-- pack-6094f48eea5b3933a6584a6925dac03cf644f01e.idx
-      |       |-- pack-6094f48eea5b3933a6584a6925dac03cf644f01e.pack
+      |       |-- pack-4aa0c3b06b81194f2e588db5ae323c7fb4550048.idx
+      |       |-- pack-4aa0c3b06b81194f2e588db5ae323c7fb4550048.pack
+      |       |-- pack-4c30edff00d7b5dff411c9bccd544e4068345179.idx
+      |       |-- pack-4c30edff00d7b5dff411c9bccd544e4068345179.pack
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
-      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
-      |       |-- pack-9f918747f4ae3e54ccf603a1e77dd40c584aa821.idx
-      |       `-- pack-9f918747f4ae3e54ccf603a1e77dd40c584aa821.pack
+      |       `-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -595,22 +595,22 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
       |   |-- info
       |   `-- pack
-      |       |-- pack-133a4127e8d4c9bdc124e21786a688c4e8f778c9.idx
-      |       |-- pack-133a4127e8d4c9bdc124e21786a688c4e8f778c9.pack
-      |       |-- pack-59055e54f993a526fd1b0200427456390db5dd2d.idx
-      |       |-- pack-59055e54f993a526fd1b0200427456390db5dd2d.pack
+      |       |-- pack-18f5e8369b2efc356f458df3e0d3e986a815dca1.idx
+      |       |-- pack-18f5e8369b2efc356f458df3e0d3e986a815dca1.pack
+      |       |-- pack-25dfa147247bd2b0466fed0bed32246eaf9fe4dc.idx
+      |       |-- pack-25dfa147247bd2b0466fed0bed32246eaf9fe4dc.pack
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
       |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
-      |       |-- pack-9344ad8c1e2b9aca23229bfb5dfbc1a19f64e2dc.idx
-      |       |-- pack-9344ad8c1e2b9aca23229bfb5dfbc1a19f64e2dc.pack
-      |       |-- pack-af3e3339c7bd303ace0b6210e7f1c13374606269.idx
-      |       |-- pack-af3e3339c7bd303ace0b6210e7f1c13374606269.pack
-      |       |-- pack-dc4dca83cf9851930e174c49e92f2de588f25e71.idx
-      |       |-- pack-dc4dca83cf9851930e174c49e92f2de588f25e71.pack
-      |       |-- pack-e27bba3e1cb78d1a86c190a38d3a40070fef9b53.idx
-      |       |-- pack-e27bba3e1cb78d1a86c190a38d3a40070fef9b53.pack
-      |       |-- pack-fb51f94a07756db0b90e50e60315402cd82f9ac3.idx
-      |       `-- pack-fb51f94a07756db0b90e50e60315402cd82f9ac3.pack
+      |       |-- pack-7d659947da11a0cbcf3b3ac6861fa1f134b9fca7.idx
+      |       |-- pack-7d659947da11a0cbcf3b3ac6861fa1f134b9fca7.pack
+      |       |-- pack-7e5b73fe75cdbeabdb46528f04e4398efebfcc03.idx
+      |       |-- pack-7e5b73fe75cdbeabdb46528f04e4398efebfcc03.pack
+      |       |-- pack-b0cbd25fb82a58313bf6d9dd8713985699bbc9f7.idx
+      |       |-- pack-b0cbd25fb82a58313bf6d9dd8713985699bbc9f7.pack
+      |       |-- pack-c97be2528535257dcd484df2a6ab4f652d8c6970.idx
+      |       |-- pack-c97be2528535257dcd484df2a6ab4f652d8c6970.pack
+      |       |-- pack-e4f530d8d5281ae2ca99953a0a81293c83ba2d08.idx
+      |       `-- pack-e4f530d8d5281ae2ca99953a0a81293c83ba2d08.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -359,12 +359,12 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-89f5d1c01530839eab589ceec8565f11ff4679a5.idx
-      |       |-- pack-89f5d1c01530839eab589ceec8565f11ff4679a5.pack
-      |       |-- pack-a75d3ca2392eb679cf1dc24a3496576475f5e849.idx
-      |       |-- pack-a75d3ca2392eb679cf1dc24a3496576475f5e849.pack
-      |       |-- pack-c455f6d9504526b7c14867a795a5b2e27610956a.idx
-      |       `-- pack-c455f6d9504526b7c14867a795a5b2e27610956a.pack
+      |       |-- pack-2009882855c8f675680efa7d980ff158d20ca33a.idx
+      |       |-- pack-2009882855c8f675680efa7d980ff158d20ca33a.pack
+      |       |-- pack-c70df139d67bfa71319bc00c4453aaef1065577f.idx
+      |       |-- pack-c70df139d67bfa71319bc00c4453aaef1065577f.pack
+      |       |-- pack-f89fa289619bb520bbd2b67c6049b117211e3da0.idx
+      |       `-- pack-f89fa289619bb520bbd2b67c6049b117211e3da0.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -448,16 +448,16 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-003dec79becceac35fcf4dc6da69067da9076b43.idx
-      |       |-- pack-003dec79becceac35fcf4dc6da69067da9076b43.pack
-      |       |-- pack-1ea36f2d466e060c9ea31389ae1b3cd2ef9ee1a0.idx
-      |       |-- pack-1ea36f2d466e060c9ea31389ae1b3cd2ef9ee1a0.pack
-      |       |-- pack-3bb8600225cc4139a131c5413ee7275d07ccd58a.idx
-      |       |-- pack-3bb8600225cc4139a131c5413ee7275d07ccd58a.pack
-      |       |-- pack-5f43de7285cc69f6f7f779f1c22bbcc404fea509.idx
-      |       |-- pack-5f43de7285cc69f6f7f779f1c22bbcc404fea509.pack
-      |       |-- pack-78ce499d43b7df7a0b507140d5134ff90a058eeb.idx
-      |       `-- pack-78ce499d43b7df7a0b507140d5134ff90a058eeb.pack
+      |       |-- pack-293c54220e20d5b4c343777de6ec1fcf469a246a.idx
+      |       |-- pack-293c54220e20d5b4c343777de6ec1fcf469a246a.pack
+      |       |-- pack-5db946bd0dcde544bac50ab27795a4775dfc0f00.idx
+      |       |-- pack-5db946bd0dcde544bac50ab27795a4775dfc0f00.pack
+      |       |-- pack-94f23201f51cbf11abc7fce7cfe7359da6844dc7.idx
+      |       |-- pack-94f23201f51cbf11abc7fce7cfe7359da6844dc7.pack
+      |       |-- pack-bd5becad2b550884155f2442b49b91a062e8eeeb.idx
+      |       |-- pack-bd5becad2b550884155f2442b49b91a062e8eeeb.pack
+      |       |-- pack-cbe98a48db32c69560001f112d79637fc2019ccd.idx
+      |       `-- pack-cbe98a48db32c69560001f112d79637fc2019ccd.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -149,8 +149,8 @@ file was created
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-8917b273641be5244854c2fbf57281b0086ccc85.idx
-      |       `-- pack-8917b273641be5244854c2fbf57281b0086ccc85.pack
+      |       |-- pack-faaf01d2dc0909611cdf7c3d1bdbbfe3ce2a9449.idx
+      |       `-- pack-faaf01d2dc0909611cdf7c3d1bdbbfe3ce2a9449.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -197,12 +197,12 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-22feba8ae58a3472f764b3f5060292f7190e37fe.idx
-      |       |-- pack-22feba8ae58a3472f764b3f5060292f7190e37fe.pack
-      |       |-- pack-6b38b3f70def6c73711d6d00ddbf675f33f854b8.idx
-      |       |-- pack-6b38b3f70def6c73711d6d00ddbf675f33f854b8.pack
-      |       |-- pack-941b0ed2e56099a0daa91129b84275672d56b2be.idx
-      |       `-- pack-941b0ed2e56099a0daa91129b84275672d56b2be.pack
+      |       |-- pack-1e3b2eb669f6830fb7caf1293ce0be84bc7dcd74.idx
+      |       |-- pack-1e3b2eb669f6830fb7caf1293ce0be84bc7dcd74.pack
+      |       |-- pack-b37b9b480fa587ae3abac4d9d69d9739c245f727.idx
+      |       |-- pack-b37b9b480fa587ae3abac4d9d69d9739c245f727.pack
+      |       |-- pack-b64c0193b9599a21219248e0ac7583470c37b5cf.idx
+      |       `-- pack-b64c0193b9599a21219248e0ac7583470c37b5cf.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -348,12 +348,12 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-61cee1ce849190d88cdfb51f8fd8aea0bcfd8e63.idx
-      |       |-- pack-61cee1ce849190d88cdfb51f8fd8aea0bcfd8e63.pack
-      |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.idx
-      |       |-- pack-72f0031d0154ceb6432b06e392ae4f19a8cfba65.pack
-      |       |-- pack-969240cacd518199eb056a306b470700114f2177.idx
-      |       `-- pack-969240cacd518199eb056a306b470700114f2177.pack
+      |       |-- pack-98fe2fcc1ca8d493770a9fe52ae4d50e96793a27.idx
+      |       |-- pack-98fe2fcc1ca8d493770a9fe52ae4d50e96793a27.pack
+      |       |-- pack-d2f1121a06a53dbc7c35b23f77a1edf526503745.idx
+      |       |-- pack-d2f1121a06a53dbc7c35b23f77a1edf526503745.pack
+      |       |-- pack-f7abe9eb33a28f534dd36b4772fec65a411fc901.idx
+      |       `-- pack-f7abe9eb33a28f534dd36b4772fec65a411fc901.pack
       `-- refs
           |-- heads
           |-- namespaces


### PR DESCRIPTION
Port the memodb flusher onto gix-pack

Pack flushes now write the pack and index directly from a Send snapshot of
the buffered objects, instead of reopening the repository and running
libgit2's packbuilder against a re-registered backend. The store captures
the resolved common object directory at construction; object buffers are
Arc-shared so the snapshot copies nothing and eviction still happens only
once the pack is durable. Objects already on disk are filtered out with a
per-flush gix-odb handle. Packs are base-only (no delta search) and
zlib-rs-compressed, so the pack names embedded in proxy test expectations
change.

Change: memodb-gix-pack-flusher
Assisted-By: anthropic/claude-fable-5