### PR TITLE
Port josh-graphql's object reads onto the memodb facade

### DIFF
--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -129,10 +129,7 @@ fn regex_replace_inner(
 
 /// The raw bytes of the blob `oid`, or `None` when the object is missing or not a blob --
 /// `find_blob`'s tolerance, in facade currency.
-pub(crate) fn blob_bytes<'a>(
-    odb: &'a josh_memodb::Odb,
-    oid: git2::Oid,
-) -> Option<josh_memodb::Bytes<'a>> {
+pub fn blob_bytes<'a>(odb: &'a josh_memodb::Odb, oid: git2::Oid) -> Option<josh_memodb::Bytes<'a>> {
     match odb.read(oid) {
         Ok((gix_object::Kind::Blob, bytes)) => Some(bytes),
         _ => None,
@@ -267,14 +264,20 @@ fn lookup_entry<'a>(
 /// whole filter arm. Lookups walk the entries lazily and allocate nothing, which suits the
 /// sites that probe a handful of paths in one tree (a path descent, the workspace files of a
 /// commit); [`ParsedTree`] is the counterpart for iterating every entry.
-pub(crate) struct TreeReader<'a> {
+pub struct TreeReader<'a> {
     bytes: cache::TreeBytes<'a>,
 }
 
 impl TreeReader<'_> {
+    /// Every entry, in stored tree order. Malformed entries are skipped.
+    pub fn entries(&self) -> impl Iterator<Item = gix_object::tree::EntryRef<'_>> {
+        gix_object::TreeRefIter::from_bytes(&self.bytes, gix_hash::Kind::Sha1)
+            .filter_map(Result::ok)
+    }
+
     /// Entry by name irrespective of kind, first occurrence winning -- tree entry order is
     /// not necessarily canonical, and a name is unique in a valid tree.
-    pub(crate) fn entry(&self, name: &[u8]) -> Option<gix_object::tree::EntryRef<'_>> {
+    pub fn entry(&self, name: &[u8]) -> Option<gix_object::tree::EntryRef<'_>> {
         gix_object::TreeRefIter::from_bytes(&self.bytes, gix_hash::Kind::Sha1)
             .filter_map(Result::ok)
             .find(|entry| entry.filename == name)
@@ -282,7 +285,7 @@ impl TreeReader<'_> {
 }
 
 /// Read the tree `oid`, erroring when the object is missing or not a tree.
-pub(crate) fn read_tree<'a>(
+pub fn read_tree<'a>(
     transaction: &cache::Transaction,
     odb: &'a josh_memodb::Odb,
     oid: git2::Oid,
