### PR TITLE
Make the memory object store authoritative behind a gix-typed facade

### DIFF
--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -71,7 +71,8 @@ impl DistributedCacheBackend {
         if let Some(oid) = self.tree_ids.lock().unwrap().get(&filter) {
             return Ok(*oid);
         }
-        let oid = josh_filter::persist::as_tree(repo, filter)?;
+        let odb = repo.odb()?;
+        let oid = josh_filter::persist::as_tree(repo, &josh_gix_ext::Git2Odb(&odb), filter)?;
         self.tree_ids.lock().unwrap().insert(filter, oid);
         Ok(oid)
     }

--- a/josh-core/src/cache/history_graph.rs
+++ b/josh-core/src/cache/history_graph.rs
@@ -66,7 +66,7 @@ pub fn collect_history_graph_info(
 
     Ok(HistoryGraphInfo {
         sequence_number: hint.sequence_number,
-        reachable_roots: read_roots_blob(transaction.repo(), blob)?,
+        reachable_roots: read_roots_blob(&transaction.odb()?, blob)?,
     })
 }
 
@@ -99,14 +99,14 @@ pub fn parents_share_root(
 
     // Parents disagree on the roots blob: read each blob and intersect.
     let mut common: std::collections::BTreeSet<git2::Oid> =
-        read_roots_blob(transaction.repo(), first_blob)?
+        read_roots_blob(&transaction.odb()?, first_blob)?
             .into_iter()
             .collect();
     for blob_oid in &parent_blobs[1..] {
         if common.is_empty() {
             return Ok(false);
         }
-        let p_set: std::collections::BTreeSet<_> = read_roots_blob(transaction.repo(), *blob_oid)?
+        let p_set: std::collections::BTreeSet<_> = read_roots_blob(&transaction.odb()?, *blob_oid)?
             .into_iter()
             .collect();
         common = common.intersection(&p_set).copied().collect();
@@ -128,11 +128,12 @@ fn ensure_hint_cached(
         return Ok(hint);
     }
 
-    if !transaction.repo().odb()?.exists(input) {
+    let odb = transaction.odb()?;
+    if !odb.contains(input) {
         return Err(anyhow!("ensure_hint_cached: input does not exist"));
     }
 
-    let parent_ids = crate::git::read_parent_ids(transaction.repo(), input)?;
+    let parent_ids = crate::git::read_parent_ids(&odb, input)?;
 
     // Fast path: every parent already has both pieces cached.
     let parents_hint: Option<Vec<(u64, git2::Oid)>> = parent_ids
@@ -144,13 +145,12 @@ fn ensure_hint_cached(
         .collect::<anyhow::Result<_>>()?;
 
     if let Some(parents_hint) = parents_hint {
-        let hint = derive_from_parents(transaction.repo(), input, &parents_hint)?;
+        let hint = derive_from_parents(&odb, input, &parents_hint)?;
         store_hint(transaction, input, hint)?;
         return Ok(hint);
     }
 
     log::info!("ensure_hint_cached: new_walk for {:?}", input);
-    let odb = transaction.repo().odb()?;
     let mut walk = crate::objects::RevWalk::new(&odb);
     walk.push(input)?;
 
@@ -170,16 +170,15 @@ fn ensure_hint_cached(
     })?;
 
     for &oid in sorted.iter().rev() {
-        let parents_hint: Vec<(u64, git2::Oid)> =
-            crate::git::read_parent_ids(transaction.repo(), oid)?
-                .into_iter()
-                .map(|p| {
-                    try_read_cached_hint(transaction, p)?
-                        .map(|(hint, blob)| (hint.sequence_number, blob))
-                        .ok_or_else(|| anyhow!("parent {} hint missing during walk for {}", p, oid))
-                })
-                .collect::<anyhow::Result<Vec<_>>>()?;
-        let hint = derive_from_parents(transaction.repo(), oid, &parents_hint)?;
+        let parents_hint: Vec<(u64, git2::Oid)> = crate::git::read_parent_ids(&odb, oid)?
+            .into_iter()
+            .map(|p| {
+                try_read_cached_hint(transaction, p)?
+                    .map(|(hint, blob)| (hint.sequence_number, blob))
+                    .ok_or_else(|| anyhow!("parent {} hint missing during walk for {}", p, oid))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let hint = derive_from_parents(&odb, oid, &parents_hint)?;
         store_hint(transaction, oid, hint)?;
     }
 
@@ -192,7 +191,7 @@ fn ensure_hint_cached(
 /// only when parents disagree on the blob; otherwise reuses the parent blob
 /// OID (or, for the root case, writes a single-element blob).
 fn derive_from_parents(
-    repo: &git2::Repository,
+    odb: &josh_memodb::Odb,
     self_oid: git2::Oid,
     parents_hint: &[(u64, git2::Oid)],
 ) -> anyhow::Result<(HistoryGraphHint, git2::Oid)> {
@@ -205,7 +204,7 @@ fn derive_from_parents(
                 jump_delta: 0,
                 jump_is_second: false,
             },
-            write_roots_blob(repo, &[self_oid])?,
+            write_roots_blob(odb, &[self_oid])?,
         ));
     }
 
@@ -233,10 +232,10 @@ fn derive_from_parents(
     } else {
         let mut set: std::collections::BTreeSet<git2::Oid> = Default::default();
         for (_, blob_oid) in parents_hint {
-            set.extend(read_roots_blob(repo, *blob_oid)?);
+            set.extend(read_roots_blob(odb, *blob_oid)?);
         }
         let roots: Vec<_> = set.into_iter().collect();
-        write_roots_blob(repo, &roots)?
+        write_roots_blob(odb, &roots)?
     };
 
     Ok((
@@ -279,17 +278,20 @@ fn store_hint(
     Ok(())
 }
 
-fn write_roots_blob(repo: &git2::Repository, roots: &[git2::Oid]) -> anyhow::Result<git2::Oid> {
+fn write_roots_blob(odb: &josh_memodb::Odb, roots: &[git2::Oid]) -> anyhow::Result<git2::Oid> {
     let mut bytes = Vec::with_capacity(roots.len() * 20);
     for r in roots {
         bytes.extend_from_slice(r.as_bytes());
     }
-    Ok(repo.blob(&bytes)?)
+    Ok(odb.write(gix_object::Kind::Blob, &bytes))
 }
 
-fn read_roots_blob(repo: &git2::Repository, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
-    let blob = repo.find_blob(oid)?;
-    let content = blob.content();
+fn read_roots_blob(odb: &josh_memodb::Odb, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
+    let (kind, content) = odb.read(oid)?;
+    if kind != gix_object::Kind::Blob {
+        return Err(anyhow!("reachable_roots object {} is not a blob", oid));
+    }
+    let content = &content[..];
     if content.len() % 20 != 0 {
         return Err(anyhow!(
             "malformed reachable_roots blob {}: length {} not a multiple of 20",

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -269,21 +269,46 @@ impl Transaction {
         &self.repo
     }
 
+    /// The transaction's object-database facade: memory store first, repository odb
+    /// fallback (see [`josh_memodb::Odb`]).
+    pub fn odb(&self) -> anyhow::Result<josh_memodb::Odb<'_>> {
+        Ok(josh_memodb::Odb::new(
+            self.mem_odb.clone(),
+            self.repo.odb()?,
+        ))
+    }
+
+    /// Add `path` (an objects directory) as a runtime alternate of both the repository odb
+    /// and the memory store's write-dedup probe (see [`josh_memodb::Odb::write`]).
+    pub fn add_disk_alternate(&self, path: &str) -> anyhow::Result<()> {
+        self.repo.odb()?.add_disk_alternate(path)?;
+        self.mem_odb.add_alternate(path)?;
+        Ok(())
+    }
+
     /// Read the raw bytes of the tree `oid` through the per-transaction [`TreeCache`]
     /// (see there for the promotion and eviction policy). `Ok(None)` means the object exists
     /// but is not a tree; a missing object is an error, like a plain odb read.
+    ///
+    /// Trees still buffered in the memory store come back as zero-copy `Arc` clones of the
+    /// store's own buffers and bypass the TreeCache promotion accounting -- caching them
+    /// again would only duplicate memory the store already holds.
     pub fn read_tree_bytes<'a>(
         &self,
-        odb: &'a git2::Odb,
+        odb: &'a josh_memodb::Odb,
         oid: git2::Oid,
     ) -> anyhow::Result<Option<TreeBytes<'a>>> {
         if let Some(bytes) = self.t2.borrow().tree_cache.get(oid) {
             return Ok(Some(TreeBytes::Cached(bytes)));
         }
-        let obj = odb.read(oid)?;
-        if obj.kind() != git2::ObjectType::Tree {
+        let (kind, bytes) = odb.read(oid)?;
+        if kind != gix_object::Kind::Tree {
             return Ok(None);
         }
+        let obj = match bytes {
+            josh_memodb::Bytes::Mem(bytes) => return Ok(Some(TreeBytes::Cached(bytes))),
+            josh_memodb::Bytes::Disk(obj) => obj,
+        };
         let mut t2 = self.t2.borrow_mut();
         if t2.tree_cache.should_promote(oid) {
             let bytes: std::sync::Arc<[u8]> = obj.data().into();
@@ -630,7 +655,7 @@ impl Transaction {
         let oid = t2.cache.read_propagate(filter, tree, hint, true).ok()??;
         // Per-subtree index trees are anchored by no ref, so gc may have pruned a
         // cached one; treat a dangling hit as a miss and reindex.
-        if self.repo.odb().ok()?.exists(oid) {
+        if self.odb().ok()?.contains(oid) {
             Some(oid)
         } else {
             None
@@ -665,7 +690,7 @@ impl Transaction {
     pub fn get_ref(&self, filter: crate::filter::Filter, from: git2::Oid) -> Option<git2::Oid> {
         if let Some(m) = REF_CACHE.read().unwrap().get(&filter.id())
             && let Some(oid) = m.get(&from)
-            && self.repo.odb().unwrap().exists(*oid)
+            && self.odb().unwrap().contains(*oid)
         {
             return Some(*oid);
         }
@@ -802,7 +827,7 @@ impl Transaction {
                 return Ok(Some(oid));
             }
 
-            if self.repo.odb()?.exists(oid) {
+            if self.odb()?.contains(oid) {
                 // Only report an object as cached if it exists in the object database.
                 // This forces a rebuild in case the object was garbage collected.
                 return Ok(Some(oid));

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -24,7 +24,7 @@ pub mod text;
 pub mod tree;
 
 pub fn as_tree(transaction: &cache::Transaction, filter: Filter) -> anyhow::Result<git2::Oid> {
-    josh_filter::persist::as_tree(transaction.repo(), filter)
+    josh_filter::persist::as_tree(transaction.repo(), &transaction.odb()?, filter)
 }
 
 pub fn from_tree(transaction: &cache::Transaction, tree_oid: git2::Oid) -> anyhow::Result<Filter> {
@@ -551,7 +551,7 @@ fn get_rev_filter(
         } else {
             return Err(anyhow!("unresolved lazy ref"));
         };
-        if match_op != &RevMatch::Default && !transaction.repo().odb()?.exists(*filter_tip) {
+        if match_op != &RevMatch::Default && !transaction.odb()?.contains(*filter_tip) {
             return Err(anyhow!("`:rev(...)` with nonexistent OID: {}", filter_tip));
         }
         let matches = match match_op {
@@ -616,10 +616,10 @@ pub fn apply_to_commit2(
             return Ok(Some(current_oid));
         }
         Op::Squash(None) => {
-            let odb = repo.odb()?;
+            let odb = transaction.odb()?;
             let commit = objects::CommitData::read(&odb, commit_id)?;
             return Some(history::rewrite_commit(
-                repo,
+                &odb,
                 &commit,
                 &[],
                 Rewrite::from_commit_data(repo, &commit)?,
@@ -646,7 +646,7 @@ pub fn apply_to_commit2(
         }
     };
 
-    let odb = repo.odb()?;
+    let odb = transaction.odb()?;
     let commit = objects::CommitData::read(&odb, commit_id)?;
 
     let rewrite_data = match &op {
@@ -832,7 +832,7 @@ pub fn apply_to_commit2(
             // A root commit (no first parent) keeps every root; when a first
             // parent is present its tree must be readable.
             let parent_tree = match commit.first_parent_id() {
-                Some(parent) => Some(repo.find_tree(git::read_tree_id(repo, parent)?)?),
+                Some(parent) => Some(repo.find_tree(git::read_tree_id(&odb, parent)?)?),
                 None => None,
             };
             if let Some(parent_tree) = parent_tree {
@@ -939,7 +939,7 @@ pub fn apply_to_commit2(
             let parent_filters = commit
                 .parent_ids()
                 .map(|parent| {
-                    let tree_id = git::read_tree_id(repo, parent)?;
+                    let tree_id = git::read_tree_id(&odb, parent)?;
                     let pcw = get_workspace(transaction, &repo.find_tree(tree_id)?, ws_path);
                     Ok((parent, pcw))
                 })
@@ -954,7 +954,7 @@ pub fn apply_to_commit2(
             let parent_filters = commit
                 .parent_ids()
                 .map(|parent| {
-                    let tree_id = git::read_tree_id(repo, parent)?;
+                    let tree_id = git::read_tree_id(&odb, parent)?;
                     let pcs = get_stored(transaction, &repo.find_tree(tree_id)?, s_path);
                     Ok((parent, pcs))
                 })
@@ -974,7 +974,7 @@ pub fn apply_to_commit2(
             let parent_filters = commit
                 .parent_ids()
                 .map(|parent| {
-                    let tree_id = git::read_tree_id(repo, parent)?;
+                    let tree_id = git::read_tree_id(&odb, parent)?;
                     let pcs =
                         get_starlark(transaction, &repo.find_tree(tree_id)?, s_path, *s_subfilter);
                     Ok((parent, pcs))
@@ -2004,7 +2004,7 @@ pub fn is_ancestor_of(
             let mut todo = vec![tip];
             let mut ancestors = std::collections::HashSet::from_iter(todo.iter().copied());
             while let Some(commit) = todo.pop() {
-                for parent in crate::git::read_parent_ids(transaction.repo(), commit)? {
+                for parent in crate::git::read_parent_ids(&transaction.odb()?, commit)? {
                     if ancestors.insert(parent) {
                         // Newly inserted! Also handle its parents.
                         todo.push(parent);
@@ -2311,7 +2311,7 @@ pub fn downstack(
     // RangeWalk needed. A base that passes the descendant check but is NOT on
     // the spine would make "the stack from base" ill-defined; error instead
     // of answering.
-    let odb = repo.odb()?;
+    let odb = transaction.odb()?;
     let mut walk = objects::RevWalk::new(&odb);
     walk.simplify_first_parent();
     walk.push(change_oid)?;
@@ -2372,7 +2372,7 @@ pub fn downstack(
         )?;
         let new_tree = repo.find_tree(new_tree_oid)?;
         let new_oid = history::rewrite_commit(
-            repo,
+            &odb,
             &objects::CommitData::read(&odb, intermediate.id())?,
             &[current_base.id()],
             Rewrite::from_tree(new_tree),
@@ -2400,7 +2400,7 @@ pub fn downstack(
     new_parents.extend(change_commit.parent_ids().skip(1));
 
     let new_oid = history::rewrite_commit(
-        repo,
+        &odb,
         &objects::CommitData::read(&odb, change_commit.id())?,
         &new_parents,
         Rewrite::from_tree(new_tree),
@@ -2643,7 +2643,8 @@ mod tests {
         let meta_filter = to_filter(Op::Meta(meta.clone(), inner_filter));
 
         // Serialize to tree
-        let tree_oid = as_tree(&repo, meta_filter).unwrap();
+        let odb = repo.odb().unwrap();
+        let tree_oid = as_tree(&repo, &objects::Git2Odb(&odb), meta_filter).unwrap();
 
         // Deserialize from tree
         let deserialized_filter = from_tree(&repo, tree_oid).unwrap();

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -8,7 +8,7 @@ pub fn pathstree<'a>(
     transaction: &'a cache::Transaction,
 ) -> anyhow::Result<git2::Tree<'a>> {
     let repo = transaction.repo();
-    let odb = repo.odb()?;
+    let odb = transaction.odb()?;
     let result = pathstree_inner(root, input, transaction, &odb)?;
     Ok(repo.find_tree(result)?)
 }
@@ -18,7 +18,7 @@ fn pathstree_inner(
     root: &str,
     input: git2::Oid,
     transaction: &cache::Transaction,
-    odb: &git2::Odb,
+    odb: &josh_memodb::Odb,
 ) -> anyhow::Result<git2::Oid> {
     if let Some(cached) = transaction.get_paths((input, root.to_string())) {
         return Ok(cached);
@@ -64,7 +64,7 @@ fn pathstree_inner(
             rebuild.keep(gix_object::tree::Entry {
                 mode: gix_object::tree::EntryKind::Blob.into(),
                 filename: entry.filename.to_owned(),
-                oid: objects::gix_oid(repo.blob(file_contents.as_bytes())?),
+                oid: objects::gix_oid(odb.write(gix_object::Kind::Blob, file_contents.as_bytes())),
             });
         }
     }
@@ -80,7 +80,7 @@ pub fn regex_replace<'a>(
     transaction: &'a cache::Transaction,
 ) -> anyhow::Result<git2::Tree<'a>> {
     let repo = transaction.repo();
-    let odb = repo.odb()?;
+    let odb = transaction.odb()?;
     let result = regex_replace_inner(input, regex, replacement, transaction, &odb)?;
     Ok(repo.find_tree(result)?)
 }
@@ -91,7 +91,7 @@ fn regex_replace_inner(
     regex: &regex::Regex,
     replacement: &str,
     transaction: &cache::Transaction,
-    odb: &git2::Odb,
+    odb: &josh_memodb::Odb,
 ) -> anyhow::Result<git2::Oid> {
     let repo = transaction.repo();
     let bytes = transaction
@@ -126,7 +126,7 @@ fn regex_replace_inner(
             rebuild.keep(gix_object::tree::Entry {
                 mode: entry.mode,
                 filename: entry.filename.to_owned(),
-                oid: objects::gix_oid(repo.blob(replaced.as_bytes())?),
+                oid: objects::gix_oid(odb.write(gix_object::Kind::Blob, replaced.as_bytes())),
             });
         }
     }
@@ -207,7 +207,7 @@ impl TreeRebuild {
     /// Write the rebuilt tree, or return `input` unchanged when nothing was dropped or
     /// rewritten: an untouched entry set reproduces `input` bit-identically, since git trees
     /// are content-addressed and the write preserves entry order.
-    fn finish(self, odb: &git2::Odb, input: git2::Oid) -> anyhow::Result<git2::Oid> {
+    fn finish(self, odb: &josh_memodb::Odb, input: git2::Oid) -> anyhow::Result<git2::Oid> {
         if self.changed {
             objects::write_tree_now(odb, self.out)
         } else {
@@ -289,7 +289,7 @@ pub fn remove_pred(
     pred: &dyn Fn(&str, bool) -> bool,
     key: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
     remove_pred_inner(transaction, &odb, path, input, pred, key)
 }
 
@@ -297,7 +297,7 @@ pub fn remove_pred(
 /// creating one per recursion level costs an FFI round-trip per tree node.
 fn remove_pred_inner(
     transaction: &cache::Transaction,
-    odb: &git2::Odb,
+    odb: &josh_memodb::Odb,
     path: &mut String,
     input: git2::Oid,
     pred: &dyn Fn(&str, bool) -> bool,
@@ -386,14 +386,14 @@ pub fn remove_pattern(
     key: git2::Oid,
     state: u64,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
     remove_pattern_inner(transaction, &odb, input, cp, key, state)
 }
 
 /// Recursive body of [`remove_pattern`]; see [`remove_pred_inner`] for why the odb is hoisted.
 fn remove_pattern_inner(
     transaction: &cache::Transaction,
-    odb: &git2::Odb,
+    odb: &josh_memodb::Odb,
     input: git2::Oid,
     cp: &CompiledPattern,
     key: git2::Oid,
@@ -515,14 +515,14 @@ pub fn subtract(
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
     subtract_inner(transaction, &odb, input1, input2)
 }
 
 /// Recursive body of [`subtract`]; see [`remove_pred_inner`] for why the odb is hoisted.
 fn subtract_inner(
     transaction: &cache::Transaction,
-    odb: &git2::Odb,
+    odb: &josh_memodb::Odb,
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
@@ -599,14 +599,14 @@ pub fn intersect(
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
     intersect_inner(transaction, &odb, input1, input2)
 }
 
 /// Recursive body of [`intersect`]; see [`remove_pred_inner`] for why the odb is hoisted.
 fn intersect_inner(
     transaction: &cache::Transaction,
-    odb: &git2::Odb,
+    odb: &josh_memodb::Odb,
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
@@ -667,12 +667,12 @@ fn component_bytes(c: &std::ffi::OsStr) -> &[u8] {
     std::os::unix::ffi::OsStrExt::as_bytes(c)
 }
 
-/// Read `oid` as a raw tree object, or `None` if it is missing or not a tree. Uncached: the
-/// insert path is used from repository-only contexts (josh-link, josh-changes) that have no
-/// transaction to hang the tree cache off.
-fn tree_object<'a>(odb: &'a git2::Odb, oid: git2::Oid) -> Option<git2::OdbObject<'a>> {
-    match odb.read(oid) {
-        Ok(obj) if obj.kind() == git2::ObjectType::Tree => Some(obj),
+/// Read `oid` as raw tree bytes, or `None` if it is missing or not a tree. Uncached: the
+/// insert path can be called without a transaction to hang the tree cache off.
+fn tree_bytes(src: &impl gix_object::Find, oid: git2::Oid) -> Option<Vec<u8>> {
+    let mut buf = Vec::new();
+    match src.try_find(&objects::gix_oid(oid), &mut buf) {
+        Ok(Some(data)) if data.kind == gix_object::Kind::Tree => Some(buf),
         _ => None,
     }
 }
@@ -683,15 +683,15 @@ fn tree_object<'a>(odb: &'a git2::Odb, oid: git2::Oid) -> Option<git2::OdbObject
 /// `child`, so duplicates of the name collapse: every occurrence is removed and the
 /// replacement takes the first one's position.
 fn replace_child_inner(
-    odb: &git2::Odb,
+    odb: &(impl gix_object::Find + gix_object::Write),
     child: &[u8],
     oid: git2::Oid,
     mode: i32,
     tree_oid: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let mut out = match tree_object(odb, tree_oid) {
-        Some(obj) => seed_entries(&gix_object::TreeRef::from_bytes(
-            obj.data(),
+    let mut out = match tree_bytes(odb, tree_oid) {
+        Some(bytes) => seed_entries(&gix_object::TreeRef::from_bytes(
+            &bytes,
             gix_hash::Kind::Sha1,
         )?),
         None => Vec::new(),
@@ -718,7 +718,7 @@ fn replace_child_inner(
 /// (`oid`, `mode`), creating intermediate trees as needed and treating blobs on the way as
 /// overwritable.
 fn insert_inner(
-    odb: &git2::Odb,
+    odb: &(impl gix_object::Find + gix_object::Write),
     full_tree: git2::Oid,
     path: &Path,
     oid: git2::Oid,
@@ -745,9 +745,9 @@ fn insert_inner(
     let mut st = full_tree;
     for c in parent.components() {
         let cb = component_bytes(c.as_os_str());
-        st = match tree_object(odb, st) {
-            Some(obj) => {
-                let tree = gix_object::TreeRef::from_bytes(obj.data(), gix_hash::Kind::Sha1)?;
+        st = match tree_bytes(odb, st) {
+            Some(bytes) => {
+                let tree = gix_object::TreeRef::from_bytes(&bytes, gix_hash::Kind::Sha1)?;
                 let sorted = entries_canonically_sorted(&tree);
                 match lookup_entry(&tree, cb.into(), sorted) {
                     Some(e) => objects::git2_oid(e.oid),
@@ -770,8 +770,10 @@ pub fn insert<'a>(
     oid: git2::Oid,
     mode: i32,
 ) -> anyhow::Result<git2::Tree<'a>> {
+    // No transaction in scope here; the repo odb still serves the memory store through the
+    // registered backend.
     let odb = repo.odb()?;
-    let result = insert_inner(&odb, full_tree.id(), path, oid, mode)?;
+    let result = insert_inner(&objects::Git2Odb(&odb), full_tree.id(), path, oid, mode)?;
     Ok(repo.find_tree(result)?)
 }
 
@@ -868,14 +870,14 @@ pub fn overlay(
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
     overlay_inner(transaction, &odb, input1, input2)
 }
 
 /// Recursive body of [`overlay`]; see [`remove_pred_inner`] for why the odb is hoisted.
 fn overlay_inner(
     transaction: &cache::Transaction,
-    odb: &git2::Odb,
+    odb: &josh_memodb::Odb,
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -240,43 +240,40 @@ impl GitCommand {
     }
 }
 
-/// Read a commit's parent OIDs directly from the raw ODB bytes, parsing only the parent lines via
-/// `gix_object::CommitRefIter`. This avoids libgit2's commit parse cache (a lock-guarded global
-/// that also decodes author/committer/message) whenever a caller only needs the parent ids.
-pub fn read_parent_ids(repo: &git2::Repository, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
-    let odb = repo.odb()?;
-    let odb_commit = odb.read(oid)?;
+/// Read a commit's parent OIDs directly from the raw object bytes, parsing only the parent
+/// lines via `gix_object::CommitRefIter`. This avoids libgit2's commit parse cache (a
+/// lock-guarded global that also decodes author/committer/message) whenever a caller only
+/// needs the parent ids; memory-store hits are zero-copy.
+pub fn read_parent_ids(odb: &josh_memodb::Odb, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
+    let (kind, bytes) = odb.read(oid)?;
     // A hard error, not an assert: this is reachable from inside git2 callback frames,
     // where unwinding across the FFI boundary would abort.
-    if odb_commit.kind() != git2::ObjectType::Commit {
+    if kind != gix_object::Kind::Commit {
         return Err(anyhow::anyhow!(
             "object {} is not a commit but a {:?}",
             oid,
-            odb_commit.kind()
+            kind
         ));
     }
-    gix_object::CommitRefIter::from_bytes(odb_commit.data(), gix_hash::Kind::Sha1)
+    gix_object::CommitRefIter::from_bytes(&bytes, gix_hash::Kind::Sha1)
         .parent_ids()
         .map(|p| Ok(git2::Oid::from_bytes(p.as_bytes())?))
         .collect()
 }
 
-/// Sibling of [`read_parent_ids`]: read a commit's tree OID from the raw ODB bytes via
-/// `gix_object::CommitRefIter`, replacing `find_commit(oid)?.tree_id()` without touching
-/// libgit2's commit parse cache.
-pub fn read_tree_id(repo: &git2::Repository, oid: git2::Oid) -> anyhow::Result<git2::Oid> {
-    let odb = repo.odb()?;
-    let odb_commit = odb.read(oid)?;
+/// Sibling of [`read_parent_ids`]: read a commit's tree OID without touching libgit2's
+/// commit parse cache.
+pub fn read_tree_id(odb: &josh_memodb::Odb, oid: git2::Oid) -> anyhow::Result<git2::Oid> {
+    let (kind, bytes) = odb.read(oid)?;
     // Same hard-error rationale as read_parent_ids.
-    if odb_commit.kind() != git2::ObjectType::Commit {
+    if kind != gix_object::Kind::Commit {
         return Err(anyhow::anyhow!(
             "object {} is not a commit but a {:?}",
             oid,
-            odb_commit.kind()
+            kind
         ));
     }
-    let tree_id =
-        gix_object::CommitRefIter::from_bytes(odb_commit.data(), gix_hash::Kind::Sha1).tree_id()?;
+    let tree_id = gix_object::CommitRefIter::from_bytes(&bytes, gix_hash::Kind::Sha1).tree_id()?;
     Ok(git2::Oid::from_bytes(tree_id.as_bytes())?)
 }
 
@@ -291,8 +288,10 @@ mod tests {
         let tree = repo.find_tree(tree_id).unwrap();
         let commit_id = repo.commit(None, &sig, &sig, "test", &tree, &[]).unwrap();
 
+        let store = josh_memodb::MemOdb::new(None, josh_memodb::objects_dir(&repo));
+        let odb = josh_memodb::Odb::new(store, repo.odb().unwrap());
         assert_eq!(
-            super::read_tree_id(&repo, commit_id).unwrap(),
+            super::read_tree_id(&odb, commit_id).unwrap(),
             repo.find_commit(commit_id).unwrap().tree_id()
         );
     }

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -23,7 +23,7 @@ pub fn walk2(
         return Ok(());
     }
 
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
 
     // `walk.push` rejects a missing or non-commit input as a hard error.
     let mut walk = objects::RevWalk::new(&odb);
@@ -106,7 +106,7 @@ fn find_unapply_base(
     // least one other commit references them as a parent ("unlocked"); the start
     // commit has no children in this subgraph, so it's unlocked immediately.
     // Processing a commit may unlock pending ones, which are then processed too.
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
     let mut walk = objects::RevWalk::new(&odb);
     walk.push(contained_in)?;
 
@@ -136,7 +136,7 @@ fn find_unapply_base(
                 return Ok(std::ops::ControlFlow::Break(()));
             }
 
-            for parent_id in git::read_parent_ids(transaction.repo(), pending_oid)? {
+            for parent_id in git::read_parent_ids(&odb, pending_oid)? {
                 unlocked.insert(parent_id);
             }
         }
@@ -170,7 +170,7 @@ pub fn find_original(
     if filter.is_nop() {
         return Ok(filtered);
     }
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
     let mut walk = objects::RevWalk::new(&odb);
     if linear {
         walk.simplify_first_parent();
@@ -179,7 +179,7 @@ pub fn find_original(
 
     for original in walk.into_topo_vec(|_| false)? {
         if filtered == filter::apply_to_commit(filter, original, transaction)? {
-            let parent_ids = git::read_parent_ids(transaction.repo(), original)?;
+            let parent_ids = git::read_parent_ids(&odb, original)?;
             if parent_ids.len() == 1 {
                 let fp = filter::apply_to_commit(filter, parent_ids[0], transaction)?;
 
@@ -197,15 +197,13 @@ pub fn find_original(
 // takes everything from base except its tree and replaces it with the tree
 // given
 pub fn rewrite_commit(
-    repo: &git2::Repository,
+    odb: &josh_memodb::Odb,
     base: &objects::CommitData,
     parents: &[git2::Oid],
     rewrite_data: filter::Rewrite,
     gpgsig: GpgsigMode,
 ) -> anyhow::Result<git2::Oid> {
     use gix_object::bstr::BString;
-
-    let odb = repo.odb()?;
 
     // gix_object::CommitRef uses byte strings for Oids, but in hex representation, not raw bytes.
     // Its `Format` implementation writes out hex-encoded bytes. Because of CommitRef's reference
@@ -294,7 +292,7 @@ pub fn rewrite_commit(
     let mut b = vec![];
     gix_object::WriteTo::write_to(&commit, &mut b)?;
 
-    Ok(odb.write(git2::ObjectType::Commit, &b)?)
+    Ok(odb.write(gix_object::Kind::Commit, &b))
 }
 
 // Given an OID of an unfiltered commit and a filter,
@@ -305,7 +303,7 @@ fn find_oldest_similar_commit(
     filter: filter::Filter,
     unfiltered: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
     let mut walk = objects::RevWalk::new(&odb);
     walk.push(unfiltered)?;
     tracing::info!("oldest similar?");
@@ -331,7 +329,7 @@ fn find_new_branch_base(
     contained_in: git2::Oid,
     filtered: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
     let mut walk = objects::RevWalk::new(&odb);
     walk.push(filtered)?;
     tracing::info!("new branch base?");
@@ -423,13 +421,13 @@ pub fn unapply_filter(
 
     tracing::info!("before walk");
 
-    let odb = transaction.repo().odb()?;
+    let odb = transaction.odb()?;
 
     // The old filtered oid can be missing from the repo (e.g. a new branch);
     // there is no range to exclude then, so take everything reachable.
     let old_filtered_exists = matches!(
         odb.read_header(old_filtered_oid),
-        Ok((_, git2::ObjectType::Commit))
+        Ok((gix_object::Kind::Commit, _))
     );
     let revs = if old_filtered_exists {
         // The sequence lookup computes hints on demand and is only consulted
@@ -697,7 +695,7 @@ pub fn unapply_filter(
         let original_parent_oids: Vec<git2::Oid> =
             original_parents.iter().map(|c| c.id()).collect();
         ret = rewrite_commit(
-            transaction.repo(),
+            &odb,
             &objects::CommitData::read(&odb, module_commit.id())?,
             &original_parent_oids,
             apply,
@@ -721,7 +719,7 @@ pub fn unapply_filter(
 }
 
 fn select_parent_commits(
-    repo: &git2::Repository,
+    odb: &josh_memodb::Odb,
     original_commit: &objects::CommitData,
     filtered_tree_id: git2::Oid,
     filtered_parents: &[(git2::Oid, git2::Oid)],
@@ -733,7 +731,7 @@ fn select_parent_commits(
     let original_tree_id = original_commit.tree_id()?;
     let mut all_diffs_empty = true;
     for p in original_commit.parent_ids() {
-        if git::read_tree_id(repo, p)? != original_tree_id {
+        if git::read_tree_id(odb, p)? != original_tree_id {
             all_diffs_empty = false;
             break;
         }
@@ -860,7 +858,9 @@ fn create_filtered_commit2(
             // No first parent is not a trivial merge; a present first parent
             // must have a readable tree.
             let was_trivial_merge = match original_commit.first_parent_id() {
-                Some(parent) => git::read_tree_id(repo, parent)? == original_commit.tree_id()?,
+                Some(parent) => {
+                    git::read_tree_id(&transaction.odb()?, parent)? == original_commit.tree_id()?
+                }
                 None => false,
             };
 
@@ -872,7 +872,7 @@ fn create_filtered_commit2(
     }
 
     let selected_filtered_parent_ids: Vec<git2::Oid> = select_parent_commits(
-        repo,
+        &transaction.odb()?,
         original_commit,
         rewrite_data.tree().id(),
         &filtered_parents,
@@ -899,7 +899,7 @@ fn create_filtered_commit2(
 
     let new_tree_id = rewrite_data.tree().id();
     let new_oid = rewrite_commit(
-        repo,
+        &transaction.odb()?,
         original_commit,
         &selected_filtered_parent_ids,
         rewrite_data,
@@ -924,7 +924,7 @@ pub(crate) fn filtered_parent_tree_id(
             return Ok(tree_id);
         }
     }
-    git::read_tree_id(transaction.repo(), oid)
+    git::read_tree_id(&transaction.odb()?, oid)
 }
 
 fn is_empty_root(repo: &git2::Repository, tree: &git2::Tree) -> bool {

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -96,7 +96,7 @@ fn push_tree_entries(
 }
 
 struct InMemoryBuilder<'a> {
-    staging: josh_gix_ext::StagingOdb<'a>,
+    staging: josh_gix_ext::StagingOdb,
     /// Present when building for persistence (`as_tree`): used to resolve the object kind of
     /// `InsertContent::Oid` so the object can be referenced as a tree entry with the correct
     /// mode. Absent when computing `Filter::id`, which must stay repository-independent.
@@ -621,7 +621,7 @@ impl<'a> InMemoryBuilder<'a> {
     /// it (and every ancestor) is always built to learn its persist-time id.
     fn build_persist(
         &mut self,
-        odb: &git2::Odb,
+        out: &impl gix_object::Exists,
         filter: Filter,
     ) -> anyhow::Result<gix_hash::ObjectId> {
         if let Some(oid) = self.persist_ids.get(&filter) {
@@ -630,13 +630,13 @@ impl<'a> InMemoryBuilder<'a> {
         let op = to_op_ref(filter);
         let mut dirty = matches!(op, Op::Insert(_, InsertContent::Oid(_)));
         for child in child_filters(op) {
-            let child_oid = self.build_persist(odb, child)?;
+            let child_oid = self.build_persist(out, child)?;
             dirty |= child_oid.as_bytes() != child.id().as_bytes();
         }
         let oid = if dirty {
             self.build_op(op)?
         } else {
-            if !odb.exists(filter.id()) {
+            if !out.exists(&josh_gix_ext::gix_oid(filter.id())) {
                 self.build_op(op)?;
             }
             gix_hash::ObjectId::from_bytes_or_panic(filter.id().as_bytes())
@@ -646,15 +646,18 @@ impl<'a> InMemoryBuilder<'a> {
     }
 }
 
-pub fn as_tree(repo: &git2::Repository, filter: Filter) -> anyhow::Result<git2::Oid> {
-    let odb = repo.odb()?;
+pub fn as_tree(
+    repo: &git2::Repository,
+    out: &(impl gix_object::Exists + gix_object::Write),
+    filter: Filter,
+) -> anyhow::Result<git2::Oid> {
     let filter = crate::opt::optimize(filter);
 
     let mut builder = InMemoryBuilder::new(Some(repo));
-    let root_oid = builder.build_persist(&odb, filter)?;
+    let root_oid = builder.build_persist(out, filter)?;
     let root_oid = git2::Oid::from_bytes(root_oid.as_bytes())?;
 
-    builder.staging.flush(&odb)?;
+    builder.staging.flush(out)?;
 
     // Now the tree should really be in the ODB
     Ok(root_oid)

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -67,17 +67,16 @@ pub fn hash_blob(data: &[u8]) -> git2::Oid {
     )
 }
 
-/// Serialize `entries` as a git tree in exactly the order given and write it straight to `odb`.
-/// Used on hot paths while git2 still owns all I/O: the write is immediately visible to every
-/// reader of the repository (and lands in the in-memory memodb store when one is registered),
-/// so ported and unported code can interleave freely.
+/// Serialize `entries` as a git tree in exactly the order given and write it straight to `out`
+/// (in practice the transaction's memodb-backed facade, so the write is immediately visible
+/// to every reader of the repository).
 ///
 /// The order is the caller's responsibility: rebuilds of existing trees preserve the input's
 /// entry order byte-for-byte (canonical or not), and freshly inserted entries are placed at
 /// their canonical position by the caller. Serialization is manual because gix's tree writer
 /// asserts canonical order, which fsck-invalid input trees do not have.
 pub fn write_tree_now(
-    odb: &git2::Odb,
+    out: &impl gix_object::Write,
     entries: Vec<gix_object::tree::Entry>,
 ) -> anyhow::Result<git2::Oid> {
     // Exact-fit upper bound: mode (<= 6 octal digits) + space + name + NUL + 20 oid bytes.
@@ -101,7 +100,10 @@ pub fn write_tree_now(
         buffer.push(0);
         buffer.extend_from_slice(entry.oid.as_bytes());
     }
-    Ok(odb.write(git2::ObjectType::Tree, &buffer)?)
+    let id = out
+        .write_buf(gix_object::Kind::Tree, &buffer)
+        .map_err(|e| anyhow::anyhow!("write_tree_now: {e}"))?;
+    Ok(git2_oid(&id))
 }
 
 /// A commit's id + raw odb bytes, owned. Send + Sync plain data; never stored in a transaction.
@@ -114,22 +116,22 @@ pub struct CommitData {
 }
 
 impl CommitData {
-    /// odb.read + kind check. Errors if the object is missing or not a commit -- matching
-    /// `find_commit`'s contract (both are hard errors there too). Reads go through the odb's
-    /// registered backends (memodb visibility preserved).
-    pub fn read(odb: &git2::Odb<'_>, oid: git2::Oid) -> anyhow::Result<CommitData> {
-        let obj = odb.read(oid)?;
-        if obj.kind() != git2::ObjectType::Commit {
+    /// Errors if the object is missing or not a commit. `src` is the transaction's facade in
+    /// practice, so unflushed in-memory commits resolve.
+    pub fn read(src: &impl gix_object::Find, oid: git2::Oid) -> anyhow::Result<CommitData> {
+        let mut bytes = Vec::new();
+        let data = src
+            .try_find(&gix_oid(oid), &mut bytes)
+            .map_err(|e| anyhow::anyhow!("CommitData::read: {e}"))?
+            .ok_or_else(|| anyhow::anyhow!("object {} not found", oid))?;
+        if data.kind != gix_object::Kind::Commit {
             return Err(anyhow::anyhow!(
                 "object {} is not a commit but a {:?}",
                 oid,
-                obj.kind()
+                data.kind
             ));
         }
-        Ok(CommitData {
-            id: oid,
-            bytes: obj.data().to_vec(),
-        })
+        Ok(CommitData { id: oid, bytes })
     }
 
     pub fn id(&self) -> git2::Oid {
@@ -173,21 +175,16 @@ impl CommitData {
     }
 }
 
-/// An in-memory staging store over an optional read-through object database.
-///
-/// Writes stage objects in a hash map; reads (via the [`gix_object::Find`] family) consult the
-/// staged objects first and fall back to the repository ODB when one is attached. Constructed
-/// without an ODB it is a pure store for computing content hashes repository-independently (the
-/// `Filter::id` use case, which must not touch a repository at all).
-pub struct StagingOdb<'a> {
+/// An in-memory staging store: a pure map for computing content hashes
+/// repository-independently (the `Filter::id` use case, which must not touch a repository at
+/// all) and for batching writes until an explicit [`flush`](StagingOdb::flush) into an object
+/// sink. Reads (via the [`gix_object::Find`] family) see only staged objects.
+pub struct StagingOdb {
     /// Staged objects by content hash: `(kind, raw bytes)`, not yet written to the repository.
     pending: HashMap<gix_hash::ObjectId, (gix_object::Kind, Vec<u8>)>,
-    /// Read-through target, when reads are needed.
-    odb: Option<git2::Odb<'a>>,
 }
 
-impl<'a> StagingOdb<'a> {
-    /// A pure in-memory store without read-through: reads only see staged objects.
+impl StagingOdb {
     pub fn new() -> Self {
         // Pre-seed the empty blob because `write_blob` short-cuts hashing for empty content;
         // seeding keeps the shortcut consistent with flushing (the object is written if missing).
@@ -196,15 +193,7 @@ impl<'a> StagingOdb<'a> {
             gix_hash::ObjectId::empty_blob(gix_hash::Kind::Sha1),
             (gix_object::Kind::Blob, Vec::new()),
         );
-        Self { pending, odb: None }
-    }
-
-    /// A staging store reading through to `odb` for objects that are not staged.
-    pub fn with_odb(odb: git2::Odb<'a>) -> Self {
-        Self {
-            odb: Some(odb),
-            ..Self::new()
-        }
+        Self { pending }
     }
 
     /// Stage a raw object that is already serialized. Returns its content hash.
@@ -242,44 +231,79 @@ impl<'a> StagingOdb<'a> {
         self.write_raw(gix_object::Kind::Commit, buffer)
     }
 
-    /// Write every staged object to `odb`, emptying the staging map. Objects the ODB already
-    /// has are skipped (see module docs).
-    pub fn flush(&mut self, odb: &git2::Odb) -> anyhow::Result<()> {
+    /// Write every staged object to `out`, emptying the staging map. Objects the sink already
+    /// has are skipped (see module docs); ids were computed at stage time and are passed on
+    /// so the sink need not re-hash.
+    pub fn flush(
+        &mut self,
+        out: &(impl gix_object::Exists + gix_object::Write),
+    ) -> anyhow::Result<()> {
         for (oid, (kind, data)) in self.pending.drain() {
-            let oid = git2_oid(&oid);
-            if !odb.exists(oid) {
-                odb.write(git2_kind(kind), &data)?;
+            if !out.exists(&oid) {
+                out.write_buf_with_known_id(kind, &data, oid)
+                    .map_err(|e| anyhow::anyhow!("staging flush: {e}"))?;
             }
         }
         Ok(())
     }
 }
 
-impl Default for StagingOdb<'_> {
+impl Default for StagingOdb {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl gix_object::Find for StagingOdb<'_> {
+impl gix_object::Find for StagingOdb {
     fn try_find<'b>(
         &self,
         id: &gix_hash::oid,
         buffer: &'b mut Vec<u8>,
     ) -> Result<Option<gix_object::Data<'b>>, gix_object::find::Error> {
-        if let Some((kind, data)) = self.pending.get(id) {
-            buffer.clear();
-            buffer.extend_from_slice(data);
-            return Ok(Some(gix_object::Data {
-                kind: *kind,
-                object_hash: id.kind(),
-                data: buffer,
-            }));
-        }
-        let Some(odb) = &self.odb else {
+        let Some((kind, data)) = self.pending.get(id) else {
             return Ok(None);
         };
-        let obj = match odb.read(git2_oid(id)) {
+        buffer.clear();
+        buffer.extend_from_slice(data);
+        Ok(Some(gix_object::Data {
+            kind: *kind,
+            object_hash: id.kind(),
+            data: buffer,
+        }))
+    }
+}
+
+impl gix_object::FindHeader for StagingOdb {
+    fn try_header(
+        &self,
+        id: &gix_hash::oid,
+    ) -> Result<Option<gix_object::Header>, gix_object::find::Error> {
+        Ok(self.pending.get(id).map(|(kind, data)| gix_object::Header {
+            kind: *kind,
+            size: data.len() as u64,
+        }))
+    }
+}
+
+impl gix_object::Exists for StagingOdb {
+    fn exists(&self, id: &gix_hash::oid) -> bool {
+        self.pending.contains_key(id)
+    }
+}
+
+/// [`gix_object`] object access over a bare `git2::Odb`: reads/exists resolve through the
+/// odb's backends (including a registered memodb and alternates), writes go through
+/// `git_odb_write`. The bridge for code that has a git2 odb handle but no memodb store —
+/// walker unit tests, and `persist::as_tree` on repositories below the cache stack.
+pub struct Git2Odb<'a>(pub &'a git2::Odb<'a>);
+
+impl gix_object::Find for Git2Odb<'_> {
+    fn try_find<'b>(
+        &self,
+        id: &gix_hash::oid,
+        buffer: &'b mut Vec<u8>,
+    ) -> Result<Option<gix_object::Data<'b>>, gix_object::find::Error> {
+        let obj = match self.0.read(git2_oid(id)) {
             Ok(obj) => obj,
             Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
             Err(e) => return Err(Box::new(e)),
@@ -297,21 +321,12 @@ impl gix_object::Find for StagingOdb<'_> {
     }
 }
 
-impl gix_object::FindHeader for StagingOdb<'_> {
+impl gix_object::FindHeader for Git2Odb<'_> {
     fn try_header(
         &self,
         id: &gix_hash::oid,
     ) -> Result<Option<gix_object::Header>, gix_object::find::Error> {
-        if let Some((kind, data)) = self.pending.get(id) {
-            return Ok(Some(gix_object::Header {
-                kind: *kind,
-                size: data.len() as u64,
-            }));
-        }
-        let Some(odb) = &self.odb else {
-            return Ok(None);
-        };
-        let (size, kind) = match odb.read_header(git2_oid(id)) {
+        let (size, kind) = match self.0.read_header(git2_oid(id)) {
             Ok(h) => h,
             Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
             Err(e) => return Err(Box::new(e)),
@@ -326,13 +341,51 @@ impl gix_object::FindHeader for StagingOdb<'_> {
     }
 }
 
-impl gix_object::Exists for StagingOdb<'_> {
+impl gix_object::Exists for Git2Odb<'_> {
     fn exists(&self, id: &gix_hash::oid) -> bool {
-        self.pending.contains_key(id)
-            || self
-                .odb
-                .as_ref()
-                .is_some_and(|odb| odb.exists(git2_oid(id)))
+        self.0.exists(git2_oid(id))
+    }
+}
+
+impl gix_object::Write for Git2Odb<'_> {
+    fn write_buf(
+        &self,
+        object: gix_object::Kind,
+        from: &[u8],
+    ) -> Result<gix_hash::ObjectId, gix_object::write::Error> {
+        let oid = self.0.write(git2_kind(object), from)?;
+        Ok(gix_oid(oid))
+    }
+
+    fn write_buf_with_known_id(
+        &self,
+        object: gix_object::Kind,
+        from: &[u8],
+        _id: gix_hash::ObjectId,
+    ) -> Result<gix_hash::ObjectId, gix_object::write::Error> {
+        // libgit2 re-hashes on write regardless; the result is the same id.
+        self.write_buf(object, from)
+    }
+
+    fn write_stream(
+        &self,
+        kind: gix_object::Kind,
+        size: u64,
+        from: &mut dyn std::io::Read,
+    ) -> Result<gix_hash::ObjectId, gix_object::write::Error> {
+        let mut data = Vec::with_capacity(size as usize);
+        from.read_to_end(&mut data)?;
+        self.write_buf(kind, &data)
+    }
+
+    fn write_stream_with_known_id(
+        &self,
+        kind: gix_object::Kind,
+        size: u64,
+        from: &mut dyn std::io::Read,
+        _id: gix_hash::ObjectId,
+    ) -> Result<gix_hash::ObjectId, gix_object::write::Error> {
+        self.write_stream(kind, size, from)
     }
 }
 

--- a/josh-gix-ext/src/revwalk.rs
+++ b/josh-gix-ext/src/revwalk.rs
@@ -30,17 +30,24 @@ use crate::git2_oid;
 
 type Visit<'v> = &'v mut dyn FnMut(git2::Oid) -> anyhow::Result<ControlFlow<()>>;
 
-/// Read a commit's parent ids: one raw odb read, one `CommitRefIter` pass
+/// Read a commit's parent ids: one raw object read, one `CommitRefIter` pass
 /// stopped at the first non-tree/parent header. A missing or non-commit
 /// object is a hard error; headers past the parents (author, committer,
 /// message) are never read or validated.
-fn read_parent_oids(odb: &git2::Odb, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
-    let obj = odb.read(oid)?;
-    if obj.kind() != git2::ObjectType::Commit {
+fn read_parent_oids(
+    src: &impl gix_object::Find,
+    oid: git2::Oid,
+    buf: &mut Vec<u8>,
+) -> anyhow::Result<Vec<git2::Oid>> {
+    let data = src
+        .try_find(&crate::gix_oid(oid), buf)
+        .map_err(|e| anyhow::anyhow!("read_parent_oids: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("object {} not found", oid))?;
+    if data.kind != gix_object::Kind::Commit {
         anyhow::bail!("object {} is not a commit", oid);
     }
     let mut parents = Vec::new();
-    for token in gix_object::CommitRefIter::from_bytes(obj.data(), gix_hash::Kind::Sha1) {
+    for token in gix_object::CommitRefIter::from_bytes(data.data, gix_hash::Kind::Sha1) {
         use gix_object::commit::ref_iter::Token;
         match token? {
             Token::Tree { .. } => {}
@@ -52,9 +59,12 @@ fn read_parent_oids(odb: &git2::Odb, oid: git2::Oid) -> anyhow::Result<Vec<git2:
 }
 
 /// Verify `oid` names a commit without decompressing it.
-fn ensure_commit(odb: &git2::Odb, oid: git2::Oid) -> anyhow::Result<()> {
-    let (_, kind) = odb.read_header(oid)?;
-    if kind != git2::ObjectType::Commit {
+fn ensure_commit(src: &impl gix_object::FindHeader, oid: git2::Oid) -> anyhow::Result<()> {
+    let header = src
+        .try_header(&crate::gix_oid(oid))
+        .map_err(|e| anyhow::anyhow!("ensure_commit: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("object {} not found", oid))?;
+    if header.kind != gix_object::Kind::Commit {
         anyhow::bail!("object {} is not a commit", oid);
     }
     Ok(())
@@ -94,23 +104,26 @@ struct Node {
 /// [`simplify_first_parent`]: RevWalk::simplify_first_parent
 /// [`into_topo_vec`]: RevWalk::into_topo_vec
 /// [`discover`]: RevWalk::discover
-pub struct RevWalk<'a> {
-    odb: &'a git2::Odb<'a>,
+pub struct RevWalk<'a, S> {
+    odb: &'a S,
     nodes: Vec<Node>,
     by_oid: HashMap<git2::Oid, usize>,
     /// Pushed tips in push order; the DFS explores them in this order.
     tips: Vec<usize>,
     first_parent: bool,
+    /// Reused per-commit read buffer, so a walk does one allocation, not one per commit.
+    scratch: Vec<u8>,
 }
 
-impl<'a> RevWalk<'a> {
-    pub fn new(odb: &'a git2::Odb<'a>) -> Self {
+impl<'a, S: gix_object::Find + gix_object::FindHeader> RevWalk<'a, S> {
+    pub fn new(odb: &'a S) -> Self {
         RevWalk {
             odb,
             nodes: Vec::new(),
             by_oid: HashMap::new(),
             tips: Vec::new(),
             first_parent: false,
+            scratch: Vec::new(),
         }
     }
 
@@ -171,7 +184,7 @@ impl<'a> RevWalk<'a> {
         if self.nodes[commit].parsed {
             return Ok(());
         }
-        let parents = read_parent_oids(self.odb, self.nodes[commit].oid)?
+        let parents = read_parent_oids(self.odb, self.nodes[commit].oid, &mut self.scratch)?
             .into_iter()
             .map(|p| self.intern(p))
             .collect();
@@ -277,16 +290,18 @@ struct RangeNode {
 ///
 /// The two strategies yield different topological orders, which is fine
 /// because the callers consume the whole yield set parents-first.
-pub struct RangeWalk<'a> {
-    odb: &'a git2::Odb<'a>,
+pub struct RangeWalk<'a, S> {
+    odb: &'a S,
     sequence_numbers: Box<dyn Fn(git2::Oid) -> anyhow::Result<u64> + 'a>,
     nodes: Vec<RangeNode>,
     by_oid: HashMap<git2::Oid, usize>,
+    /// Reused per-commit read buffer, so a walk does one allocation, not one per commit.
+    scratch: Vec<u8>,
 }
 
-impl<'a> RangeWalk<'a> {
+impl<'a, S: gix_object::Find + gix_object::FindHeader> RangeWalk<'a, S> {
     pub fn new(
-        odb: &'a git2::Odb<'a>,
+        odb: &'a S,
         sequence_numbers: impl Fn(git2::Oid) -> anyhow::Result<u64> + 'a,
     ) -> Self {
         RangeWalk {
@@ -294,6 +309,7 @@ impl<'a> RangeWalk<'a> {
             sequence_numbers: Box::new(sequence_numbers),
             nodes: Vec::new(),
             by_oid: HashMap::new(),
+            scratch: Vec::new(),
         }
     }
 
@@ -343,7 +359,7 @@ impl<'a> RangeWalk<'a> {
         if self.nodes[commit].parsed {
             return Ok(());
         }
-        let parents = read_parent_oids(self.odb, self.nodes[commit].oid)?
+        let parents = read_parent_oids(self.odb, self.nodes[commit].oid, &mut self.scratch)?
             .into_iter()
             .map(|p| self.intern(p))
             .collect();
@@ -565,6 +581,7 @@ mod tests {
         first_parent: bool,
     ) -> anyhow::Result<Vec<git2::Oid>> {
         let odb = repo.odb().unwrap();
+        let odb = crate::Git2Odb(&odb);
         let mut walk = RevWalk::new(&odb);
         if first_parent {
             walk.simplify_first_parent();
@@ -582,6 +599,7 @@ mod tests {
     ) -> anyhow::Result<Vec<git2::Oid>> {
         let memo = std::cell::RefCell::new(HashMap::new());
         let odb = repo.odb().unwrap();
+        let odb = crate::Git2Odb(&odb);
         let walk = RangeWalk::new(&odb, |oid| exact_seq(repo, &memo, oid));
         walk.into_topo_vec(tip, base)
     }
@@ -800,6 +818,7 @@ mod tests {
         let memo = std::cell::RefCell::new(HashMap::new());
         let calls = std::cell::Cell::new(0usize);
         let odb = t.repo.odb().unwrap();
+        let odb = crate::Git2Odb(&odb);
         let walk = RangeWalk::new(&odb, |oid| {
             calls.set(calls.get() + 1);
             exact_seq(&t.repo, &memo, oid)
@@ -832,6 +851,7 @@ mod tests {
         for blind in [tip, base, b] {
             let memo = std::cell::RefCell::new(HashMap::new());
             let odb = t.repo.odb().unwrap();
+            let odb = crate::Git2Odb(&odb);
             let walk = RangeWalk::new(&odb, |oid| {
                 if oid == blind {
                     anyhow::bail!("no sequence number for {}", oid);
@@ -871,6 +891,7 @@ mod tests {
         let dup = t.raw_commit("dup", &[b, b, a]);
         let mut calls = Vec::new();
         let odb = t.repo.odb().unwrap();
+        let odb = crate::Git2Odb(&odb);
         let mut w = RevWalk::new(&odb);
         w.push(dup).unwrap();
         w.into_topo_vec(|oid| {
@@ -931,6 +952,7 @@ mod tests {
         let tag = t.repo.tag("v1", &obj, &sig, "annotated", false).unwrap();
 
         let odb = t.repo.odb().unwrap();
+        let odb = crate::Git2Odb(&odb);
         // Missing oids and non-commits (including annotated tags, which are
         // NOT peeled) error immediately.
         for bad in [missing, blob, tree, tag] {
@@ -950,6 +972,7 @@ mod tests {
 
         // A pushed commit with a missing parent errors during the walk.
         let odb = t.repo.odb().unwrap();
+        let odb = crate::Git2Odb(&odb);
         let mut w = RevWalk::new(&odb);
         w.push(dangling).unwrap();
         assert!(w.into_topo_vec(|_| false).is_err());
@@ -983,6 +1006,7 @@ mod tests {
                 format!("tree {}\n", tree_id).as_bytes(),
             )
             .unwrap();
+        let odb = crate::Git2Odb(&odb);
         let tip = t.raw_commit("tip", &[trunc]);
         let mut w = RevWalk::new(&odb);
         w.push(tip).unwrap();
@@ -997,6 +1021,7 @@ mod tests {
         let c = t.commit("c", &[a]);
         let m = t.commit("m", &[b, c]);
         let odb = t.repo.odb().unwrap();
+        let odb = crate::Git2Odb(&odb);
 
         // Pre-order: each commit before its parents, first parent's subgraph
         // before the second's.

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -195,7 +195,7 @@ impl Revision {
         let transaction = context.transaction.lock().unwrap();
         let filter_commit_id = filter::apply_to_commit(self.filter, self.commit_id, &transaction)?;
 
-        let parents = josh_core::git::read_parent_ids(transaction.repo(), filter_commit_id)?
+        let parents = josh_core::git::read_parent_ids(&transaction.odb()?, filter_commit_id)?
             .into_iter()
             .map(|id| Revision {
                 filter: self.filter,
@@ -248,7 +248,7 @@ impl Revision {
 
                 if orig != git2::Oid::ZERO_SHA1 {
                     ids[i] = orig;
-                    contained_in = josh_core::git::read_parent_ids(transaction.repo(), ids[i])?
+                    contained_in = josh_core::git::read_parent_ids(&transaction.odb()?, ids[i])?
                         .into_iter()
                         .next()
                         .unwrap_or(ids[i]);

--- a/josh-memodb/src/lib.rs
+++ b/josh-memodb/src/lib.rs
@@ -9,10 +9,12 @@
 mod flusher;
 pub mod hash;
 pub mod mem_odb;
+pub mod odb;
 mod odb_backend;
 pub mod pack;
 
 pub use hash::PassthroughHasher;
 pub use mem_odb::MemOdb;
+pub use odb::{Bytes, Odb};
 pub use odb_backend::{OdbBackend, register};
 pub use pack::objects_dir;

--- a/josh-memodb/src/mem_odb.rs
+++ b/josh-memodb/src/mem_odb.rs
@@ -16,18 +16,19 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use git2::{ErrorClass, ErrorCode, ObjectType, Oid};
-use libgit2_sys as raw;
+use gix_hash::ObjectId;
+use gix_object::Kind;
 
 use crate::odb_backend::{self, OdbBackend};
 
 /// Object bytes are held behind an `Arc` so a flush can snapshot them without copying: the store
 /// must keep serving reads while the flusher packs (eviction only happens once the pack is
 /// durable), so the snapshot shares the buffers instead of draining or cloning them.
-type ObjectMap = BTreeMap<Oid, (raw::git_object_t, Arc<[u8]>)>;
+type ObjectMap = BTreeMap<ObjectId, (Kind, Arc<[u8]>)>;
 
 /// A `Send` snapshot of buffered objects in sorted-oid order (the `ObjectMap` iteration order),
 /// which keeps the resulting packfile — and hence its checksum-derived name — deterministic.
-pub(crate) type Snapshot = Vec<(Oid, raw::git_object_t, Arc<[u8]>)>;
+pub(crate) type Snapshot = Vec<(ObjectId, Kind, Arc<[u8]>)>;
 
 /// The buffered objects plus a running total of their data size, guarded by one lock so that an
 /// insert and the overflow check following it are observed atomically.
@@ -51,6 +52,15 @@ pub struct MemOdb {
     /// path does not pile up redundant chunk requests every time the store crosses its limit.
     /// Cleared by the flusher once the chunk has packed and evicted.
     chunk_in_flight: AtomicBool,
+    /// A mirror of the runtime alternates registered on the owning repository
+    /// (see [`MemOdb::add_alternate`]): an odb over ONLY the alternate object directories, no
+    /// repository attached. The direct write path probes it so alternate-resident objects
+    /// (the proxy overlay's mirror) are never buffered — flushed packs must not contain
+    /// duplicates of mirror objects, and the pack-time disk filter cannot see runtime
+    /// alternates. Deliberately excludes the repository's own odb: locally-durable objects
+    /// are dropped at pack time instead, and with no alternates registered the probe is a
+    /// `None` check, no filesystem I/O.
+    alternates: Mutex<Option<git2::Odb<'static>>>,
 }
 
 impl MemOdb {
@@ -68,7 +78,30 @@ impl MemOdb {
             limit,
             objects_dir,
             chunk_in_flight: AtomicBool::new(false),
+            alternates: Mutex::new(None),
         })
+    }
+
+    /// Record `path` (an objects directory) as a runtime alternate of the owning repository.
+    /// Callers add the alternate to the repository odb themselves (`Odb::add_disk_alternate`);
+    /// this mirror only feeds the direct write path's dedup probe (see [`Self::alternates`]).
+    pub fn add_alternate(&self, path: &str) -> Result<(), git2::Error> {
+        let mut alternates = self.alternates.lock().unwrap();
+        let odb = match alternates.as_mut() {
+            Some(odb) => odb,
+            None => alternates.insert(git2::Odb::new()?),
+        };
+        odb.add_disk_alternate(path)
+    }
+
+    /// Whether `oid` exists in one of the registered alternates. `false` without filesystem
+    /// I/O when no alternates are registered.
+    pub(crate) fn exists_in_alternates(&self, oid: Oid) -> bool {
+        self.alternates
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|odb| odb.exists(oid))
     }
 
     /// Replace `repo`'s object database with a backend that reads from / writes to this store,
@@ -83,15 +116,58 @@ impl MemOdb {
         );
     }
 
-    /// Buffer `oid` (a no-op for a content-addressed duplicate) and return whether the store has now
-    /// exceeded its size limit, so the caller can flush.
-    fn insert(&self, oid: Oid, kind: raw::git_object_t, data: Arc<[u8]>) -> bool {
+    /// Buffer `oid` and return whether the store has now exceeded its size limit, so the caller
+    /// can flush. A content-addressed duplicate is a no-op and never reports overflow: it adds
+    /// no bytes, so it must not trigger a pack.
+    fn insert(&self, oid: ObjectId, kind: Kind, data: Arc<[u8]>) -> bool {
         let len = data.len();
         let mut inner = self.inner.lock().unwrap();
-        if inner.map.insert(oid, (kind, data)).is_none() {
-            inner.size += len;
+        if inner.map.insert(oid, (kind, data)).is_some() {
+            return false;
         }
+        inner.size += len;
         self.limit.is_some_and(|limit| inner.size > limit)
+    }
+
+    /// Hash `data` and buffer it, enqueueing a background pack if the store overflows its
+    /// limit. Callers that dedup against on-disk objects gate before calling (see
+    /// [`crate::odb::Odb`]); the store itself only dedups against its own buffered contents.
+    pub fn write(self: &Arc<Self>, kind: Kind, data: &[u8]) -> ObjectId {
+        let id = gix_object::compute_hash(gix_hash::Kind::Sha1, kind, data)
+            .expect("failed to compute hash");
+        self.write_with_id(id, kind, data);
+        id
+    }
+
+    /// [`MemOdb::write`] with a caller-computed content hash, trusted verbatim.
+    pub fn write_with_id(self: &Arc<Self>, id: ObjectId, kind: Kind, data: &[u8]) {
+        if self.insert(id, kind, data.into()) {
+            self.enqueue_chunk();
+        }
+    }
+
+    /// The buffered object `id`, as a zero-copy clone of the store's shared buffer.
+    pub fn get(&self, id: &gix_hash::oid) -> Option<(Kind, Arc<[u8]>)> {
+        self.inner
+            .lock()
+            .unwrap()
+            .map
+            .get(id)
+            .map(|(kind, data)| (*kind, data.clone()))
+    }
+
+    /// Kind and size of the buffered object `id`, without touching its bytes.
+    pub fn header(&self, id: &gix_hash::oid) -> Option<(Kind, u64)> {
+        self.inner
+            .lock()
+            .unwrap()
+            .map
+            .get(id)
+            .map(|(kind, data)| (*kind, data.len() as u64))
+    }
+
+    pub fn contains(&self, id: &gix_hash::oid) -> bool {
+        self.inner.lock().unwrap().map.contains_key(id)
     }
 
     /// Drain every in-memory object into a packfile on disk and evict it from the store, blocking
@@ -186,28 +262,31 @@ fn not_found() -> git2::Error {
 impl OdbBackend for MemBackend {
     fn read_header(&self, oid: Oid) -> Result<(usize, ObjectType), git2::Error> {
         self.store
-            .inner
-            .lock()
-            .unwrap()
-            .map
-            .get(&oid)
-            .map(|(kind, data)| (data.len(), raw_to_kind(*kind)))
+            .header(&josh_gix_ext::gix_oid(oid))
+            .map(|(kind, size)| (size as usize, josh_gix_ext::git2_kind(kind)))
             .ok_or_else(not_found)
     }
 
     fn read(&self, oid: Oid) -> Result<(Vec<u8>, ObjectType), git2::Error> {
         self.store
-            .inner
-            .lock()
-            .unwrap()
-            .map
-            .get(&oid)
-            .map(|(kind, data)| (data.to_vec(), raw_to_kind(*kind)))
+            .get(&josh_gix_ext::gix_oid(oid))
+            .map(|(kind, data)| (data.to_vec(), josh_gix_ext::git2_kind(kind)))
             .ok_or_else(not_found)
     }
 
     fn write(&mut self, oid: Oid, data: Vec<u8>, kind: ObjectType) -> Result<(), git2::Error> {
-        let overflow = self.store.insert(oid, kind.raw(), data.into());
+        // No dedup gate here: `git_odb__freshen` runs before this trampoline and is the
+        // dedup for the git2 write path.
+        let Some(kind) = josh_gix_ext::gix_kind(kind) else {
+            return Err(git2::Error::new(
+                git2::ErrorCode::Invalid,
+                ErrorClass::Odb,
+                "not a writable object kind",
+            ));
+        };
+        let overflow = self
+            .store
+            .insert(josh_gix_ext::gix_oid(oid), kind, data.into());
         if overflow {
             self.store.enqueue_chunk();
         }
@@ -215,7 +294,7 @@ impl OdbBackend for MemBackend {
     }
 
     fn exists(&self, oid: Oid) -> bool {
-        self.store.inner.lock().unwrap().map.contains_key(&oid)
+        self.store.contains(&josh_gix_ext::gix_oid(oid))
     }
 
     fn exists_prefix(&self, _oid: Oid, _oid_len: usize) -> Option<Oid> {
@@ -223,10 +302,6 @@ impl OdbBackend for MemBackend {
         // (the hot path) are unaffected, and prefix lookups fall through to the on-disk backends.
         None
     }
-}
-
-fn raw_to_kind(kind: raw::git_object_t) -> ObjectType {
-    ObjectType::from_raw(kind).expect("stored objects always have a valid git type")
 }
 
 #[cfg(test)]

--- a/josh-memodb/src/odb.rs
+++ b/josh-memodb/src/odb.rs
@@ -1,0 +1,314 @@
+//! The transaction object-database facade: the [`MemOdb`] store consulted directly, backed by
+//! the repository's git2 object database for objects that are not buffered.
+//!
+//! Implements the [`gix_object`] object-access traits (memory-first, disk fallback) plus
+//! inherent helpers in `git2::Oid` currency; memory hits hand out zero-copy `Arc` buffers.
+//! The `disk` side is deliberately `repo.odb()` after [`MemOdb::register`]: it starts with
+//! the registered memory backend and includes any runtime alternates added later (josh-proxy
+//! overlays add the mirror), so the facade and plain git2 calls resolve exactly the same
+//! objects. Write dedup goes through the store's own alternate mirror instead (see
+//! [`Odb::write`]) and never touches `disk`.
+//!
+//! Lock discipline: never call into `disk` while holding the store mutex — the git2 path
+//! locks `disk` first and the store second (inside the backend trampolines), so the facade
+//! always probes the store and the disk sequentially, holding at most one lock at a time.
+
+use std::sync::Arc;
+
+use gix_hash::ObjectId;
+use gix_object::Kind;
+
+use crate::MemOdb;
+
+/// Raw object bytes from a facade read: zero-copy shared buffer for memory hits, a libgit2
+/// odb object for disk hits. Derefs to the raw serialized object bytes either way.
+pub enum Bytes<'a> {
+    Mem(Arc<[u8]>),
+    Disk(git2::OdbObject<'a>),
+}
+
+impl std::ops::Deref for Bytes<'_> {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        match self {
+            Bytes::Mem(data) => data,
+            Bytes::Disk(obj) => obj.data(),
+        }
+    }
+}
+
+/// See the module docs. A cheap per-call value: an `Arc` clone onto the transaction's store
+/// plus the repository's odb handle, obtained via `Transaction::odb()`.
+pub struct Odb<'repo> {
+    mem: Arc<MemOdb>,
+    disk: git2::Odb<'repo>,
+}
+
+impl<'repo> Odb<'repo> {
+    pub fn new(mem: Arc<MemOdb>, disk: git2::Odb<'repo>) -> Self {
+        Odb { mem, disk }
+    }
+
+    /// Read the raw bytes and kind of `oid`; memory hits are zero-copy. A missing object is an
+    /// error, like a plain odb read.
+    pub fn read(&self, oid: git2::Oid) -> Result<(Kind, Bytes<'_>), git2::Error> {
+        if let Some((kind, data)) = self.mem.get(&josh_gix_ext::gix_oid(oid)) {
+            return Ok((kind, Bytes::Mem(data)));
+        }
+        let obj = self.disk.read(oid)?;
+        let kind = josh_gix_ext::gix_kind(obj.kind()).ok_or_else(|| {
+            git2::Error::new(
+                git2::ErrorCode::Invalid,
+                git2::ErrorClass::Odb,
+                "object has no concrete kind",
+            )
+        })?;
+        Ok((kind, Bytes::Disk(obj)))
+    }
+
+    /// Kind and size of `oid` without reading (or decompressing) its bytes.
+    pub fn read_header(&self, oid: git2::Oid) -> Result<(Kind, u64), git2::Error> {
+        if let Some(header) = self.mem.header(&josh_gix_ext::gix_oid(oid)) {
+            return Ok(header);
+        }
+        let (size, kind) = self.disk.read_header(oid)?;
+        let kind = josh_gix_ext::gix_kind(kind).ok_or_else(|| {
+            git2::Error::new(
+                git2::ErrorCode::Invalid,
+                git2::ErrorClass::Odb,
+                "object has no concrete kind",
+            )
+        })?;
+        Ok((kind, size as u64))
+    }
+
+    pub fn contains(&self, oid: git2::Oid) -> bool {
+        self.mem.contains(&josh_gix_ext::gix_oid(oid)) || self.disk.exists(oid)
+    }
+
+    /// Hash and buffer an object in the memory store, returning its content id. The buffer is
+    /// skipped when the object is already in memory or in a runtime alternate: proxy overlays
+    /// must never buffer mirror objects, or flushed packs would gain duplicates and change
+    /// names (the pack-time disk filter cannot see runtime alternates). The same rule governs
+    /// `git_odb__freshen` on the registered backend, so both write paths buffer the same
+    /// objects. The gate never probes the repository's own on-disk odb: objects already
+    /// durable there are buffered anyway and dropped at pack time, and a repository without
+    /// alternates writes with zero filesystem I/O.
+    pub fn write(&self, kind: Kind, data: &[u8]) -> git2::Oid {
+        let id = gix_object::compute_hash(gix_hash::Kind::Sha1, kind, data)
+            .expect("failed to compute hash");
+        self.write_with_id(id, kind, data);
+        josh_gix_ext::git2_oid(&id)
+    }
+
+    /// [`Odb::write`] with a caller-computed content hash, trusted verbatim.
+    fn write_with_id(&self, id: ObjectId, kind: Kind, data: &[u8]) {
+        if self.mem.contains(&id) || self.mem.exists_in_alternates(josh_gix_ext::git2_oid(&id)) {
+            return;
+        }
+        self.mem.write_with_id(id, kind, data);
+    }
+}
+
+impl gix_object::Find for Odb<'_> {
+    fn try_find<'b>(
+        &self,
+        id: &gix_hash::oid,
+        buffer: &'b mut Vec<u8>,
+    ) -> Result<Option<gix_object::Data<'b>>, gix_object::find::Error> {
+        if let Some((kind, data)) = self.mem.get(id) {
+            buffer.clear();
+            buffer.extend_from_slice(&data);
+            return Ok(Some(gix_object::Data {
+                kind,
+                object_hash: id.kind(),
+                data: buffer,
+            }));
+        }
+        let obj = match self.disk.read(josh_gix_ext::git2_oid(id)) {
+            Ok(obj) => obj,
+            Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
+            Err(e) => return Err(Box::new(e)),
+        };
+        let Some(kind) = josh_gix_ext::gix_kind(obj.kind()) else {
+            return Ok(None);
+        };
+        buffer.clear();
+        buffer.extend_from_slice(obj.data());
+        Ok(Some(gix_object::Data {
+            kind,
+            object_hash: id.kind(),
+            data: buffer,
+        }))
+    }
+}
+
+impl gix_object::FindHeader for Odb<'_> {
+    fn try_header(
+        &self,
+        id: &gix_hash::oid,
+    ) -> Result<Option<gix_object::Header>, gix_object::find::Error> {
+        if let Some((kind, size)) = self.mem.header(id) {
+            return Ok(Some(gix_object::Header { kind, size }));
+        }
+        let (size, kind) = match self.disk.read_header(josh_gix_ext::git2_oid(id)) {
+            Ok(h) => h,
+            Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
+            Err(e) => return Err(Box::new(e)),
+        };
+        let Some(kind) = josh_gix_ext::gix_kind(kind) else {
+            return Ok(None);
+        };
+        Ok(Some(gix_object::Header {
+            kind,
+            size: size as u64,
+        }))
+    }
+}
+
+impl gix_object::Exists for Odb<'_> {
+    fn exists(&self, id: &gix_hash::oid) -> bool {
+        self.mem.contains(id) || self.disk.exists(josh_gix_ext::git2_oid(id))
+    }
+}
+
+impl gix_object::Write for Odb<'_> {
+    fn write_buf(&self, object: Kind, from: &[u8]) -> Result<ObjectId, gix_object::write::Error> {
+        Ok(josh_gix_ext::gix_oid(self.write(object, from)))
+    }
+
+    fn write_buf_with_known_id(
+        &self,
+        object: Kind,
+        from: &[u8],
+        id: ObjectId,
+    ) -> Result<ObjectId, gix_object::write::Error> {
+        self.write_with_id(id, object, from);
+        Ok(id)
+    }
+
+    fn write_stream(
+        &self,
+        kind: Kind,
+        size: u64,
+        from: &mut dyn std::io::Read,
+    ) -> Result<ObjectId, gix_object::write::Error> {
+        let mut data = Vec::with_capacity(size as usize);
+        from.read_to_end(&mut data)?;
+        self.write_buf(kind, &data)
+    }
+
+    fn write_stream_with_known_id(
+        &self,
+        kind: Kind,
+        size: u64,
+        from: &mut dyn std::io::Read,
+        id: ObjectId,
+    ) -> Result<ObjectId, gix_object::write::Error> {
+        let mut data = Vec::with_capacity(size as usize);
+        from.read_to_end(&mut data)?;
+        self.write_buf_with_known_id(kind, &data, id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gix_object::{Exists as _, Find as _};
+
+    fn facade<'a>(store: &Arc<MemOdb>, repo: &'a git2::Repository) -> Odb<'a> {
+        Odb::new(store.clone(), repo.odb().unwrap())
+    }
+
+    /// A facade write is served from memory (zero-copy) and through the registered git2
+    /// backend, is invisible to a plain reopened repository until `flush`, and durable after.
+    #[test]
+    fn facade_write_visible_before_flush_durable_after() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
+        store.register(&repo);
+
+        let odb = facade(&store, &repo);
+        let oid = odb.write(Kind::Blob, b"facade blob");
+
+        let (kind, bytes) = odb.read(oid).unwrap();
+        assert_eq!(kind, Kind::Blob);
+        assert!(matches!(bytes, Bytes::Mem(_)));
+        assert_eq!(&*bytes, b"facade blob");
+        assert!(odb.contains(oid));
+        // The git2 side sees the same store through the registered backend view.
+        assert_eq!(repo.find_blob(oid).unwrap().content(), b"facade blob");
+
+        // Not yet on disk.
+        let fresh = git2::Repository::open(dir.path()).unwrap();
+        assert!(fresh.find_blob(oid).is_err());
+
+        store.flush().unwrap();
+        let fresh = git2::Repository::open(dir.path()).unwrap();
+        assert_eq!(fresh.find_blob(oid).unwrap().content(), b"facade blob");
+    }
+
+    /// The write gate: an object already in a registered runtime alternate is not buffered
+    /// (so flushed packs never gain alternate duplicates), while an object merely on the
+    /// repository's own disk is buffered (the pack-time filter drops it again) — the same
+    /// objects the registered backend's freshen check lets through.
+    #[test]
+    fn facade_write_gate_matches_freshen() {
+        let tmp = tempfile::tempdir().unwrap();
+        // "Mirror" repo holding the alternate-resident object.
+        let mirror = git2::Repository::init(tmp.path().join("mirror")).unwrap();
+        let in_alternate = mirror.blob(b"mirror blob").unwrap();
+
+        let dir = tmp.path().join("overlay");
+        let repo = git2::Repository::init(&dir).unwrap();
+        // A loose blob written before the store is registered, so it is main-disk-only.
+        let on_disk = repo.blob(b"already on disk").unwrap();
+        let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
+        store.register(&repo);
+        let alt = crate::pack::objects_dir(&mirror);
+        repo.odb()
+            .unwrap()
+            .add_disk_alternate(alt.to_str().unwrap())
+            .unwrap();
+        store.add_alternate(alt.to_str().unwrap()).unwrap();
+
+        let odb = facade(&store, &repo);
+
+        // Alternate hit: skipped, still readable through the disk chain.
+        let oid = odb.write(Kind::Blob, b"mirror blob");
+        assert_eq!(oid, in_alternate);
+        assert!(!store.contains(&josh_gix_ext::gix_oid(oid)));
+        assert!(matches!(odb.read(oid).unwrap().1, Bytes::Disk(_)));
+
+        // Main-disk object: buffered — the gate does not probe the repository's own odb.
+        let oid = odb.write(Kind::Blob, b"already on disk");
+        assert_eq!(oid, on_disk);
+        assert!(store.contains(&josh_gix_ext::gix_oid(oid)));
+        assert!(matches!(odb.read(oid).unwrap().1, Bytes::Mem(_)));
+    }
+
+    /// git2-side writes (through the registered backend) and facade reads share one store.
+    #[test]
+    fn git2_write_visible_through_facade() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
+        store.register(&repo);
+
+        let oid = repo.blob(b"git2 blob").unwrap();
+        let odb = facade(&store, &repo);
+        assert!(store.contains(&josh_gix_ext::gix_oid(oid)));
+        assert!(matches!(odb.read(oid).unwrap().1, Bytes::Mem(_)));
+
+        // The gix trait surface resolves it too.
+        let mut buf = Vec::new();
+        let data = odb
+            .try_find(&josh_gix_ext::gix_oid(oid), &mut buf)
+            .unwrap()
+            .unwrap();
+        assert_eq!(data.kind, Kind::Blob);
+        assert_eq!(data.data, b"git2 blob");
+        assert!(odb.exists(&josh_gix_ext::gix_oid(oid)));
+    }
+}

--- a/josh-memodb/src/pack.rs
+++ b/josh-memodb/src/pack.rs
@@ -46,16 +46,11 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> Result<
     let mut odb = gix_odb::at(objects_dir.to_owned()).map_err(pack_error)?;
     odb.refresh = gix_odb::store::RefreshMode::Never;
 
-    let to_pack = snapshot
+    let to_pack: Vec<_> = snapshot
         .iter()
-        .filter(|(oid, _, _)| !odb.exists(&josh_gix_ext::gix_oid(*oid)))
-        .map(|(oid, kind, data)| {
-            let kind = git2::ObjectType::from_raw(*kind)
-                .and_then(josh_gix_ext::gix_kind)
-                .ok_or_else(|| pack_error(format!("object {oid} has no packable kind")))?;
-            Ok((josh_gix_ext::gix_oid(*oid), kind, data))
-        })
-        .collect::<Result<Vec<_>, git2::Error>>()?;
+        .filter(|(oid, _, _)| !odb.exists(oid))
+        .map(|(oid, kind, data)| (*oid, *kind, data))
+        .collect();
     if to_pack.is_empty() {
         return Ok(());
     }

--- a/josh-proxy/src/housekeeping.rs
+++ b/josh-proxy/src/housekeeping.rs
@@ -148,8 +148,6 @@ pub fn run(
         .open()?;
 
     transaction_overlay
-        .repo()
-        .odb()?
         .add_disk_alternate(repo_path.join("mirror").join("objects").to_str().unwrap())?;
 
     let mirror_object_count: ParsedCommandResult<CountObjectsOutput> = run_command(

--- a/josh-proxy/src/service.rs
+++ b/josh-proxy/src/service.rs
@@ -637,9 +637,7 @@ async fn filter_to_namespace(
         };
 
         let t2 = service.open_overlay(None)?;
-        t2.repo()
-            .odb()?
-            .add_disk_alternate(repo_path.join("mirror").join("objects").to_str().unwrap())?;
+        t2.add_disk_alternate(repo_path.join("mirror").join("objects").to_str().unwrap())?;
 
         let (filtered_refs, _) = josh_core::filter_refs(&t2, filter, &refs_to_filter);
         let populate_refs = filtered_refs
@@ -1334,7 +1332,7 @@ async fn serve_render_template(
 
         let transaction = serv.open_overlay(None)?;
 
-        transaction.repo().odb()?.add_disk_alternate(
+        transaction.add_disk_alternate(
             serv.repo_path
                 .join("mirror")
                 .join("objects")
@@ -1438,7 +1436,7 @@ async fn handle_graphql(
 
     let transaction = serv.open_overlay(None)?;
 
-    transaction.repo().odb()?.add_disk_alternate(
+    transaction.add_disk_alternate(
         serv.repo_path
             .join("mirror")
             .join("objects")

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -336,7 +336,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
         let transaction = transaction_ctx.open()?;
         let transaction_mirror = transaction_mirror_ctx.open()?;
 
-        transaction.repo().odb()?.add_disk_alternate(
+        transaction.add_disk_alternate(
             transaction_mirror
                 .repo()
                 .path()

--- a/josh-templates/src/templates.rs
+++ b/josh-templates/src/templates.rs
@@ -37,7 +37,7 @@ impl GraphQLHelper {
 
         let path = josh_core::normalize_path(&path);
         let transaction = if let Ok(to) = self.transaction_context(&mirror_path).open() {
-            to.repo().odb()?.add_disk_alternate(
+            to.add_disk_alternate(
                 self.repo_path
                     .join("overlay")
                     .join("objects")
@@ -67,7 +67,7 @@ impl GraphQLHelper {
 
         let (transaction, transaction_mirror) =
             if let Ok(to) = self.transaction_context(&overlay_path).open() {
-                to.repo().odb()?.add_disk_alternate(
+                to.add_disk_alternate(
                     self.repo_path
                         .join("mirror")
                         .join("objects")
@@ -179,7 +179,7 @@ pub fn render(
 
             let (transaction, transaction_mirror) =
                 if let Ok(to) = TransactionContext::new(&overlay_path, cache.clone()).open() {
-                    to.repo().odb()?.add_disk_alternate(
+                    to.add_disk_alternate(
                         transaction
                             .repo()
                             .path()


### PR DESCRIPTION
Make the memory object store authoritative behind a gix-typed facade

MemOdb is now keyed by gix types (same memcmp order as git2 oids, so
pack names are unchanged) and exposes direct reads and writes; the new
josh_memodb::Odb facade implements the gix object traits over it --
memory-first with zero-copy reads, git2 disk fallback -- and
josh-core/josh-filter object I/O goes through it via Transaction::odb().
The libgit2 backend stays registered as a view over the same store, so
reads and writes still going through git2 behave exactly as before.

Facade writes reproduce git_odb_write's freshen dedup: skip on a memory
hit or an alternate hit (the store mirrors runtime alternates, fed by
the new Transaction::add_disk_alternate), never probing the repository's
own disk. RevWalk/RangeWalk and the other josh-gix-ext helpers become
generic over the gix traits; StagingOdb loses its dormant read-through
and becomes a pure staging map; the new Git2Odb adapter bridges bare
git2 odbs.

Change: memodb-authoritative-store
Assisted-By: anthropic/claude-fable-5