### PR TITLE
Port josh-proxy and josh-link writes onto the memodb facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,6 +3481,7 @@ version = "26.7.28"
 dependencies = [
  "anyhow",
  "git2",
+ "gix-actor",
  "gix-hash",
  "gix-object",
  "tempfile",

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -848,7 +848,7 @@ fn replace_child_inner(
 /// Oid-level body of [`insert`]: replace whatever is at `path` inside the tree `full_tree` with
 /// (`oid`, `mode`), creating intermediate trees as needed and treating blobs on the way as
 /// overwritable.
-pub(crate) fn insert_oid(
+pub fn insert_oid(
     odb: &(impl gix_object::Find + gix_object::Write),
     full_tree: git2::Oid,
     path: &Path,

--- a/josh-gix-ext/Cargo.toml
+++ b/josh-gix-ext/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2024"
 [dependencies]
 anyhow.workspace = true
 git2.workspace = true
+gix-actor.workspace = true
 gix-hash.workspace = true
 gix-object.workspace = true
 

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -159,6 +159,54 @@ pub fn write_tree_now(
     Ok(git2_oid(&id))
 }
 
+/// Write `data` as a blob to `out`.
+pub fn write_blob(out: &impl gix_object::Write, data: &[u8]) -> anyhow::Result<git2::Oid> {
+    let id = out
+        .write_buf(gix_object::Kind::Blob, data)
+        .map_err(|e| anyhow::anyhow!("write_blob: {e}"))?;
+    Ok(git2_oid(&id))
+}
+
+/// Serialize a new commit and write it to `out`. Signatures carry the seconds and UTC
+/// offset of the given git2 signatures; the message is written verbatim, so any cleanup is
+/// the caller's business.
+pub fn write_commit(
+    out: &impl gix_object::Write,
+    tree: git2::Oid,
+    parents: &[git2::Oid],
+    author: &git2::Signature<'_>,
+    committer: &git2::Signature<'_>,
+    message: &str,
+) -> anyhow::Result<git2::Oid> {
+    let commit = gix_object::Commit {
+        tree: gix_oid(tree),
+        parents: parents.iter().map(|p| gix_oid(*p)).collect(),
+        author: gix_signature(author)?,
+        committer: gix_signature(committer)?,
+        encoding: None,
+        message: message.into(),
+        extra_headers: vec![],
+    };
+    let mut buffer = Vec::with_capacity(commit.size() as usize);
+    gix_object::WriteTo::write_to(&commit, &mut buffer)?;
+    let id = out
+        .write_buf(gix_object::Kind::Commit, &buffer)
+        .map_err(|e| anyhow::anyhow!("write_commit: {e}"))?;
+    Ok(git2_oid(&id))
+}
+
+fn gix_signature(sig: &git2::Signature<'_>) -> anyhow::Result<gix_actor::Signature> {
+    let when = sig.when();
+    Ok(gix_actor::Signature {
+        name: sig.name_bytes().into(),
+        email: sig.email_bytes().into(),
+        time: gix_actor::date::Time {
+            seconds: when.seconds(),
+            offset: i32::from(when.offset_minutes()) * 60,
+        },
+    })
+}
+
 /// A commit's id + raw odb bytes, owned. Send + Sync plain data; never stored in a transaction.
 /// Parse-on-demand: `CommitRef`/`CommitRefIter` borrow `&self` and never outlive the frame.
 /// The internal representation can become `Arc<[u8]>` later without any signature change.
@@ -494,6 +542,94 @@ mod tests {
             .unwrap()
             .write(git2::ObjectType::Commit, &data)
             .unwrap()
+    }
+
+    /// Commits written here must be byte-identical to the ones libgit2 writes for the same
+    /// inputs -- every ref josh publishes is content-addressed, so a formatting difference
+    /// would renumber history.
+    #[test]
+    fn write_commit_matches_git2() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init_bare(dir.path()).unwrap();
+        let odb = repo.odb().unwrap();
+
+        let tree = repo.treebuilder(None).unwrap().write().unwrap();
+        let blob = repo.blob(b"x").unwrap();
+        let mut b = repo.treebuilder(None).unwrap();
+        b.insert("f", blob, 0o100644).unwrap();
+        let tree2 = b.write().unwrap();
+
+        let sig = |name: &str, email: &str, secs: i64, offset: i32| {
+            git2::Signature::new(name, email, &git2::Time::new(secs, offset)).unwrap()
+        };
+
+        let cases: Vec<(git2::Signature, git2::Signature, &str, git2::Oid)> = vec![
+            (
+                sig("A", "a@e", 0, 0),
+                sig("A", "a@e", 0, 0),
+                "subject\n",
+                tree,
+            ),
+            (
+                sig("A", "a@e", 1234567890, 120),
+                sig("B", "b@e", 1234567899, -330),
+                "subject\n\nbody with trailing newline\n",
+                tree2,
+            ),
+            (
+                sig("Ünïcode Nàme", "u@e", 42, -60),
+                sig("Ünïcode Nàme", "u@e", 42, -60),
+                "no trailing newline",
+                tree2,
+            ),
+            (sig("A", "a@e", 99, 0), sig("A", "a@e", 99, 0), "", tree),
+        ];
+
+        for (author, committer, message, tree) in &cases {
+            for parents in [vec![], vec![0usize], vec![0, 1]] {
+                // Build the parent commits with git2 so both writers see identical inputs.
+                let parent_ids: Vec<git2::Oid> = parents
+                    .iter()
+                    .map(|i| {
+                        let t = repo.find_tree(*tree).unwrap();
+                        repo.commit(None, author, committer, &format!("parent {i}"), &t, &[])
+                            .unwrap()
+                    })
+                    .collect();
+                let parent_commits: Vec<git2::Commit> = parent_ids
+                    .iter()
+                    .map(|id| repo.find_commit(*id).unwrap())
+                    .collect();
+                let parent_refs: Vec<&git2::Commit> = parent_commits.iter().collect();
+
+                let want = repo
+                    .commit(
+                        None,
+                        author,
+                        committer,
+                        message,
+                        &repo.find_tree(*tree).unwrap(),
+                        &parent_refs,
+                    )
+                    .unwrap();
+                let got = write_commit(
+                    &Git2Odb(&odb),
+                    *tree,
+                    &parent_ids,
+                    author,
+                    committer,
+                    message,
+                )
+                .unwrap();
+                assert_eq!(
+                    want,
+                    got,
+                    "commit id diverged for {:?} with {} parents",
+                    message,
+                    parent_ids.len()
+                );
+            }
+        }
     }
 
     #[test]

--- a/josh-link/src/lib.rs
+++ b/josh-link/src/lib.rs
@@ -18,21 +18,13 @@ impl PreparedLinkAdd {
         head_commit: git2::Oid,
         signature: &git2::Signature,
     ) -> anyhow::Result<git2::Oid> {
-        let repo = transaction.repo();
-        let tree = repo
-            .find_tree(self.tree_oid)
-            .context("Failed to find tree")?;
-        let head_commit = repo
-            .find_commit(head_commit)
-            .context("Failed to find commit")?;
-
-        repo.commit(
-            None,
+        josh_core::objects::write_commit(
+            &transaction.odb()?,
+            self.tree_oid,
+            &[head_commit],
             signature,
             signature,
             &format!("Add link: {}", self.path.display()),
-            &tree,
-            &[&head_commit],
         )
         .context("Failed to create commit")
     }
@@ -66,8 +58,6 @@ pub fn collect_all_link_refs(
     transaction: &josh_core::cache::Transaction,
     commit: git2::Oid,
 ) -> anyhow::Result<HashSet<LinkRef>> {
-    let repo = transaction.repo();
-
     // Apply a filter that keeps only .link.josh files. This prunes the history
     // to only commits that actually changed those files, so the revwalk below
     // visits far fewer commits on typical repositories.
@@ -83,18 +73,19 @@ pub fn collect_all_link_refs(
 
     let mut refs = HashSet::new();
 
-    let mut walk = repo.revwalk().context("Failed to create revwalk")?;
+    let odb = transaction.odb()?;
+    let mut walk = josh_core::objects::RevWalk::new(&odb);
     walk.push(filtered_commit)
         .context("Failed to push commit to revwalk")?;
 
-    for oid in walk {
-        let oid = oid.context("Failed to get OID from revwalk")?;
-        let commit = repo.find_commit(oid).context("Failed to find commit")?;
-        let tree = commit.tree().context("Failed to get commit tree")?;
+    for oid in walk
+        .into_topo_vec(|_| false)
+        .context("Failed to walk history")?
+    {
+        let tree = josh_core::git::read_tree_id(&odb, oid).context("Failed to get commit tree")?;
 
         let link_files =
-            josh_core::link::find_link_files(&josh_core::objects::Git2Odb(&repo.odb()?), tree.id())
-                .context("Failed to find link files")?;
+            josh_core::link::find_link_files(&odb, tree).context("Failed to find link files")?;
 
         for (_, filter) in link_files {
             if let (Some(remote), Some(commit)) =
@@ -138,10 +129,7 @@ pub fn prepare_link_add(
     head_tree: git2::Oid,
     mode: josh_core::filter::LinkMode,
 ) -> anyhow::Result<PreparedLinkAdd> {
-    let repo = transaction.repo();
-    let head_tree = repo
-        .find_tree(head_tree)
-        .context("Failed to find head tree")?;
+    let odb = transaction.odb()?;
 
     // Strip leading slash if present (git tree paths are always relative)
     let path = path.strip_prefix("/").unwrap_or(path);
@@ -161,18 +149,12 @@ pub fn prepare_link_add(
         .with_meta("mode", mode.to_string());
     let link_content = josh_core::filter::as_file(link_filter, 0);
 
-    // Create the blob for the .link.josh file
-    let link_blob = repo
-        .blob(link_content.as_bytes())
-        .context("Failed to create blob")?;
-
-    // Create the path for the .link.josh file
+    let link_blob = josh_core::objects::write_blob(&odb, link_content.as_bytes())?;
     let link_path = path.join(".link.josh");
 
-    // Insert the .link.josh file into the tree
-    let new_tree = tree::insert(
-        repo,
-        &head_tree,
+    let new_tree = tree::insert_oid(
+        &odb,
+        head_tree,
         &link_path,
         link_blob,
         git2::FileMode::Blob.into(),
@@ -180,7 +162,7 @@ pub fn prepare_link_add(
     .context("Failed to insert link file into tree")?;
 
     Ok(PreparedLinkAdd {
-        tree_oid: new_tree.id(),
+        tree_oid: new_tree,
         path: path.to_path_buf(),
     })
 }
@@ -191,19 +173,13 @@ pub fn update_links(
     links_to_update: Vec<(PathBuf, git2::Oid)>,
     signature: &git2::Signature,
 ) -> anyhow::Result<Option<UpdateLinksResult>> {
-    let repo = transaction.repo();
-    let head_commit = repo
-        .find_commit(head_commit)
-        .context("Failed to find commit")?;
-    let head_tree = head_commit.tree().context("Failed to get HEAD tree")?;
-    let head_tree_id = head_tree.id();
+    let odb = transaction.odb()?;
+    let head_tree_id =
+        josh_core::git::read_tree_id(&odb, head_commit).context("Failed to get HEAD tree")?;
 
     // Find all link files to get their current metadata
-    let link_files = josh_core::link::find_link_files(
-        &josh_core::objects::Git2Odb(&repo.odb()?),
-        head_tree.id(),
-    )
-    .context("Failed to find link files")?;
+    let link_files = josh_core::link::find_link_files(&odb, head_tree_id)
+        .context("Failed to find link files")?;
 
     // Update the link files with new commit OIDs
     let mut updated_link_files: Vec<(PathBuf, josh_core::filter::Filter)> = Vec::new();
@@ -221,21 +197,14 @@ pub fn update_links(
     }
 
     // Create new tree with updated .link.josh files
-    let mut new_tree = head_tree;
+    let mut new_tree = head_tree_id;
     for (path, link_file) in &updated_link_files {
         let link_content = josh_core::filter::as_file(*link_file, 0);
-
-        // Create the blob for the .link.josh file
-        let link_blob = repo
-            .blob(link_content.as_bytes())
-            .context("Failed to create blob")?;
-
-        // Create the path for the .link.josh file
+        let link_blob = josh_core::objects::write_blob(&odb, link_content.as_bytes())?;
         let link_path = path.join(".link.josh");
 
-        // Insert the updated .link.josh file into the tree
-        new_tree =
-            tree::insert(repo, &new_tree, &link_path, link_blob, 0o0100644).with_context(|| {
+        new_tree = tree::insert_oid(&odb, new_tree, &link_path, link_blob, 0o0100644)
+            .with_context(|| {
                 format!(
                     "Failed to insert link file into tree at path '{}'",
                     path.display()
@@ -243,28 +212,27 @@ pub fn update_links(
             })?;
     }
 
-    if new_tree.id() == head_tree_id {
+    if new_tree == head_tree_id {
         return Ok(None);
     }
 
     // Create a new commit with the updated tree
-    let commit_with_updates = repo
-        .commit(
-            None, // Don't update any reference
-            signature,
-            signature,
-            &format!(
-                "Update links: {}",
-                updated_link_files
-                    .iter()
-                    .map(|(p, _)| p.display().to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
-            &new_tree,
-            &[&head_commit],
-        )
-        .context("Failed to create commit")?;
+    let commit_with_updates = josh_core::objects::write_commit(
+        &odb,
+        new_tree,
+        &[head_commit],
+        signature,
+        signature,
+        &format!(
+            "Update links: {}",
+            updated_link_files
+                .iter()
+                .map(|(p, _)| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    )
+    .context("Failed to create commit")?;
 
     // Apply the :link filter to the new commit
     let link_filter = josh_core::filter::parse(":link").context("Failed to parse :link filter")?;

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -299,22 +299,25 @@ pub fn merge_meta(
     }
     let rev = transaction_mirror.refname("refs/josh/meta");
 
-    let (tree, parent) = if let Some(meta_oid) = transaction_mirror.resolve_ref(&rev)? {
-        let meta_commit = transaction.repo().find_commit(meta_oid)?;
-        let tree = meta_commit.tree()?;
-        (tree, Some(meta_commit))
+    let odb = transaction.odb()?;
+    let (mut tree, parents) = if let Some(meta_oid) = transaction_mirror.resolve_ref(&rev)? {
+        let meta_commit = josh_core::objects::CommitData::read(&odb, meta_oid)?;
+        (meta_commit.tree_id()?, vec![meta_oid])
     } else {
-        (josh_core::filter::tree::empty(transaction.repo()), None)
+        (josh_core::filter::tree::empty_id(), vec![])
     };
 
-    let mut tree = tree;
-
     for (path, add_lines) in meta_add.iter() {
-        let prev = if let Ok(e) = tree.get_path(path) {
-            let blob = transaction.repo().find_blob(e.id())?;
-            std::str::from_utf8(blob.content())?.to_owned()
-        } else {
-            "".to_owned()
+        let prev = match josh_core::filter::tree::get_path_entry(transaction, &odb, tree, path)? {
+            Some(entry) => {
+                let blob = josh_core::filter::tree::blob_bytes(
+                    &odb,
+                    josh_core::objects::git2_oid(&entry.oid),
+                )
+                .ok_or_else(|| anyhow!("not a blob: {}", entry.oid))?;
+                std::str::from_utf8(&blob)?.to_owned()
+            }
+            None => "".to_owned(),
         };
 
         let mut lines = prev
@@ -327,20 +330,14 @@ pub fn merge_meta(
         lines.sort_unstable();
         lines.dedup();
 
-        let blob = transaction.repo().blob(lines.join("\n").as_bytes())?;
+        let blob = josh_core::objects::write_blob(&odb, lines.join("\n").as_bytes())?;
 
-        tree = josh_core::filter::tree::insert(transaction.repo(), &tree, path, blob, 0o0100644)?;
+        tree = josh_core::filter::tree::insert_oid(&odb, tree, path, blob, 0o0100644)?;
     }
 
     let signature = josh_core::git::josh_commit_signature()?;
-    let oid = transaction.repo().commit(
-        None,
-        &signature,
-        &signature,
-        "marker",
-        &tree,
-        &parent.as_ref().into_iter().collect::<Vec<_>>(),
-    )?;
+    let oid =
+        josh_core::objects::write_commit(&odb, tree, &parents, &signature, &signature, "marker")?;
 
     Ok(Some(("refs/josh/meta".to_string(), oid)))
 }

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -446,21 +446,22 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
         };
 
         let oid_to_push = if push_options.merge {
-            let backward_commit = transaction.repo().find_commit(backward_new_oid)?;
             if let Some(base_commit_id) = transaction_mirror.resolve_ref(&original_target_ref)? {
                 let signature = josh_core::git::josh_commit_signature()?;
+                // PORT: libgit2-internal merge compute over possibly-unflushed commits.
+                let backward_commit = transaction.repo().find_commit(backward_new_oid)?;
                 let base_commit = transaction.repo().find_commit(base_commit_id)?;
                 let merged_tree = transaction
                     .repo()
                     .merge_commits(&base_commit, &backward_commit, None)?
                     .write_tree_to(transaction.repo())?;
-                transaction.repo().commit(
-                    None,
+                josh_core::objects::write_commit(
+                    &transaction.odb()?,
+                    merged_tree,
+                    &[base_commit_id, backward_new_oid],
                     &signature,
                     &signature,
                     &format!("Merge from {}", &repo_update.filter_spec),
-                    &transaction.repo().find_tree(merged_tree)?,
-                    &[&base_commit, &backward_commit],
                 )?
             } else {
                 return Err(anyhow!("josh_merge failed"));
@@ -509,7 +510,8 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
             let mut warnings = josh_core::filter::compute_warnings(
                 &transaction,
                 filter,
-                transaction.repo().find_commit(push_ref.oid)?.tree_id(),
+                josh_core::objects::CommitData::read(&transaction.odb()?, push_ref.oid)?
+                    .tree_id()?,
             );
 
             if !warnings.is_empty() {


### PR DESCRIPTION
Port josh-proxy and josh-link writes onto the memodb facade

Commits, blobs and tree inserts in both crates go through the
transaction facade. josh-gix-ext gains `write_commit` and `write_blob`
for that; a unit test pins `write_commit` against libgit2's commit ids
across signatures, timezone offsets, unicode names, empty messages and
zero to two parents, since every ref josh publishes is content
addressed.

josh-link also reads link files and history through the facade, and
josh-core exposes `tree::insert_oid` for leaf crates.

The merge that `-o merge` performs stays on the repository handle
behind a PORT marker.

Change: proxy-link-writes-facade
Assisted-By: anthropic/claude-fable-5