@@ -339,7 +342,7 @@ fn path_components(path: &Path) -> Option<Vec<&[u8]>> {
 /// intermediate entry; the final entry may be any kind (gitlinks included). Per level the
 /// bytes come from `read_tree_bytes` (memory zero-copy / TreeCache), so unflushed trees
 /// resolve.
-pub(crate) fn get_path_entry(
+pub fn get_path_entry(
     transaction: &cache::Transaction,
     odb: &josh_memodb::Odb,
     root: git2::Oid,
@@ -354,7 +357,7 @@ pub(crate) fn get_path_entry(
 
 /// [`get_path_entry`] resolving the first component against a caller-held parse -- the hoist
 /// for multi-probe sites, which pay one root parse for N descents.
-pub(crate) fn get_path_entry_at(
+pub fn get_path_entry_at(
     transaction: &cache::Transaction,
     odb: &josh_memodb::Odb,
     root: &TreeReader,

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod submodules;
 pub mod trailers;
 
 pub use josh_gix_ext as objects;
+pub use josh_memodb as memodb;
 
 #[derive(
     Clone, Hash, PartialEq, Eq, Copy, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize,

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -2,6 +2,9 @@
 
 use anyhow::anyhow;
 use josh_core::filter::Rewrite;
+use josh_core::filter::tree;
+use josh_core::objects;
+use josh_core::objects::CommitData;
 use josh_core::{cache, filter, history};
 use juniper::{EmptyMutation, EmptySubscription, FieldResult, graphql_object};
 
@@ -12,40 +15,83 @@ pub struct Revision {
 
 fn find_paths(
     transaction: &cache::Transaction,
-    tree: git2::Tree,
+    odb: &josh_core::memodb::Odb,
+    tree: git2::Oid,
     at: Option<String>,
     depth: Option<i32>,
     kind: git2::ObjectType,
 ) -> anyhow::Result<Vec<std::path::PathBuf>> {
-    let tree = if let Some(at) = at.as_ref() {
-        if at.is_empty() {
-            tree
-        } else {
-            let path = std::path::Path::new(&at).to_owned();
-            transaction.repo().find_tree(tree.get_path(&path)?.id())?
+    let tree = match at.as_deref() {
+        Some(at) if !at.is_empty() => {
+            let entry = tree::get_path_entry(transaction, odb, tree, std::path::Path::new(at))?
+                .ok_or_else(|| anyhow!("no such path: {}", at))?;
+            if !entry.mode.is_tree() {
+                return Err(anyhow!("not a directory: {}", at));
+            }
+            objects::git2_oid(&entry.oid)
         }
-    } else {
-        tree
+        _ => tree,
     };
 
     let base = std::path::Path::new(&at.as_ref().unwrap_or(&"".to_string())).to_owned();
 
     let mut ws = vec![];
-    tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
-        if Some(kind) == entry.kind()
-            && let Ok(name) = entry.name()
-        {
-            let path = std::path::Path::new(root).join(name);
-            if let Some(limit) = depth
-                && path.components().count() as i32 > limit
-            {
-                return 1;
-            }
-            ws.push(base.join(path));
-        }
-        0
-    })?;
+    collect_paths(transaction, odb, tree, &base, 1, depth, kind, &mut ws)?;
     Ok(ws)
+}
+
+/// Collect paths of entries of the requested kind. A depth-limited listing never reads the
+/// subtrees it could not report.
+fn collect_paths(
+    transaction: &cache::Transaction,
+    odb: &josh_core::memodb::Odb,
+    tree: git2::Oid,
+    prefix: &std::path::Path,
+    level: i32,
+    depth: Option<i32>,
+    kind: git2::ObjectType,
+    out: &mut Vec<std::path::PathBuf>,
+) -> anyhow::Result<()> {
+    let reader = tree::read_tree(transaction, odb, tree)?;
+    for entry in reader.entries() {
+        let Ok(name) = std::str::from_utf8(entry.filename) else {
+            continue;
+        };
+        let path = prefix.join(name);
+        let is_tree = entry.mode.is_tree();
+        // Gitlinks are neither blobs nor trees, so they are never listed.
+        let matches = if is_tree {
+            kind == git2::ObjectType::Tree
+        } else {
+            kind == git2::ObjectType::Blob && !entry.mode.is_commit()
+        };
+        if matches && depth.is_none_or(|limit| level <= limit) {
+            out.push(path.clone());
+        }
+        if is_tree && depth.is_none_or(|limit| level < limit) {
+            collect_paths(
+                transaction,
+                odb,
+                objects::git2_oid(&entry.oid),
+                &path,
+                level + 1,
+                depth,
+                kind,
+                out,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Apply the filter to `commit_id` and read back the commit it produced.
+fn filtered_commit(
+    transaction: &cache::Transaction,
+    filter: filter::Filter,
+    commit_id: git2::Oid,
+) -> anyhow::Result<CommitData> {
+    let filtered = filter::apply_to_commit(filter, commit_id, transaction)?;
+    CommitData::read(&transaction.odb()?, filtered)
 }
 
 pub struct DiffPath {
@@ -73,17 +119,15 @@ impl Revision {
         kind: git2::ObjectType,
     ) -> FieldResult<Option<Vec<Path>>> {
         let transaction = context.transaction.lock().unwrap();
-        let commit = transaction.repo().find_commit(self.commit_id)?;
+        let odb = transaction.odb()?;
+        let commit = CommitData::read(&odb, self.commit_id)?;
         let x = filter::apply(
             &transaction,
             self.filter,
-            Rewrite::from_tree(commit.tree_id()),
+            Rewrite::from_tree(commit.tree_id()?),
         )?;
         let tree_id = x.tree_id();
-        // PORT: the typed helpers below take a git2::Tree; the bridge read resolves
-        // fresh filtered trees through the registered backend.
-        let tree = transaction.repo().find_tree(tree_id)?;
-        let paths = find_paths(&transaction, tree, at, depth, kind)?;
+        let paths = find_paths(&transaction, &odb, tree_id, at, depth, kind)?;
         let mut ws = vec![];
         for path in paths {
             ws.push(Path {
@@ -107,56 +151,36 @@ impl Revision {
         let transaction = context.transaction.lock().unwrap();
         // Existence/type probe: a bogus id (e.g. the zero oid `parents` substitutes when
         // find_original fails) must error here, not filter to a bogus hash under a nop filter.
-        transaction.repo().find_commit(self.commit_id)?;
+        CommitData::read(&transaction.odb()?, self.commit_id)?;
         let filter_commit = filter::apply_to_commit(self.filter, self.commit_id, &transaction)?;
         Ok(format!("{}", filter_commit))
     }
 
     fn author_email(&self, context: &Context) -> FieldResult<String> {
         let transaction = context.transaction.lock().unwrap();
-        let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
-            self.filter,
-            self.commit_id,
-            &transaction,
-        )?)?;
-        let a = filter_commit.author();
-        Ok(a.email().unwrap_or("").to_owned())
+        let filter_commit = filtered_commit(&transaction, self.filter, self.commit_id)?;
+        let email = filter_commit.parsed()?.author()?.email;
+        Ok(String::from_utf8_lossy(email).into_owned())
     }
 
     fn summary(&self, context: &Context) -> FieldResult<String> {
         let transaction = context.transaction.lock().unwrap();
-        let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
-            self.filter,
-            self.commit_id,
-            &transaction,
-        )?)?;
-        Ok(filter_commit
-            .summary()
-            .ok()
-            .flatten()
-            .unwrap_or("")
-            .to_owned())
+        let filter_commit = filtered_commit(&transaction, self.filter, self.commit_id)?;
+        Ok(filter_commit.summary().unwrap_or_default())
     }
 
     fn message(&self, context: &Context) -> FieldResult<String> {
         let transaction = context.transaction.lock().unwrap();
-        let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
-            self.filter,
-            self.commit_id,
-            &transaction,
-        )?)?;
-        Ok(filter_commit.message().unwrap_or("").to_owned())
+        let filter_commit = filtered_commit(&transaction, self.filter, self.commit_id)?;
+        let message = filter_commit.message()?;
+        Ok(String::from_utf8_lossy(message).into_owned())
     }
 
     fn date(&self, format: String, context: &Context) -> FieldResult<String> {
         let transaction = context.transaction.lock().unwrap();
-        let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
-            self.filter,
-            self.commit_id,
-            &transaction,
-        )?)?;
+        let filter_commit = filtered_commit(&transaction, self.filter, self.commit_id)?;
 
-        let ts = filter_commit.time().seconds();
+        let ts = filter_commit.parsed()?.committer()?.seconds();
 
         let ndt = chrono::DateTime::from_timestamp(ts, 0).ok_or(anyhow!("from_timestamp_opt"))?;
 
@@ -171,11 +195,7 @@ impl Revision {
     ) -> FieldResult<Option<Revision>> {
         let commit_id = if let Some(true) = original {
             let transaction = context.transaction.lock().unwrap();
-            let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
-                self.filter,
-                self.commit_id,
-                &transaction,
-            )?)?;
+            let filter_commit = filtered_commit(&transaction, self.filter, self.commit_id)?;
 
             history::find_original(
                 &transaction,
@@ -225,24 +245,23 @@ impl Revision {
         let limit = limit.unwrap_or(1) as usize;
         let offset = offset.unwrap_or(0) as usize;
         let transaction = context.transaction.lock().unwrap();
-        let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
-            self.filter,
-            self.commit_id,
-            &transaction,
-        )?)?;
+        let filter_commit = filtered_commit(&transaction, self.filter, self.commit_id)?;
 
-        let mut walk = transaction.repo().revwalk()?;
-        walk.simplify_first_parent()?;
-        walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
-        walk.push(filter_commit.id())?;
+        // First parents only, followed just far enough to fill the requested window.
+        let odb = transaction.odb()?;
+        let mut ids = vec![];
+        let mut next = Some(filter_commit.id());
+        for i in 0..offset + limit {
+            let Some(id) = next else { break };
+            if i >= offset {
+                ids.push(id);
+            }
+            next = josh_core::git::read_parent_ids(&odb, id)?
+                .into_iter()
+                .next();
+        }
 
         let mut contained_in = self.commit_id;
-        let mut ids = {
-            walk.skip(offset)
-                .take(limit)
-                .map(|id| id.unwrap_or(git2::Oid::ZERO_SHA1))
-                .collect::<Vec<git2::Oid>>()
-        };
 
         {
             for i in 0..ids.len() {
@@ -296,24 +315,16 @@ impl Revision {
         context: &Context,
     ) -> FieldResult<Option<Vec<DiffPath>>> {
         let transaction = context.transaction.lock().unwrap();
-        let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
-            self.filter,
-            self.commit_id,
-            &transaction,
-        )?)?;
+        let filter_commit = filtered_commit(&transaction, self.filter, self.commit_id)?;
 
-        let (parent_id, parent_tree_id) = filter_commit
-            .parents()
-            .next()
-            .map(|p| (p.id(), p.tree_id()))
-            .unwrap_or((git2::Oid::ZERO_SHA1, git2::Oid::ZERO_SHA1));
+        let odb = transaction.odb()?;
+        let (parent_id, parent_tree_id) = match filter_commit.first_parent_id() {
+            Some(parent) => (parent, josh_core::git::read_tree_id(&odb, parent)?),
+            None => (git2::Oid::ZERO_SHA1, git2::Oid::ZERO_SHA1),
+        };
 
-        let d = filter::tree::diff_paths(
-            &transaction.odb()?,
-            parent_tree_id,
-            filter_commit.tree_id(),
-            "",
-        )?;
+        let filter_tree_id = filter_commit.tree_id()?;
+        let d = filter::tree::diff_paths(&transaction.odb()?, parent_tree_id, filter_tree_id, "")?;
 
         let df = d
             .into_iter()
@@ -324,7 +335,7 @@ impl Revision {
                         path: std::path::Path::new(&path).to_owned(),
                         commit_id: self.commit_id,
                         filter: self.filter,
-                        tree: filter_commit.tree_id(),
+                        tree: filter_tree_id,
                     }),
                 },
                 -1 => DiffPath {
@@ -347,7 +358,7 @@ impl Revision {
                         path: std::path::Path::new(&path).to_owned(),
                         commit_id: self.commit_id,
                         filter: self.filter,
-                        tree: filter_commit.tree_id(),
+                        tree: filter_tree_id,
                     }),
                 },
             })
@@ -359,14 +370,13 @@ impl Revision {
     fn file(&self, path: String, context: &Context) -> FieldResult<Option<Path>> {
         let transaction = context.transaction.lock().unwrap();
         let path = std::path::Path::new(&path).to_owned();
-        let tree = transaction.repo().find_commit(self.commit_id)?.tree_id();
+        let odb = transaction.odb()?;
+        let tree = CommitData::read(&odb, self.commit_id)?.tree_id()?;
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
 
-        // PORT: git2::Tree bridge read (see files_or_dirs).
-        let filtered_tree = transaction.repo().find_tree(x.tree_id())?;
-        if let Ok(entry) = filtered_tree.get_path(&path) {
-            if let Some(git2::ObjectType::Blob) = entry.kind() {
+        if let Ok(Some(entry)) = tree::get_path_entry(&transaction, &odb, x.tree_id(), &path) {
+            if !entry.mode.is_tree() && !entry.mode.is_commit() {
                 Ok(Some(Path {
                     path,
                     commit_id: self.commit_id,
@@ -384,7 +394,8 @@ impl Revision {
     fn dir(&self, path: Option<String>, context: &Context) -> FieldResult<Option<Path>> {
         let path = path.unwrap_or_default();
         let transaction = context.transaction.lock().unwrap();
-        let tree = transaction.repo().find_commit(self.commit_id)?.tree_id();
+        let odb = transaction.odb()?;
+        let tree = CommitData::read(&odb, self.commit_id)?.tree_id()?;
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
 
@@ -399,10 +410,8 @@ impl Revision {
             }));
         }
 
-        // PORT: git2::Tree bridge read (see files_or_dirs).
-        let filtered_tree = transaction.repo().find_tree(x.tree_id())?;
-        if let Ok(entry) = filtered_tree.get_path(&path) {
-            if let Some(git2::ObjectType::Tree) = entry.kind() {
+        if let Ok(Some(entry)) = tree::get_path_entry(&transaction, &odb, x.tree_id(), &path) {
+            if entry.mode.is_tree() {
                 Ok(Some(Path {
                     path,
                     commit_id: self.commit_id,
@@ -419,9 +428,9 @@ impl Revision {
 
     fn warnings(&self, context: &Context) -> FieldResult<Option<Vec<Warning>>> {
         let transaction = context.transaction.lock().unwrap();
-        let commit = transaction.repo().find_commit(self.commit_id)?;
+        let commit = CommitData::read(&transaction.odb()?, self.commit_id)?;
 
-        let warnings = filter::compute_warnings(&transaction, self.filter, commit.tree_id())
+        let warnings = filter::compute_warnings(&transaction, self.filter, commit.tree_id()?)
             .into_iter()
             .map(|text| Warning { text })
             .collect();
@@ -431,13 +440,13 @@ impl Revision {
 
     fn search(&self, string: String, context: &Context) -> FieldResult<Option<Vec<SearchResult>>> {
         let transaction = context.transaction.lock().unwrap();
-        let tree = transaction.repo().find_commit(self.commit_id)?.tree_id();
+        let odb = transaction.odb()?;
+        let tree = CommitData::read(&odb, self.commit_id)?.tree_id()?;
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
 
-        // PORT: git2::Tree bridge read (see files_or_dirs).
+        // PORT: josh-search takes a git2::Tree, so these reads stay on the repo handle.
         let filtered_tree = transaction.repo().find_tree(x.tree_id())?;
-        /* let start = std::time::Instant::now(); */
         // The trigram index is experimental; without it every file is a candidate and
         // search_matches does all the filtering, so results are identical, just slower.
         let candidates = if filter::experimental_features_enabled() {
@@ -452,19 +461,20 @@ impl Revision {
             )?
         } else {
             let mut scan = vec![];
-            filtered_tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
-                if entry.kind() == Some(git2::ObjectType::Blob)
-                    && let Ok(name) = entry.name()
+            objects::walk_tree_preorder(&odb, x.tree_id(), &mut |parent, entry| {
+                if !entry.mode.is_tree()
+                    && !entry.mode.is_commit()
+                    && let Ok(name) = std::str::from_utf8(entry.filename)
                 {
-                    scan.push(format!("{}{}", root, name));
+                    let separator = if parent.is_empty() { "" } else { "/" };
+                    scan.push(format!("{}{}{}", parent, separator, name));
                 }
-                0
+                Ok(())
             })?;
             scan
         };
         let results =
             josh_search::search_matches(transaction.repo(), &filtered_tree, &string, &candidates)?;
-        /* let duration = start.elapsed(); */
 
         let mut r = vec![];
         for m in results {
@@ -484,7 +494,6 @@ impl Revision {
             r.push(SearchResult { path, matches });
         }
         Ok(Some(r))
-        /* println!("\n Search took {:?}", duration); */
     }
 }
 
@@ -538,18 +547,20 @@ impl SearchResult {
     }
 }
 
-pub fn linecount(repo: &git2::Repository, id: git2::Oid) -> usize {
-    if let Ok(blob) = repo.find_blob(id) {
-        return blob.content().iter().filter(|x| **x == b'\n').count()
-            + if blob.content().is_empty() { 0 } else { 1 };
+pub fn linecount(
+    transaction: &cache::Transaction,
+    odb: &josh_core::memodb::Odb,
+    id: git2::Oid,
+) -> usize {
+    if let Some(blob) = tree::blob_bytes(odb, id) {
+        return blob.iter().filter(|x| **x == b'\n').count() + if blob.is_empty() { 0 } else { 1 };
     }
 
-    if let Ok(tree) = repo.find_tree(id) {
-        let mut c = 0;
-        for i in tree.iter() {
-            c += linecount(repo, i.id());
-        }
-        return c;
+    if let Ok(reader) = tree::read_tree(transaction, odb, id) {
+        return reader
+            .entries()
+            .map(|e| linecount(transaction, odb, objects::git2_oid(&e.oid)))
+            .sum();
     }
     0
 }
@@ -571,11 +582,11 @@ impl Markers {
 
         // Resolve on the mirror, read objects on the overlay: the overlay repo sees the
         // mirror's objects through a disk alternate.
+        let odb = transaction.odb()?;
         let tree = if let Some(id) = transaction_mirror.resolve_ref(&refname)? {
-            let commit = transaction.repo().find_commit(id)?;
-            commit.tree()?
+            CommitData::read(&odb, id)?.tree_id()?
         } else {
-            filter::tree::empty(transaction.repo())
+            filter::tree::empty_id()
         };
 
         let commit = self.commit_id.to_string();
@@ -583,16 +594,18 @@ impl Markers {
         let path = if self.filter.is_nop() {
             marker_path(&commit, &self.topic).join(&self.path)
         } else {
-            let t = transaction.repo().find_commit(self.commit_id)?.tree_id();
+            let t = CommitData::read(&odb, self.commit_id)?.tree_id()?;
             let o = filter::tree::original_path(&transaction, self.filter, t, &self.path)?;
             marker_path(&commit, &self.topic).join(o)
         };
 
-        let prev = if let Ok(e) = tree.get_path(&path) {
-            let blob = transaction.repo().find_blob(e.id())?;
-            std::str::from_utf8(blob.content())?.to_owned()
-        } else {
-            "".to_owned()
+        let prev = match tree::get_path_entry(&transaction, &odb, tree, &path)? {
+            Some(entry) => {
+                let blob = tree::blob_bytes(&odb, objects::git2_oid(&entry.oid))
+                    .ok_or_else(|| anyhow!("not a blob: {}", entry.oid))?;
+                std::str::from_utf8(&blob)?.to_owned()
+            }
+            None => "".to_owned(),
         };
 
         let lines = prev
@@ -622,37 +635,40 @@ impl Markers {
 
         let refname = transaction_mirror.refname("refs/josh/meta");
 
+        let odb = transaction.odb()?;
         let mtree = if let Some(id) = transaction_mirror.resolve_ref(&refname)? {
-            let commit = transaction.repo().find_commit(id)?;
-            commit.tree()?
+            CommitData::read(&odb, id)?.tree_id()?
         } else {
-            filter::tree::empty(transaction.repo())
+            filter::tree::empty_id()
         };
 
         let commit = self.commit_id.to_string();
-        let mtree = mtree
-            .get_path(&marker_path(&commit, &self.topic))
-            .map(|p| transaction.repo().find_tree(p.id()).ok())
-            .ok()
-            .flatten()
-            .unwrap_or_else(|| filter::tree::empty(transaction.repo()));
+        let mtree = tree::get_path_entry(
+            &transaction,
+            &odb,
+            mtree,
+            &marker_path(&commit, &self.topic),
+        )
+        .ok()
+        .flatten()
+        .filter(|entry| entry.mode.is_tree())
+        .map(|entry| objects::git2_oid(&entry.oid))
+        .unwrap_or_else(filter::tree::empty_id);
 
         let mtree = if self.filter.is_nop() {
             mtree
         } else {
-            transaction
-                .repo()
-                .find_tree(filter::tree::repopulated_tree(
-                    &transaction,
-                    self.filter,
-                    transaction.repo().find_commit(self.commit_id)?.tree_id(),
-                    mtree.id(),
-                )?)?
+            filter::tree::repopulated_tree(
+                &transaction,
+                self.filter,
+                CommitData::read(&odb, self.commit_id)?.tree_id()?,
+                mtree,
+            )?
         };
-        if let Ok(p) = mtree.get_path(&self.path) {
-            return Ok(linecount(transaction.repo(), p.id()) as i32);
+        if let Ok(Some(p)) = tree::get_path_entry(&transaction, &odb, mtree, &self.path) {
+            return Ok(linecount(&transaction, &odb, objects::git2_oid(&p.oid)) as i32);
         } else if self.path == std::path::Path::new("") {
-            return Ok(linecount(transaction.repo(), mtree.id()) as i32);
+            return Ok(linecount(&transaction, &odb, mtree) as i32);
         }
         Ok(0)
     }
@@ -669,11 +685,10 @@ impl Path {
         let id = if self.path == std::path::Path::new("") {
             self.tree
         } else {
-            transaction
-                .repo()
-                .find_tree(self.tree)?
-                .get_path(&self.path)?
-                .id()
+            let odb = transaction.odb()?;
+            let entry = tree::get_path_entry(&transaction, &odb, self.tree, &self.path)?
+                .ok_or_else(|| anyhow!("no such path: {}", self.path.display()))?;
+            objects::git2_oid(&entry.oid)
         };
         to_result(&transaction, id)
     }
@@ -684,9 +699,10 @@ impl Path {
         str_to_value: impl FnOnce(&str) -> Result<serde_json::Value, E>,
     ) -> FieldResult<Document> {
         self.internal_serialize(context, |transaction, id| {
-            let blob = transaction.repo().find_blob(id)?;
-            let value = str_to_value(std::str::from_utf8(blob.content())?)
-                .unwrap_or_else(|_| serde_json::json!({}));
+            let odb = transaction.odb()?;
+            let blob = tree::blob_bytes(&odb, id).ok_or_else(|| anyhow!("not a blob: {}", id))?;
+            let value =
+                str_to_value(std::str::from_utf8(&blob)?).unwrap_or_else(|_| serde_json::json!({}));
             Ok(Document { id, value })
         })
     }
@@ -733,8 +749,9 @@ impl Path {
     }
     fn text(&self, context: &Context) -> FieldResult<Option<String>> {
         self.internal_serialize(context, |transaction, id| {
-            let blob = transaction.repo().find_blob(id)?;
-            Ok(Some(std::str::from_utf8(blob.content())?.to_string()))
+            let odb = transaction.odb()?;
+            let blob = tree::blob_bytes(&odb, id).ok_or_else(|| anyhow!("not a blob: {}", id))?;
+            Ok(Some(std::str::from_utf8(&blob)?.to_string()))
         })
     }
 
@@ -939,11 +956,8 @@ impl RevMut {
     fn push(&self, target: String, repo: Option<String>, context: &Context) -> FieldResult<bool> {
         let transaction = context.transaction.lock().unwrap();
 
-        let filter_commit = transaction.repo().find_commit(filter::apply_to_commit(
-            self.filter,
-            git2::Oid::from_str(&self.at)?,
-            &transaction,
-        )?)?;
+        let filter_commit =
+            filtered_commit(&transaction, self.filter, git2::Oid::from_str(&self.at)?)?;
 
         if let Ok(mut to_push) = context.to_push.lock() {
             to_push.insert((filter_commit.id(), target, repo));
@@ -991,9 +1005,7 @@ impl RepositoryMut {
         let transaction_mirror = context.transaction_mirror.lock().unwrap();
 
         // Just check that the commit exists
-        transaction_mirror
-            .repo()
-            .find_commit(git2::Oid::from_str(&at)?)?;
+        CommitData::read(&transaction_mirror.odb()?, git2::Oid::from_str(&at)?)?;
 
         let filter = if let Some(spec) = filter {
             filter::parse(&spec)?

--- a/tests/proxy/graphql_fields.t
+++ b/tests/proxy/graphql_fields.t
@@ -1,0 +1,344 @@
+  $ . ${TESTDIR}/setup_test_env.sh
+  $ cd ${TESTTMP}
+
+  $ git clone -q http://localhost:8001/real_repo.git
+  warning: You appear to have cloned an empty repository.
+
+  $ cd real_repo
+
+  $ git checkout -b master
+  Switched to a new branch 'master'
+
+  $ mkdir sub1 sub2
+  $ echo c1 > sub1/file1
+  $ echo c2 > sub1/test
+  $ git add .
+  $ git commit -m "add file1" 1> /dev/null
+
+  $ echo c3 > sub2/file2
+  $ git add .
+  $ git commit -m "add file2" 1> /dev/null
+
+  $ mkdir sub2/nested
+  $ echo c4 > sub2/nested/file3
+  $ git add .
+  $ git commit -m "third commit subject" -m "and a body line" 1> /dev/null
+
+  $ git push
+  To http://localhost:8001/real_repo.git
+   * [new branch]      master -> master
+
+  $ cd ${TESTTMP}
+
+History is the filtered commit's first-parent chain, windowed by limit and offset
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { history(limit: 2) { hash summary } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "history": [
+          {
+            "hash": "649cd08b3651125286542f5f3d254a32e398c6a2",
+            "summary": "third commit subject"
+          },
+          {
+            "hash": "0330ee19fb76a77a368600634c10a17dd0dc9343",
+            "summary": "add file2"
+          }
+        ]
+      }
+    }
+  }
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { history(limit: 2, offset: 1) { hash summary } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "history": [
+          {
+            "hash": "0330ee19fb76a77a368600634c10a17dd0dc9343",
+            "summary": "add file2"
+          },
+          {
+            "hash": "c71731c57cf0d21a79a3ff2f297ee69904054931",
+            "summary": "add file1"
+          }
+        ]
+      }
+    }
+  }
+
+A limit past the end of the chain stops at the root commit
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { history(limit: 99) { summary } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "history": [
+          {
+            "summary": "third commit subject"
+          },
+          {
+            "summary": "add file2"
+          },
+          {
+            "summary": "add file1"
+          }
+        ]
+      }
+    }
+  }
+
+Commit fields come from the filtered commit
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { summary message authorEmail date(format: \"%Y-%m-%d %H:%M:%S\") } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "summary": "third commit subject",
+        "message": "third commit subject\n\nand a body line\n",
+        "authorEmail": "josh@example.com",
+        "date": "2005-04-07 22:13:13"
+      }
+    }
+  }
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\", filter:\"::sub1/\") { summary authorEmail history(limit: 2) { summary } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "summary": "add file1",
+        "authorEmail": "josh@example.com",
+        "history": [
+          {
+            "summary": "add file1"
+          }
+        ]
+      }
+    }
+  }
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { parents { summary } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "parents": [
+          {
+            "summary": "add file2"
+          }
+        ]
+      }
+    }
+  }
+
+A filter that matches nothing is reported as a warning
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\", filter:\"::nonexistent/\") { warnings { message } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "warnings": [
+          {
+            "message": "No match for \"::nonexistent/\""
+          }
+        ]
+      }
+    }
+  }
+
+Listings are depth-limited, and directories exclude blobs
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { files { path } dirs { path } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "files": [
+          {
+            "path": "sub1/file1"
+          },
+          {
+            "path": "sub1/test"
+          },
+          {
+            "path": "sub2/file2"
+          },
+          {
+            "path": "sub2/nested/file3"
+          }
+        ],
+        "dirs": [
+          {
+            "path": "sub1"
+          },
+          {
+            "path": "sub2"
+          },
+          {
+            "path": "sub2/nested"
+          }
+        ]
+      }
+    }
+  }
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { files(depth: 1) { path } dirs(depth: 1) { path } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "files": [],
+        "dirs": [
+          {
+            "path": "sub1"
+          },
+          {
+            "path": "sub2"
+          }
+        ]
+      }
+    }
+  }
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { files(at:\"sub2\") { path } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "files": [
+          {
+            "path": "sub2/file2"
+          },
+          {
+            "path": "sub2/nested/file3"
+          }
+        ]
+      }
+    }
+  }
+
+Listing a path that is missing, or is a file, is an error
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { files(at:\"nope\") { path } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "files": null
+      }
+    },
+    "errors": [
+      {
+        "message": "no such path: nope",
+        "locations": [
+          {
+            "line": 1,
+            "column": 33
+          }
+        ],
+        "path": [
+          "rev",
+          "files"
+        ]
+      }
+    ]
+  }
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { files(at:\"sub1/file1\") { path } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "files": null
+      }
+    },
+    "errors": [
+      {
+        "message": "not a directory: sub1/file1",
+        "locations": [
+          {
+            "line": 1,
+            "column": 33
+          }
+        ],
+        "path": [
+          "rev",
+          "files"
+        ]
+      }
+    ]
+  }
+
+Blob contents, and a path that does not exist
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { file(path:\"sub1/file1\") { path text } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "file": {
+          "path": "sub1/file1",
+          "text": "c1\n"
+        }
+      }
+    }
+  }
+
+  $ cat > ../query << EOF
+  > {"query": "{ rev(at:\"refs/heads/master\") { file(path:\"nope/missing\") { path } } }"}
+  > EOF
+
+  $ cat ../query | curl -s -X POST -H "content-type: application/json" --data @- "http://localhost:8002/~/graphql/real_repo.git"
+  {
+    "data": {
+      "rev": {
+        "file": null
+      }
+    }
+  }


### PR DESCRIPTION
Port josh-graphql's object reads onto the memodb facade

Commit fields read CommitData, and path lookups and blob reads go
through the transaction facade. `history` follows the filtered commit's
first-parent chain, reading only the commits its window returns, and
`find_paths` descends no further than the requested depth.

josh-core exposes what leaf crates need for this: the memodb re-export,
`tree::read_tree`, `TreeReader`, `get_path_entry` and `blob_bytes`.

A new test covers the graphql fields that had none: history windows,
commit metadata, depth-limited listings and the path errors.

The josh-search bridges and rev-parse stay on the repository handle
behind PORT markers.

Change: graphql-reads-facade
Assisted-By: anthropic/claude-fable-5