### PR TITLE
Port josh-core's typed-object reads onto the memodb facade

### DIFF
--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -330,8 +330,10 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     if args.get_flag("discover") {
         // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
         let r = repo.revparse_single(&input_ref)?;
-        let hs =
-            josh_core::housekeeping::find_all_workspaces_and_subdirectories(&r.peel_to_tree()?)?;
+        let hs = josh_core::housekeeping::find_all_workspaces_and_subdirectories(
+            &josh_core::objects::Git2Odb(&repo.odb()?),
+            r.peel_to_tree()?.id(),
+        )?;
         for i in hs {
             let (mut updated_refs, _) = josh_core::filter_refs(
                 &transaction,

--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -303,11 +303,15 @@ fn handle_link_update(
                 .context("Failed to find filtered commit")?
                 .tree()
                 .context("Failed to get filtered tree")?;
-            josh_core::link::find_link_files(&repo, &filtered_tree)
-                .context("Failed to find link files in filtered tree")?
+            josh_core::link::find_link_files(
+                &josh_core::objects::Git2Odb(&repo.odb()?),
+                filtered_tree.id(),
+            )
+            .context("Failed to find link files in filtered tree")?
         }
     } else {
-        josh_core::link::find_link_files(&repo, &head_tree).context("Failed to find link files")?
+        josh_core::link::find_link_files(&josh_core::objects::Git2Odb(&repo.odb()?), head_tree.id())
+            .context("Failed to find link files")?
     };
 
     if link_files.is_empty() {
@@ -393,8 +397,11 @@ fn handle_link_push(
     }
 
     // Find the .link.josh file at the given path
-    let link_files =
-        josh_core::link::find_link_files(&repo, &head_tree).context("Failed to find link files")?;
+    let link_files = josh_core::link::find_link_files(
+        &josh_core::objects::Git2Odb(&repo.odb()?),
+        head_tree.id(),
+    )
+    .context("Failed to find link files")?;
 
     let link_path = std::path::PathBuf::from(normalized_path);
     let (_, link_file) = link_files

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -27,6 +27,8 @@ pub fn as_tree(transaction: &cache::Transaction, filter: Filter) -> anyhow::Resu
     josh_filter::persist::as_tree(transaction.repo(), &transaction.odb()?, filter)
 }
 
+// PORT: persist::from_tree reads possibly-unflushed filter trees through the registered
+// libgit2 backend; it must move to the facade before the backend can be unregistered.
 pub fn from_tree(transaction: &cache::Transaction, tree_oid: git2::Oid) -> anyhow::Result<Filter> {
     josh_filter::persist::from_tree(transaction.repo(), tree_oid)
 }
@@ -62,29 +64,21 @@ pub enum SigRewrite {
     Raw(BString),
 }
 
-#[derive(Debug)]
-pub struct Rewrite<'a> {
-    tree: git2::Tree<'a>,
+/// A pending commit rewrite in plain oid currency: the tree the rewritten commit will
+/// point at, the base commit it derives from, and the metadata overrides. Tree objects are
+/// never loaded on its behalf -- consumers read the tree through the transaction facade
+/// when (and only when) they need its contents.
+#[derive(Debug, Clone)]
+pub struct Rewrite {
+    tree: git2::Oid,
     commit: git2::Oid,
     pub author: Option<SigRewrite>,
     pub committer: Option<SigRewrite>,
     pub message: Option<BString>,
 }
 
-impl<'a> Clone for Rewrite<'a> {
-    fn clone(&self) -> Self {
-        Rewrite {
-            tree: self.tree.clone(),
-            commit: self.commit,
-            author: self.author.clone(),
-            committer: self.committer.clone(),
-            message: self.message.clone(),
-        }
-    }
-}
-
-impl<'a> Rewrite<'a> {
-    pub fn from_tree(tree: git2::Tree<'a>) -> Self {
+impl Rewrite {
+    pub fn from_tree(tree: git2::Oid) -> Self {
         Rewrite {
             tree,
             author: None,
@@ -95,7 +89,7 @@ impl<'a> Rewrite<'a> {
     }
 
     pub fn from_tree_with_metadata(
-        tree: git2::Tree<'a>,
+        tree: git2::Oid,
         author: Option<SigRewrite>,
         committer: Option<SigRewrite>,
         message: Option<BString>,
@@ -112,12 +106,11 @@ impl<'a> Rewrite<'a> {
     /// The metadata slots stay `None`: rewrite_commit keeps the base commit's raw
     /// signature and message bytes verbatim unless a filter overrides them, so the
     /// commit's author/committer/message are never parsed on the passthrough path.
-    pub fn from_commit_data(
-        repo: &'a git2::Repository,
-        commit: &objects::CommitData,
-    ) -> anyhow::Result<Self> {
+    /// Only the tree id is taken from the header -- nothing validates the tree object
+    /// here; a missing tree surfaces at the first actual tree read.
+    pub fn from_commit_data(commit: &objects::CommitData) -> anyhow::Result<Self> {
         Ok(Rewrite {
-            tree: repo.find_tree(commit.tree_id()?)?,
+            tree: commit.tree_id()?,
             commit: commit.id(),
             author: None,
             committer: None,
@@ -127,49 +120,30 @@ impl<'a> Rewrite<'a> {
 
     pub fn with_author(self, author: (BString, BString)) -> Self {
         Rewrite {
-            tree: self.tree,
             author: Some(SigRewrite::NameEmail(author.0, author.1)),
-            commit: self.commit,
-            committer: self.committer,
-            message: self.message,
+            ..self
         }
     }
 
     pub fn with_committer(self, committer: (BString, BString)) -> Self {
         Rewrite {
-            tree: self.tree,
-            author: self.author,
-            commit: self.commit,
             committer: Some(SigRewrite::NameEmail(committer.0, committer.1)),
-            message: self.message,
+            ..self
         }
     }
 
     pub fn with_message(self, message: BString) -> Self {
         Rewrite {
-            tree: self.tree,
-            author: self.author,
-            commit: self.commit,
-            committer: self.committer,
             message: Some(message),
+            ..self
         }
     }
 
-    pub fn with_tree(self, tree: git2::Tree<'a>) -> Self {
-        Rewrite {
-            tree,
-            author: self.author,
-            commit: self.commit,
-            committer: self.committer,
-            message: self.message,
-        }
+    pub fn with_tree(self, tree: git2::Oid) -> Self {
+        Rewrite { tree, ..self }
     }
 
-    pub fn tree(&self) -> &git2::Tree<'a> {
-        &self.tree
-    }
-
-    pub fn into_tree(self) -> git2::Tree<'a> {
+    pub fn tree_id(&self) -> git2::Oid {
         self.tree
     }
 }
@@ -416,13 +390,19 @@ pub fn apply_to_commit(
 // Handle workspace.josh files that contain ":workspace=..." as their only filter as
 // a "redirect" to that other workspace. We chain an exclude of the redirecting workspace
 // in front to prevent infinite recursion.
-fn resolve_workspace_redirect<'a>(
-    repo: &'a git2::Repository,
-    tree: &'a git2::Tree<'a>,
+fn resolve_workspace_redirect(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    reader: &tree::TreeReader,
     path: &Path,
 ) -> Option<(Filter, std::path::PathBuf)> {
-    let f = parse(&tree::get_blob(repo, tree, &path.join("workspace.josh")))
-        .unwrap_or_else(|_| to_filter(Op::Empty));
+    let f = parse(&tree::get_blob_at(
+        transaction,
+        odb,
+        reader,
+        &path.join("workspace.josh"),
+    ))
+    .unwrap_or_else(|_| to_filter(Op::Empty));
 
     if let Op::Workspace(p) = peel_op(f) {
         let inner = to_filter(Op::Exclude(Filter::new().file(path))).chain(f.peel());
@@ -432,9 +412,11 @@ fn resolve_workspace_redirect<'a>(
     }
 }
 
-fn get_workspace<'a>(
+fn get_workspace(
     transaction: &cache::Transaction,
-    tree: &'a git2::Tree<'a>,
+    odb: &josh_memodb::Odb,
+    tree: git2::Oid,
+    reader: &tree::TreeReader,
     path: &Path,
 ) -> Filter {
     let wsj_file = Filter::new().file("workspace.josh");
@@ -443,35 +425,43 @@ fn get_workspace<'a>(
     compose(&[
         wsj_file,
         compose(&[
-            get_filter(transaction, tree, &path.join("workspace.josh")),
+            get_filter(transaction, odb, tree, reader, &path.join("workspace.josh")),
             base,
         ]),
     ])
 }
 
-fn get_stored<'a>(
+fn get_stored(
     transaction: &cache::Transaction,
-    tree: &'a git2::Tree<'a>,
+    odb: &josh_memodb::Odb,
+    tree: git2::Oid,
+    reader: &tree::TreeReader,
     path: &Path,
 ) -> Filter {
     let stored_path = path.with_added_extension("josh");
     let sj_file = Filter::new().file(stored_path.clone());
-    compose(&[sj_file, get_filter(transaction, tree, &stored_path)])
+    compose(&[
+        sj_file,
+        get_filter(transaction, odb, tree, reader, &stored_path),
+    ])
 }
 
-fn get_starlark<'a>(
+fn get_starlark(
     transaction: &cache::Transaction,
-    tree: &'a git2::Tree<'a>,
+    odb: &josh_memodb::Odb,
+    tree: git2::Oid,
+    reader: &tree::TreeReader,
     path: &Path,
     subfilter: Filter,
 ) -> Filter {
     let star_path = path.with_added_extension("star");
-    let script = tree::get_blob(transaction.repo(), tree, &star_path);
-    let filtered_tree = match apply(transaction, subfilter, Rewrite::from_tree(tree.clone())) {
-        Ok(rw) => rw.into_tree(),
+    let script = tree::get_blob_at(transaction, odb, reader, &star_path);
+    let filtered_tree = match apply(transaction, subfilter, Rewrite::from_tree(tree)) {
+        Ok(rw) => rw.tree_id(),
         Err(_) => return to_filter(Op::Empty),
     };
-    match josh_starlark::evaluate(&script, filtered_tree.id(), transaction.repo()) {
+    // PORT: josh-starlark reads the filtered tree through the repo handle.
+    match josh_starlark::evaluate(&script, filtered_tree, transaction.repo()) {
         Ok(f) => {
             let star_file = Filter::new().file(star_path);
             compose(&[star_file, subfilter, f])
@@ -483,23 +473,30 @@ fn get_starlark<'a>(
     }
 }
 
-fn get_filter<'a>(
+fn get_filter(
     transaction: &cache::Transaction,
-    tree: &'a git2::Tree<'a>,
+    odb: &josh_memodb::Odb,
+    tree: git2::Oid,
+    reader: &tree::TreeReader,
     path: &Path,
 ) -> Filter {
     let ws_path = normalize_path(path);
-    let ws_id = ok_or!(tree.get_path(&ws_path), {
-        return to_filter(Op::Empty);
-    })
-    .id();
-    let ws_blob = tree::get_blob(transaction.repo(), tree, &ws_path);
+    // One descent resolves both the WORKSPACES cache key (the workspace.josh entry oid)
+    // and the blob to parse.
+    let ws_id = match tree::get_path_entry_at(transaction, odb, reader, &ws_path) {
+        Ok(Some(entry)) => objects::git2_oid(&entry.oid),
+        _ => {
+            return to_filter(Op::Empty);
+        }
+    };
+    let ws_blob = tree::blob_text(odb, ws_id);
 
     if let Some(f) = WORKSPACES.lock().unwrap().get(&ws_id) {
         *f
     } else {
         let f = parse(&ws_blob).unwrap_or_else(|_| to_filter(Op::Empty));
-        let f = legalize_stored(transaction, f, tree).unwrap_or_else(|_| to_filter(Op::Empty));
+        let f = legalize_stored(transaction, odb, f, tree, reader)
+            .unwrap_or_else(|_| to_filter(Op::Empty));
 
         let f = if invert(f).is_ok() {
             f
@@ -511,18 +508,21 @@ fn get_filter<'a>(
     }
 }
 
-fn read_josh_link<'a>(
-    repo: &'a git2::Repository,
-    tree: &git2::Tree<'a>,
+fn read_josh_link(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    reader: &tree::TreeReader,
     root: &std::path::Path,
     filename: &str,
 ) -> Option<Filter> {
     use anyhow::Context;
 
     let link_path = root.join(filename);
-    let link_entry = tree.get_path(&link_path).ok()?;
-    let link_blob = repo.find_blob(link_entry.id()).ok()?;
-    let b = std::str::from_utf8(link_blob.content())
+    let link_entry = tree::get_path_entry_at(transaction, odb, reader, &link_path)
+        .ok()
+        .flatten()?;
+    let link_blob = tree::blob_bytes(odb, objects::git2_oid(&link_entry.oid))?;
+    let b = std::str::from_utf8(&link_blob)
         .with_context(|| format!("invalid utf8 in {}", filename))
         .ok()?;
 
@@ -590,7 +590,6 @@ pub fn apply_to_commit2(
     commit_id: git2::Oid,
     transaction: &cache::Transaction,
 ) -> anyhow::Result<Option<git2::Oid>> {
-    let repo = transaction.repo();
     let op = peel_op(filter);
 
     if filter == Filter::new() {
@@ -618,11 +617,12 @@ pub fn apply_to_commit2(
         Op::Squash(None) => {
             let odb = transaction.odb()?;
             let commit = objects::CommitData::read(&odb, commit_id)?;
+            odb.read_header(commit.tree_id()?)?;
             return Some(history::rewrite_commit(
                 &odb,
                 &commit,
                 &[],
-                Rewrite::from_commit_data(repo, &commit)?,
+                Rewrite::from_commit_data(&commit)?,
                 history::GpgsigMode::Remove,
             ))
             .transpose();
@@ -631,7 +631,7 @@ pub fn apply_to_commit2(
             if let Some(oid) = transaction.get(filter, commit_id)? {
                 return Ok(Some(oid));
             }
-            let new_oid = downstack(repo, transaction, commit_id, *base)?;
+            let new_oid = downstack(transaction, commit_id, *base)?;
             transaction.insert(filter, commit_id, new_oid, false)?;
             return Ok(Some(new_oid));
         }
@@ -648,6 +648,11 @@ pub fn apply_to_commit2(
 
     let odb = transaction.odb()?;
     let commit = objects::CommitData::read(&odb, commit_id)?;
+    // Validate the commit's tree before any filter work (a header probe: no decompression,
+    // no parse). Without this gate, an apply over a partially unreadable input can buffer
+    // fresh objects into the store before a later read aborts the walk, and the partial
+    // write would change the next flush's pack.
+    odb.read_header(commit.tree_id()?)?;
 
     let rewrite_data = match &op {
         Op::Squash(Some(ids)) => {
@@ -668,12 +673,11 @@ pub fn apply_to_commit2(
                 let rc = objects::CommitData::read(&odb, oid)?;
                 let rcr = rc.parsed()?;
                 Rewrite::from_tree_with_metadata(
-                    repo.find_tree(rc.tree_id()?)?,
+                    rc.tree_id()?,
                     Some(SigRewrite::Raw(rcr.author.to_owned())),
                     Some(SigRewrite::Raw(rcr.committer.to_owned())),
                     Some(rcr.message.to_owned()),
                 )
-                //commit.tree()?
             } else {
                 if let Some(parent) = commit.first_parent_id() {
                     return Ok(if let Some(fparent) = transaction.get(filter, parent)? {
@@ -715,7 +719,7 @@ pub fn apply_to_commit2(
                 }
             }
 
-            Rewrite::from_commit_data(repo, &commit)?
+            Rewrite::from_commit_data(&commit)?
         }
         Op::Export => {
             check_experimental_features_enabled("export filter")?;
@@ -745,10 +749,17 @@ pub fn apply_to_commit2(
             //         return Err(anyhow!("missing commit"));
             //     }
 
-            let tree = repo.find_tree(commit.tree_id()?)?;
-            if let Some(link_file) =
-                read_josh_link(repo, &tree, &std::path::PathBuf::new(), ".link.josh")
-            {
+            let tree = commit.tree_id()?;
+            // The link probe below folds every failure into "no link", so an unreadable
+            // or unparseable commit tree must error here.
+            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            if let Some(link_file) = read_josh_link(
+                transaction,
+                &odb,
+                &tree_reader,
+                &std::path::PathBuf::new(),
+                ".link.josh",
+            ) {
                 if let Some(commit_str) = link_file.get_meta("commit") {
                     if let Ok(commit_oid) = git2::Oid::from_str(&commit_str) {
                         if filtered_parent_ids.contains(&commit_oid) {
@@ -763,11 +774,7 @@ pub fn apply_to_commit2(
             return Some(history::create_filtered_commit(
                 &commit,
                 filtered_parent_ids,
-                apply(
-                    transaction,
-                    filter,
-                    Rewrite::from_commit_data(repo, &commit)?,
-                )?,
+                apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?,
                 transaction,
                 filter,
             ))
@@ -787,9 +794,8 @@ pub fn apply_to_commit2(
             let mut filtered_parent_ids: Vec<git2::Oid> =
                 some_or!(filtered_parent_ids, { return Ok(None) });
 
-            let tree = repo.find_tree(commit.tree_id()?)?;
             let mut link_parents = vec![];
-            for (link_path, link_file) in find_link_files(&repo, &tree)?.into_iter() {
+            for (link_path, link_file) in find_link_files(&odb, commit.tree_id()?)?.into_iter() {
                 if let Some(commit_str) = link_file.get_meta("commit") {
                     if let Ok(commit_oid) = git2::Oid::from_str(&commit_str) {
                         if let Some(cmt) =
@@ -807,11 +813,7 @@ pub fn apply_to_commit2(
                 }
             }
 
-            let new_tree = apply(
-                transaction,
-                filter,
-                Rewrite::from_commit_data(repo, &commit)?,
-            )?;
+            let new_tree = apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?;
 
             filtered_parent_ids.retain(|c| !link_parents.contains(c));
 
@@ -826,28 +828,30 @@ pub fn apply_to_commit2(
         }
         Op::Link(mode) => {
             check_experimental_features_enabled("link filter")?;
-            let tree = repo.find_tree(commit.tree_id()?)?;
-            let mut roots = get_link_roots(repo, transaction, &tree)?;
+            let tree = commit.tree_id()?;
+            // An unreadable commit tree is a hard error -- the retain probes and link
+            // reads below fold their failures -- and they all share this one parse.
+            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            let mut roots = get_link_roots(transaction, &odb, tree)?;
 
             // A root commit (no first parent) keeps every root; when a first
-            // parent is present its tree must be readable.
-            let parent_tree = match commit.first_parent_id() {
-                Some(parent) => Some(repo.find_tree(git::read_tree_id(&odb, parent)?)?),
-                None => None,
-            };
-            if let Some(parent_tree) = parent_tree {
+            // parent is present its tree must be readable (the retain closure below cannot
+            // error).
+            if let Some(parent) = commit.first_parent_id() {
+                let parent_tree = git::read_tree_id(&odb, parent)?;
+                let parent_reader = tree::read_tree(transaction, &odb, parent_tree)?;
                 roots.retain(|root| {
-                    if let (Ok(a), Ok(b)) = (tree.get_path(&root), parent_tree.get_path(&root))
-                        && a.id() == b.id()
-                    {
-                        false
-                    } else {
-                        true
+                    match (
+                        tree::get_path_entry_at(transaction, &odb, &tree_reader, root),
+                        tree::get_path_entry_at(transaction, &odb, &parent_reader, root),
+                    ) {
+                        (Ok(Some(a)), Ok(Some(b))) if a.oid == b.oid => false,
+                        _ => true,
                     }
                 });
-            };
+            }
 
-            let all_links = links_from_roots(repo, &tree, roots)?;
+            let all_links = links_from_roots(transaction, &odb, &tree_reader, roots)?;
 
             // Only embedded-mode links get extra parent commits spliced in
             let embedded_links: Vec<_> = all_links
@@ -864,11 +868,7 @@ pub fn apply_to_commit2(
                 .collect();
 
             if embedded_links.is_empty() {
-                apply(
-                    transaction,
-                    filter,
-                    Rewrite::from_commit_data(repo, &commit)?,
-                )?
+                apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?
             } else {
                 let normal_parents = commit
                     .parent_ids()
@@ -903,11 +903,8 @@ pub fn apply_to_commit2(
                     extra_parents
                 };
 
-                let filtered_tree = apply(
-                    transaction,
-                    filter,
-                    Rewrite::from_commit_data(repo, &commit)?,
-                )?;
+                let filtered_tree =
+                    apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?;
                 let filtered_parent_ids = normal_parents
                     .into_iter()
                     .chain(extra_parents)
@@ -924,8 +921,13 @@ pub fn apply_to_commit2(
             }
         }
         Op::Workspace(ws_path) => {
-            let tree = repo.find_tree(commit.tree_id()?)?;
-            if let Some((redirect, _)) = resolve_workspace_redirect(repo, &tree, ws_path) {
+            // The get_* helpers return a bare Filter and would fold an unreadable tree to
+            // Op::Empty, so bad input must error here; every probe below shares the read.
+            let tree = commit.tree_id()?;
+            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            if let Some((redirect, _)) =
+                resolve_workspace_redirect(transaction, &odb, &tree_reader, ws_path)
+            {
                 if let Some(r) = apply_to_commit2(redirect, commit_id, transaction)? {
                     transaction.insert(filter, commit.id(), r, true)?;
                     return Ok(Some(r));
@@ -934,13 +936,14 @@ pub fn apply_to_commit2(
                 }
             }
 
-            let commit_filter = get_workspace(transaction, &tree, ws_path);
+            let commit_filter = get_workspace(transaction, &odb, tree, &tree_reader, ws_path);
 
             let parent_filters = commit
                 .parent_ids()
                 .map(|parent| {
                     let tree_id = git::read_tree_id(&odb, parent)?;
-                    let pcw = get_workspace(transaction, &repo.find_tree(tree_id)?, ws_path);
+                    let reader = tree::read_tree(transaction, &odb, tree_id)?;
+                    let pcw = get_workspace(transaction, &odb, tree_id, &reader, ws_path);
                     Ok((parent, pcw))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
@@ -948,14 +951,16 @@ pub fn apply_to_commit2(
             return per_rev_filter(transaction, &commit, filter, commit_filter, parent_filters);
         }
         Op::Stored(s_path) => {
-            let commit_filter =
-                get_stored(transaction, &repo.find_tree(commit.tree_id()?)?, s_path);
+            let tree = commit.tree_id()?;
+            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            let commit_filter = get_stored(transaction, &odb, tree, &tree_reader, s_path);
 
             let parent_filters = commit
                 .parent_ids()
                 .map(|parent| {
                     let tree_id = git::read_tree_id(&odb, parent)?;
-                    let pcs = get_stored(transaction, &repo.find_tree(tree_id)?, s_path);
+                    let reader = tree::read_tree(transaction, &odb, tree_id)?;
+                    let pcs = get_stored(transaction, &odb, tree_id, &reader, s_path);
                     Ok((parent, pcs))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
@@ -964,19 +969,18 @@ pub fn apply_to_commit2(
         }
         Op::Starlark(s_path, s_subfilter) => {
             check_experimental_features_enabled("Starlark filter")?;
-            let commit_filter = get_starlark(
-                transaction,
-                &repo.find_tree(commit.tree_id()?)?,
-                s_path,
-                *s_subfilter,
-            );
+            let tree = commit.tree_id()?;
+            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            let commit_filter =
+                get_starlark(transaction, &odb, tree, &tree_reader, s_path, *s_subfilter);
 
             let parent_filters = commit
                 .parent_ids()
                 .map(|parent| {
                     let tree_id = git::read_tree_id(&odb, parent)?;
+                    let reader = tree::read_tree(transaction, &odb, tree_id)?;
                     let pcs =
-                        get_starlark(transaction, &repo.find_tree(tree_id)?, s_path, *s_subfilter);
+                        get_starlark(transaction, &odb, tree_id, &reader, s_path, *s_subfilter);
                     Ok((parent, pcs))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
@@ -1015,8 +1019,7 @@ pub fn apply_to_commit2(
                 filtered_tree = tree::overlay(transaction, filtered_tree, t)?;
             }
 
-            let filtered_tree = repo.find_tree(filtered_tree)?;
-            Rewrite::from_commit_data(repo, &commit)?.with_tree(filtered_tree)
+            Rewrite::from_commit_data(&commit)?.with_tree(filtered_tree)
         }
         Op::Hook(hook) => {
             let commit_filter = transaction.lookup_filter_hook(hook, commit.id())?;
@@ -1040,10 +1043,15 @@ pub fn apply_to_commit2(
                 // first parent that is present must be readable.
                 if let Some(parent_id) = target.first_parent_id() {
                     let parent = objects::CommitData::read(&odb, parent_id)?;
-                    let ptree = apply(transaction, *uf, Rewrite::from_commit_data(repo, &parent)?)?;
+                    let ptree = apply(transaction, *uf, Rewrite::from_commit_data(&parent)?)?;
+                    // The link probe folds every failure into "no link", so an unreadable
+                    // filtered tree must error here.
+                    let ptree_id = ptree.tree_id();
+                    let ptree_reader = tree::read_tree(transaction, &odb, ptree_id)?;
                     if let Some(link) = read_josh_link(
-                        repo,
-                        &ptree.tree(),
+                        transaction,
+                        &odb,
+                        &ptree_reader,
                         &std::path::PathBuf::new(),
                         ".link.josh",
                     ) {
@@ -1069,14 +1077,18 @@ pub fn apply_to_commit2(
             apply(
                 transaction,
                 filter,
-                Rewrite::from_commit_data(repo, &commit)?, /* Rewrite::from_commit_data(repo, &commit)?.with_parents(filtered_parent_ids), */
+                Rewrite::from_commit_data(&commit)?, /* Rewrite::from_commit_data(&commit)?.with_parents(filtered_parent_ids), */
             )?
         }
         Op::Embed(path) => {
             check_experimental_features_enabled("embed filter")?;
 
-            let tree = repo.find_tree(commit.tree_id()?)?;
-            if let Some(link) = read_josh_link(repo, &tree, &path, ".link.josh") {
+            let tree = commit.tree_id()?;
+            // The link probe below folds every failure into "no link", so an unreadable
+            // or unparseable commit tree must error here.
+            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            if let Some(link) = read_josh_link(transaction, &odb, &tree_reader, path, ".link.josh")
+            {
                 let subdir = filter::invert(link.peel())?;
                 let unapply = to_filter(Op::Unapply(LazyRef::Resolved(commit.id()), subdir));
                 if let Some(commit_str) = link.get_meta("commit") {
@@ -1092,11 +1104,7 @@ pub fn apply_to_commit2(
             return Ok(Some(git2::Oid::ZERO_SHA1));
         }
 
-        _ => apply(
-            transaction,
-            filter,
-            Rewrite::from_commit_data(repo, &commit)?,
-        )?,
+        _ => apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?,
     };
 
     let tree_data = rewrite_data;
@@ -1120,9 +1128,10 @@ pub fn apply_to_commit2(
     .transpose()
 }
 
-fn extract_submodule_commits<'a>(
-    repo: &'a git2::Repository,
-    tree: &git2::Tree<'a>,
+fn extract_submodule_commits(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    tree: git2::Oid,
 ) -> anyhow::Result<
     std::collections::BTreeMap<
         std::path::PathBuf,
@@ -1130,8 +1139,16 @@ fn extract_submodule_commits<'a>(
     >,
 > {
     use crate::submodules::{ParsedSubmoduleEntry, parse_gitmodules};
-    // Get .gitmodules blob from the tree
-    let gitmodules_content = tree::get_blob(repo, tree, std::path::Path::new(".gitmodules"));
+    // One hoisted parse for the .gitmodules probe and every per-submodule probe; an
+    // unreadable tree is a hard error (the probes below fold their failures).
+    let tree_reader = tree::read_tree(transaction, odb, tree)?;
+
+    let gitmodules_content = tree::get_blob_at(
+        transaction,
+        odb,
+        &tree_reader,
+        std::path::Path::new(".gitmodules"),
+    );
 
     if gitmodules_content.is_empty() {
         // No .gitmodules file, return empty map
@@ -1154,13 +1171,11 @@ fn extract_submodule_commits<'a>(
 
     for parsed in submodule_entries {
         let submodule_path = parsed.path.clone();
-        // Get the submodule entry from the tree
-        if let Ok(entry) = tree.get_path(&submodule_path) {
-            // Check if this is a commit (submodule) entry
-            if entry.kind() == Some(git2::ObjectType::Commit) {
-                // Get the commit OID stored in the tree entry
-                let commit_oid = entry.id();
-                // Store OID and parsed entry metadata
+        if let Ok(Some(entry)) =
+            tree::get_path_entry_at(transaction, odb, &tree_reader, &submodule_path)
+        {
+            if entry.mode.is_commit() {
+                let commit_oid = objects::git2_oid(&entry.oid);
                 submodule_commits.insert(submodule_path, (commit_oid, parsed));
             }
         }
@@ -1169,37 +1184,37 @@ fn extract_submodule_commits<'a>(
     Ok(submodule_commits)
 }
 
-fn get_link_roots<'a>(
-    _repo: &'a git2::Repository,
-    transaction: &'a cache::Transaction,
-    tree: &'a git2::Tree<'a>,
+fn get_link_roots(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    tree: git2::Oid,
 ) -> anyhow::Result<Vec<std::path::PathBuf>> {
     let link_filter = to_filter(Op::pattern("**/.link.josh")?);
-    let link_tree = apply(transaction, link_filter, Rewrite::from_tree(tree.clone()))?;
+    let link_tree = apply_impl(transaction, odb, link_filter, Rewrite::from_tree(tree))?;
 
+    // Stored-order preorder is load-bearing: the roots order feeds the extra-parents
+    // order of created merge commits.
     let mut roots = vec![];
-    link_tree
-        .tree()
-        .walk(git2::TreeWalkMode::PreOrder, |root, entry| {
-            let root = root.trim_matches('/');
-            let root = std::path::PathBuf::from(root);
-            if entry.name().ok() == Some(".link.josh") {
-                roots.push(root);
-            }
-            0
-        })?;
+    objects::walk_tree_preorder(odb, link_tree.tree_id(), &mut |root, entry| {
+        let root = std::path::PathBuf::from(root);
+        if &entry.filename[..] == b".link.josh" {
+            roots.push(root);
+        }
+        Ok(())
+    })?;
 
     Ok(roots)
 }
 
-fn links_from_roots<'a>(
-    repo: &'a git2::Repository,
-    tree: &git2::Tree<'a>,
+fn links_from_roots(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    reader: &tree::TreeReader,
     roots: Vec<std::path::PathBuf>,
 ) -> anyhow::Result<Vec<(std::path::PathBuf, Filter)>> {
     let mut v = vec![];
     for root in roots {
-        if let Some(link_filter) = read_josh_link(repo, tree, &root, ".link.josh") {
+        if let Some(link_filter) = read_josh_link(transaction, odb, reader, &root, ".link.josh") {
             v.push((root, link_filter));
         }
     }
@@ -1207,16 +1222,27 @@ fn links_from_roots<'a>(
 }
 
 /// Filter a single tree. This does not involve walking history and is thus fast in most cases.
-pub fn apply<'a>(
-    transaction: &'a cache::Transaction,
+pub fn apply(
+    transaction: &cache::Transaction,
     filter: Filter,
-    x: Rewrite<'a>,
-) -> anyhow::Result<Rewrite<'a>> {
-    let repo = transaction.repo();
+    x: Rewrite,
+) -> anyhow::Result<Rewrite> {
+    // One facade handle for the whole (possibly deeply recursive) application -- building it
+    // per recursion level would cost an FFI round-trip each.
+    let odb = transaction.odb()?;
+    apply_impl(transaction, &odb, filter, x)
+}
+
+fn apply_impl(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    filter: Filter,
+    x: Rewrite,
+) -> anyhow::Result<Rewrite> {
     let op = peel_op(filter);
     match &op {
         Op::Nop => Ok(x),
-        Op::Empty => Ok(x.with_tree(tree::empty(repo))),
+        Op::Empty => Ok(x.with_tree(tree::empty_id())),
         Op::Fold => Ok(x),
         Op::Squash(None) => Ok(x),
         Op::Author(author, email) => {
@@ -1227,33 +1253,67 @@ pub fn apply<'a>(
         }
         Op::Squash(Some(_)) => Err(anyhow!("not applicable to tree: squash")),
         Op::Message(m, r) => {
-            let tree_id = x.tree().id().to_string();
+            // Rewriting a message leaves the tree alone, so with neither a commit nor a
+            // message to transform this is identity, like the other history-only filters.
+            if x.commit == git2::Oid::ZERO_SHA1 && x.message.is_none() {
+                return Ok(x);
+            }
+
+            let tree = x.tree_id();
+            let tree_id = tree.to_string();
             let commit = x.commit;
             let commit_id = commit.to_string();
 
-            // The template transform is the one consumer that needs the message as text, so
-            // the UTF-8 decode happens here (and only here), erroring loudly.
+            // The template is the one consumer that needs the message as text, so the UTF-8
+            // decode happens here, and only here. A commit that cannot be read or parsed is
+            // an error rather than an empty message.
             let message = if let Some(ref m) = x.message {
                 std::str::from_utf8(m.as_ref())?.to_string()
-            } else if let Ok(c) = transaction.repo().find_commit(commit) {
-                std::str::from_utf8(c.message_raw_bytes())?.to_string()
             } else {
-                "".to_string()
+                let base = objects::CommitData::read(odb, commit)?;
+                std::str::from_utf8(base.message_raw()?)?.to_string()
             };
 
-            let tree = x.tree().clone();
+            // One lazily-read tree shared by all template keys: a key-less template reads
+            // nothing, and an unreadable tree keeps the keys' tolerance ("" / zero oid).
+            let tree_reader = std::cell::OnceCell::new();
+            let reader = || {
+                tree_reader
+                    .get_or_init(|| tree::read_tree(transaction, odb, tree).ok())
+                    .as_ref()
+            };
+
             Ok(x.with_message(
                 text::transform_with_template(r, m, &message, |key: &str| -> Option<String> {
                     match key {
                         "#" => Some(tree_id.clone()),
                         "@" => Some(commit_id.clone()),
-                        key if key.starts_with("/") => {
-                            Some(tree::get_blob(repo, &tree, std::path::Path::new(&key[1..])))
-                        }
+                        key if key.starts_with("/") => Some(
+                            reader()
+                                .map(|p| {
+                                    tree::get_blob_at(
+                                        transaction,
+                                        odb,
+                                        p,
+                                        std::path::Path::new(&key[1..]),
+                                    )
+                                })
+                                .unwrap_or_default(),
+                        ),
 
                         key if key.starts_with("#") => Some(
-                            tree.get_path(std::path::Path::new(&key[1..]))
-                                .map(|e| e.id())
+                            reader()
+                                .and_then(|p| {
+                                    tree::get_path_entry_at(
+                                        transaction,
+                                        odb,
+                                        p,
+                                        std::path::Path::new(&key[1..]),
+                                    )
+                                    .ok()
+                                    .flatten()
+                                })
+                                .map(|e| objects::git2_oid(&e.oid))
                                 .unwrap_or(git2::Oid::ZERO_SHA1)
                                 .to_string(),
                         ),
@@ -1265,11 +1325,12 @@ pub fn apply<'a>(
         }
         Op::Prune => Ok(x),
         Op::Adapt(adapter) => {
-            let mut result_tree = x.tree().clone();
+            let mut result_tree = x.tree_id();
             match adapter.as_ref() {
                 "submodules" => {
                     // Extract submodule commits
-                    let submodule_commits = extract_submodule_commits(repo, &result_tree)?;
+                    let submodule_commits =
+                        extract_submodule_commits(transaction, odb, result_tree)?;
 
                     // Process each submodule commit
                     for (submodule_path, (commit_oid, meta)) in submodule_commits {
@@ -1283,19 +1344,19 @@ pub fn apply<'a>(
                             .with_meta("mode", josh_filter::LinkMode::Pointer.to_string());
                         let link_content = as_file(link_filter, 0);
 
-                        result_tree = tree::insert(
-                            repo,
-                            &result_tree,
+                        result_tree = tree::insert_oid(
+                            odb,
+                            result_tree,
                             &submodule_path.join(".link.josh"),
-                            repo.blob(link_content.as_bytes())?,
+                            odb.write(gix_object::Kind::Blob, link_content.as_bytes()),
                             0o0100644,
                         )?;
                     }
 
                     // Remove .gitmodules file by setting it to zero OID
-                    result_tree = tree::insert(
-                        repo,
-                        &result_tree,
+                    result_tree = tree::insert_oid(
+                        odb,
+                        result_tree,
                         std::path::Path::new(".gitmodules"),
                         git2::Oid::ZERO_SHA1,
                         0o0100644,
@@ -1307,11 +1368,11 @@ pub fn apply<'a>(
             Ok(x.with_tree(result_tree))
         }
         Op::Export => {
-            let tree = x.tree().clone();
-            Ok(x.with_tree(tree::insert(
-                repo,
-                &tree,
-                &std::path::Path::new(".link.josh"),
+            let tree = x.tree_id();
+            Ok(x.with_tree(tree::insert_oid(
+                odb,
+                tree,
+                std::path::Path::new(".link.josh"),
                 git2::Oid::ZERO_SHA1,
                 0o0100644,
             )?))
@@ -1319,33 +1380,32 @@ pub fn apply<'a>(
         Op::Unlink => {
             check_experimental_features_enabled("unlink filter")?;
             use crate::link::find_link_files;
-            let mut result_tree = x.tree.clone();
-            for (link_path, link_file) in find_link_files(&repo, &result_tree)?.iter() {
-                result_tree = tree::insert(
-                    repo,
-                    &result_tree,
-                    &link_path,
-                    git2::Oid::ZERO_SHA1,
-                    0o0100644,
-                )?;
+            let mut result_tree = x.tree;
+            for (link_path, link_file) in find_link_files(odb, result_tree)?.iter() {
+                result_tree =
+                    tree::insert_oid(odb, result_tree, link_path, git2::Oid::ZERO_SHA1, 0o0100644)?;
 
                 // The link_file is already a filter with metadata, just serialize it
                 let link_content = as_file(*link_file, 0);
 
-                result_tree = tree::insert(
-                    repo,
-                    &result_tree,
+                result_tree = tree::insert_oid(
+                    odb,
+                    result_tree,
                     &link_path.join(".link.josh"),
-                    repo.blob(link_content.as_bytes())?,
+                    odb.write(gix_object::Kind::Blob, link_content.as_bytes()),
                     0o0100644,
                 )?;
             }
             Ok(x.with_tree(result_tree))
         }
         Op::Link(mode) => {
-            let roots = get_link_roots(repo, transaction, &x.tree())?;
-            let v = links_from_roots(repo, &x.tree(), roots)?;
-            let mut result_tree = x.tree().clone();
+            let tree = x.tree_id();
+            // An unreadable input tree is a hard error; the hoisted parse serves the
+            // link reads below.
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
+            let roots = get_link_roots(transaction, odb, tree)?;
+            let v = links_from_roots(transaction, odb, &tree_reader, roots)?;
+            let mut result_tree = tree;
 
             for (root, link_file) in v {
                 // Get commit from metadata
@@ -1354,18 +1414,17 @@ pub fn apply<'a>(
                     .and_then(|s| git2::Oid::from_str(&s).ok())
                     .ok_or_else(|| anyhow!("Link file missing commit metadata"))?;
 
-                let submodule_tree = repo.find_commit(commit_oid)?.tree()?;
+                let submodule_tree = git::read_tree_id(odb, commit_oid)?;
                 let inner_filter = link_file.peel();
-                let submodule_tree = apply(
+                let submodule_tree = apply_impl(
                     transaction,
+                    odb,
                     inner_filter,
                     Rewrite::from_tree(submodule_tree),
                 )
                 .unwrap();
 
-                let result_tree_id =
-                    tree::overlay(transaction, result_tree.id(), submodule_tree.tree().id())?;
-                result_tree = repo.find_tree(result_tree_id)?;
+                result_tree = tree::overlay(transaction, result_tree, submodule_tree.tree_id())?;
                 let effective_mode = mode.clone().unwrap_or_else(|| {
                     link_file
                         .get_meta("mode")
@@ -1375,11 +1434,11 @@ pub fn apply<'a>(
                 let link_content =
                     as_file(link_file.with_meta("mode", effective_mode.to_string()), 0);
 
-                result_tree = tree::insert(
-                    repo,
-                    &result_tree,
+                result_tree = tree::insert_oid(
+                    odb,
+                    result_tree,
                     &root.join(".link.josh"),
-                    repo.blob(link_content.as_bytes())?,
+                    odb.write(gix_object::Kind::Blob, link_content.as_bytes()),
                     0o0100644,
                 )?;
             }
@@ -1388,15 +1447,15 @@ pub fn apply<'a>(
         }
         Op::Rev(_) => Err(anyhow!("not applicable to tree: rev")),
         Op::RegexReplace(replacements) => {
-            let mut t = x.tree().clone();
+            let mut t = x.tree_id();
             for (regex, replacement) in replacements {
-                t = tree::regex_replace(t.id(), regex, replacement, transaction)?;
+                t = tree::regex_replace(t, regex, replacement, transaction)?;
             }
             Ok(x.with_tree(t))
         }
 
         Op::Pattern(cp) => {
-            let input = x.tree().id();
+            let input = x.tree_id();
             let key = peel_filter(filter).id();
             let t = if cp.fallback {
                 // More components than the NFA state mask can hold: match full paths.
@@ -1418,20 +1477,20 @@ pub fn apply<'a>(
                     tree::CompiledPattern::initial_state(),
                 )?
             };
-            Ok(if t == input {
-                x
-            } else {
-                x.with_tree(repo.find_tree(t)?)
-            })
+            Ok(if t == input { x } else { x.with_tree(t) })
         }
         Op::Insert(dest_path, content) => {
             let (oid, mode, is_tree) = match content {
-                InsertContent::Inline(s) => {
-                    (repo.blob(s.as_bytes())?, git2::FileMode::Blob.into(), false)
-                }
-                InsertContent::Oid(oid) => match repo.find_object(*oid, None)?.kind() {
-                    Some(git2::ObjectType::Blob) => (*oid, git2::FileMode::Blob.into(), false),
-                    Some(git2::ObjectType::Tree) => (*oid, git2::FileMode::Tree.into(), true),
+                InsertContent::Inline(s) => (
+                    odb.write(gix_object::Kind::Blob, s.as_bytes()),
+                    git2::FileMode::Blob.into(),
+                    false,
+                ),
+                // The kind comes from the header alone; a missing oid folds into the
+                // "neither" arm below.
+                InsertContent::Oid(oid) => match odb.try_kind(*oid) {
+                    Ok(Some(gix_object::Kind::Blob)) => (*oid, git2::FileMode::Blob.into(), false),
+                    Ok(Some(gix_object::Kind::Tree)) => (*oid, git2::FileMode::Tree.into(), true),
                     _ => {
                         return Err(anyhow::anyhow!(
                             "insert: {} is neither a blob nor a tree",
@@ -1445,29 +1504,31 @@ pub fn apply<'a>(
             // silently dropped, since git trees cannot have a blob at their root).
             if dest_path.as_path() == std::path::Path::new(".") {
                 if is_tree {
-                    return Ok(x.clone().with_tree(repo.find_tree(oid)?));
+                    return Ok(x.with_tree(oid));
                 }
                 return Err(anyhow::anyhow!(
                     "insert: `:$.=<oid>` requires a tree; a blob cannot be placed at the tree root"
                 ));
             }
-            Ok(x.clone().with_tree(tree::insert(
-                repo,
-                &tree::empty(repo),
-                &dest_path,
+            Ok(x.with_tree(tree::insert_oid(
+                odb,
+                tree::empty_id(),
+                dest_path,
                 oid,
                 mode,
             )?))
         }
         Op::File(dest_path, source_path) => {
-            let (file, mode) = x
-                .tree()
-                .get_path(source_path)
-                .map(|x| (x.id(), x.filemode()))
-                .unwrap_or((git2::Oid::ZERO_SHA1, git2::FileMode::Blob.into()));
-            Ok(x.with_tree(tree::insert(
-                repo,
-                &tree::empty(repo),
+            // The source entry's raw mode is carried into the copy, like every other kept
+            // entry; lookup failures fold into the fallback.
+            let (file, mode) =
+                match tree::get_path_entry(transaction, odb, x.tree_id(), source_path) {
+                    Ok(Some(e)) => (objects::git2_oid(&e.oid), e.mode.value() as i32),
+                    _ => (git2::Oid::ZERO_SHA1, git2::FileMode::Blob.into()),
+                };
+            Ok(x.with_tree(tree::insert_oid(
+                odb,
+                tree::empty_id(),
                 dest_path,
                 file,
                 mode,
@@ -1475,87 +1536,105 @@ pub fn apply<'a>(
         }
 
         Op::Subdir(path) => {
-            // A missing path or a non-tree entry (e.g. a blob) has no subtree;
-            // a present tree entry must load.
-            let subtree = match x.tree().get_path(path) {
-                Ok(entry) if entry.kind() == Some(git2::ObjectType::Tree) => {
-                    repo.find_tree(entry.id())?
-                }
-                _ => tree::empty(repo),
+            // A missing path, a non-tree entry (e.g. a blob), or a failed lookup has no
+            // subtree.
+            let subtree = match tree::get_path_entry(transaction, odb, x.tree_id(), path) {
+                Ok(Some(entry)) if entry.mode.is_tree() => objects::git2_oid(&entry.oid),
+                _ => tree::empty_id(),
             };
-            Ok(x.clone().with_tree(subtree))
+            Ok(x.with_tree(subtree))
         }
-        Op::Prefix(path) => Ok(x.clone().with_tree(tree::insert(
-            repo,
-            &tree::empty(repo),
-            path,
-            x.tree().id(),
-            git2::FileMode::Tree.into(),
-        )?)),
-
-        Op::Subtract(a, b) => {
-            let af = apply(transaction, *a, x.clone())?;
-            let bf = apply(transaction, *b, x.clone())?;
-            let bu = apply(transaction, invert(*b)?, bf.clone())?;
-            let ba = apply(transaction, *a, bu.clone())?.tree().id();
-            Ok(x.with_tree(repo.find_tree(tree::subtract(transaction, af.tree().id(), ba)?)?))
-        }
-        Op::Exclude(b) => {
-            let bf = apply(transaction, *b, x.clone())?.tree().id();
-            Ok(x.clone().with_tree(repo.find_tree(tree::subtract(
-                transaction,
-                x.tree().id(),
-                bf,
-            )?)?))
-        }
-        Op::Select(b) => {
-            let bf = apply(transaction, *b, x.clone())?.tree().id();
-            let inside = tree::intersect(transaction, x.tree().id(), bf)?;
-            Ok(x.clone().with_tree(repo.find_tree(inside)?))
-        }
-
-        Op::Paths => Ok(x
-            .clone()
-            .with_tree(tree::pathstree("", x.tree().id(), transaction)?)),
-        Op::Index => {
-            let index_cache = transaction.trigram_index_cache(x.commit);
-            Ok(x.clone().with_tree(josh_search::trigram_index(
-                transaction.repo(),
-                &index_cache,
-                &mut transaction.trigram_indexer(),
-                x.tree().clone(),
+        Op::Prefix(path) => {
+            let tree = x.tree_id();
+            Ok(x.with_tree(tree::insert_oid(
+                odb,
+                tree::empty_id(),
+                path,
+                tree,
+                git2::FileMode::Tree.into(),
             )?))
         }
 
-        Op::Invert => {
-            Ok(x.clone()
-                .with_tree(tree::invert_paths(transaction, "", x.tree().clone())?))
+        Op::Subtract(a, b) => {
+            let af = apply_impl(transaction, odb, *a, x.clone())?;
+            let bf = apply_impl(transaction, odb, *b, x.clone())?;
+            let bu = apply_impl(transaction, odb, invert(*b)?, bf)?;
+            let ba = apply_impl(transaction, odb, *a, bu)?.tree_id();
+            Ok(x.with_tree(tree::subtract(transaction, af.tree_id(), ba)?))
+        }
+        Op::Exclude(b) => {
+            let bf = apply_impl(transaction, odb, *b, x.clone())?.tree_id();
+            let tree = x.tree_id();
+            Ok(x.with_tree(tree::subtract(transaction, tree, bf)?))
+        }
+        Op::Select(b) => {
+            let bf = apply_impl(transaction, odb, *b, x.clone())?.tree_id();
+            let inside = tree::intersect(transaction, x.tree_id(), bf)?;
+            Ok(x.with_tree(inside))
         }
 
-        Op::Workspace(path) => apply(transaction, get_workspace(transaction, x.tree(), path), x),
-        Op::Stored(path) => apply(transaction, get_stored(transaction, x.tree(), path), x),
-        Op::Starlark(path, subfilter) => apply(
-            transaction,
-            get_starlark(transaction, x.tree(), path, *subfilter),
-            x,
-        ),
+        Op::Paths => {
+            let tree = x.tree_id();
+            Ok(x.with_tree(tree::pathstree("", tree, transaction)?))
+        }
+        Op::Index => {
+            let index_cache = transaction.trigram_index_cache(x.commit);
+            // PORT: josh_search::trigram_index takes a git2::Tree; the bridge read
+            // resolves fresh filtered trees through the registered backend.
+            let input_tree = transaction.repo().find_tree(x.tree_id())?;
+            Ok(x.with_tree(
+                josh_search::trigram_index(
+                    transaction.repo(),
+                    &index_cache,
+                    &mut transaction.trigram_indexer(),
+                    input_tree,
+                )?
+                .id(),
+            ))
+        }
+
+        Op::Invert => {
+            let tree = x.tree_id();
+            Ok(x.with_tree(tree::invert_paths(transaction, odb, "", tree)?))
+        }
+
+        Op::Workspace(path) => {
+            // An unreadable or unparseable input tree is a hard error (the get_* helpers
+            // below would fold it to Op::Empty), and every probe shares the one parse.
+            let tree = x.tree_id();
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
+            let f = get_workspace(transaction, odb, tree, &tree_reader, path);
+            apply_impl(transaction, odb, f, x)
+        }
+        Op::Stored(path) => {
+            let tree = x.tree_id();
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
+            let f = get_stored(transaction, odb, tree, &tree_reader, path);
+            apply_impl(transaction, odb, f, x)
+        }
+        Op::Starlark(path, subfilter) => {
+            let tree = x.tree_id();
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
+            let f = get_starlark(transaction, odb, tree, &tree_reader, path, *subfilter);
+            apply_impl(transaction, odb, f, x)
+        }
         Op::TreeId(path, subfilter) => {
-            let applied = apply(transaction, *subfilter, x.clone())?;
-            let oid_str = applied.tree().id().to_string();
-            apply(
+            let applied = apply_impl(transaction, odb, *subfilter, x.clone())?;
+            let oid_str = applied.tree_id().to_string();
+            apply_impl(
                 transaction,
+                odb,
                 to_filter(Op::Insert(path.clone(), InsertContent::Inline(oid_str))),
                 x,
             )
         }
         Op::ObjectRef(path) => {
-            let repo = transaction.repo();
-            if let Ok(entry) = x.tree().get_path(path) {
-                let oid_str = entry.id().to_string();
-                let blob_oid = repo.blob(oid_str.as_bytes())?;
-                Ok(x.clone().with_tree(tree::insert(
-                    repo,
-                    &tree::empty(repo),
+            if let Ok(Some(entry)) = tree::get_path_entry(transaction, odb, x.tree_id(), path) {
+                let oid_str = objects::git2_oid(&entry.oid).to_string();
+                let blob_oid = odb.write(gix_object::Kind::Blob, oid_str.as_bytes());
+                Ok(x.with_tree(tree::insert_oid(
+                    odb,
+                    tree::empty_id(),
                     path,
                     blob_oid,
                     git2::FileMode::Blob.into(),
@@ -1565,15 +1644,14 @@ pub fn apply<'a>(
             }
         }
         Op::ObjectDeref(path) => {
-            let repo = transaction.repo();
             // If path doesn't exist in input, do nothing (nop).
-            let entry = match x.tree().get_path(path) {
-                Ok(e) => e,
-                Err(_) => return Ok(x),
+            let entry = match tree::get_path_entry(transaction, odb, x.tree_id(), path) {
+                Ok(Some(e)) => e,
+                _ => return Ok(x),
             };
             // Path exists: read OID string from blob content.
-            let oid_str = if let Ok(blob) = repo.find_blob(entry.id()) {
-                std::str::from_utf8(blob.content())?
+            let oid_str = if let Some(blob) = tree::blob_bytes(odb, objects::git2_oid(&entry.oid)) {
+                std::str::from_utf8(&blob)?
                     .lines()
                     .next()
                     .unwrap_or("")
@@ -1583,20 +1661,22 @@ pub fn apply<'a>(
                 String::new()
             };
             if let Ok(oid) = git2::Oid::from_str(&oid_str) {
-                let (oid, mode) = if repo.find_tree(oid).is_ok() {
-                    (oid, git2::FileMode::Tree.into())
-                } else if repo.find_blob(oid).is_ok() {
-                    (oid, git2::FileMode::Blob.into())
-                } else {
-                    return Err(anyhow::anyhow!(":#: object not found in repo: {}", oid));
+                // Kind by header, never by `contains`: `read_header`'s disk fallback
+                // virtualizes the empty tree, `exists` does not.
+                let (oid, mode) = match odb.try_kind(oid) {
+                    Ok(Some(gix_object::Kind::Tree)) => (oid, git2::FileMode::Tree.into()),
+                    Ok(Some(gix_object::Kind::Blob)) => (oid, git2::FileMode::Blob.into()),
+                    _ => {
+                        return Err(anyhow::anyhow!(":#: object not found in repo: {}", oid));
+                    }
                 };
-                Ok(x.with_tree(tree::insert(repo, &tree::empty(repo), path, oid, mode)?))
+                Ok(x.with_tree(tree::insert_oid(odb, tree::empty_id(), path, oid, mode)?))
             } else {
                 // Content is not a valid OID: insert empty blob at path.
-                let empty_blob = repo.blob(b"")?;
-                Ok(x.with_tree(tree::insert(
-                    repo,
-                    &tree::empty(repo),
+                let empty_blob = odb.write(gix_object::Kind::Blob, b"");
+                Ok(x.with_tree(tree::insert_oid(
+                    odb,
+                    tree::empty_id(),
                     path,
                     empty_blob,
                     git2::FileMode::Blob.into(),
@@ -1607,11 +1687,11 @@ pub fn apply<'a>(
         Op::Compose(filters) => {
             let filtered: Vec<_> = filters
                 .iter()
-                .map(|f| apply(transaction, *f, x.clone()))
+                .map(|f| apply_impl(transaction, odb, *f, x.clone()))
                 .collect::<anyhow::Result<_>>()?;
             let filtered: Vec<_> = filters
                 .iter()
-                .zip(filtered.iter().map(|t| t.tree().clone()))
+                .zip(filtered.iter().map(|t| t.tree_id()))
                 .collect();
             Ok(x.with_tree(tree::compose(transaction, filtered)?))
         }
@@ -1619,7 +1699,7 @@ pub fn apply<'a>(
         Op::Chain(filters) => {
             let mut result = x;
             for filter in filters {
-                result = apply(transaction, *filter, result)?;
+                result = apply_impl(transaction, odb, *filter, result)?;
             }
             Ok(result)
         }
@@ -1629,15 +1709,17 @@ pub fn apply<'a>(
         Op::Unapply(target, uf) => {
             check_experimental_features_enabled("unapply filter")?;
             if let LazyRef::Resolved(target) = target {
-                let target = repo.find_commit(*target)?;
-                let target = git2::Oid::from_str(target.message().unwrap())?;
-                let target = repo.find_commit(target)?;
+                let target = objects::CommitData::read(odb, *target)?;
+                // The message must parse as an oid, so non-UTF-8 is an error.
+                let target_msg = target.message()?;
+                let target = git2::Oid::from_str(std::str::from_utf8(target_msg)?)?;
+                let target_tree = git::read_tree_id(odb, target)?;
                 /* dbg!(&uf); */
                 Ok(Rewrite::from_tree(filter::unapply(
                     transaction,
                     *uf,
-                    x.tree().clone(),
-                    target.tree()?,
+                    x.tree_id(),
+                    target_tree,
                     None,
                 )?))
             } else {
@@ -1657,13 +1739,13 @@ pub fn apply<'a>(
 /// `parent_tree`. It is required to reverse commit-resolved per-commit filters (`:rev` / `:hook`),
 /// whose sub-filter is chosen from commit identity rather than the tree; callers that only ever pass
 /// tree-reversible filters pass `None`.
-pub fn unapply<'a, 'b>(
-    transaction: &'a cache::Transaction,
+pub fn unapply(
+    transaction: &cache::Transaction,
     filter: Filter,
-    tree: git2::Tree<'a>,
-    parent_tree: git2::Tree<'a>,
-    commits: Option<(&'b git2::Commit<'b>, &'b git2::Commit<'b>)>,
-) -> anyhow::Result<git2::Tree<'a>> {
+    tree: git2::Oid,
+    parent_tree: git2::Oid,
+    commits: Option<(git2::Oid, git2::Oid)>,
+) -> anyhow::Result<git2::Oid> {
     // A `:rev(...)` filter has no static inverse (`invert` returns `Err`, like `:workspace` /
     // `:stored` / `:starlark`), so this generic path is automatically skipped for it and it falls
     // through to the per-commit handler / chain recursion below.
@@ -1671,29 +1753,21 @@ pub fn unapply<'a, 'b>(
         let filtered = apply(
             transaction,
             invert(inverted)?,
-            Rewrite::from_tree(parent_tree.clone()),
+            Rewrite::from_tree(parent_tree),
         )?;
-        let matching = apply(transaction, inverted, filtered.clone())?;
-        let stripped = tree::subtract(transaction, parent_tree.id(), matching.tree().id())?;
+        let matching = apply(transaction, inverted, filtered)?;
+        let stripped = tree::subtract(transaction, parent_tree, matching.tree_id())?;
         let x = apply(transaction, inverted, Rewrite::from_tree(tree))?;
 
-        return Ok(transaction.repo().find_tree(tree::overlay(
-            transaction,
-            x.tree().id(),
-            stripped,
-        )?)?);
+        return tree::overlay(transaction, x.tree_id(), stripped);
     }
 
     // `peel_op` (not `to_op`) so a `:~(...)[...]` meta wrapper around e.g. `:rev(...)` is seen
     // through: the meta options (history flags) only affect the forward direction, and the
     // per-commit reverse handler needs the wrapped operator.
-    if let Some(ws) = unapply_per_rev_filter(
-        transaction,
-        &peel_op(filter),
-        tree.clone(),
-        parent_tree.clone(),
-        commits,
-    )? {
+    if let Some(ws) =
+        unapply_per_rev_filter(transaction, &peel_op(filter), tree, parent_tree, commits)?
+    {
         return Ok(ws);
     }
 
@@ -1722,12 +1796,7 @@ pub fn unapply<'a, 'b>(
                 )
             })?;
             let parent_filter = resolve_commit_filter(transaction, &first_op, parent)?;
-            apply(
-                transaction,
-                parent_filter,
-                Rewrite::from_tree(parent_tree.clone()),
-            )?
-            .into_tree()
+            apply(transaction, parent_filter, Rewrite::from_tree(parent_tree))?.tree_id()
         } else {
             let first_normalized = if let Ok(first_inverted) = invert(*first) {
                 invert(first_inverted)?
@@ -1737,9 +1806,9 @@ pub fn unapply<'a, 'b>(
             apply(
                 transaction,
                 first_normalized,
-                Rewrite::from_tree(parent_tree.clone()),
+                Rewrite::from_tree(parent_tree),
             )?
-            .into_tree()
+            .tree_id()
         };
 
         // Recursively unapply: first unapply the rest, then unapply first
@@ -1760,25 +1829,23 @@ pub fn unapply<'a, 'b>(
 /// the sub-filter resolved for the commit, `original_filter` the one resolved for the specific
 /// parent whose tree is `parent_tree`. The reconstruction reproduces the out-of-filter content of
 /// `parent_tree` (strip) and overlays the reconstructed in-filter content of `tree`.
-fn reverse_strip_overlay<'a>(
-    transaction: &'a cache::Transaction,
+fn reverse_strip_overlay(
+    transaction: &cache::Transaction,
     filter: Filter,
     original_filter: Filter,
-    tree: git2::Tree<'a>,
-    parent_tree: git2::Tree<'a>,
-) -> anyhow::Result<git2::Tree<'a>> {
+    tree: git2::Oid,
+    parent_tree: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
     let filtered = apply(
         transaction,
         original_filter,
-        Rewrite::from_tree(parent_tree.clone()),
+        Rewrite::from_tree(parent_tree),
     )?;
-    let matching = apply(transaction, invert(original_filter)?, filtered.clone())?;
-    let stripped = tree::subtract(transaction, parent_tree.id(), matching.tree().id())?;
+    let matching = apply(transaction, invert(original_filter)?, filtered)?;
+    let stripped = tree::subtract(transaction, parent_tree, matching.tree_id())?;
     let x = apply(transaction, invert(filter)?, Rewrite::from_tree(tree))?;
 
-    Ok(transaction
-        .repo()
-        .find_tree(tree::overlay(transaction, x.tree().id(), stripped)?)?)
+    tree::overlay(transaction, x.tree_id(), stripped)
 }
 
 /// Resolve the concrete sub-filter of a per-commit filter whose selector lives in *commit identity*
@@ -1788,11 +1855,11 @@ fn reverse_strip_overlay<'a>(
 fn resolve_commit_filter(
     transaction: &cache::Transaction,
     op: &Op,
-    commit: &git2::Commit,
+    commit: git2::Oid,
 ) -> anyhow::Result<Filter> {
     match op {
-        Op::Rev(revs) => get_rev_filter(transaction, commit.id(), revs),
-        Op::Hook(hook) => transaction.lookup_filter_hook(hook, commit.id()),
+        Op::Rev(revs) => get_rev_filter(transaction, commit, revs),
+        Op::Hook(hook) => transaction.lookup_filter_hook(hook, commit),
         _ => Err(anyhow!("not a per-commit (rev/hook) filter")),
     }
 }
@@ -1803,13 +1870,13 @@ fn is_commit_resolved_filter(op: &Op) -> bool {
     matches!(op, Op::Rev(_) | Op::Hook(_))
 }
 
-fn unapply_per_rev_filter<'a, 'b>(
-    transaction: &'a cache::Transaction,
+fn unapply_per_rev_filter(
+    transaction: &cache::Transaction,
     op: &Op,
-    tree: git2::Tree<'a>,
-    parent_tree: git2::Tree<'a>,
-    commits: Option<(&'b git2::Commit<'b>, &'b git2::Commit<'b>)>,
-) -> anyhow::Result<Option<git2::Tree<'a>>> {
+    tree: git2::Oid,
+    parent_tree: git2::Oid,
+    commits: Option<(git2::Oid, git2::Oid)>,
+) -> anyhow::Result<Option<git2::Oid>> {
     if is_commit_resolved_filter(op) {
         // `:rev`/`:hook` select their sub-filter from commit identity (mirroring the forward
         // `Op::Rev`/`Op::Hook` paths): resolve it for the commit being reconstructed and for the
@@ -1832,10 +1899,24 @@ fn unapply_per_rev_filter<'a, 'b>(
 
     match op {
         Op::Workspace(path) => {
+            let odb = transaction.odb()?;
             let tree = pre_process_tree(transaction, tree)?;
-            let workspace = get_filter(transaction, &tree, Path::new("workspace.josh"));
-            let original_workspace =
-                get_filter(transaction, &parent_tree, &path.join("workspace.josh"));
+            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            let parent_reader = tree::read_tree(transaction, &odb, parent_tree)?;
+            let workspace = get_filter(
+                transaction,
+                &odb,
+                tree,
+                &tree_reader,
+                Path::new("workspace.josh"),
+            );
+            let original_workspace = get_filter(
+                transaction,
+                &odb,
+                parent_tree,
+                &parent_reader,
+                &path.join("workspace.josh"),
+            );
 
             let root = to_filter(Op::Subdir(path.to_owned()));
             let wsj_file = to_filter(Op::File(
@@ -1854,9 +1935,13 @@ fn unapply_per_rev_filter<'a, 'b>(
             )?))
         }
         Op::Stored(path) => {
+            let odb = transaction.odb()?;
             let stored_path = path.with_added_extension("josh");
-            let stored = get_filter(transaction, &tree, &stored_path);
-            let original_stored = get_filter(transaction, &parent_tree, &stored_path);
+            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            let parent_reader = tree::read_tree(transaction, &odb, parent_tree)?;
+            let stored = get_filter(transaction, &odb, tree, &tree_reader, &stored_path);
+            let original_stored =
+                get_filter(transaction, &odb, parent_tree, &parent_reader, &stored_path);
 
             let sj_file = Filter::new().file(stored_path.clone());
             let filter = compose(&[sj_file, stored]);
@@ -1870,8 +1955,18 @@ fn unapply_per_rev_filter<'a, 'b>(
             )?))
         }
         Op::Starlark(path, subfilter) => {
-            let filter = get_starlark(transaction, &tree, path, *subfilter);
-            let original_filter = get_starlark(transaction, &parent_tree, path, *subfilter);
+            let odb = transaction.odb()?;
+            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            let parent_reader = tree::read_tree(transaction, &odb, parent_tree)?;
+            let filter = get_starlark(transaction, &odb, tree, &tree_reader, path, *subfilter);
+            let original_filter = get_starlark(
+                transaction,
+                &odb,
+                parent_tree,
+                &parent_reader,
+                path,
+                *subfilter,
+            );
             Ok(Some(reverse_strip_overlay(
                 transaction,
                 filter,
@@ -1884,13 +1979,13 @@ fn unapply_per_rev_filter<'a, 'b>(
     }
 }
 
-fn pre_process_tree<'a>(
-    transaction: &'a cache::Transaction,
-    tree: git2::Tree<'a>,
-) -> anyhow::Result<git2::Tree<'a>> {
-    let repo = transaction.repo();
+fn pre_process_tree(
+    transaction: &cache::Transaction,
+    tree: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    let odb = transaction.odb()?;
     let path = Path::new("workspace.josh");
-    let ws_file = tree::get_blob(repo, &tree, path);
+    let ws_file = tree::get_blob(transaction, &odb, tree, path);
     let parsed = filter::parse(&ws_file)?;
 
     if invert(parsed).is_err() {
@@ -1905,11 +2000,11 @@ fn pre_process_tree<'a>(
     }
     let blob = &format!("{}{}\n", &blob, pretty(parsed, 0));
 
-    let tree = tree::insert(
-        repo,
-        &tree,
+    let tree = tree::insert_oid(
+        &odb,
+        tree,
         path,
-        repo.blob(blob.as_bytes())?,
+        odb.write(gix_object::Kind::Blob, blob.as_bytes()),
         git2::FileMode::Blob.into(), // Should this handle filemode?
     )?;
 
@@ -1917,18 +2012,24 @@ fn pre_process_tree<'a>(
 }
 
 /// Compute the warnings (filters not matching anything) for the filter applied to the tree
-pub fn compute_warnings<'a>(
-    transaction: &'a cache::Transaction,
+pub fn compute_warnings(
+    transaction: &cache::Transaction,
     filter: Filter,
-    tree: git2::Tree<'a>,
+    tree: git2::Oid,
 ) -> Vec<String> {
     let mut warnings = Vec::new();
     let mut filter = filter;
 
+    let odb = match transaction.odb() {
+        Ok(odb) => odb,
+        Err(_) => return warnings,
+    };
+
     if let Op::Workspace(path) = to_op(filter) {
         let workspace_filter = &tree::get_blob(
-            transaction.repo(),
-            &tree,
+            transaction,
+            &odb,
+            tree,
             &path.join(Path::new("workspace.josh")),
         );
         if let Ok(res) = parse(workspace_filter) {
@@ -1941,7 +2042,7 @@ pub fn compute_warnings<'a>(
 
     if let Op::Stored(path) = to_op(filter) {
         let stored_path = path.with_added_extension("josh");
-        let stored_filter = &tree::get_blob(transaction.repo(), &tree, &stored_path);
+        let stored_filter = &tree::get_blob(transaction, &odb, tree, &stored_path);
         if let Ok(res) = parse(stored_filter) {
             filter = res;
         } else {
@@ -1953,10 +2054,7 @@ pub fn compute_warnings<'a>(
     let filter = opt::flatten(filter);
     if let Op::Compose(filters) = to_op(filter) {
         for f in filters {
-            let tree = transaction.repo().find_tree(tree.id());
-            if let Ok(tree) = tree {
-                warnings.append(&mut compute_warnings2(transaction, f, tree));
-            }
+            warnings.append(&mut compute_warnings2(transaction, f, tree));
         }
     } else {
         warnings.append(&mut compute_warnings2(transaction, filter, tree));
@@ -1964,16 +2062,16 @@ pub fn compute_warnings<'a>(
     warnings
 }
 
-fn compute_warnings2<'a>(
-    transaction: &'a cache::Transaction,
+fn compute_warnings2(
+    transaction: &cache::Transaction,
     filter: Filter,
-    tree: git2::Tree<'a>,
+    tree: git2::Oid,
 ) -> Vec<String> {
     let mut warnings = Vec::new();
 
     let x = apply(transaction, filter, Rewrite::from_tree(tree));
     if let Ok(x) = x
-        && x.tree().is_empty()
+        && x.tree_id() == tree::empty_id()
     {
         warnings.push(format!("No match for \"{}\"", pretty(filter, 2)));
     }
@@ -2049,33 +2147,47 @@ fn needs_legalization(f: Filter) -> bool {
     }
 }
 
-fn legalize_stored(t: &cache::Transaction, f: Filter, tree: &git2::Tree) -> anyhow::Result<Filter> {
+fn legalize_stored(
+    t: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    f: Filter,
+    tree: git2::Oid,
+    reader: &tree::TreeReader,
+) -> anyhow::Result<Filter> {
     if !needs_legalization(f) {
         return Ok(f);
     }
 
-    if let Some(f) = t.get_legalize((f, tree.id())) {
+    if let Some(f) = t.get_legalize((f, tree)) {
         return Ok(f);
     }
 
     // Put an entry into the hashtable to prevent infinite recursion.
     // If we get called with the same arguments again before we return,
     // Above check breaks the recursion.
-    t.insert_legalize((f, tree.id()), Filter::new().empty());
+    t.insert_legalize((f, tree), Filter::new().empty());
 
     let r = match to_op(f) {
         Op::Compose(f) => {
             let f = f
                 .into_iter()
-                .map(|f| legalize_stored(t, f, tree))
+                .map(|f| legalize_stored(t, odb, f, tree, reader))
                 .collect::<anyhow::Result<Vec<_>>>()?;
             to_filter(Op::Compose(f))
         }
         Op::Chain(filters) => {
             let mut result = Vec::with_capacity(filters.len());
-            let mut current_tree = tree.clone();
+            let mut current_tree = tree;
             for (i, filter) in filters.iter().enumerate() {
-                let legalized = legalize_stored(t, *filter, &current_tree)?;
+                // Chain steps past the first run against freshly applied intermediate
+                // trees; those need their own read+parse (the caller's parse only covers
+                // `tree`).
+                let legalized = if current_tree == tree {
+                    legalize_stored(t, odb, *filter, tree, reader)?
+                } else {
+                    let current_parsed = tree::read_tree(t, odb, current_tree)?;
+                    legalize_stored(t, odb, *filter, current_tree, &current_parsed)?
+                };
                 result.push(legalized);
                 // Only compute the intermediate tree if a subsequent element still needs
                 // legalization — the tree is passed to legalize_stored, which uses it to
@@ -2083,27 +2195,35 @@ fn legalize_stored(t: &cache::Transaction, f: Filter, tree: &git2::Tree) -> anyh
                 // (e.g. a trailing Prefix) return immediately via the fast-path, so
                 // running apply just to compute a tree they'll never use is pure waste.
                 if filters[i + 1..].iter().any(|&f| needs_legalization(f)) {
-                    current_tree =
-                        apply(t, legalized, Rewrite::from_tree(current_tree.clone()))?.tree;
+                    current_tree = apply(t, legalized, Rewrite::from_tree(current_tree))?.tree;
                 }
             }
             to_filter(Op::Chain(result))
         }
         Op::Subtract(a, b) => to_filter(Op::Subtract(
-            legalize_stored(t, a, tree)?,
-            legalize_stored(t, b, tree)?,
+            legalize_stored(t, odb, a, tree, reader)?,
+            legalize_stored(t, odb, b, tree, reader)?,
         )),
-        Op::Exclude(f) => to_filter(Op::Exclude(legalize_stored(t, f, tree)?)),
-        Op::Select(f) => to_filter(Op::Select(legalize_stored(t, f, tree)?)),
-        Op::Meta(meta, f) => to_filter(Op::Meta(meta, legalize_stored(t, f, tree)?)),
-        Op::Pin(f) => to_filter(Op::Pin(legalize_stored(t, f, tree)?)),
-        Op::Stored(path) => get_stored(t, tree, &path),
-        Op::Starlark(path, sub) => get_starlark(t, tree, &path, legalize_stored(t, sub, tree)?),
-        Op::TreeId(path, f) => to_filter(Op::TreeId(path, legalize_stored(t, f, tree)?)),
+        Op::Exclude(f) => to_filter(Op::Exclude(legalize_stored(t, odb, f, tree, reader)?)),
+        Op::Select(f) => to_filter(Op::Select(legalize_stored(t, odb, f, tree, reader)?)),
+        Op::Meta(meta, f) => to_filter(Op::Meta(meta, legalize_stored(t, odb, f, tree, reader)?)),
+        Op::Pin(f) => to_filter(Op::Pin(legalize_stored(t, odb, f, tree, reader)?)),
+        Op::Stored(path) => get_stored(t, odb, tree, reader, &path),
+        Op::Starlark(path, sub) => get_starlark(
+            t,
+            odb,
+            tree,
+            reader,
+            &path,
+            legalize_stored(t, odb, sub, tree, reader)?,
+        ),
+        Op::TreeId(path, f) => {
+            to_filter(Op::TreeId(path, legalize_stored(t, odb, f, tree, reader)?))
+        }
         _ => f,
     };
 
-    t.insert_legalize((f, tree.id()), r);
+    t.insert_legalize((f, tree), r);
 
     Ok(r)
 }
@@ -2197,7 +2317,7 @@ fn per_rev_filter(
             let pin_subtract = apply(
                 transaction,
                 opt::optimize(to_filter(Op::Subtract(legalized_a, legalized_b))),
-                Rewrite::from_commit_data(transaction.repo(), commit)?,
+                Rewrite::from_commit_data(commit)?,
             )?;
 
             let parent_tree_id = history::filtered_parent_tree_id(transaction, parent)?;
@@ -2206,9 +2326,9 @@ fn per_rev_filter(
             // parent's entries whose path is pinned. Equivalent to the older
             // `populate(pathstree(pin_subtract), parent)` spelling of "select the pinned paths out
             // of the previous tree", but in a single path-intersection pass.
-            let pin_overlay = tree::intersect(transaction, parent_tree_id, pin_subtract.tree.id())?;
+            let pin_overlay = tree::intersect(transaction, parent_tree_id, pin_subtract.tree_id())?;
 
-            Some((pin_subtract.tree.id(), pin_overlay))
+            Some((pin_subtract.tree_id(), pin_overlay))
         } else {
             None
         }
@@ -2245,6 +2365,8 @@ fn per_rev_filter(
                 .iter()
                 .filter(|x| **x != git2::Oid::ZERO_SHA1 && **x != target_id)
             {
+                // PORT: libgit2 graph compute over filtered (possibly unflushed)
+                // commits, served by the registered backend.
                 if !transaction.repo().graph_descendant_of(target_id, *id)? {
                     return Err(anyhow!(
                         "cannot squash {}: its filtered parents {} and {} do not descend \
@@ -2267,14 +2389,14 @@ fn per_rev_filter(
     let mut tree_data = apply(
         transaction,
         commit_filter,
-        Rewrite::from_commit_data(transaction.repo(), commit)?,
+        Rewrite::from_commit_data(commit)?,
     )?;
 
     if let Some((pin_subtract, pin_overlay)) = pin_details {
-        let with_exclude = tree::subtract(transaction, tree_data.tree().id(), pin_subtract)?;
+        let with_exclude = tree::subtract(transaction, tree_data.tree_id(), pin_subtract)?;
         let with_overlay = tree::overlay(transaction, pin_overlay, with_exclude)?;
 
-        tree_data = tree_data.with_tree(transaction.repo().find_tree(with_overlay)?);
+        tree_data = tree_data.with_tree(with_overlay);
     }
 
     return Some(history::create_filtered_commit_with_meta(
@@ -2292,12 +2414,16 @@ fn per_rev_filter(
 /// whose changed paths are disjoint from the tip's changes, then reapply the tip
 /// onto the minimised base via a 3-way merge. Returns the new tip OID.
 pub fn downstack(
-    repo: &git2::Repository,
     transaction: &cache::Transaction,
     change_oid: git2::Oid,
     base_oid: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    if !repo.graph_descendant_of(change_oid, base_oid)? {
+    // PORT: libgit2 graph compute over possibly-unflushed commits, served by the
+    // registered backend.
+    if !transaction
+        .repo()
+        .graph_descendant_of(change_oid, base_oid)?
+    {
         return Err(anyhow!(
             "change {} is not a descendant of base {}",
             change_oid,
@@ -2336,74 +2462,80 @@ pub fn downstack(
         return Ok(change_oid);
     }
 
-    let mut commits: Vec<git2::Commit> = oids
+    let mut commits: Vec<objects::CommitData> = oids
         .into_iter()
-        .map(|oid| repo.find_commit(oid))
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(|oid| objects::CommitData::read(&odb, oid))
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
     // The last commit is `change`; split it off from the intermediates
     let change_commit = commits.pop().unwrap();
 
     // Seed the affected dependency set with the change's own deps, then walk
     // intermediates backwards, keeping any commit whose deps intersect.
-    let mut affected = downstack_commit_deps(repo, transaction, &change_commit)?;
+    let mut affected = downstack_commit_deps(transaction, &odb, &change_commit)?;
     let mut needed: Vec<bool> = vec![false; commits.len()];
     for (i, intermediate) in commits.iter().enumerate().rev() {
-        let deps = downstack_commit_deps(repo, transaction, intermediate)?;
+        let deps = downstack_commit_deps(transaction, &odb, intermediate)?;
         if !deps.is_disjoint(&affected) {
             needed[i] = true;
             affected.extend(deps);
         }
     }
 
-    // Rebase needed intermediates forward onto current_base.
-    let mut current_base = repo.find_commit(base_oid)?;
+    // Rebase needed intermediates forward onto current_base. The rebuilt base's tree is the
+    // merge result just written, so no commit read-back is needed between steps.
+    let mut current_base_id = base_oid;
+    let mut current_base_tree = git::read_tree_id(&odb, base_oid)?;
     for (intermediate, is_needed) in commits.iter().zip(needed.iter()) {
         if !is_needed {
             continue;
         }
-        let inter_parent = intermediate.parent(0)?;
+        let inter_parent = intermediate.first_parent_id().ok_or_else(|| {
+            anyhow!(
+                "downstack: intermediate {} has no parent",
+                intermediate.id()
+            )
+        })?;
         let new_tree_oid = cached_merge_trees(
-            repo,
             transaction,
-            inter_parent.tree_id(),
-            current_base.tree_id(),
-            intermediate.tree_id(),
+            git::read_tree_id(&odb, inter_parent)?,
+            current_base_tree,
+            intermediate.tree_id()?,
         )?;
-        let new_tree = repo.find_tree(new_tree_oid)?;
         let new_oid = history::rewrite_commit(
             &odb,
-            &objects::CommitData::read(&odb, intermediate.id())?,
-            &[current_base.id()],
-            Rewrite::from_tree(new_tree),
+            intermediate,
+            &[current_base_id],
+            Rewrite::from_tree(new_tree_oid),
             history::GpgsigMode::Preserve,
         )?;
-        current_base = repo.find_commit(new_oid)?;
+        current_base_id = new_oid;
+        current_base_tree = new_tree_oid;
     }
 
     // Apply the change on top of the minimal base via 3-way merge.
-    let change_parent = change_commit.parent(0)?;
+    let change_parent = change_commit
+        .first_parent_id()
+        .ok_or_else(|| anyhow!("downstack: change {} has no parent", change_commit.id()))?;
     let new_tree_oid = cached_merge_trees(
-        repo,
         transaction,
-        change_parent.tree_id(),
-        current_base.tree_id(),
-        change_commit.tree_id(),
+        git::read_tree_id(&odb, change_parent)?,
+        current_base_tree,
+        change_commit.tree_id()?,
     )?;
-    let new_tree = repo.find_tree(new_tree_oid)?;
 
     // First-parent is remapped onto the minimal base; any further parents are
     // carried through untouched. A merge commit in the stack is treated as an
     // ordinary linear change (diffed against its first parent), but the rebuilt
     // change keeps its second-parent link so the merge survives the rewrite.
-    let mut new_parents = vec![current_base.id()];
+    let mut new_parents = vec![current_base_id];
     new_parents.extend(change_commit.parent_ids().skip(1));
 
     let new_oid = history::rewrite_commit(
         &odb,
-        &objects::CommitData::read(&odb, change_commit.id())?,
+        &change_commit,
         &new_parents,
-        Rewrite::from_tree(new_tree),
+        Rewrite::from_tree(new_tree_oid),
         history::GpgsigMode::Preserve,
     )?;
 
@@ -2418,7 +2550,6 @@ pub fn downstack(
 /// than process-wide) keeps `josh-proxy` from accumulating entries across
 /// unrelated operations.
 fn cached_merge_trees(
-    repo: &git2::Repository,
     transaction: &cache::Transaction,
     a: git2::Oid,
     b: git2::Oid,
@@ -2439,6 +2570,9 @@ fn cached_merge_trees(
     if let Some(hit) = transaction.get_merge_trees(key) {
         return Ok(hit);
     }
+    // PORT: libgit2-internal merge compute -- the find_tree bridges read and
+    // `write_tree_to` writes possibly-unflushed objects through the registered backend.
+    let repo = transaction.repo();
     let tree_a = repo.find_tree(a)?;
     let tree_b = repo.find_tree(b)?;
     let tree_c = repo.find_tree(c)?;
@@ -2465,9 +2599,9 @@ pub(crate) enum DownstackDep {
 /// lives on the transaction so `josh-proxy` doesn't accumulate entries
 /// across unrelated operations.
 fn downstack_commit_deps(
-    repo: &git2::Repository,
     transaction: &cache::Transaction,
-    commit: &git2::Commit,
+    odb: &josh_memodb::Odb,
+    commit: &objects::CommitData,
 ) -> anyhow::Result<std::collections::HashSet<DownstackDep>> {
     let oid = commit.id();
     if let Some(hit) = transaction.get_downstack_deps(oid) {
@@ -2477,20 +2611,27 @@ fn downstack_commit_deps(
     // Use the in-crate `tree::diff_paths` rather than git2's full diff
     // pipeline: it short-circuits subtrees by oid equality, which collapses
     // the typical "stack of single-file commits" deps walk down to a few
-    // tree lookups per call.
-    let parent_tree_id = if commit.parent_count() > 0 {
-        commit.parent(0)?.tree()?.id()
-    } else {
-        git2::Oid::ZERO_SHA1
-    };
-    let commit_tree_id = commit.tree()?.id();
+    // tree lookups per call. An unreadable first parent is a hard error;
+    // only the no-parent case diffs against nothing.
+    let parent_tree_id = commit
+        .first_parent_id()
+        .map(|p| git::read_tree_id(odb, p))
+        .transpose()?
+        .unwrap_or(git2::Oid::ZERO_SHA1);
+    let commit_tree_id = commit.tree_id()?;
 
     let mut deps = std::collections::HashSet::new();
-    for (path, _polarity) in tree::diff_paths(repo, parent_tree_id, commit_tree_id, "")? {
+    for (path, _polarity) in tree::diff_paths(odb, parent_tree_id, commit_tree_id, "")? {
         deps.insert(DownstackDep::Path(path));
     }
 
-    let (_, series) = crate::trailers::parse_change_meta(commit.message().unwrap_or(""));
+    // A non-UTF-8 message reads as empty.
+    let message = commit
+        .message()
+        .ok()
+        .and_then(|m| std::str::from_utf8(m).ok())
+        .unwrap_or("");
+    let (_, series) = crate::trailers::parse_change_meta(message);
     for s in series {
         deps.insert(DownstackDep::Series(s));
     }
@@ -2694,7 +2835,6 @@ mod tests {
         let tree = b
             .create_updated(&repo, &repo.find_tree(empty).unwrap())
             .unwrap();
-        let tree = repo.find_tree(tree).unwrap();
 
         let cachestack = std::sync::Arc::new(
             cache::CacheStack::new().with_backend(cache::SledCacheBackend::new(td.path())),
@@ -2703,7 +2843,7 @@ mod tests {
         let t = ctx.open().unwrap();
 
         let apply_tree = |f: Filter| -> anyhow::Result<git2::Oid> {
-            Ok(apply(&t, f, Rewrite::from_tree(tree.clone()))?.tree().id())
+            Ok(apply(&t, f, Rewrite::from_tree(tree))?.tree_id())
         };
 
         // The pin-legalisation subtract, built exactly like per_rev_filter.
@@ -2850,7 +2990,7 @@ mod tests {
         let t = ctx.open().unwrap();
 
         let out = repo
-            .find_commit(downstack(t.repo(), &t, merge, base).unwrap())
+            .find_commit(downstack(&t, merge, base).unwrap())
             .unwrap();
         assert_eq!(out.parent_count(), 2, "merge change lost its second parent");
         assert_eq!(
@@ -2867,7 +3007,7 @@ mod tests {
         // A single-parent change is unaffected by the parent-preserving rewrite.
         let linear = mk_commit(mk_tree(&[("a", "1"), ("n", "n")]), &[base], "linear change");
         let out_linear = repo
-            .find_commit(downstack(t.repo(), &t, linear, base).unwrap())
+            .find_commit(downstack(&t, linear, base).unwrap())
             .unwrap();
         assert_eq!(out_linear.parent_count(), 1);
     }

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -2,15 +2,13 @@ use super::*;
 use crate::objects;
 use anyhow::anyhow;
 
-pub fn pathstree<'a>(
+pub fn pathstree(
     root: &str,
     input: git2::Oid,
-    transaction: &'a cache::Transaction,
-) -> anyhow::Result<git2::Tree<'a>> {
-    let repo = transaction.repo();
+    transaction: &cache::Transaction,
+) -> anyhow::Result<git2::Oid> {
     let odb = transaction.odb()?;
-    let result = pathstree_inner(root, input, transaction, &odb)?;
-    Ok(repo.find_tree(result)?)
+    pathstree_inner(root, input, transaction, &odb)
 }
 
 /// Oid-level body of [`pathstree`]; the odb is hoisted like in [`remove_pred_inner`].
@@ -24,7 +22,6 @@ fn pathstree_inner(
         return Ok(cached);
     }
 
-    let repo = transaction.repo();
     let bytes = transaction
         .read_tree_bytes(odb, input)?
         .ok_or_else(|| anyhow!("pathstree: {} is not a tree", input))?;
@@ -56,7 +53,7 @@ fn pathstree_inner(
                 format!(
                     "#{}\n{}",
                     path_string,
-                    blob_text(repo, objects::git2_oid(entry.oid))
+                    blob_text(odb, objects::git2_oid(entry.oid))
                 )
             } else {
                 path_string.to_string()
@@ -73,16 +70,14 @@ fn pathstree_inner(
     Ok(result)
 }
 
-pub fn regex_replace<'a>(
+pub fn regex_replace(
     input: git2::Oid,
     regex: &regex::Regex,
     replacement: &str,
-    transaction: &'a cache::Transaction,
-) -> anyhow::Result<git2::Tree<'a>> {
-    let repo = transaction.repo();
+    transaction: &cache::Transaction,
+) -> anyhow::Result<git2::Oid> {
     let odb = transaction.odb()?;
-    let result = regex_replace_inner(input, regex, replacement, transaction, &odb)?;
-    Ok(repo.find_tree(result)?)
+    regex_replace_inner(input, regex, replacement, transaction, &odb)
 }
 
 /// Oid-level body of [`regex_replace`]; the odb is hoisted like in [`remove_pred_inner`].
@@ -93,7 +88,6 @@ fn regex_replace_inner(
     transaction: &cache::Transaction,
     odb: &josh_memodb::Odb,
 ) -> anyhow::Result<git2::Oid> {
-    let repo = transaction.repo();
     let bytes = transaction
         .read_tree_bytes(odb, input)?
         .ok_or_else(|| anyhow!("regex_replace: {} is not a tree", input))?;
@@ -120,7 +114,7 @@ fn regex_replace_inner(
                 });
             }
         } else if !entry.mode.is_commit() {
-            let file_contents = blob_text(repo, objects::git2_oid(entry.oid));
+            let file_contents = blob_text(odb, objects::git2_oid(entry.oid));
             let replaced = regex.replacen(&file_contents, 0, replacement);
 
             rebuild.keep(gix_object::tree::Entry {
@@ -133,16 +127,30 @@ fn regex_replace_inner(
     objects::write_tree_now(odb, rebuild.out)
 }
 
-/// The text content of the blob `oid`, or the empty string when the blob is missing, binary, or
-/// not valid UTF-8 -- the same tolerant semantics as [`get_blob`], minus the path lookup.
-fn blob_text(repo: &git2::Repository, oid: git2::Oid) -> String {
-    let blob = ok_or!(repo.find_blob(oid), {
+/// The raw bytes of the blob `oid`, or `None` when the object is missing or not a blob --
+/// `find_blob`'s tolerance, in facade currency.
+pub(crate) fn blob_bytes<'a>(
+    odb: &'a josh_memodb::Odb,
+    oid: git2::Oid,
+) -> Option<josh_memodb::Bytes<'a>> {
+    match odb.read(oid) {
+        Ok((gix_object::Kind::Blob, bytes)) => Some(bytes),
+        _ => None,
+    }
+}
+
+/// The text content of the blob `oid`, or the empty string when the blob is missing, contains
+/// a NUL byte, or is not valid UTF-8 -- the same tolerant semantics as [`get_blob`], minus the
+/// path lookup. The NUL check keeps binary blobs from reading as content in workspace/link
+/// parsing and text transforms.
+pub(crate) fn blob_text(odb: &josh_memodb::Odb, oid: git2::Oid) -> String {
+    let bytes = some_or!(blob_bytes(odb, oid), {
         return "".to_owned();
     });
-    if blob.is_binary() {
+    if bytes.contains(&0) {
         return "".to_owned();
     }
-    let content = ok_or!(std::str::from_utf8(blob.content()), {
+    let content = ok_or!(std::str::from_utf8(&bytes), {
         return "".to_owned();
     });
     content.to_owned()
@@ -253,6 +261,126 @@ fn lookup_entry<'a>(
     } else {
         tree.entries.iter().find(|e| e.filename == name).copied()
     }
+}
+
+/// A tree held by its raw bytes, so it can be returned from [`read_tree`] and kept across a
+/// whole filter arm. Lookups walk the entries lazily and allocate nothing, which suits the
+/// sites that probe a handful of paths in one tree (a path descent, the workspace files of a
+/// commit); [`ParsedTree`] is the counterpart for iterating every entry.
+pub(crate) struct TreeReader<'a> {
+    bytes: cache::TreeBytes<'a>,
+}
+
+impl TreeReader<'_> {
+    /// Entry by name irrespective of kind, first occurrence winning -- tree entry order is
+    /// not necessarily canonical, and a name is unique in a valid tree.
+    pub(crate) fn entry(&self, name: &[u8]) -> Option<gix_object::tree::EntryRef<'_>> {
+        gix_object::TreeRefIter::from_bytes(&self.bytes, gix_hash::Kind::Sha1)
+            .filter_map(Result::ok)
+            .find(|entry| entry.filename == name)
+    }
+}
+
+/// Read the tree `oid`, erroring when the object is missing or not a tree.
+pub(crate) fn read_tree<'a>(
+    transaction: &cache::Transaction,
+    odb: &'a josh_memodb::Odb,
+    oid: git2::Oid,
+) -> anyhow::Result<TreeReader<'a>> {
+    let bytes = transaction
+        .read_tree_bytes(odb, oid)?
+        .ok_or_else(|| anyhow!("{} is not a tree", oid))?;
+    Ok(TreeReader { bytes })
+}
+
+/// A parsed tree with its canonical-order flag computed once, so sites that iterate every
+/// entry can also bisect for names. Borrows a caller-held buffer.
+pub(crate) struct ParsedTree<'b> {
+    tree: gix_object::TreeRef<'b>,
+    sorted: bool,
+}
+
+impl<'b> ParsedTree<'b> {
+    pub(crate) fn from_bytes(bytes: &'b [u8]) -> anyhow::Result<Self> {
+        let tree = gix_object::TreeRef::from_bytes(bytes, gix_hash::Kind::Sha1)?;
+        let sorted = entries_canonically_sorted(&tree);
+        Ok(ParsedTree { tree, sorted })
+    }
+
+    /// Entry by name irrespective of kind (see [`lookup_entry`]).
+    pub(crate) fn entry(&self, name: &[u8]) -> Option<gix_object::tree::EntryRef<'b>> {
+        lookup_entry(&self.tree, name.into(), self.sorted)
+    }
+
+    pub(crate) fn entries(&self) -> &[gix_object::tree::EntryRef<'b>] {
+        &self.tree.entries
+    }
+}
+
+/// The normal components of `path`, or `None` for path shapes that can never name a tree
+/// entry (empty, absolute, or containing `..`) -- rejected paths read as lookup misses.
+/// `.` components and redundant separators normalize away.
+fn path_components(path: &Path) -> Option<Vec<&[u8]>> {
+    let mut components = vec![];
+    for c in path.components() {
+        match c {
+            std::path::Component::Normal(name) => components.push(component_bytes(name)),
+            std::path::Component::CurDir => {}
+            _ => return None,
+        }
+    }
+    if components.is_empty() {
+        return None;
+    }
+    Some(components)
+}
+
+/// Descend `path` from the tree `root`. `Ok(None)` covers a missing component and a non-tree
+/// intermediate entry; the final entry may be any kind (gitlinks included). Per level the
+/// bytes come from `read_tree_bytes` (memory zero-copy / TreeCache), so unflushed trees
+/// resolve.
+pub(crate) fn get_path_entry(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    root: git2::Oid,
+    path: &Path,
+) -> anyhow::Result<Option<gix_object::tree::Entry>> {
+    let bytes = match transaction.read_tree_bytes(odb, root)? {
+        Some(bytes) => bytes,
+        None => return Ok(None),
+    };
+    get_path_entry_at(transaction, odb, &(TreeReader { bytes }), path)
+}
+
+/// [`get_path_entry`] resolving the first component against a caller-held parse -- the hoist
+/// for multi-probe sites, which pay one root parse for N descents.
+pub(crate) fn get_path_entry_at(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    root: &TreeReader,
+    path: &Path,
+) -> anyhow::Result<Option<gix_object::tree::Entry>> {
+    let Some(components) = path_components(path) else {
+        return Ok(None);
+    };
+    let mut entry: gix_object::tree::Entry = match root.entry(components[0]) {
+        Some(entry) => entry.into(),
+        None => return Ok(None),
+    };
+    for name in &components[1..] {
+        if !entry.mode.is_tree() {
+            return Ok(None);
+        }
+        let bytes = match transaction.read_tree_bytes(odb, objects::git2_oid(&entry.oid))? {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
+        entry = match (TreeReader { bytes }).entry(name) {
+            Some(entry) => entry.into(),
+            None => return Ok(None),
+        };
+    }
+    Ok(Some(entry))
 }
 
 /// Insert `entry` at its canonical position in `out`, scanning back from the end (O(1) for
@@ -717,7 +845,7 @@ fn replace_child_inner(
 /// Oid-level body of [`insert`]: replace whatever is at `path` inside the tree `full_tree` with
 /// (`oid`, `mode`), creating intermediate trees as needed and treating blobs on the way as
 /// overwritable.
-fn insert_inner(
+pub(crate) fn insert_oid(
     odb: &(impl gix_object::Find + gix_object::Write),
     full_tree: git2::Oid,
     path: &Path,
@@ -760,9 +888,13 @@ fn insert_inner(
 
     let subtree = replace_child_inner(odb, component_bytes(name), oid, mode, st)?;
 
-    insert_inner(odb, full_tree, parent, subtree, 0o0040000)
+    insert_oid(odb, full_tree, parent, subtree, 0o0040000)
 }
 
+// PORT: retained pub API for the leaf crates (josh-proxy, josh-changes, josh-link,
+// josh-cq); its `Git2Odb` reads and writes resolve through the registered backend, so it
+// must be facade-backed or gone before the backend can be unregistered (the writes would
+// otherwise land loose on disk).
 pub fn insert<'a>(
     repo: &'a git2::Repository,
     full_tree: &git2::Tree,
@@ -770,15 +902,31 @@ pub fn insert<'a>(
     oid: git2::Oid,
     mode: i32,
 ) -> anyhow::Result<git2::Tree<'a>> {
-    // No transaction in scope here; the repo odb still serves the memory store through the
-    // registered backend.
     let odb = repo.odb()?;
-    let result = insert_inner(&objects::Git2Odb(&odb), full_tree.id(), path, oid, mode)?;
+    let result = insert_oid(&objects::Git2Odb(&odb), full_tree.id(), path, oid, mode)?;
     Ok(repo.find_tree(result)?)
 }
 
+/// Kind of `oid`, or `None` when the object is missing (the zero oid included) or the
+/// header unreadable -- both read as an ordinary miss.
+fn kind_of(src: &impl gix_object::FindHeader, oid: git2::Oid) -> Option<gix_object::Kind> {
+    src.try_header(&objects::gix_oid(oid))
+        .ok()
+        .flatten()
+        .map(|h| h.kind)
+}
+
+/// Fill `buf` with the raw bytes of `oid` if it is a readable tree object. Parse failures
+/// fold to `None` at the caller, keeping the probe arms tolerant of corrupt trees.
+fn read_tree_into(src: &impl gix_object::Find, oid: git2::Oid, buf: &mut Vec<u8>) -> bool {
+    matches!(
+        src.try_find(&objects::gix_oid(oid), buf),
+        Ok(Some(data)) if data.kind == gix_object::Kind::Tree
+    )
+}
+
 pub fn diff_paths(
-    repo: &git2::Repository,
+    src: &(impl gix_object::Find + gix_object::FindHeader),
     input1: git2::Oid,
     input2: git2::Oid,
     root: &str,
@@ -787,46 +935,59 @@ pub fn diff_paths(
         return Ok(vec![]);
     }
 
-    if let (Ok(_), Ok(_)) = (repo.find_blob(input1), repo.find_blob(input2)) {
+    use gix_object::Kind;
+    let kind1 = kind_of(src, input1);
+    let kind2 = kind_of(src, input2);
+
+    if let (Some(Kind::Blob), Some(Kind::Blob)) = (kind1, kind2) {
         return Ok(vec![(root.to_string(), 0)]);
     }
 
-    if let (Ok(_), Err(_)) = (repo.find_blob(input1), repo.find_blob(input2)) {
+    if let (Some(Kind::Blob), _) = (kind1, kind2) {
         return Ok(vec![(root.to_string(), -1)]);
     }
 
-    if let (Err(_), Ok(_)) = (repo.find_blob(input1), repo.find_blob(input2)) {
+    if let (_, Some(Kind::Blob)) = (kind1, kind2) {
         return Ok(vec![(root.to_string(), 1)]);
     }
 
     let mut r = vec![];
 
-    if let (Ok(tree1), Ok(tree2)) = (repo.find_tree(input1), repo.find_tree(input2)) {
-        for entry in tree2.iter() {
-            let name = entry.name()?;
-            if let Some(e) = tree1.get_name(entry.name()?) {
+    let mut buf1 = Vec::new();
+    let mut buf2 = Vec::new();
+    let tree1 = read_tree_into(src, input1, &mut buf1)
+        .then(|| ParsedTree::from_bytes(&buf1).ok())
+        .flatten();
+    let tree2 = read_tree_into(src, input2, &mut buf2)
+        .then(|| ParsedTree::from_bytes(&buf2).ok())
+        .flatten();
+
+    if let (Some(tree1), Some(tree2)) = (&tree1, &tree2) {
+        for entry in tree2.entries() {
+            let name = std::str::from_utf8(entry.filename).map_err(|_| anyhow!("no name"))?;
+            if let Some(e) = tree1.entry(entry.filename) {
                 r.append(&mut diff_paths(
-                    repo,
-                    e.id(),
-                    entry.id(),
+                    src,
+                    objects::git2_oid(e.oid),
+                    objects::git2_oid(entry.oid),
                     &format!("{}{}{}", root, if root.is_empty() { "" } else { "/" }, name),
                 )?);
             } else {
                 r.append(&mut diff_paths(
-                    repo,
+                    src,
                     git2::Oid::ZERO_SHA1,
-                    entry.id(),
+                    objects::git2_oid(entry.oid),
                     &format!("{}{}{}", root, if root.is_empty() { "" } else { "/" }, name),
                 )?);
             }
         }
 
-        for entry in tree1.iter() {
-            let name = entry.name()?;
-            if tree2.get_name(entry.name()?).is_none() {
+        for entry in tree1.entries() {
+            let name = std::str::from_utf8(entry.filename).map_err(|_| anyhow!("no name"))?;
+            if tree2.entry(entry.filename).is_none() {
                 r.append(&mut diff_paths(
-                    repo,
-                    entry.id(),
+                    src,
+                    objects::git2_oid(entry.oid),
                     git2::Oid::ZERO_SHA1,
                     &format!("{}{}{}", root, if root.is_empty() { "" } else { "/" }, name),
                 )?);
@@ -836,25 +997,25 @@ pub fn diff_paths(
         return Ok(r);
     }
 
-    if let Ok(tree2) = repo.find_tree(input2) {
-        for entry in tree2.iter() {
-            let name = entry.name()?;
+    if let Some(tree2) = &tree2 {
+        for entry in tree2.entries() {
+            let name = std::str::from_utf8(entry.filename).map_err(|_| anyhow!("no name"))?;
             r.append(&mut diff_paths(
-                repo,
+                src,
                 git2::Oid::ZERO_SHA1,
-                entry.id(),
+                objects::git2_oid(entry.oid),
                 &format!("{}{}{}", root, if root.is_empty() { "" } else { "/" }, name),
             )?);
         }
         return Ok(r);
     }
 
-    if let Ok(tree1) = repo.find_tree(input1) {
-        for entry in tree1.iter() {
-            let name = entry.name()?;
+    if let Some(tree1) = &tree1 {
+        for entry in tree1.entries() {
+            let name = std::str::from_utf8(entry.filename).map_err(|_| anyhow!("no name"))?;
             r.append(&mut diff_paths(
-                repo,
-                entry.id(),
+                src,
+                objects::git2_oid(entry.oid),
                 git2::Oid::ZERO_SHA1,
                 &format!("{}{}{}", root, if root.is_empty() { "" } else { "/" }, name),
             )?);
@@ -951,49 +1112,60 @@ pub fn pathline(b: &str) -> anyhow::Result<String> {
     }
 }
 
-pub fn invert_paths<'a>(
-    transaction: &'a cache::Transaction,
+pub fn invert_paths(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
     root: &str,
-    tree: git2::Tree<'a>,
-) -> anyhow::Result<git2::Tree<'a>> {
-    let repo = transaction.repo();
-    if let Some(cached) = transaction.get_invert((tree.id(), root.to_string())) {
-        return Ok(repo.find_tree(cached)?);
+    tree: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    if let Some(cached) = transaction.get_invert((tree, root.to_string())) {
+        return Ok(cached);
     }
 
-    let mut result = empty(repo);
+    let mut result = empty_id();
 
-    for entry in tree.iter() {
-        let name = entry.name()?;
+    let bytes = transaction
+        .read_tree_bytes(odb, tree)?
+        .ok_or_else(|| anyhow!("invert_paths: {} is not a tree", tree))?;
+    let parsed = ParsedTree::from_bytes(&bytes)?;
 
-        if entry.kind() == Some(git2::ObjectType::Blob) {
+    for entry in parsed.entries() {
+        let name = std::str::from_utf8(entry.filename).map_err(|_| anyhow!("no name"))?;
+
+        if !entry.mode.is_tree() && !entry.mode.is_commit() {
             let mpath = normalize_path(&Path::new(root).join(name))
                 .to_string_lossy()
                 .to_string();
-            let b = get_blob(repo, &tree, Path::new(name));
+            // Same one-level lookup get_blob did (first-match by name, not this iteration's
+            // entry) -- resolved on the hoisted parse.
+            let b = parsed
+                .entry(entry.filename)
+                .map(|e| blob_text(odb, objects::git2_oid(e.oid)))
+                .unwrap_or_default();
             let opath = pathline(&b)?;
 
-            result = insert(
-                repo,
-                &result,
+            result = insert_oid(
+                odb,
+                result,
                 Path::new(&opath),
-                repo.blob(mpath.as_bytes())?,
+                odb.write(gix_object::Kind::Blob, mpath.as_bytes()),
                 0o0100644,
             )
             .unwrap();
         }
 
-        if entry.kind() == Some(git2::ObjectType::Tree) {
+        if entry.mode.is_tree() {
             let s = invert_paths(
                 transaction,
+                odb,
                 &format!("{}{}{}", root, if root.is_empty() { "" } else { "/" }, name),
-                repo.find_tree(entry.id())?,
+                objects::git2_oid(entry.oid),
             )?;
-            result = repo.find_tree(overlay(transaction, result.id(), s.id())?)?;
+            result = overlay(transaction, result, s)?;
         }
     }
 
-    transaction.insert_invert((tree.id(), root.to_string()), result.id());
+    transaction.insert_invert((tree, root.to_string()), result);
 
     Ok(result)
 }
@@ -1001,7 +1173,7 @@ pub fn invert_paths<'a>(
 pub fn original_path(
     transaction: &cache::Transaction,
     filter: Filter,
-    tree: git2::Tree,
+    tree: git2::Oid,
     path: &Path,
 ) -> anyhow::Result<String> {
     let paths_tree = apply(
@@ -1009,15 +1181,15 @@ pub fn original_path(
         to_filter(Op::Paths).chain(filter),
         Rewrite::from_tree(tree),
     )?;
-    let b = get_blob(transaction.repo(), paths_tree.tree(), path);
+    let b = get_blob(transaction, &transaction.odb()?, paths_tree.tree_id(), path);
     pathline(&b)
 }
 
 pub fn repopulated_tree(
     transaction: &cache::Transaction,
     filter: Filter,
-    full_tree: git2::Tree,
-    partial_tree: git2::Tree,
+    full_tree: git2::Oid,
+    partial_tree: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
     let paths_tree = apply(
         transaction,
@@ -1025,12 +1197,14 @@ pub fn repopulated_tree(
         Rewrite::from_tree(full_tree),
     )?;
 
-    let ipaths = invert_paths(transaction, "", paths_tree.into_tree())?;
-    populate(transaction, ipaths.id(), partial_tree.id())
+    let odb = transaction.odb()?;
+    let ipaths = invert_paths(transaction, &odb, "", paths_tree.tree_id())?;
+    populate(transaction, &odb, ipaths, partial_tree)
 }
 
 pub fn populate(
     transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
     paths: git2::Oid,
     content: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
@@ -1038,26 +1212,36 @@ pub fn populate(
         return Ok(cached);
     }
 
-    let repo = transaction.repo();
+    use gix_object::Kind;
+    let paths_kind = odb.read_header(paths).map(|(kind, _)| kind).ok();
+    let content_kind = odb.read_header(content).map(|(kind, _)| kind).ok();
 
     let mut result_tree = empty_id();
-    if let (Ok(paths), Ok(content)) = (repo.find_blob(paths), repo.find_blob(content)) {
-        let ipath = pathline(std::str::from_utf8(paths.content())?)?;
-        result_tree = insert(
-            repo,
-            &repo.find_tree(result_tree)?,
-            Path::new(&ipath),
-            content.id(),
-            0o0100644,
-        )?
-        .id();
-    } else if let (Ok(paths), Ok(content)) = (repo.find_tree(paths), repo.find_tree(content)) {
-        for entry in content.iter() {
-            if let Some(e) = paths.get_name(entry.name()?) {
+    if let (Some(Kind::Blob), Some(Kind::Blob)) = (paths_kind, content_kind) {
+        let paths_bytes = blob_bytes(odb, paths).ok_or_else(|| anyhow!("populate: blob read"))?;
+        let ipath = pathline(std::str::from_utf8(&paths_bytes)?)?;
+        result_tree = insert_oid(odb, result_tree, Path::new(&ipath), content, 0o0100644)?;
+    } else if let (Some(Kind::Tree), Some(Kind::Tree)) = (paths_kind, content_kind) {
+        let paths_bytes = transaction
+            .read_tree_bytes(odb, paths)?
+            .ok_or_else(|| anyhow!("populate: {} is not a tree", paths))?;
+        let content_bytes = transaction
+            .read_tree_bytes(odb, content)?
+            .ok_or_else(|| anyhow!("populate: {} is not a tree", content))?;
+        let paths_tree = ParsedTree::from_bytes(&paths_bytes)?;
+        let content_tree = ParsedTree::from_bytes(&content_bytes)?;
+        for entry in content_tree.entries() {
+            std::str::from_utf8(entry.filename).map_err(|_| anyhow!("no name"))?;
+            if let Some(e) = paths_tree.entry(entry.filename) {
                 result_tree = overlay(
                     transaction,
                     result_tree,
-                    populate(transaction, e.id(), entry.id())?,
+                    populate(
+                        transaction,
+                        odb,
+                        objects::git2_oid(e.oid),
+                        objects::git2_oid(entry.oid),
+                    )?,
                 )?;
             }
         }
@@ -1068,6 +1252,7 @@ pub fn populate(
     Ok(result_tree)
 }
 
+// PORT: dead code, zero callers workspace-wide.
 pub fn compose_fast(
     transaction: &cache::Transaction,
     trees: Vec<git2::Oid>,
@@ -1081,15 +1266,14 @@ pub fn compose_fast(
     Ok(repo.find_tree(result)?)
 }
 
-pub fn compose<'a>(
-    transaction: &'a cache::Transaction,
-    trees: Vec<(&Filter, git2::Tree<'a>)>,
-) -> anyhow::Result<git2::Tree<'a>> {
-    let repo = transaction.repo();
-    let mut result = empty(repo);
-    let mut taken = empty(repo);
+pub fn compose(
+    transaction: &cache::Transaction,
+    trees: Vec<(&Filter, git2::Oid)>,
+) -> anyhow::Result<git2::Oid> {
+    let mut result = empty_id();
+    let mut taken = empty_id();
     for (f, applied) in trees {
-        let tid = taken.id();
+        let tid = taken;
         // If a filter creates a tree entry that does not exist in the input (Like TreeId and Blob),
         // the "output uniqueness handling" will cause it's output entry to be removed from the
         // tree during compose.
@@ -1101,54 +1285,60 @@ pub fn compose<'a>(
         let taken_applied = if let Some(cached) = transaction.get_apply(f, tid) {
             cached
         } else {
-            apply(transaction, f, Rewrite::from_tree(taken.clone()))?
-                .tree()
-                .id()
+            apply(transaction, f, Rewrite::from_tree(taken))?.tree_id()
         };
         transaction.insert_apply(f, tid, taken_applied);
 
-        let subtracted = repo.find_tree(subtract(transaction, applied.id(), taken_applied)?)?;
+        let subtracted = subtract(transaction, applied, taken_applied)?;
 
-        let aid = applied.id();
+        let aid = applied;
         let unapplied = if let Some(cached) = transaction.get_unapply(f, aid) {
             cached
         } else {
-            apply(transaction, invert(f)?, Rewrite::from_tree(applied))?
-                .tree()
-                .id()
+            apply(transaction, invert(f)?, Rewrite::from_tree(applied))?.tree_id()
         };
         transaction.insert_unapply(f, aid, unapplied);
-        taken = repo.find_tree(overlay(transaction, taken.id(), unapplied)?)?;
-        result = repo.find_tree(overlay(transaction, subtracted.id(), result.id())?)?;
+        taken = overlay(transaction, taken, unapplied)?;
+        result = overlay(transaction, subtracted, result)?;
     }
 
     Ok(result)
 }
 
-pub fn get_blob(repo: &git2::Repository, tree: &git2::Tree, path: &Path) -> String {
-    let entry_oid = ok_or!(tree.get_path(path).map(|x| x.id()), {
-        return "".to_owned();
-    });
+pub fn get_blob(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    tree: git2::Oid,
+    path: &Path,
+) -> String {
+    let entry = match get_path_entry(transaction, odb, tree, path) {
+        Ok(Some(entry)) => entry,
+        _ => return "".to_owned(),
+    };
+    blob_text(odb, objects::git2_oid(&entry.oid))
+}
 
-    let blob = ok_or!(repo.find_blob(entry_oid), {
-        return "".to_owned();
-    });
-
-    if blob.is_binary() {
-        return "".to_owned();
-    }
-
-    let content = ok_or!(std::str::from_utf8(blob.content()), {
-        return "".to_owned();
-    });
-
-    content.to_owned()
+/// [`get_blob`] over a caller-held parse of the root tree (see [`get_path_entry_at`]).
+pub(crate) fn get_blob_at(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    root: &TreeReader,
+    path: &Path,
+) -> String {
+    let entry = match get_path_entry_at(transaction, odb, root, path) {
+        Ok(Some(entry)) => entry,
+        _ => return "".to_owned(),
+    };
+    blob_text(odb, objects::git2_oid(&entry.oid))
 }
 
 pub fn empty_id() -> git2::Oid {
     git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap()
 }
 
+// PORT: retained pub API for the leaf crates (in-core callers compare against
+// `empty_id()` instead); the lookup resolves through the registered backend's disk
+// fallback, which virtualizes the empty tree.
 pub fn empty(repo: &git2::Repository) -> git2::Tree<'_> {
     repo.find_tree(empty_id()).unwrap()
 }
@@ -1645,6 +1835,75 @@ mod tests {
         assert_eq!(out, want, "b/f.txt must not be kept via the a/ cache entry");
     }
 
+    // get_path_entry misses on missing components and non-tree intermediates, resolves final
+    // entries of any kind (gitlinks included), normalizes redundant path syntax, tolerates
+    // non-canonical trees via the linear-lookup fallback, and reads the virtualized empty
+    // tree.
+    #[test]
+    fn get_path_entry_contract() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(td.path()).unwrap();
+        let blob = repo.blob(b"content").unwrap();
+        let t = open_transaction(&td);
+        let odb = t.odb().unwrap();
+
+        let gitlink = git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap();
+        let mut b = git2::build::TreeUpdateBuilder::new();
+        b.upsert("a/b/deep.txt", blob, git2::FileMode::Blob);
+        b.upsert("top.txt", blob, git2::FileMode::Blob);
+        b.upsert("a/sub", gitlink, git2::FileMode::Commit);
+        let base = repo.treebuilder(None).unwrap().write().unwrap();
+        let root = b
+            .create_updated(&repo, &repo.find_tree(base).unwrap())
+            .unwrap();
+
+        let entry = get_path_entry(&t, &odb, root, Path::new("a/b/deep.txt"))
+            .unwrap()
+            .expect("hit at depth 2");
+        assert_eq!(objects::git2_oid(&entry.oid), blob);
+        assert!(!entry.mode.is_tree());
+
+        let entry = get_path_entry(&t, &odb, root, Path::new("a/sub"))
+            .unwrap()
+            .expect("gitlink entry resolves");
+        assert!(entry.mode.is_commit());
+
+        for miss in ["a/b/missing.txt", "a/missing/deep.txt", "top.txt/below"] {
+            assert!(
+                get_path_entry(&t, &odb, root, Path::new(miss))
+                    .unwrap()
+                    .is_none(),
+                "{miss} must be a miss"
+            );
+        }
+
+        // Path normalization: `.` components and redundant separators are ignored, while
+        // absolute paths and `..` can never name a tree entry and read as misses.
+        for hit in ["a/./b/deep.txt", "a//b/deep.txt", "./top.txt", "a/b/"] {
+            assert!(
+                get_path_entry(&t, &odb, root, Path::new(hit))
+                    .unwrap()
+                    .is_some(),
+                "{hit} must resolve"
+            );
+        }
+        for miss in ["../top.txt", "/top.txt", "."] {
+            assert!(
+                get_path_entry(&t, &odb, root, Path::new(miss))
+                    .unwrap()
+                    .is_none(),
+                "{miss} must be a miss"
+            );
+        }
+
+        // The empty tree reads through the virtualized disk fallback: no entries, plain miss.
+        assert!(
+            get_path_entry(&t, &odb, empty_id(), Path::new("anything"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
     // Removing a whole subdirectory must report every file under it as removed. This exercises
     // the "input1 is a tree, input2 is gone" branch of diff_paths, which is only reachable via
     // the recursion for entries present in tree1 but absent from tree2.
@@ -1656,13 +1915,14 @@ mod tests {
         let tree1 = make_tree(&repo, &["dir/file1", "dir/file2", "kept"]);
         let tree2 = make_tree(&repo, &["kept"]);
 
-        let removed = diff_paths(&repo, tree1, tree2, "").unwrap();
+        let odb = repo.odb().unwrap();
+        let removed = diff_paths(&objects::Git2Odb(&odb), tree1, tree2, "").unwrap();
         assert_eq!(
             removed,
             vec![("dir/file1".to_string(), -1), ("dir/file2".to_string(), -1)]
         );
 
-        let added = diff_paths(&repo, tree2, tree1, "").unwrap();
+        let added = diff_paths(&objects::Git2Odb(&odb), tree2, tree1, "").unwrap();
         assert_eq!(
             added,
             vec![("dir/file1".to_string(), 1), ("dir/file2".to_string(), 1)]

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -208,7 +208,7 @@ pub fn rewrite_commit(
     // gix_object::CommitRef uses byte strings for Oids, but in hex representation, not raw bytes.
     // Its `Format` implementation writes out hex-encoded bytes. Because of CommitRef's reference
     // lifetimes we have to this, before creating CommitRef
-    let tree_id = BString::from(rewrite_data.tree().id().to_string());
+    let tree_id = BString::from(rewrite_data.tree_id().to_string());
     let parent_ids = parents
         .iter()
         .map(|p| BString::from(p.to_string()))
@@ -451,13 +451,15 @@ pub fn unapply_filter(
         let _span_guard = span.enter();
 
         tracing::info!("walk commit: {:?}", rev);
-        let module_commit = transaction.repo().find_commit(rev)?;
+        let module_commit = objects::CommitData::read(&odb, rev)?;
 
         if filtered_to_original.contains_key(&module_commit.id()) {
             continue;
         }
 
         let mut filtered_parent_ids: Vec<_> = module_commit.parent_ids().collect();
+        // PORT: libgit2 graph compute over filtered (possibly unflushed) commits,
+        // served by the registered backend.
         let has_new_orphan = filtered_parent_ids.len() > 1
             && transaction
                 .repo()
@@ -479,7 +481,7 @@ pub fn unapply_filter(
                           '-o merge' to import new history by creating merge commit
                           '-o edit' if you are editing a stored filter or workspace
                         "###,
-                        module_commit.summary().ok().flatten().unwrap_or_default(),
+                        module_commit.summary().unwrap_or_default(),
                         module_commit.id(),
                     )));
                 }
@@ -506,14 +508,14 @@ pub fn unapply_filter(
                 }
             })
             .map(|unapply_base| -> anyhow::Result<_> {
-                Ok(transaction.repo().find_commit(unapply_base?)?)
+                objects::CommitData::read(&odb, unapply_base?)
             })
             .collect();
 
         // If there are no parents and "reparent" option is given, use the given OID as a parent
         let mut original_parents = original_parents?;
         if let (0, Some(reparent)) = (original_parents.len(), reparent_orphans) {
-            original_parents = vec![transaction.repo().find_commit(reparent)?];
+            original_parents = vec![objects::CommitData::read(&odb, reparent)?];
         }
 
         tracing::info!(
@@ -522,14 +524,10 @@ pub fn unapply_filter(
             filtered_parent_ids
         );
 
-        // Convert original_parents to a vector of (rust) references
-        let original_parents: Vec<&git2::Commit> = original_parents.iter().collect();
-        let tree = module_commit.tree()?;
+        let tree = module_commit.tree_id()?;
         let commit_message = module_commit
             .summary()
-            .ok()
-            .flatten()
-            .unwrap_or("NO COMMIT MESSAGE");
+            .unwrap_or_else(|| "NO COMMIT MESSAGE".to_string());
 
         let new_trees: anyhow::Result<Vec<_>> = {
             let span = tracing::span!(
@@ -547,14 +545,13 @@ pub fn unapply_filter(
                 .map(|commit| -> anyhow::Result<_> {
                     // Pass the commit context so a `:rev(...)` cutoff in the filter is resolved
                     // per commit (current vs this parent) rather than collapsed uniformly.
-                    Ok(filter::unapply(
+                    filter::unapply(
                         transaction,
                         filter,
-                        tree.clone(),
-                        commit.tree()?,
-                        Some((&module_commit, *commit)),
-                    )?
-                    .id())
+                        tree,
+                        commit.tree_id()?,
+                        Some((module_commit.id(), commit.id())),
+                    )
                 })
                 .collect()
         };
@@ -582,7 +579,7 @@ pub fn unapply_filter(
             // The normal case: Either there was only one parent or all of them where the same
             // outside of the current filter in which case they collapse into one tree and that
             // is the one we pick
-            1 => transaction.repo().find_tree(new_trees[0])?,
+            1 => new_trees[0],
 
             // 0 means the history is unrelated. Pushing it will fail if we are not
             // dealing with either a force push or a push with the "merge" option set.
@@ -594,8 +591,8 @@ pub fn unapply_filter(
                     transaction,
                     filter,
                     tree,
-                    filter::tree::empty(transaction.repo()),
-                    Some((&module_commit, &module_commit)),
+                    filter::tree::empty_id(),
+                    Some((module_commit.id(), module_commit.id())),
                 )?
             }
 
@@ -606,6 +603,7 @@ pub fn unapply_filter(
                 for i in 0..parent_count {
                     // If one of the parents is a descendant of the target branch and the other is
                     // not, pick the tree of the one that is a descendant.
+                    // PORT: libgit2 graph compute, served by the registered backend.
                     if (original_parents[i].id() == original_target)
                         || transaction
                             .repo()
@@ -628,42 +626,44 @@ pub fn unapply_filter(
                     // If our assumption was correct and all conflicts were in filtered files,
                     // both resulting trees will be the same and we can pick the result to proceed.
 
+                    // PORT: libgit2-internal merge compute -- the find_commit bridges and
+                    // `write_tree_to` move possibly-unflushed objects through the
+                    // registered backend.
+                    let parent0 = transaction.repo().find_commit(original_parents[0].id())?;
+                    let parent1 = transaction.repo().find_commit(original_parents[1].id())?;
+
                     let mut mergeopts = git2::MergeOptions::new();
                     mergeopts.file_favor(git2::FileFavor::Ours);
 
-                    let mut merged_index = transaction.repo().merge_commits(
-                        original_parents[0],
-                        original_parents[1],
-                        Some(&mergeopts),
-                    )?;
+                    let mut merged_index =
+                        transaction
+                            .repo()
+                            .merge_commits(&parent0, &parent1, Some(&mergeopts))?;
                     let base_tree = merged_index.write_tree_to(transaction.repo())?;
                     // The base is a merge of both original parents; resolve any `:rev(...)` cutoff
                     // against the first parent (mirrors the descendant-pick preference above).
                     let tid_ours = filter::unapply(
                         transaction,
                         filter,
-                        tree.clone(),
-                        transaction.repo().find_tree(base_tree)?,
-                        Some((&module_commit, original_parents[0])),
-                    )?
-                    .id();
+                        tree,
+                        base_tree,
+                        Some((module_commit.id(), original_parents[0].id())),
+                    )?;
 
                     mergeopts.file_favor(git2::FileFavor::Theirs);
 
-                    let mut merged_index = transaction.repo().merge_commits(
-                        original_parents[0],
-                        original_parents[1],
-                        Some(&mergeopts),
-                    )?;
+                    let mut merged_index =
+                        transaction
+                            .repo()
+                            .merge_commits(&parent0, &parent1, Some(&mergeopts))?;
                     let base_tree = merged_index.write_tree_to(transaction.repo())?;
                     let tid_theirs = filter::unapply(
                         transaction,
                         filter,
-                        tree.clone(),
-                        transaction.repo().find_tree(base_tree)?,
-                        Some((&module_commit, original_parents[0])),
-                    )?
-                    .id();
+                        tree,
+                        base_tree,
+                        Some((module_commit.id(), original_parents[0].id())),
+                    )?;
 
                     if tid_ours == tid_theirs {
                         tid = tid_ours;
@@ -677,7 +677,7 @@ pub fn unapply_filter(
                     return Err(anyhow!(
                         "rejecting merge with {} parents:\n{:?} ({:?})\n1) {:?} ({:?})\n2) {:?} ({:?})",
                         parent_count,
-                        module_commit.summary().ok().flatten().unwrap_or_default(),
+                        module_commit.summary().unwrap_or_default(),
                         module_commit.id(),
                         original_parents[0].summary().unwrap_or_default(),
                         original_parents[0].id(),
@@ -686,25 +686,28 @@ pub fn unapply_filter(
                     ));
                 }
 
-                transaction.repo().find_tree(tid)?
+                tid
             }
         };
 
-        let apply = filter::Rewrite::from_tree(new_tree.clone());
+        let apply = filter::Rewrite::from_tree(new_tree);
 
         let original_parent_oids: Vec<git2::Oid> =
             original_parents.iter().map(|c| c.id()).collect();
         ret = rewrite_commit(
             &odb,
-            &objects::CommitData::read(&odb, module_commit.id())?,
+            &module_commit,
             &original_parent_oids,
             apply,
             GpgsigMode::Preserve,
         )?;
 
         ret = if original_parents.len() == 1
-            && new_tree.id() == original_parents[0].tree_id()
-            && Some(module_commit.tree_id()) != module_commit.parents().next().map(|x| x.tree_id())
+            && new_tree == original_parents[0].tree_id()?
+            && Some(module_commit.tree_id()?)
+                != module_commit
+                    .first_parent_id()
+                    .and_then(|p| git::read_tree_id(&odb, p).ok())
         {
             original_parents[0].id()
         } else {
@@ -810,7 +813,7 @@ fn create_filtered_commit2(
     rewrite_data: filter::Rewrite,
     options: BTreeMap<String, String>,
 ) -> anyhow::Result<(git2::Oid, bool)> {
-    let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let mut filtered_parents: Vec<(git2::Oid, git2::Oid)> = filtered_parent_ids
         .iter()
         .filter(|x| **x != git2::Oid::ZERO_SHA1)
@@ -854,13 +857,11 @@ fn create_filtered_commit2(
         "keep-trivial-merges",
     ) {
         if filtered_parents.len() > 1 {
-            let is_trivial_merge = filtered_parents[0].1 == rewrite_data.tree().id();
+            let is_trivial_merge = filtered_parents[0].1 == rewrite_data.tree_id();
             // No first parent is not a trivial merge; a present first parent
             // must have a readable tree.
             let was_trivial_merge = match original_commit.first_parent_id() {
-                Some(parent) => {
-                    git::read_tree_id(&transaction.odb()?, parent)? == original_commit.tree_id()?
-                }
+                Some(parent) => git::read_tree_id(&odb, parent)? == original_commit.tree_id()?,
                 None => false,
             };
 
@@ -872,21 +873,21 @@ fn create_filtered_commit2(
     }
 
     let selected_filtered_parent_ids: Vec<git2::Oid> = select_parent_commits(
-        &transaction.odb()?,
+        &odb,
         original_commit,
-        rewrite_data.tree().id(),
+        rewrite_data.tree_id(),
         &filtered_parents,
     )?;
 
     if selected_filtered_parent_ids.is_empty()
         && !(original_commit.parent_count() == 0
-            && is_empty_root(repo, &repo.find_tree(original_commit.tree_id()?)?))
+            && is_empty_root(transaction, &odb, original_commit.tree_id()?)?)
     {
         if !filtered_parents.is_empty() {
             // Returning the parent id here means the commit is dropped from the output history
             return Ok((filtered_parents[0].0, false));
         }
-        if rewrite_data.tree().id() == filter::tree::empty_id() {
+        if rewrite_data.tree_id() == filter::tree::empty_id() {
             return Ok((git2::Oid::ZERO_SHA1, false));
         }
     }
@@ -897,9 +898,9 @@ fn create_filtered_commit2(
         _ => GpgsigMode::Preserve,
     };
 
-    let new_tree_id = rewrite_data.tree().id();
+    let new_tree_id = rewrite_data.tree_id();
     let new_oid = rewrite_commit(
-        &transaction.odb()?,
+        &odb,
         original_commit,
         &selected_filtered_parent_ids,
         rewrite_data,
@@ -927,19 +928,102 @@ pub(crate) fn filtered_parent_tree_id(
     git::read_tree_id(&transaction.odb()?, oid)
 }
 
-fn is_empty_root(repo: &git2::Repository, tree: &git2::Tree) -> bool {
-    if tree.id() == filter::tree::empty_id() {
+/// Whether `oid` is a tree containing nothing but (recursively) empty trees. An unreadable
+/// root is a hard error, while unreadable or non-tree entries below fold to `false`.
+fn is_empty_root(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    oid: git2::Oid,
+) -> anyhow::Result<bool> {
+    if oid == filter::tree::empty_id() {
+        return Ok(true);
+    }
+
+    let bytes = transaction
+        .read_tree_bytes(odb, oid)?
+        .ok_or_else(|| anyhow!("{} is not a tree", oid))?;
+    let tree = gix_object::TreeRef::from_bytes(&bytes, gix_hash::Kind::Sha1)?;
+    Ok(tree
+        .entries
+        .iter()
+        .all(|e| e.mode.is_tree() && is_empty_subtree(transaction, odb, objects::git2_oid(e.oid))))
+}
+
+fn is_empty_subtree(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    oid: git2::Oid,
+) -> bool {
+    if oid == filter::tree::empty_id() {
         return true;
     }
+    let Ok(Some(bytes)) = transaction.read_tree_bytes(odb, oid) else {
+        return false;
+    };
+    let Ok(tree) = gix_object::TreeRef::from_bytes(&bytes, gix_hash::Kind::Sha1) else {
+        return false;
+    };
+    tree.entries
+        .iter()
+        .all(|e| e.mode.is_tree() && is_empty_subtree(transaction, odb, objects::git2_oid(e.oid)))
+}
 
-    let mut all_empty = true;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    for e in tree.iter() {
-        if let Ok(Ok(t)) = e.to_object(repo).map(|x| x.into_tree()) {
-            all_empty = all_empty && is_empty_root(repo, &t);
-        } else {
-            return false;
-        }
+    // A root is "empty" iff it contains nothing but (recursively) empty trees: the empty tree
+    // itself and nested empty chains qualify; any blob or gitlink anywhere disqualifies.
+    #[test]
+    fn is_empty_root_contract() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(td.path()).unwrap();
+        let cachestack = std::sync::Arc::new(
+            cache::CacheStack::new().with_backend(cache::SledCacheBackend::new(td.path())),
+        );
+        let ctx = cache::TransactionContext::new(td.path(), cachestack);
+        let t = ctx.open().unwrap();
+        let odb = t.odb().unwrap();
+
+        let empty = filter::tree::empty_id();
+        assert!(is_empty_root(&t, &odb, empty).unwrap());
+
+        // A chain of trees bottoming out in the (virtualized) empty tree is empty. Built by
+        // hand: normal tree builders drop empty subtrees.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"40000 sub");
+        data.push(0);
+        data.extend_from_slice(empty.as_bytes());
+        let chain = repo
+            .odb()
+            .unwrap()
+            .write(git2::ObjectType::Tree, &data)
+            .unwrap();
+        let mut data = Vec::new();
+        data.extend_from_slice(b"40000 nested");
+        data.push(0);
+        data.extend_from_slice(chain.as_bytes());
+        let chain2 = repo
+            .odb()
+            .unwrap()
+            .write(git2::ObjectType::Tree, &data)
+            .unwrap();
+        assert!(is_empty_root(&t, &odb, chain2).unwrap());
+
+        // A blob anywhere makes the root non-empty; so does a gitlink.
+        let blob = repo.blob(b"x").unwrap();
+        let mut b = git2::build::TreeUpdateBuilder::new();
+        b.upsert("a/b/file.txt", blob, git2::FileMode::Blob);
+        let base = repo.treebuilder(None).unwrap().write().unwrap();
+        let with_blob = b
+            .create_updated(&repo, &repo.find_tree(base).unwrap())
+            .unwrap();
+        assert!(!is_empty_root(&t, &odb, with_blob).unwrap());
+
+        let gitlink = git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap();
+        let mut b = repo.treebuilder(None).unwrap();
+        b.insert("sub", gitlink, 0o160000).unwrap();
+        let with_gitlink = b.write().unwrap();
+        assert!(!is_empty_root(&t, &odb, with_gitlink).unwrap());
     }
-    all_empty
 }

--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -123,6 +123,7 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
     let trace_s = span!(Level::TRACE, "discover_filter_candidates");
     let _e = trace_s.enter();
 
+    let odb = repo.odb()?;
     transaction.for_each_ref_prefixed("refs/josh/upstream/", |name, target| {
         if !name.ends_with(".git/HEAD") {
             return Ok(());
@@ -139,12 +140,12 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
             .or_insert_with(|| (git2::Oid::ZERO_SHA1, BTreeSet::new()));
 
         if known_f.0 != target {
+            // PORT: mirror-resident fetched target, and `peel` tolerates annotated tags --
+            // stays on git2 until flag day.
             let tree = repo
                 .find_object(target, None)?
                 .peel(git2::ObjectType::Tree)?;
-            let hs = find_all_workspaces_and_subdirectories(
-                tree.as_tree().ok_or_else(|| anyhow!("not a tree"))?,
-            )?;
+            let hs = find_all_workspaces_and_subdirectories(&objects::Git2Odb(&odb), tree.id())?;
             known_f.0 = target;
             for i in hs {
                 known_f.1.insert(i);
@@ -170,28 +171,31 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
 }
 
 pub fn find_all_workspaces_and_subdirectories(
-    tree: &git2::Tree,
+    src: &impl gix_object::Find,
+    tree: git2::Oid,
 ) -> anyhow::Result<std::collections::HashSet<String>> {
     let _trace_s = span!(Level::TRACE, "find_all_workspaces_and_subdirectories");
     let mut hs = std::collections::HashSet::new();
-    tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
+    objects::walk_tree_preorder(src, tree, &mut |root, entry| {
         if root.is_empty() {
-            return 0;
+            return Ok(());
         }
 
-        if entry.name().ok() == Some("workspace.josh") {
-            hs.insert(format!(":workspace={}", root.trim_matches('/')));
+        if &entry.filename[..] == b"workspace.josh" {
+            hs.insert(format!(":workspace={}", root));
         }
-        let v = format!("::{}/", root.trim_matches('/'));
+        let v = format!("::{}/", root);
         if v.chars().filter(|x| *x == '/').count() < 3 {
             hs.insert(v);
         }
 
-        0
+        Ok(())
     })?;
     Ok(hs)
 }
 
+// PORT: dead code, zero callers workspace-wide; reads filtered commits through the repo
+// handle.
 pub fn get_info(
     transaction: &cache::Transaction,
     filter: filter::Filter,

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -171,6 +171,8 @@ pub fn filter_commit(
     oid: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
     let original_commit = {
+        // PORT: oid comes from refs and `peel_to_commit` tolerates annotated tags -- stays
+        // on git2 until flag day.
         let obj = transaction.repo().find_object(oid, None)?;
         obj.peel_to_commit()?
     };

--- a/josh-core/src/link.rs
+++ b/josh-core/src/link.rs
@@ -1,48 +1,49 @@
 pub fn find_link_files(
-    repo: &git2::Repository,
-    tree: &git2::Tree,
+    src: &impl gix_object::Find,
+    tree: git2::Oid,
 ) -> anyhow::Result<Vec<(std::path::PathBuf, crate::filter::Filter)>> {
     use crate::filter;
+    use crate::objects;
     use anyhow::Context;
     let mut link_files = Vec::new();
 
-    tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
-        if let Ok(name) = entry.name() {
-            if name == ".link.josh" {
-                // Found a link file
-                let link_blob = match repo.find_blob(entry.id()) {
-                    Ok(blob) => blob,
-                    Err(e) => {
-                        eprintln!("Failed to find blob: {}", e);
-                        return git2::TreeWalkResult::Skip;
-                    }
-                };
+    objects::walk_tree_preorder(src, tree, &mut |root, entry| {
+        if &entry.filename[..] == b".link.josh" {
+            let mut buf = Vec::new();
+            let link_content = match src.try_find(entry.oid, &mut buf) {
+                Ok(Some(data)) if data.kind == gix_object::Kind::Blob => data.data,
+                Ok(_) => {
+                    eprintln!("Failed to find blob: object {} not found", entry.oid);
+                    return Ok(());
+                }
+                Err(e) => {
+                    eprintln!("Failed to find blob: {}", e);
+                    return Ok(());
+                }
+            };
 
-                let link_content = match std::str::from_utf8(link_blob.content()) {
-                    Ok(content) => content,
-                    Err(e) => {
-                        eprintln!("Failed to parse link file content: {}", e);
-                        return git2::TreeWalkResult::Skip;
-                    }
-                };
+            let link_content = match std::str::from_utf8(link_content) {
+                Ok(content) => content,
+                Err(e) => {
+                    eprintln!("Failed to parse link file content: {}", e);
+                    return Ok(());
+                }
+            };
 
-                let filter = match filter::parse(link_content.trim()) {
-                    Ok(f) => f,
-                    Err(e) => {
-                        eprintln!("Failed to parse .link.josh filter: {}", e);
-                        return git2::TreeWalkResult::Skip;
-                    }
-                };
+            let filter = match filter::parse(link_content.trim()) {
+                Ok(f) => f,
+                Err(e) => {
+                    eprintln!("Failed to parse .link.josh filter: {}", e);
+                    return Ok(());
+                }
+            };
 
-                let root = root.trim_matches('/');
-                // Use root as the directory path where the .link.josh file is located
-                let path = std::path::PathBuf::from(root);
+            let path = std::path::PathBuf::from(root);
 
-                link_files.push((path, filter));
-            }
+            link_files.push((path, filter));
         }
 
-        git2::TreeWalkResult::Ok
+        Ok(())
     })
     .context("Failed to walk tree")?;
 

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -67,6 +67,59 @@ pub fn hash_blob(data: &[u8]) -> git2::Oid {
     )
 }
 
+/// Preorder tree walk: entries in stored tree order, the callback firing for a tree entry
+/// before its descent, `parent` being the slash-separated path of the containing directory
+/// (`""` at the root level). Non-tree entry objects are never loaded. Descending into a tree
+/// whose name is not UTF-8 errors the walk (`parent` is a `&str`); non-UTF-8 *entry* names
+/// are the consumer's concern, the callback sees raw bytes.
+///
+/// Stored order is load-bearing: `filter::get_link_roots` turns it into the parent order of
+/// the merge commits it creates.
+pub fn walk_tree_preorder(
+    src: &impl gix_object::Find,
+    root: git2::Oid,
+    cb: &mut dyn FnMut(&str, &gix_object::tree::EntryRef<'_>) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    let mut path = String::new();
+    walk_tree_preorder_inner(src, root, &mut path, cb)
+}
+
+fn walk_tree_preorder_inner(
+    src: &impl gix_object::Find,
+    tree: git2::Oid,
+    path: &mut String,
+    cb: &mut dyn FnMut(&str, &gix_object::tree::EntryRef<'_>) -> anyhow::Result<()>,
+) -> anyhow::Result<()> {
+    let mut buf = Vec::new();
+    let data = src
+        .try_find(&gix_oid(tree), &mut buf)
+        .map_err(|e| anyhow::anyhow!("walk_tree_preorder: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("object {} not found", tree))?;
+    if data.kind != gix_object::Kind::Tree {
+        return Err(anyhow::anyhow!(
+            "object {} is not a tree but a {:?}",
+            tree,
+            data.kind
+        ));
+    }
+    let parsed = gix_object::TreeRef::from_bytes(&buf, gix_hash::Kind::Sha1)?;
+    for entry in &parsed.entries {
+        cb(path, entry)?;
+        if entry.mode.is_tree() {
+            let name = std::str::from_utf8(entry.filename)
+                .map_err(|_| anyhow::anyhow!("non-utf8 directory name in tree walk"))?;
+            let base = path.len();
+            if !path.is_empty() {
+                path.push('/');
+            }
+            path.push_str(name);
+            walk_tree_preorder_inner(src, git2_oid(entry.oid), path, cb)?;
+            path.truncate(base);
+        }
+    }
+    Ok(())
+}
+
 /// Serialize `entries` as a git tree in exactly the order given and write it straight to `out`
 /// (in practice the transaction's memodb-backed facade, so the write is immediately visible
 /// to every reader of the repository).
@@ -156,6 +209,27 @@ impl CommitData {
         let id =
             gix_object::CommitRefIter::from_bytes(&self.bytes, gix_hash::Kind::Sha1).tree_id()?;
         Ok(git2_oid(&id))
+    }
+
+    /// The stored message verbatim, by way of a full commit parse -- an unparseable commit
+    /// is a hard error.
+    pub fn message_raw(&self) -> anyhow::Result<&gix_object::bstr::BStr> {
+        Ok(self.parsed()?.message)
+    }
+
+    /// The message with leading newlines trimmed. Load-bearing for callers that parse the
+    /// message as an oid.
+    pub fn message(&self) -> anyhow::Result<&gix_object::bstr::BStr> {
+        let msg = self.message_raw()?;
+        let start = msg.iter().position(|&b| b != b'\n').unwrap_or(msg.len());
+        Ok(msg[start..].into())
+    }
+
+    /// The commit summary ([`gix_object::CommitRef::message_summary`]); `None` when the
+    /// commit does not parse or the summary is not UTF-8.
+    pub fn summary(&self) -> Option<String> {
+        let commit = self.parsed().ok()?;
+        String::from_utf8(commit.message_summary().into_owned().into()).ok()
     }
 
     /// Binary parent ids read from the parsed commit header id array via
@@ -391,6 +465,8 @@ impl gix_object::Write for Git2Odb<'_> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn hash_blob_matches_git2() {
         for data in [&b""[..], b"x", b"1:{\"a\":1}\n"] {
@@ -403,5 +479,125 @@ mod tests {
             super::hash_blob(b"").to_string(),
             "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
         );
+    }
+
+    /// Write a commit with `message` verbatim through the raw odb, so non-UTF-8 messages can
+    /// be expressed too.
+    fn commit_with_message(repo: &git2::Repository, message: &[u8]) -> git2::Oid {
+        let tree = repo.treebuilder(None).unwrap().write().unwrap();
+        let mut data = Vec::new();
+        data.extend_from_slice(format!("tree {}\n", tree).as_bytes());
+        data.extend_from_slice(b"author t <t@e> 0 +0000\n");
+        data.extend_from_slice(b"committer t <t@e> 0 +0000\n\n");
+        data.extend_from_slice(message);
+        repo.odb()
+            .unwrap()
+            .write(git2::ObjectType::Commit, &data)
+            .unwrap()
+    }
+
+    #[test]
+    fn message_trims_leading_newlines() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(dir.path()).unwrap();
+        let odb = repo.odb().unwrap();
+
+        // Load-bearing for the tree-level `:unapply`, which parses an oid out of the
+        // message.
+        let oid = commit_with_message(&repo, b"\n\n0123456789012345678901234567890123456789");
+        let data = CommitData::read(&Git2Odb(&odb), oid).unwrap();
+        assert_eq!(
+            data.message().unwrap(),
+            "0123456789012345678901234567890123456789"
+        );
+        assert_eq!(
+            data.summary().unwrap(),
+            "0123456789012345678901234567890123456789"
+        );
+    }
+
+    /// The walk yields entries in stored tree order (never canonically sorted), fires for a
+    /// tree entry before descending into it, and hands the callback the containing
+    /// directory's slash-separated path.
+    #[test]
+    fn walk_tree_preorder_yields_stored_order_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(dir.path()).unwrap();
+        let odb = repo.odb().unwrap();
+        let blob = repo.blob(b"x").unwrap();
+
+        let write_tree = |entries: &[(&str, &str, git2::Oid)]| -> git2::Oid {
+            let mut data = Vec::new();
+            for (mode, name, oid) in entries {
+                data.extend_from_slice(mode.as_bytes());
+                data.push(b' ');
+                data.extend_from_slice(name.as_bytes());
+                data.push(0);
+                data.extend_from_slice(oid.as_bytes());
+            }
+            repo.odb()
+                .unwrap()
+                .write(git2::ObjectType::Tree, &data)
+                .unwrap()
+        };
+
+        let deep = write_tree(&[("100644", "leaf.txt", blob)]);
+        let sub = write_tree(&[("40000", "deep", deep), ("100644", "f.txt", blob)]);
+        // Stored order is deliberately non-canonical ("z.txt" before "a", and the tree "a"
+        // before the blob "a.txt" that canonical order would sort first).
+        let root = write_tree(&[
+            ("100644", "z.txt", blob),
+            ("40000", "a", sub),
+            ("100644", "a.txt", blob),
+        ]);
+
+        let mut seen = vec![];
+        walk_tree_preorder(&Git2Odb(&odb), root, &mut |parent, entry| {
+            seen.push(format!(
+                "{}|{}",
+                parent,
+                std::str::from_utf8(entry.filename).unwrap()
+            ));
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(
+            seen,
+            [
+                "|z.txt",
+                "|a",
+                "a|deep",
+                "a/deep|leaf.txt",
+                "a|f.txt",
+                "|a.txt",
+            ]
+        );
+    }
+
+    /// A tree whose name is not UTF-8 cannot be part of the callback's path argument, so
+    /// descending into it errors the whole walk.
+    #[test]
+    fn walk_tree_preorder_errors_on_non_utf8_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(dir.path()).unwrap();
+        let odb = repo.odb().unwrap();
+        let blob = repo.blob(b"x").unwrap();
+
+        let mut inner = repo.treebuilder(None).unwrap();
+        inner.insert("f.txt", blob, 0o100644).unwrap();
+        let inner = inner.write().unwrap();
+
+        let mut data = Vec::new();
+        data.extend_from_slice(b"40000 bad\xff");
+        data.push(0);
+        data.extend_from_slice(inner.as_bytes());
+        let root = repo
+            .odb()
+            .unwrap()
+            .write(git2::ObjectType::Tree, &data)
+            .unwrap();
+
+        assert!(walk_tree_preorder(&Git2Odb(&odb), root, &mut |_, _| Ok(())).is_err());
     }
 }

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -77,10 +77,13 @@ impl Revision {
         let x = filter::apply(
             &transaction,
             self.filter,
-            Rewrite::from_tree(commit.tree()?),
+            Rewrite::from_tree(commit.tree_id()),
         )?;
-        let tree_id = x.tree().id();
-        let paths = find_paths(&transaction, x.tree().clone(), at, depth, kind)?;
+        let tree_id = x.tree_id();
+        // PORT: the typed helpers below take a git2::Tree; the bridge read resolves
+        // fresh filtered trees through the registered backend.
+        let tree = transaction.repo().find_tree(tree_id)?;
+        let paths = find_paths(&transaction, tree, at, depth, kind)?;
         let mut ws = vec![];
         for path in paths {
             ws.push(Path {
@@ -306,7 +309,7 @@ impl Revision {
             .unwrap_or((git2::Oid::ZERO_SHA1, git2::Oid::ZERO_SHA1));
 
         let d = filter::tree::diff_paths(
-            transaction.repo(),
+            &transaction.odb()?,
             parent_tree_id,
             filter_commit.tree_id(),
             "",
@@ -356,17 +359,19 @@ impl Revision {
     fn file(&self, path: String, context: &Context) -> FieldResult<Option<Path>> {
         let transaction = context.transaction.lock().unwrap();
         let path = std::path::Path::new(&path).to_owned();
-        let tree = transaction.repo().find_commit(self.commit_id)?.tree()?;
+        let tree = transaction.repo().find_commit(self.commit_id)?.tree_id();
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
 
-        if let Ok(entry) = x.tree().get_path(&path) {
+        // PORT: git2::Tree bridge read (see files_or_dirs).
+        let filtered_tree = transaction.repo().find_tree(x.tree_id())?;
+        if let Ok(entry) = filtered_tree.get_path(&path) {
             if let Some(git2::ObjectType::Blob) = entry.kind() {
                 Ok(Some(Path {
                     path,
                     commit_id: self.commit_id,
                     filter: self.filter,
-                    tree: x.tree().id(),
+                    tree: x.tree_id(),
                 }))
             } else {
                 Err(anyhow!("not a blob").into())
@@ -379,7 +384,7 @@ impl Revision {
     fn dir(&self, path: Option<String>, context: &Context) -> FieldResult<Option<Path>> {
         let path = path.unwrap_or_default();
         let transaction = context.transaction.lock().unwrap();
-        let tree = transaction.repo().find_commit(self.commit_id)?.tree()?;
+        let tree = transaction.repo().find_commit(self.commit_id)?.tree_id();
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
 
@@ -390,17 +395,19 @@ impl Revision {
                 path,
                 commit_id: self.commit_id,
                 filter: self.filter,
-                tree: x.tree().id(),
+                tree: x.tree_id(),
             }));
         }
 
-        if let Ok(entry) = x.tree().get_path(&path) {
+        // PORT: git2::Tree bridge read (see files_or_dirs).
+        let filtered_tree = transaction.repo().find_tree(x.tree_id())?;
+        if let Ok(entry) = filtered_tree.get_path(&path) {
             if let Some(git2::ObjectType::Tree) = entry.kind() {
                 Ok(Some(Path {
                     path,
                     commit_id: self.commit_id,
                     filter: self.filter,
-                    tree: x.tree().id(),
+                    tree: x.tree_id(),
                 }))
             } else {
                 Err(anyhow!("not a tree").into())
@@ -414,7 +421,7 @@ impl Revision {
         let transaction = context.transaction.lock().unwrap();
         let commit = transaction.repo().find_commit(self.commit_id)?;
 
-        let warnings = filter::compute_warnings(&transaction, self.filter, commit.tree()?)
+        let warnings = filter::compute_warnings(&transaction, self.filter, commit.tree_id())
             .into_iter()
             .map(|text| Warning { text })
             .collect();
@@ -424,25 +431,28 @@ impl Revision {
 
     fn search(&self, string: String, context: &Context) -> FieldResult<Option<Vec<SearchResult>>> {
         let transaction = context.transaction.lock().unwrap();
-        let tree = transaction.repo().find_commit(self.commit_id)?.tree()?;
+        let tree = transaction.repo().find_commit(self.commit_id)?.tree_id();
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
 
+        // PORT: git2::Tree bridge read (see files_or_dirs).
+        let filtered_tree = transaction.repo().find_tree(x.tree_id())?;
         /* let start = std::time::Instant::now(); */
         // The trigram index is experimental; without it every file is a candidate and
         // search_matches does all the filtering, so results are identical, just slower.
         let candidates = if filter::experimental_features_enabled() {
             let ifilterobj = filter::parse(":SQUASH:INDEX")?;
             let index_tree = filter::apply(&transaction, ifilterobj, x.clone())?;
+            let index_tree = transaction.repo().find_tree(index_tree.tree_id())?;
             josh_search::search_candidates(
                 transaction.repo(),
-                index_tree.tree(),
-                x.tree(),
+                &index_tree,
+                &filtered_tree,
                 &string,
             )?
         } else {
             let mut scan = vec![];
-            x.tree().walk(git2::TreeWalkMode::PreOrder, |root, entry| {
+            filtered_tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
                 if entry.kind() == Some(git2::ObjectType::Blob)
                     && let Ok(name) = entry.name()
                 {
@@ -453,7 +463,7 @@ impl Revision {
             scan
         };
         let results =
-            josh_search::search_matches(transaction.repo(), x.tree(), &string, &candidates)?;
+            josh_search::search_matches(transaction.repo(), &filtered_tree, &string, &candidates)?;
         /* let duration = start.elapsed(); */
 
         let mut r = vec![];
@@ -469,7 +479,7 @@ impl Revision {
                 path: std::path::PathBuf::from(m.0),
                 commit_id: self.commit_id,
                 filter: self.filter,
-                tree: x.tree().id(),
+                tree: x.tree_id(),
             };
             r.push(SearchResult { path, matches });
         }
@@ -573,7 +583,7 @@ impl Markers {
         let path = if self.filter.is_nop() {
             marker_path(&commit, &self.topic).join(&self.path)
         } else {
-            let t = transaction.repo().find_commit(self.commit_id)?.tree()?;
+            let t = transaction.repo().find_commit(self.commit_id)?.tree_id();
             let o = filter::tree::original_path(&transaction, self.filter, t, &self.path)?;
             marker_path(&commit, &self.topic).join(o)
         };
@@ -635,8 +645,8 @@ impl Markers {
                 .find_tree(filter::tree::repopulated_tree(
                     &transaction,
                     self.filter,
-                    transaction.repo().find_commit(self.commit_id)?.tree()?,
-                    mtree,
+                    transaction.repo().find_commit(self.commit_id)?.tree_id(),
+                    mtree.id(),
                 )?)?
         };
         if let Ok(p) = mtree.get_path(&self.path) {

--- a/josh-link/src/lib.rs
+++ b/josh-link/src/lib.rs
@@ -93,7 +93,8 @@ pub fn collect_all_link_refs(
         let tree = commit.tree().context("Failed to get commit tree")?;
 
         let link_files =
-            josh_core::link::find_link_files(repo, &tree).context("Failed to find link files")?;
+            josh_core::link::find_link_files(&josh_core::objects::Git2Odb(&repo.odb()?), tree.id())
+                .context("Failed to find link files")?;
 
         for (_, filter) in link_files {
             if let (Some(remote), Some(commit)) =
@@ -198,8 +199,11 @@ pub fn update_links(
     let head_tree_id = head_tree.id();
 
     // Find all link files to get their current metadata
-    let link_files =
-        josh_core::link::find_link_files(repo, &head_tree).context("Failed to find link files")?;
+    let link_files = josh_core::link::find_link_files(
+        &josh_core::objects::Git2Odb(&repo.odb()?),
+        head_tree.id(),
+    )
+    .context("Failed to find link files")?;
 
     // Update the link files with new commit OIDs
     let mut updated_link_files: Vec<(PathBuf, josh_core::filter::Filter)> = Vec::new();

--- a/josh-memodb/src/odb.rs
+++ b/josh-memodb/src/odb.rs
@@ -86,6 +86,21 @@ impl<'repo> Odb<'repo> {
         self.mem.contains(&josh_gix_ext::gix_oid(oid)) || self.disk.exists(oid)
     }
 
+    /// Kind of `oid`, or `None` if the object does not exist. Never decompresses. The disk
+    /// fallback resolves the empty tree even when it is stored nowhere, so probes on
+    /// possibly-empty trees belong here and never on [`contains`](Odb::contains).
+    pub fn try_kind(&self, oid: git2::Oid) -> Result<Option<Kind>, git2::Error> {
+        if let Some((kind, _)) = self.mem.header(&josh_gix_ext::gix_oid(oid)) {
+            return Ok(Some(kind));
+        }
+        let (_, kind) = match self.disk.read_header(oid) {
+            Ok(h) => h,
+            Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        Ok(josh_gix_ext::gix_kind(kind))
+    }
+
     /// Hash and buffer an object in the memory store, returning its content id. The buffer is
     /// skipped when the object is already in memory or in a runtime alternate: proxy overlays
     /// must never buffer mirror objects, or flushed packs would gain duplicates and change
@@ -286,6 +301,29 @@ mod tests {
         assert_eq!(oid, on_disk);
         assert!(store.contains(&josh_gix_ext::gix_oid(oid)));
         assert!(matches!(odb.read(oid).unwrap().1, Bytes::Mem(_)));
+    }
+
+    /// The empty tree reads as an existing tree through `try_kind` even when it is absent
+    /// from memory AND disk, while `contains` reports it absent -- kind probes on
+    /// possibly-empty trees rely on exactly this.
+    #[test]
+    fn try_kind_virtualizes_empty_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
+        store.register(&repo);
+        let odb = facade(&store, &repo);
+
+        let empty_tree = git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap();
+        assert!(!store.contains(&josh_gix_ext::gix_oid(empty_tree)));
+        assert_eq!(odb.try_kind(empty_tree).unwrap(), Some(Kind::Tree));
+        assert!(!odb.contains(empty_tree));
+
+        // A genuinely absent object is None; a buffered object reports its memory kind.
+        let absent = git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap();
+        assert_eq!(odb.try_kind(absent).unwrap(), None);
+        let blob = odb.write(Kind::Blob, b"probe");
+        assert_eq!(odb.try_kind(blob).unwrap(), Some(Kind::Blob));
     }
 
     /// git2-side writes (through the registered backend) and facade reads share one store.

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -509,7 +509,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
             let mut warnings = josh_core::filter::compute_warnings(
                 &transaction,
                 filter,
-                transaction.repo().find_commit(push_ref.oid)?.tree()?,
+                transaction.repo().find_commit(push_ref.oid)?.tree_id(),
             );
 
             if !warnings.is_empty() {


### PR DESCRIPTION
Port josh-core's typed-object reads onto the memodb facade

Rewrite carries a tree oid instead of a git2::Tree, so its lifetime and
every find_tree tail disappear. filter/mod.rs, history.rs, link.rs and
housekeeping.rs read trees, commits and blobs through the transaction
facade, with one hoisted tree read per multi-probe site. josh-gix-ext
gains a preorder tree walker and CommitData message accessors;
josh-memodb gains Odb::try_kind.

apply_to_commit2 now validates a commit's tree before filtering it:
without that gate a partial apply over unreadable input buffers objects
before aborting, which changes pack contents.

The libgit2 graph and merge compute sites stay on the registered
backend behind PORT markers.

Change: core-typed-reads-facade
Assisted-By: anthropic/claude-fable-5