### PR TITLE
Port josh-changes and josh-cq onto the memodb facade

### DIFF
--- a/cq/josh-cq/src/cq.rs
+++ b/cq/josh-cq/src/cq.rs
@@ -84,10 +84,7 @@ pub fn handle_track(
     )?
     .into_tree_oid();
 
-    let tree_with_link = repo
-        .find_tree(tree_with_link_oid)
-        .context("Failed to find tree with link")?;
-
+    let odb = transaction.odb()?;
     let refs_blob = {
         let refs_map: BTreeMap<String, String> = refs
             .iter()
@@ -97,31 +94,30 @@ pub fn handle_track(
         let refs_json =
             serde_json::to_string_pretty(&refs_map).context("Failed to serialize refs to JSON")?;
 
-        repo.blob(refs_json.as_bytes())
+        josh_core::objects::write_blob(&odb, refs_json.as_bytes())
             .context("Failed to create refs.json blob")?
     };
 
     let refs_path = std::path::Path::new("remotes").join(id).join("refs.json");
 
-    let final_tree = tree::insert(
-        repo,
-        &tree_with_link,
+    let final_tree = tree::insert_oid(
+        &odb,
+        tree_with_link_oid,
         &refs_path,
         refs_blob,
         git2::FileMode::Blob.into(),
     )
     .context("Failed to insert refs.json into tree")?;
 
-    let final_commit = repo
-        .commit(
-            None,
-            &signature,
-            &signature,
-            &format!("Track remote: {}", id),
-            &final_tree,
-            &[&head_commit],
-        )
-        .context("Failed to create final commit")?;
+    let final_commit = josh_core::objects::write_commit(
+        &odb,
+        final_tree,
+        &[head_commit.id()],
+        &signature,
+        &signature,
+        &format!("Track remote: {}", id),
+    )
+    .context("Failed to create final commit")?;
 
     transaction
         .update_ref(

--- a/josh-changes/src/change.rs
+++ b/josh-changes/src/change.rs
@@ -1,6 +1,8 @@
 use crate::refs::ChangesRef;
 use crate::store::store_diff_data;
 use anyhow::anyhow;
+use josh_core::filter::tree;
+use josh_core::objects;
 use josh_core::trailers::{commit_change_meta, parse_change_meta};
 
 #[derive(Debug, Clone)]
@@ -17,12 +19,20 @@ impl Change {
         transaction: &josh_core::cache::Transaction,
         commit: git2::Oid,
     ) -> anyhow::Result<Self> {
-        Ok(Self::from_commit(&transaction.repo().find_commit(commit)?))
+        Ok(Self::from_commit(&objects::CommitData::read(
+            &transaction.odb()?,
+            commit,
+        )?))
     }
 
-    pub(crate) fn from_commit(commit: &git2::Commit) -> Self {
+    pub(crate) fn from_commit(commit: &objects::CommitData) -> Self {
+        let author = commit
+            .parsed()
+            .and_then(|c| Ok(c.author()?.email.to_owned()))
+            .map(|email| String::from_utf8_lossy(&email).into_owned())
+            .unwrap_or_default();
         let mut change = Self {
-            author: commit.author().email().unwrap_or("").to_string(),
+            author,
             id: None,
             series: Vec::new(),
             commit: commit.id(),
@@ -63,14 +73,14 @@ impl Change {
         &self,
         transaction: &josh_core::cache::Transaction,
     ) -> anyhow::Result<Vec<git2::Oid>> {
-        let mut walk = transaction.repo().revwalk()?;
-        walk.simplify_first_parent()?;
-        walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+        // First-parent walk down to (but not including) the base.
+        let odb = transaction.odb()?;
+        let mut walk = objects::RevWalk::new(&odb);
+        walk.simplify_first_parent();
         walk.push(self.commit)?;
-        if self.base != git2::Oid::ZERO_SHA1 {
-            walk.hide(self.base)?;
-        }
-        let mut oids: Vec<git2::Oid> = walk.collect::<Result<Vec<_>, _>>()?;
+        let base = self.base;
+        let mut oids = walk.into_topo_vec(|oid| base != git2::Oid::ZERO_SHA1 && oid == base)?;
+        oids.retain(|oid| *oid != base);
         if oids.first() == Some(&self.commit) {
             oids.remove(0);
         }
@@ -91,23 +101,17 @@ pub fn create_synthetic_merge_commit(
     target_branch_tip: git2::Oid,
     message: &str,
 ) -> anyhow::Result<git2::Oid> {
-    let repo = transaction.repo();
-    let pr_head = repo.find_commit(pr_head)?;
-    let target_branch_tip = repo.find_commit(target_branch_tip)?;
-    let tree = pr_head.tree()?;
-    let author = pr_head.author();
-    let committer = pr_head.committer();
+    let odb = transaction.odb()?;
+    let head = objects::CommitData::read(&odb, pr_head)?;
+    let tree = head.tree_id()?;
 
-    let oid = repo.commit(
-        None,
-        &author,
-        &committer,
+    objects::write_commit_with_signatures_of(
+        &odb,
+        &head,
+        tree,
+        &[target_branch_tip, pr_head],
         message,
-        &tree,
-        &[&target_branch_tip, &pr_head],
-    )?;
-
-    Ok(oid)
+    )
 }
 
 pub(crate) fn decode_change_id_path(enc: &str) -> String {
@@ -139,18 +143,17 @@ pub(crate) fn get_changes(
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<std::collections::HashMap<git2::Oid, Change>> {
-    let repo = transaction.repo();
-    let mut walk = repo.revwalk()?;
-    walk.set_sorting(git2::Sort::REVERSE | git2::Sort::TOPOLOGICAL)?;
-    walk.simplify_first_parent()?;
+    let odb = transaction.odb()?;
+    let mut walk = objects::RevWalk::new(&odb);
+    walk.simplify_first_parent();
     walk.push(tip)?;
-    if base != git2::Oid::ZERO_SHA1 {
-        walk.hide(base)?;
-    }
+    let mut oids = walk.into_topo_vec(|oid| base != git2::Oid::ZERO_SHA1 && oid == base)?;
+    oids.retain(|oid| *oid != base);
+    oids.reverse();
 
     let mut changes = std::collections::HashMap::new();
-    for rev in walk {
-        let commit = repo.find_commit(rev?)?;
+    for rev in oids {
+        let commit = objects::CommitData::read(&odb, rev)?;
         let mut change = Change::from_commit(&commit);
         if change.id.is_none() {
             continue;
@@ -183,45 +186,38 @@ pub fn list_changes(
     transaction: &josh_core::cache::Transaction,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<Change>> {
-    let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let tree = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => repo.find_commit(oid)?.tree()?,
+        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
         None => return Ok(Vec::new()),
     };
 
-    let diffs_tree = match tree
-        .get_name("diffs")
-        .and_then(|e| e.to_object(repo).ok())
-        .and_then(|o| o.peel_to_tree().ok())
-    {
-        Some(t) => t,
-        None => return Ok(Vec::new()),
-    };
+    let diffs_tree =
+        match crate::store::get_tree(transaction, &odb, tree, std::path::Path::new("diffs")) {
+            Some(t) => t,
+            None => return Ok(Vec::new()),
+        };
 
     let mut changes = Vec::new();
-    for entry in diffs_tree.iter() {
-        let change_id = decode_change_id_path(entry.name().unwrap_or(""));
-        if change_id.is_empty() {
+    for entry in tree::read_tree(transaction, &odb, diffs_tree)?.entries() {
+        let change_id = decode_change_id_path(std::str::from_utf8(entry.filename).unwrap_or(""));
+        if change_id.is_empty() || !entry.mode.is_tree() {
             continue;
         }
-        let subtree = match entry
-            .to_object(repo)
-            .ok()
-            .and_then(|o| o.peel_to_tree().ok())
-        {
-            Some(t) => t,
-            None => continue,
+        let subtree = match tree::read_tree(transaction, &odb, objects::git2_oid(&entry.oid)) {
+            Ok(t) => t,
+            Err(_) => continue,
         };
         // The subtree has a single blob named by its content hash.
         // Read it to get tip and base OIDs.
         let mut tip_oid = git2::Oid::ZERO_SHA1;
         let mut base_oid = git2::Oid::ZERO_SHA1;
-        for se in subtree.iter() {
-            let blob = match se.to_object(repo).ok().and_then(|o| o.peel_to_blob().ok()) {
+        for se in subtree.entries() {
+            let blob = match tree::blob_bytes(&odb, objects::git2_oid(&se.oid)) {
                 Some(b) => b,
                 None => continue,
             };
-            let content = String::from_utf8_lossy(blob.content());
+            let content = String::from_utf8_lossy(&blob);
             if let Some((tip_str, base_str)) = content.split_once('\n') {
                 tip_oid = git2::Oid::from_str(tip_str).unwrap_or(git2::Oid::ZERO_SHA1);
                 base_oid = git2::Oid::from_str(base_str).unwrap_or(git2::Oid::ZERO_SHA1);
@@ -231,7 +227,7 @@ pub fn list_changes(
         if tip_oid == git2::Oid::ZERO_SHA1 {
             continue;
         }
-        let commit = match repo.find_commit(tip_oid) {
+        let commit = match objects::CommitData::read(&odb, tip_oid) {
             Ok(c) => c,
             Err(_) => continue,
         };
@@ -251,9 +247,10 @@ pub fn resolve_change(
     spec: &str,
 ) -> anyhow::Result<Change> {
     let repo = transaction.repo();
+    let odb = transaction.odb()?;
     // Try as a full OID first.
     if let Ok(oid) = git2::Oid::from_str(spec) {
-        if let Ok(commit) = repo.find_commit(oid) {
+        if let Ok(commit) = objects::CommitData::read(&odb, oid) {
             return Ok(Change::from_commit(&commit));
         }
     }
@@ -261,20 +258,25 @@ pub fn resolve_change(
     // Try as a revparse (branch, tag, short SHA).
     // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
     if let Ok(obj) = repo.revparse_single(spec) {
-        if let Ok(commit) = obj.peel_to_commit() {
+        if let Ok(commit) = obj.peel_to_commit()
+            && let Ok(commit) = objects::CommitData::read(&odb, commit.id())
+        {
             return Ok(Change::from_commit(&commit));
         }
     }
 
     // Walk from head to find a commit with matching Change-Id.
-    let mut walk = repo.revwalk()?;
-    walk.simplify_first_parent()?;
-    walk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+    let mut walk = objects::RevWalk::new(&odb);
+    walk.simplify_first_parent();
     walk.push(head)?;
-    for oid in walk {
-        let oid = oid?;
-        if let Ok(c) = repo.find_commit(oid) {
-            let (id, _) = parse_change_meta(c.message().unwrap_or(""));
+    for oid in walk.into_topo_vec(|_| false)? {
+        if let Ok(c) = objects::CommitData::read(&odb, oid) {
+            let message = c
+                .message()
+                .ok()
+                .and_then(|m| std::str::from_utf8(m).ok())
+                .unwrap_or("");
+            let (id, _) = parse_change_meta(message);
             if id.as_deref() == Some(spec) {
                 return Ok(Change::from_commit(&c));
             }

--- a/josh-changes/src/comments.rs
+++ b/josh-changes/src/comments.rs
@@ -3,6 +3,9 @@ use crate::refs::ChangesRef;
 use crate::store::{get_tree, write_changes_tree};
 use anyhow::anyhow;
 use josh_core::cache::{Expected, Transaction};
+use josh_core::filter::tree;
+use josh_core::memodb::Odb;
+use josh_core::objects;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Location {
@@ -101,7 +104,6 @@ fn write_comment_inner(
         return Err(anyhow::anyhow!("comment message must not be empty"));
     }
 
-    let repo = transaction.repo();
     let change_id = change
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
@@ -109,7 +111,8 @@ fn write_comment_inner(
     let content = serde_json::to_string(meta)?;
     let content_hash =
         git2::Oid::hash_object(git2::ObjectType::Blob, content.as_bytes())?.to_string();
-    let blob_oid = repo.blob(content.as_bytes())?;
+    let odb = transaction.odb()?;
+    let blob_oid = objects::write_blob(&odb, content.as_bytes())?;
 
     let prefix = std::path::Path::new(path_prefix);
     let path = if let Some(ref file) = meta.file {
@@ -117,12 +120,12 @@ fn write_comment_inner(
             Some(s) => git2::Oid::from_str(s)?,
             None => change.commit(),
         };
-        let commit = repo.find_commit(resolve_commit)?;
-        let file_blob = commit
-            .tree()?
-            .get_path(std::path::Path::new(file))?
-            .id()
-            .to_string();
+        let commit_tree = objects::CommitData::read(&odb, resolve_commit)?.tree_id()?;
+        let file_blob =
+            tree::get_path_entry(transaction, &odb, commit_tree, std::path::Path::new(file))?
+                .ok_or_else(|| anyhow!("no such path: {}", file))?
+                .oid
+                .to_string();
         prefix
             .join("F")
             .join(encode_change_id_path(&change_id))
@@ -162,31 +165,34 @@ pub fn comment_author(
     file: Option<&str>,
     scope: &ChangesRef,
 ) -> anyhow::Result<(String, String)> {
-    let repo = transaction.repo();
     let change_id = match change.id() {
         Some(id) => id,
         None => return Err(anyhow!("change has no Change-Id")),
     };
 
+    let odb = transaction.odb()?;
     let ref_name = scope.ref_name();
     let head = match transaction.resolve_ref(&ref_name)? {
-        Some(oid) => repo.find_commit(oid)?,
+        Some(oid) => oid,
         None => return Err(anyhow!("{} not found", ref_name)),
     };
 
     let path = if let Some(f) = file {
         // Find the blob_id for this comment in the current tree.
-        let head_tree = head.tree()?;
+        let head_tree = objects::CommitData::read(&odb, head)?.tree_id()?;
         let cid_path = std::path::Path::new("comments")
             .join("F")
             .join(encode_change_id_path(change_id));
         let mut found = None;
-        if let Some(cid_tree) = get_tree(repo, &head_tree, &cid_path) {
-            for blob_entry in cid_tree.iter() {
-                let blob_name = blob_entry.name().unwrap_or("");
+        if let Some(cid_tree) = get_tree(transaction, &odb, head_tree, &cid_path) {
+            for blob_entry in tree::read_tree(transaction, &odb, cid_tree)?.entries() {
+                let blob_name = std::str::from_utf8(blob_entry.filename).unwrap_or("");
                 let sub = std::path::Path::new(f).join(comment_id);
                 let full = cid_path.join(blob_name).join(&sub);
-                if head_tree.get_path(&full).is_ok() {
+                if matches!(
+                    tree::get_path_entry(transaction, &odb, head_tree, &full),
+                    Ok(Some(_))
+                ) {
                     found = Some(full);
                     break;
                 }
@@ -205,28 +211,31 @@ pub fn comment_author(
             .join(comment_id)
     };
 
-    let mut walk = repo.revwalk()?;
-    walk.simplify_first_parent()?;
-    walk.push(head.id())?;
+    let mut walk = objects::RevWalk::new(&odb);
+    walk.simplify_first_parent();
+    walk.push(head)?;
 
-    for oid in walk {
-        let oid = oid?;
-        let commit = repo.find_commit(oid)?;
-        let tree = commit.tree()?;
-        if let Ok(entry) = tree.get_path(&path) {
-            // Check if this blob is new (not in parent) or changed.
-            let is_new = match commit.parent(0) {
-                Ok(parent) => parent
-                    .tree()
+    for oid in walk.into_topo_vec(|_| false)? {
+        let commit = objects::CommitData::read(&odb, oid)?;
+        let tree = commit.tree_id()?;
+        if let Ok(Some(entry)) = tree::get_path_entry(transaction, &odb, tree, &path) {
+            // The commit that introduced or last changed this blob authored the comment.
+            let is_new = match commit.first_parent_id() {
+                Some(parent) => josh_core::git::read_tree_id(&odb, parent)
                     .ok()
-                    .and_then(|pt| pt.get_path(&path).ok())
-                    .map_or(true, |e| e.id() != entry.id()),
-                Err(_) => true,
+                    .and_then(|pt| {
+                        tree::get_path_entry(transaction, &odb, pt, &path)
+                            .ok()
+                            .flatten()
+                    })
+                    .is_none_or(|e| e.oid != entry.oid),
+                None => true,
             };
             if is_new {
-                let time = commit.time();
-                let date = format!("{}", time.seconds());
-                return Ok((commit.author().email().unwrap_or("").to_string(), date));
+                let parsed = commit.parsed()?;
+                let date = format!("{}", parsed.committer()?.seconds());
+                let email = parsed.author()?.email;
+                return Ok((String::from_utf8_lossy(email).into_owned(), date));
             }
         }
     }
@@ -235,13 +244,15 @@ pub fn comment_author(
 }
 
 fn parse_comment_blob(
-    repo: &git2::Repository,
-    entry: &git2::TreeEntry,
+    odb: &Odb,
+    name: &[u8],
+    blob_oid: git2::Oid,
     file: Option<String>,
 ) -> anyhow::Result<Comment> {
-    let id = entry.name().unwrap_or("").to_string();
-    let blob = entry.to_object(repo)?.peel_to_blob()?;
-    let meta: CommentMeta = serde_json::from_slice(blob.content())?;
+    let id = String::from_utf8_lossy(name).into_owned();
+    let blob =
+        tree::blob_bytes(odb, blob_oid).ok_or_else(|| anyhow!("not a blob: {}", blob_oid))?;
+    let meta: CommentMeta = serde_json::from_slice(&blob)?;
     Ok(Comment {
         id,
         message: meta.message,
@@ -260,22 +271,31 @@ pub fn read_comments(
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<Comment>> {
-    let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let ref_name = scope.ref_name();
     let head_commit = match transaction.resolve_ref(&ref_name)? {
-        Some(oid) => repo.find_commit(oid)?,
+        Some(oid) => oid,
         None => return Ok(Vec::new()),
     };
-    let tree = head_commit.tree()?;
+    let tree = objects::CommitData::read(&odb, head_commit)?.tree_id()?;
 
     let mut comments = Vec::new();
 
     // Posted/fetched: comments/{C,F}/...
-    collect_comments_at_prefix(repo, &tree, change_id, "comments", false, &mut comments)?;
+    collect_comments_at_prefix(
+        transaction,
+        &odb,
+        tree,
+        change_id,
+        "comments",
+        false,
+        &mut comments,
+    )?;
     // Pending outbox (only meaningful on Remote refs): outbox/comments/{C,F}/...
     collect_comments_at_prefix(
-        repo,
-        &tree,
+        transaction,
+        &odb,
+        tree,
         change_id,
         "outbox/comments",
         true,
@@ -283,13 +303,15 @@ pub fn read_comments(
     )?;
 
     // Walk history once to resolve author/timestamp for all comments.
-    let mut walk = repo.revwalk().unwrap_or_else(|_| repo.revwalk().unwrap());
-    let _ = walk.simplify_first_parent();
-    let _ = walk.push(head_commit.id());
-    'outer: for oid in walk.flatten() {
-        if let Ok(commit) = repo.find_commit(oid) {
-            let tree = commit.tree().unwrap();
-            let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
+    let mut walk = objects::RevWalk::new(&odb);
+    walk.simplify_first_parent();
+    let _ = walk.push(head_commit);
+    'outer: for oid in walk.into_topo_vec(|_| false)?.into_iter() {
+        if let Ok(commit) = objects::CommitData::read(&odb, oid) {
+            let Ok(tree) = commit.tree_id() else { continue };
+            let parent_tree = commit
+                .first_parent_id()
+                .and_then(|p| josh_core::git::read_tree_id(&odb, p).ok());
             for c in &mut comments {
                 if c.author.is_some() {
                     continue;
@@ -304,38 +326,49 @@ pub fn read_comments(
                         .join("C")
                         .join(encode_change_id_path(change_id))
                         .join(&c.id);
-                    if let Ok(entry) = tree.get_path(&p) {
+                    if let Ok(Some(entry)) = tree::get_path_entry(transaction, &odb, tree, &p) {
                         let is_new = parent_tree
-                            .as_ref()
-                            .and_then(|pt| pt.get_path(&p).ok())
-                            .map_or(true, |e| e.id() != entry.id());
-                        if is_new {
-                            let time = commit.time();
-                            let ts = time.seconds().to_string();
-                            c.author = Some(commit.author().email().unwrap_or("").to_string());
-                            c.timestamp = Some(ts);
+                            .and_then(|pt| {
+                                tree::get_path_entry(transaction, &odb, pt, &p)
+                                    .ok()
+                                    .flatten()
+                            })
+                            .is_none_or(|e| e.oid != entry.oid);
+                        if is_new && let Ok(parsed) = commit.parsed() {
+                            c.timestamp = parsed.committer().ok().map(|t| t.seconds().to_string());
+                            c.author = parsed
+                                .author()
+                                .ok()
+                                .map(|a| String::from_utf8_lossy(a.email).into_owned());
                         }
                     }
                 } else {
                     let cid_path = std::path::Path::new(prefix)
                         .join("F")
                         .join(encode_change_id_path(change_id));
-                    if let Some(cid_tree) = get_tree(repo, &tree, &cid_path) {
-                        for blob_entry in cid_tree.iter() {
-                            let blob_name = blob_entry.name().unwrap_or("");
+                    if let Some(cid_tree) = get_tree(transaction, &odb, tree, &cid_path)
+                        && let Ok(reader) = tree::read_tree(transaction, &odb, cid_tree)
+                    {
+                        for blob_entry in reader.entries() {
+                            let blob_name = std::str::from_utf8(blob_entry.filename).unwrap_or("");
                             let sub = std::path::Path::new(c.file.as_ref().unwrap()).join(&c.id);
                             let full_path = cid_path.join(blob_name).join(&sub);
-                            if let Ok(entry) = tree.get_path(&full_path) {
-                                let parent_entry = parent_tree
-                                    .as_ref()
-                                    .and_then(|pt| pt.get_path(&full_path).ok());
-                                let is_new = parent_entry.map_or(true, |e| e.id() != entry.id());
-                                if is_new {
-                                    let time = commit.time();
-                                    let ts = time.seconds().to_string();
-                                    c.author =
-                                        Some(commit.author().email().unwrap_or("").to_string());
-                                    c.timestamp = Some(ts);
+                            if let Ok(Some(entry)) =
+                                tree::get_path_entry(transaction, &odb, tree, &full_path)
+                            {
+                                let parent_entry = parent_tree.and_then(|pt| {
+                                    tree::get_path_entry(transaction, &odb, pt, &full_path)
+                                        .ok()
+                                        .flatten()
+                                });
+                                let is_new = parent_entry.is_none_or(|e| e.oid != entry.oid);
+                                if is_new && let Ok(parsed) = commit.parsed() {
+                                    c.timestamp =
+                                        parsed.committer().ok().map(|t| t.seconds().to_string());
+                                    c.author = parsed
+                                        .author()
+                                        .ok()
+                                        .map(|a| String::from_utf8_lossy(a.email).into_owned());
                                 }
                             }
                         }
@@ -351,27 +384,32 @@ pub fn read_comments(
     Ok(comments)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_comments_at_prefix(
-    repo: &git2::Repository,
-    tree: &git2::Tree,
+    transaction: &Transaction,
+    odb: &Odb,
+    tree: git2::Oid,
     change_id: &str,
     prefix: &str,
     pending: bool,
     out: &mut Vec<Comment>,
 ) -> anyhow::Result<()> {
-    let root = match get_tree(repo, tree, std::path::Path::new(prefix)) {
+    let root = match get_tree(transaction, odb, tree, std::path::Path::new(prefix)) {
         Some(t) => t,
         None => return Ok(()),
     };
 
     // Non-file: <prefix>/C/<change_id>/
     if let Some(cid_tree) = get_tree(
-        repo,
-        &root,
+        transaction,
+        odb,
+        root,
         &std::path::Path::new("C").join(encode_change_id_path(change_id)),
     ) {
-        for entry in cid_tree.iter() {
-            if let Ok(mut c) = parse_comment_blob(repo, &entry, None) {
+        for entry in tree::read_tree(transaction, odb, cid_tree)?.entries() {
+            if let Ok(mut c) =
+                parse_comment_blob(odb, entry.filename, objects::git2_oid(&entry.oid), None)
+            {
                 c.pending = pending;
                 out.push(c);
             }
@@ -380,17 +418,21 @@ fn collect_comments_at_prefix(
 
     // File: <prefix>/F/<change_id>/<blob_id>/<path>/<to>/<file>/<content_hash>
     if let Some(cid_tree) = get_tree(
-        repo,
-        &root,
+        transaction,
+        odb,
+        root,
         &std::path::Path::new("F").join(encode_change_id_path(change_id)),
     ) {
-        for blob_entry in cid_tree.iter() {
-            let blob_name = blob_entry.name().unwrap_or("");
-            if let Some(blob_tree) = get_tree(repo, &cid_tree, std::path::Path::new(blob_name)) {
+        for blob_entry in tree::read_tree(transaction, odb, cid_tree)?.entries() {
+            let blob_name = std::str::from_utf8(blob_entry.filename).unwrap_or("");
+            if let Some(blob_tree) =
+                get_tree(transaction, odb, cid_tree, std::path::Path::new(blob_name))
+            {
                 let mut found = Vec::new();
                 collect_comments_under_into(
-                    repo,
-                    &blob_tree,
+                    transaction,
+                    odb,
+                    blob_tree,
                     std::path::Path::new(""),
                     &mut found,
                 )?;
@@ -406,28 +448,35 @@ fn collect_comments_at_prefix(
 }
 
 fn collect_comments_under_into(
-    repo: &git2::Repository,
-    tree: &git2::Tree,
+    transaction: &Transaction,
+    odb: &Odb,
+    tree: git2::Oid,
     file_prefix: &std::path::Path,
     out: &mut Vec<Comment>,
 ) -> anyhow::Result<()> {
-    for entry in tree.iter() {
-        let name = entry.name().unwrap_or("");
-        match entry.kind() {
-            Some(git2::ObjectType::Tree) => {
-                let subtree = entry.to_object(repo)?.peel_to_tree()?;
-                let child_file = file_prefix.join(name);
-                collect_comments_under_into(repo, &subtree, &child_file, out)?;
-            }
-            Some(git2::ObjectType::Blob) => {
-                let file = if file_prefix.as_os_str().is_empty() {
-                    None
-                } else {
-                    Some(file_prefix.to_string_lossy().to_string())
-                };
-                out.push(parse_comment_blob(repo, &entry, file)?);
-            }
-            _ => {}
+    for entry in tree::read_tree(transaction, odb, tree)?.entries() {
+        let name = std::str::from_utf8(entry.filename).unwrap_or("");
+        if entry.mode.is_tree() {
+            let child_file = file_prefix.join(name);
+            collect_comments_under_into(
+                transaction,
+                odb,
+                objects::git2_oid(&entry.oid),
+                &child_file,
+                out,
+            )?;
+        } else if !entry.mode.is_commit() {
+            let file = if file_prefix.as_os_str().is_empty() {
+                None
+            } else {
+                Some(file_prefix.to_string_lossy().to_string())
+            };
+            out.push(parse_comment_blob(
+                odb,
+                entry.filename,
+                objects::git2_oid(&entry.oid),
+                file,
+            )?);
         }
     }
     Ok(())
@@ -446,23 +495,24 @@ pub fn delete_outbox_comments(
         return Ok(0);
     }
     let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let want: std::collections::HashSet<&str> = content_hashes.iter().map(|s| s.as_str()).collect();
 
     let ref_name = scope.ref_name();
     let prev_commit = match transaction.resolve_ref(&ref_name)? {
-        Some(oid) => repo.find_commit(oid)?,
+        Some(oid) => oid,
         None => return Ok(0),
     };
-    let mut tree = prev_commit.tree()?;
+    let mut tree = objects::CommitData::read(&odb, prev_commit)?.tree_id()?;
 
     let encoded = encode_change_id_path(change_id);
     let mut paths_to_remove: Vec<std::path::PathBuf> = Vec::new();
 
     // Non-file: outbox/comments/C/<change>/<hash>
     let c_prefix = std::path::Path::new("outbox/comments/C").join(&encoded);
-    if let Some(c_tree) = get_tree(repo, &tree, &c_prefix) {
-        for entry in c_tree.iter() {
-            if let Ok(name) = entry.name() {
+    if let Some(c_tree) = get_tree(transaction, &odb, tree, &c_prefix) {
+        for entry in tree::read_tree(transaction, &odb, c_tree)?.entries() {
+            if let Ok(name) = std::str::from_utf8(entry.filename) {
                 if want.contains(name) {
                     paths_to_remove.push(c_prefix.join(name));
                 }
@@ -472,8 +522,15 @@ pub fn delete_outbox_comments(
 
     // File: outbox/comments/F/<change>/<blob_id>/<path>/<to>/<file>/<hash>
     let f_prefix = std::path::Path::new("outbox/comments/F").join(&encoded);
-    if let Some(f_tree) = get_tree(repo, &tree, &f_prefix) {
-        collect_outbox_file_paths(repo, &f_tree, &f_prefix, &want, &mut paths_to_remove)?;
+    if let Some(f_tree) = get_tree(transaction, &odb, tree, &f_prefix) {
+        collect_outbox_file_paths(
+            transaction,
+            &odb,
+            f_tree,
+            &f_prefix,
+            &want,
+            &mut paths_to_remove,
+        )?;
     }
 
     if paths_to_remove.is_empty() {
@@ -481,15 +538,18 @@ pub fn delete_outbox_comments(
     }
 
     for path in &paths_to_remove {
-        if tree.get_path(path).is_ok() {
-            tree = josh_core::filter::tree::insert(repo, &tree, path, git2::Oid::ZERO_SHA1, 0)?;
+        if matches!(
+            tree::get_path_entry(transaction, &odb, tree, path),
+            Ok(Some(_))
+        ) {
+            tree = tree::insert_oid(&odb, tree, path, git2::Oid::ZERO_SHA1, 0)?;
         }
     }
 
     let sig = repo.signature()?;
     let msg = format!("cleanup posted outbox comments on {}\n", ref_name);
-    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &[&prev_commit])?;
-    transaction.update_ref(&ref_name, Expected::At(prev_commit.id()), new_oid, &msg)?;
+    let new_oid = objects::write_commit(&odb, tree, &[prev_commit], &sig, &sig, &msg)?;
+    transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;
 
     Ok(paths_to_remove.len())
 }
@@ -577,23 +637,30 @@ pub fn store_fetched_comments(
 }
 
 fn collect_outbox_file_paths(
-    repo: &git2::Repository,
-    tree: &git2::Tree,
+    transaction: &Transaction,
+    odb: &Odb,
+    tree: git2::Oid,
     cur: &std::path::Path,
     want: &std::collections::HashSet<&str>,
     out: &mut Vec<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
-    for entry in tree.iter() {
-        let name = match entry.name() {
+    for entry in tree::read_tree(transaction, odb, tree)?.entries() {
+        let name = match std::str::from_utf8(entry.filename) {
             Ok(n) => n,
             Err(_) => continue,
         };
-        match entry.kind() {
-            Some(git2::ObjectType::Tree) => {
-                let subtree = entry.to_object(repo)?.peel_to_tree()?;
-                collect_outbox_file_paths(repo, &subtree, &cur.join(name), want, out)?;
+        match () {
+            _ if entry.mode.is_tree() => {
+                collect_outbox_file_paths(
+                    transaction,
+                    odb,
+                    objects::git2_oid(&entry.oid),
+                    &cur.join(name),
+                    want,
+                    out,
+                )?;
             }
-            Some(git2::ObjectType::Blob) => {
+            _ if !entry.mode.is_commit() => {
                 if want.contains(name) {
                     out.push(cur.join(name));
                 }

--- a/josh-changes/src/forges/gerrit.rs
+++ b/josh-changes/src/forges/gerrit.rs
@@ -74,16 +74,18 @@ fn message_with_gerrit_change_id(message: &str, gerrit_id: &str) -> String {
 /// a stable id and re-publishing lands as a new patchset on the same Gerrit
 /// change rather than a duplicate.
 fn rewrite_chain_with_gerrit_ids(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
+    let odb = transaction.odb()?;
+
     // Collect the chain from tip down to (but excluding) base, first parent only.
     let mut chain: Vec<git2::Oid> = Vec::new();
     let mut cur = tip;
     while cur != base {
         chain.push(cur);
-        match repo.find_commit(cur)?.parent_ids().next() {
+        match josh_core::objects::CommitData::read(&odb, cur)?.first_parent_id() {
             Some(p) => cur = p,
             None => break,
         }
@@ -92,26 +94,24 @@ fn rewrite_chain_with_gerrit_ids(
 
     let mut new_parent = (base != git2::Oid::ZERO_SHA1).then_some(base);
     for oid in chain {
-        let commit = repo.find_commit(oid)?;
+        let commit = josh_core::objects::CommitData::read(&odb, oid)?;
         let (josh_id, _) = josh_core::trailers::commit_change_meta(&commit);
         // A commit with no josh change id gets one derived from its own oid: rare
         // for a change stack, but Gerrit requires a Change-Id on every commit.
         let gerrit_id = gerrit_change_id(josh_id.as_deref().unwrap_or(&oid.to_string()))?;
-        let new_message = message_with_gerrit_change_id(commit.message().unwrap_or(""), &gerrit_id);
+        let message = commit
+            .message()
+            .ok()
+            .and_then(|m| std::str::from_utf8(m).ok())
+            .unwrap_or("");
+        let new_message = message_with_gerrit_change_id(message, &gerrit_id);
 
-        let parents: Vec<git2::Commit> = new_parent
-            .map(|p| repo.find_commit(p))
-            .transpose()?
-            .into_iter()
-            .collect();
-        let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
-        new_parent = Some(repo.commit(
-            None,
-            &commit.author(),
-            &commit.committer(),
+        new_parent = Some(josh_core::objects::write_commit_with_signatures_of(
+            &odb,
+            &commit,
+            commit.tree_id()?,
+            new_parent.as_slice(),
             &new_message,
-            &commit.tree()?,
-            &parent_refs,
         )?);
     }
 
@@ -142,7 +142,7 @@ pub fn build_gerrit_push(
         return Ok(vec![]);
     }
 
-    let new_tip = rewrite_chain_with_gerrit_ids(transaction.repo(), tip, base)?;
+    let new_tip = rewrite_chain_with_gerrit_ids(transaction, tip, base)?;
     Ok(vec![PushRef {
         ref_name: format!("refs/for/{}", branch),
         oid: new_tip,
@@ -196,7 +196,7 @@ pub fn build_gerrit_independent_push(
         }
 
         let gerrit_id = gerrit_change_id(&josh_id)?;
-        let new_tip = rewrite_chain_with_gerrit_ids(repo, change.commit, base)?;
+        let new_tip = rewrite_chain_with_gerrit_ids(transaction, change.commit, base)?;
         refs.push(PushRef {
             ref_name: ref_name.clone(),
             oid: new_tip,

--- a/josh-changes/src/revisions.rs
+++ b/josh-changes/src/revisions.rs
@@ -1,5 +1,7 @@
 use crate::change::{Change, encode_change_id_path};
 use crate::refs::ChangesRef;
+use josh_core::filter::tree;
+use josh_core::objects;
 
 #[derive(Debug, Clone)]
 pub struct Revision {
@@ -13,87 +15,74 @@ pub fn read_revisions(
     change: &Change,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<Revision>> {
-    let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let change_id = match change.id() {
         Some(id) => id,
         None => return Ok(Vec::new()),
     };
 
     let head = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => repo.find_commit(oid)?,
+        Some(oid) => oid,
         None => return Ok(Vec::new()),
+    };
+
+    // The change's diffs subtree, when the commit has one.
+    let diffs_of = |tree: git2::Oid| -> Option<git2::Oid> {
+        crate::store::get_tree(
+            transaction,
+            &odb,
+            tree,
+            &std::path::Path::new("diffs").join(encode_change_id_path(change_id)),
+        )
     };
 
     let mut revs: Vec<Revision> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut walk = repo.revwalk()?;
-    walk.simplify_first_parent()?;
-    walk.push(head.id())?;
+    let mut walk = objects::RevWalk::new(&odb);
+    walk.simplify_first_parent();
+    walk.push(head)?;
 
-    for oid in walk {
-        let oid = oid?;
-        let commit = repo.find_commit(oid)?;
-        let tree = match commit.parent(0) {
-            Ok(p) => (p.tree().ok(), commit.tree().ok()),
-            Err(_) => (None, commit.tree().ok()),
+    for oid in walk.into_topo_vec(|_| false)? {
+        let commit = objects::CommitData::read(&odb, oid)?;
+        let Ok(cur_tree) = commit.tree_id() else {
+            continue;
         };
-        let (parent_tree, cur_tree) = tree;
-        let cur_tree = match cur_tree {
+        let cid_tree = match diffs_of(cur_tree) {
             Some(t) => t,
             None => continue,
         };
+        let parent_cid_tree = commit
+            .first_parent_id()
+            .and_then(|p| josh_core::git::read_tree_id(&odb, p).ok())
+            .and_then(diffs_of)
+            .and_then(|t| tree::read_tree(transaction, &odb, t).ok());
 
-        let diffs_tree = match cur_tree
-            .get_name("diffs")
-            .and_then(|e| e.to_object(repo).ok())
-            .and_then(|o| o.peel_to_tree().ok())
-        {
-            Some(t) => t,
-            None => continue,
-        };
-        let cid_tree = match diffs_tree
-            .get_name(&encode_change_id_path(change_id))
-            .and_then(|e| e.to_object(repo).ok())
-            .and_then(|o| o.peel_to_tree().ok())
-        {
-            Some(t) => t,
-            None => continue,
-        };
-
-        let parent_cid_tree = parent_tree.as_ref().and_then(|pt| {
-            let diffs = pt
-                .get_name("diffs")?
-                .to_object(repo)
-                .ok()?
-                .peel_to_tree()
-                .ok()?;
-            let cid = diffs
-                .get_name(&encode_change_id_path(change_id))?
-                .to_object(repo)
-                .ok()?
-                .peel_to_tree()
-                .ok()?;
-            Some(cid)
-        });
-
-        for entry in cid_tree.iter() {
-            let commit_oid = entry.name().unwrap_or("").to_string();
+        for entry in tree::read_tree(transaction, &odb, cid_tree)?.entries() {
+            let commit_oid = String::from_utf8_lossy(entry.filename).into_owned();
             if commit_oid.is_empty() || seen.contains(&commit_oid) {
                 continue;
             }
             let is_new = parent_cid_tree
                 .as_ref()
-                .and_then(|pt| pt.get_name(&commit_oid))
-                .map_or(true, |e| e.id() != entry.id());
+                .and_then(|pt| pt.entry(entry.filename))
+                .is_none_or(|e| e.oid != entry.oid);
             if !is_new {
                 continue;
             }
-            let time = commit.time();
+            let Ok(parsed) = commit.parsed() else {
+                continue;
+            };
             seen.insert(commit_oid.clone());
             revs.push(Revision {
                 commit_oid,
-                author: commit.author().email().unwrap_or("").to_string(),
-                timestamp: time.seconds().to_string(),
+                author: parsed
+                    .author()
+                    .map(|a| String::from_utf8_lossy(a.email).into_owned())
+                    .unwrap_or_default(),
+                timestamp: parsed
+                    .committer()
+                    .map(|t| t.seconds().to_string())
+                    .unwrap_or_default(),
             });
         }
     }

--- a/josh-changes/src/stacked.rs
+++ b/josh-changes/src/stacked.rs
@@ -95,11 +95,9 @@ pub(crate) fn changes_to_refs(
                 oid: change.commit,
                 change_id: change_id.clone(),
             });
-            if let Some(parent_sha) = transaction
-                .repo()
-                .find_commit(change.commit)?
-                .parent_ids()
-                .next()
+            if let Some(parent_sha) =
+                josh_core::objects::CommitData::read(&transaction.odb()?, change.commit)?
+                    .first_parent_id()
             {
                 refs.push(PushRef {
                     ref_name: StackedRef::ChangeRef(change_ref.as_base()).ref_name(),

--- a/josh-changes/src/store.rs
+++ b/josh-changes/src/store.rs
@@ -1,16 +1,34 @@
 use crate::change::{Change, encode_change_id_path};
 use crate::refs::ChangesRef;
 use josh_core::cache::{Expected, Transaction};
+use josh_core::filter::tree;
+use josh_core::memodb::Odb;
+use josh_core::objects;
 
-pub(crate) fn get_tree<'a>(
-    repo: &'a git2::Repository,
-    tree: &'a git2::Tree,
+/// The subtree at `path`, or `None` when it is missing or not a tree.
+pub(crate) fn get_tree(
+    transaction: &Transaction,
+    odb: &Odb,
+    root: git2::Oid,
     path: &std::path::Path,
-) -> Option<git2::Tree<'a>> {
-    tree.get_path(path)
+) -> Option<git2::Oid> {
+    tree::get_path_entry(transaction, odb, root, path)
         .ok()
-        .and_then(|e| e.to_object(repo).ok())
-        .and_then(|o| o.peel_to_tree().ok())
+        .flatten()
+        .filter(|entry| entry.mode.is_tree())
+        .map(|entry| objects::git2_oid(&entry.oid))
+}
+
+/// The tree of `scope`'s ref, or `None` when the ref does not exist.
+fn scope_tree(
+    transaction: &Transaction,
+    odb: &Odb,
+    scope: &ChangesRef,
+) -> anyhow::Result<Option<git2::Oid>> {
+    match transaction.resolve_ref(&scope.ref_name())? {
+        Some(oid) => Ok(Some(objects::CommitData::read(odb, oid)?.tree_id()?)),
+        None => Ok(None),
+    }
 }
 
 pub(crate) fn parse_timestamp(s: Option<&str>) -> git2::Time {
@@ -37,33 +55,22 @@ pub fn write_changes_tree(
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let ref_name = scope.ref_name();
-    let prev_commit = transaction
-        .resolve_ref(&ref_name)?
-        .and_then(|oid| repo.find_commit(oid).ok());
-    let base_tree = prev_commit
-        .as_ref()
-        .and_then(|c| c.tree().ok())
-        .unwrap_or_else(|| repo.find_tree(josh_core::filter::tree::empty_id()).unwrap());
+    let prev_commit = transaction.resolve_ref(&ref_name)?;
+    let base_tree = match prev_commit {
+        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        None => tree::empty_id(),
+    };
 
     // Skip if the blob already exists at this path.
-    if let Some(existing) = base_tree
-        .get_path(path)
-        .ok()
-        .and_then(|e| e.to_object(repo).ok())
-    {
-        if existing.id() == blob_oid {
+    if let Ok(Some(existing)) = tree::get_path_entry(transaction, &odb, base_tree, path) {
+        if objects::git2_oid(&existing.oid) == blob_oid {
             return Ok(());
         }
     }
 
-    let tree = josh_core::filter::tree::insert(
-        repo,
-        &base_tree,
-        path,
-        blob_oid,
-        git2::FileMode::Blob.into(),
-    )?;
+    let tree = tree::insert_oid(&odb, base_tree, path, blob_oid, git2::FileMode::Blob.into())?;
 
     let sig = match author {
         Some(name) => {
@@ -73,14 +80,11 @@ pub fn write_changes_tree(
         }
         None => josh_core::git::user_signature(repo)?,
     };
-    let parents: Vec<&git2::Commit> = prev_commit.iter().collect();
     let msg = format!("update {}\n", ref_name);
-    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &parents)?;
+    let new_oid = objects::write_commit(&odb, tree, prev_commit.as_slice(), &sig, &sig, &msg)?;
     transaction.update_ref(
         &ref_name,
-        prev_commit
-            .as_ref()
-            .map_or(Expected::Absent, |c| Expected::At(c.id())),
+        prev_commit.map_or(Expected::Absent, Expected::At),
         new_oid,
         &msg,
     )?;
@@ -95,23 +99,20 @@ pub fn read_blob_map(
     scope: &ChangesRef,
     path: &std::path::Path,
 ) -> anyhow::Result<std::collections::HashMap<String, String>> {
-    let repo = transaction.repo();
-    let tree = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => repo.find_commit(oid)?.tree()?,
+    let odb = transaction.odb()?;
+    let tree = match scope_tree(transaction, &odb, scope)? {
+        Some(tree) => tree,
         None => return Ok(Default::default()),
     };
-    let subtree = match get_tree(repo, &tree, path) {
+    let subtree = match get_tree(transaction, &odb, tree, path) {
         Some(t) => t,
         None => return Ok(Default::default()),
     };
     let mut map = std::collections::HashMap::new();
-    for entry in subtree.iter() {
-        if let Ok(name) = entry.name() {
-            if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
-                map.insert(
-                    name.to_string(),
-                    String::from_utf8_lossy(blob.content()).to_string(),
-                );
+    for entry in tree::read_tree(transaction, &odb, subtree)?.entries() {
+        if let Ok(name) = std::str::from_utf8(entry.filename) {
+            if let Some(blob) = tree::blob_bytes(&odb, objects::git2_oid(&entry.oid)) {
+                map.insert(name.to_string(), String::from_utf8_lossy(&blob).to_string());
             }
         }
     }
@@ -124,6 +125,7 @@ pub fn store_diff_data(
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let change_id = change
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
@@ -131,63 +133,54 @@ pub fn store_diff_data(
     let commit_oid_str = change.commit().to_string();
     let base_str = change.base().to_string();
     let content = format!("{}\n{}", commit_oid_str, base_str);
-    let blob_oid = repo.blob(content.as_bytes())?;
+    let blob_oid = objects::write_blob(&odb, content.as_bytes())?;
 
-    let mut tb = repo.treebuilder(None)?;
     let entry_name = blob_oid.to_string();
-    tb.insert(&entry_name, blob_oid, git2::FileMode::Blob.into())?;
-    let tree_oid = tb.write()?;
+    let tree_oid = tree::insert_oid(
+        &odb,
+        tree::empty_id(),
+        std::path::Path::new(&entry_name),
+        blob_oid,
+        git2::FileMode::Blob.into(),
+    )?;
 
     let ref_name = scope.ref_name();
-    let prev_tip = transaction
-        .resolve_ref(&ref_name)?
-        .and_then(|oid| repo.find_commit(oid).ok());
-    let base_tree = prev_tip
-        .as_ref()
-        .and_then(|c| c.tree().ok())
-        .unwrap_or_else(|| repo.find_tree(josh_core::filter::tree::empty_id()).unwrap());
+    let prev_tip = transaction.resolve_ref(&ref_name)?;
+    let base_tree = match prev_tip {
+        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        None => tree::empty_id(),
+    };
 
     let path = std::path::Path::new("diffs").join(encode_change_id_path(&change_id));
 
-    if let Some(existing) = base_tree
-        .get_path(&path)
-        .ok()
-        .and_then(|e| e.to_object(repo).ok())
-    {
-        if existing.id() == tree_oid {
+    if let Ok(Some(existing)) = tree::get_path_entry(transaction, &odb, base_tree, &path) {
+        if objects::git2_oid(&existing.oid) == tree_oid {
             return Ok(());
         }
     }
 
-    let tree = josh_core::filter::tree::insert(repo, &base_tree, &path, tree_oid, 0o0040000)?;
+    let tree = tree::insert_oid(&odb, base_tree, &path, tree_oid, 0o0040000)?;
 
     let sig = repo.signature()?;
 
-    let source_commit = repo.find_commit(change.commit())?;
     let anchor_sig = git2::Signature::new("JOSH", "josh@josh-project.dev", &git2::Time::new(0, 0))?;
-    let empty_tree = repo.find_tree(josh_core::filter::tree::empty_id())?;
-    let anchor_oid = repo.commit(
-        None,
+    let anchor_oid = objects::write_commit(
+        &odb,
+        tree::empty_id(),
+        &[change.commit()],
         &anchor_sig,
         &anchor_sig,
         "josh\n",
-        &empty_tree,
-        &[&source_commit],
     )?;
-    let anchor_commit = repo.find_commit(anchor_oid)?;
 
-    let mut parents: Vec<&git2::Commit> = Vec::new();
-    if let Some(ref c) = prev_tip {
-        parents.push(c);
-    }
-    parents.push(&anchor_commit);
+    let mut parents: Vec<git2::Oid> = Vec::new();
+    parents.extend(prev_tip);
+    parents.push(anchor_oid);
     let msg = format!("update {}\n", ref_name);
-    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &parents)?;
+    let new_oid = objects::write_commit(&odb, tree, &parents, &sig, &sig, &msg)?;
     transaction.update_ref(
         &ref_name,
-        prev_tip
-            .as_ref()
-            .map_or(Expected::Absent, |c| Expected::At(c.id())),
+        prev_tip.map_or(Expected::Absent, Expected::At),
         new_oid,
         &msg,
     )?;
@@ -202,44 +195,40 @@ pub fn store_pr_data(
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
-    let blob_oid = repo.blob(json.as_bytes())?;
+    let odb = transaction.odb()?;
+    let blob_oid = objects::write_blob(&odb, json.as_bytes())?;
 
-    let mut tb = repo.treebuilder(None)?;
-    tb.insert(&blob_oid.to_string(), blob_oid, git2::FileMode::Blob.into())?;
-    let tree_oid = tb.write()?;
+    let tree_oid = tree::insert_oid(
+        &odb,
+        tree::empty_id(),
+        std::path::Path::new(&blob_oid.to_string()),
+        blob_oid,
+        git2::FileMode::Blob.into(),
+    )?;
 
     let ref_name = scope.ref_name();
-    let prev_tip = transaction
-        .resolve_ref(&ref_name)?
-        .and_then(|oid| repo.find_commit(oid).ok());
-    let base_tree = prev_tip
-        .as_ref()
-        .and_then(|c| c.tree().ok())
-        .unwrap_or_else(|| repo.find_tree(josh_core::filter::tree::empty_id()).unwrap());
+    let prev_tip = transaction.resolve_ref(&ref_name)?;
+    let base_tree = match prev_tip {
+        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        None => tree::empty_id(),
+    };
 
     let path = std::path::Path::new("gh").join(encode_change_id_path(change_id));
 
-    if let Some(existing) = base_tree
-        .get_path(&path)
-        .ok()
-        .and_then(|e| e.to_object(repo).ok())
-    {
-        if existing.id() == tree_oid {
+    if let Ok(Some(existing)) = tree::get_path_entry(transaction, &odb, base_tree, &path) {
+        if objects::git2_oid(&existing.oid) == tree_oid {
             return Ok(());
         }
     }
 
-    let tree = josh_core::filter::tree::insert(repo, &base_tree, &path, tree_oid, 0o0040000)?;
+    let tree = tree::insert_oid(&odb, base_tree, &path, tree_oid, 0o0040000)?;
 
     let sig = repo.signature()?;
-    let parents: Vec<&git2::Commit> = prev_tip.iter().collect();
     let msg = format!("update {}\n", ref_name);
-    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &parents)?;
+    let new_oid = objects::write_commit(&odb, tree, prev_tip.as_slice(), &sig, &sig, &msg)?;
     transaction.update_ref(
         &ref_name,
-        prev_tip
-            .as_ref()
-            .map_or(Expected::Absent, |c| Expected::At(c.id())),
+        prev_tip.map_or(Expected::Absent, Expected::At),
         new_oid,
         &msg,
     )?;
@@ -253,19 +242,19 @@ pub fn read_pr_data(
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Option<String>> {
-    let repo = transaction.repo();
-    let tree = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => repo.find_commit(oid)?.tree()?,
+    let odb = transaction.odb()?;
+    let tree = match scope_tree(transaction, &odb, scope)? {
+        Some(tree) => tree,
         None => return Ok(None),
     };
     let gh_path = std::path::Path::new("gh").join(encode_change_id_path(change_id));
-    let subtree = match get_tree(repo, &tree, &gh_path) {
+    let subtree = match get_tree(transaction, &odb, tree, &gh_path) {
         Some(t) => t,
         None => return Ok(None),
     };
-    for entry in subtree.iter() {
-        if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
-            return Ok(Some(String::from_utf8_lossy(blob.content()).to_string()));
+    for entry in tree::read_tree(transaction, &odb, subtree)?.entries() {
+        if let Some(blob) = tree::blob_bytes(&odb, objects::git2_oid(&entry.oid)) {
+            return Ok(Some(String::from_utf8_lossy(&blob).to_string()));
         }
     }
     Ok(None)
@@ -280,16 +269,15 @@ pub fn delete_change(
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let encoded = encode_change_id_path(change_id);
 
     let ref_name = scope.ref_name();
     let prev_commit = match transaction.resolve_ref(&ref_name)? {
-        Some(oid) => repo.find_commit(oid)?,
+        Some(oid) => oid,
         None => return Ok(()),
     };
-    let base_tree = prev_commit.tree()?;
-
-    let mut tree = base_tree;
+    let mut tree = objects::CommitData::read(&odb, prev_commit)?.tree_id()?;
     for prefix in &[
         "diffs",
         "comments/C",
@@ -303,15 +291,18 @@ pub fn delete_change(
         "gh_vote_ids",
     ] {
         let path = std::path::Path::new(prefix).join(&encoded);
-        if tree.get_path(&path).is_ok() {
-            tree = josh_core::filter::tree::insert(repo, &tree, &path, git2::Oid::ZERO_SHA1, 0)?;
+        if matches!(
+            tree::get_path_entry(transaction, &odb, tree, &path),
+            Ok(Some(_))
+        ) {
+            tree = tree::insert_oid(&odb, tree, &path, git2::Oid::ZERO_SHA1, 0)?;
         }
     }
 
     let sig = repo.signature()?;
     let msg = format!("update {}\n", ref_name);
-    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &[&prev_commit])?;
-    transaction.update_ref(&ref_name, Expected::At(prev_commit.id()), new_oid, &msg)?;
+    let new_oid = objects::write_commit(&odb, tree, &[prev_commit], &sig, &sig, &msg)?;
+    transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;
 
     Ok(())
 }

--- a/josh-changes/src/votes.rs
+++ b/josh-changes/src/votes.rs
@@ -2,6 +2,8 @@ use crate::change::{Change, encode_change_id_path};
 use crate::refs::ChangesRef;
 use crate::store::{get_tree, parse_timestamp};
 use josh_core::cache::{Expected, Transaction};
+use josh_core::filter::tree;
+use josh_core::objects;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct VoteData {
@@ -75,11 +77,16 @@ fn write_vote_inner(
     let content = json.to_string();
     let content_hash =
         git2::Oid::hash_object(git2::ObjectType::Blob, content.as_bytes())?.to_string();
-    let blob_oid = repo.blob(content.as_bytes())?;
+    let odb = transaction.odb()?;
+    let blob_oid = objects::write_blob(&odb, content.as_bytes())?;
 
-    let mut tb = repo.treebuilder(None)?;
-    tb.insert(&blob_oid.to_string(), blob_oid, git2::FileMode::Blob.into())?;
-    let tree_oid = tb.write()?;
+    let tree_oid = tree::insert_oid(
+        &odb,
+        tree::empty_id(),
+        std::path::Path::new(&blob_oid.to_string()),
+        blob_oid,
+        git2::FileMode::Blob.into(),
+    )?;
 
     let user = match author {
         Some(name) => name.to_string(),
@@ -91,25 +98,19 @@ fn write_vote_inner(
         .join(&user);
 
     let ref_name = scope.ref_name();
-    let prev_commit = transaction
-        .resolve_ref(&ref_name)?
-        .and_then(|oid| repo.find_commit(oid).ok());
-    let base_tree = prev_commit
-        .as_ref()
-        .and_then(|c| c.tree().ok())
-        .unwrap_or_else(|| repo.find_tree(josh_core::filter::tree::empty_id()).unwrap());
+    let prev_commit = transaction.resolve_ref(&ref_name)?;
+    let base_tree = match prev_commit {
+        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        None => tree::empty_id(),
+    };
 
-    if let Some(existing) = base_tree
-        .get_path(&path)
-        .ok()
-        .and_then(|e| e.to_object(repo).ok())
-    {
-        if existing.id() == tree_oid {
+    if let Ok(Some(existing)) = tree::get_path_entry(transaction, &odb, base_tree, &path) {
+        if objects::git2_oid(&existing.oid) == tree_oid {
             return Ok(content_hash);
         }
     }
 
-    let tree = josh_core::filter::tree::insert(repo, &base_tree, &path, tree_oid, 0o0040000)?;
+    let tree = tree::insert_oid(&odb, base_tree, &path, tree_oid, 0o0040000)?;
 
     let sig = match author {
         Some(name) => {
@@ -119,14 +120,11 @@ fn write_vote_inner(
         }
         None => repo.signature()?,
     };
-    let parents: Vec<&git2::Commit> = prev_commit.iter().collect();
     let msg = format!("update {}\n", ref_name);
-    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &parents)?;
+    let new_oid = objects::write_commit(&odb, tree, prev_commit.as_slice(), &sig, &sig, &msg)?;
     transaction.update_ref(
         &ref_name,
-        prev_commit
-            .as_ref()
-            .map_or(Expected::Absent, |c| Expected::At(c.id())),
+        prev_commit.map_or(Expected::Absent, Expected::At),
         new_oid,
         &msg,
     )?;
@@ -141,8 +139,9 @@ pub fn read_vote(
     scope: &ChangesRef,
 ) -> anyhow::Result<Option<VoteData>> {
     let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let tree = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => repo.find_commit(oid)?.tree()?,
+        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
         None => return Ok(None),
     };
 
@@ -155,13 +154,13 @@ pub fn read_vote(
         .join(encode_change_id_path(change_id))
         .join(&user);
 
-    let subtree = match get_tree(repo, &tree, &path) {
+    let subtree = match get_tree(transaction, &odb, tree, &path) {
         Some(t) => t,
         None => return Ok(None),
     };
-    for entry in subtree.iter() {
-        if let Ok(blob) = entry.to_object(repo).and_then(|o| o.peel_to_blob()) {
-            let data: VoteData = serde_json::from_slice(blob.content())?;
+    for entry in tree::read_tree(transaction, &odb, subtree)?.entries() {
+        if let Some(blob) = tree::blob_bytes(&odb, objects::git2_oid(&entry.oid)) {
+            let data: VoteData = serde_json::from_slice(&blob)?;
             return Ok(Some(data));
         }
     }
@@ -192,29 +191,32 @@ fn list_votes_at_prefix(
     scope: &ChangesRef,
     path_prefix: &str,
 ) -> anyhow::Result<Vec<(String, VoteData)>> {
-    let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let tree = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => repo.find_commit(oid)?.tree()?,
+        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
         None => return Ok(Default::default()),
     };
     let path = std::path::Path::new(path_prefix).join(encode_change_id_path(change_id));
-    let subtree = match get_tree(repo, &tree, &path) {
+    let subtree = match get_tree(transaction, &odb, tree, &path) {
         Some(t) => t,
         None => return Ok(Default::default()),
     };
     let mut votes = Vec::new();
-    for entry in subtree.iter() {
-        let user = match entry.name() {
+    for entry in tree::read_tree(transaction, &odb, subtree)?.entries() {
+        let user = match std::str::from_utf8(entry.filename) {
             Ok(name) => name.to_string(),
             Err(_) => continue,
         };
-        let user_tree = match entry.to_object(repo).and_then(|o| o.peel_to_tree()) {
+        if !entry.mode.is_tree() {
+            continue;
+        }
+        let user_tree = match tree::read_tree(transaction, &odb, objects::git2_oid(&entry.oid)) {
             Ok(t) => t,
             Err(_) => continue,
         };
-        for child in user_tree.iter() {
-            if let Ok(blob) = child.to_object(repo).and_then(|o| o.peel_to_blob()) {
-                if let Ok(data) = serde_json::from_slice::<VoteData>(blob.content()) {
+        for child in user_tree.entries() {
+            if let Some(blob) = tree::blob_bytes(&odb, objects::git2_oid(&child.oid)) {
+                if let Ok(data) = serde_json::from_slice::<VoteData>(&blob) {
                     votes.push((user.clone(), data));
                 }
             }
@@ -236,21 +238,25 @@ pub fn delete_outbox_votes(
     }
 
     let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let encoded = encode_change_id_path(change_id);
     let ref_name = scope.ref_name();
     let prev_commit = match transaction.resolve_ref(&ref_name)? {
-        Some(oid) => repo.find_commit(oid)?,
+        Some(oid) => oid,
         None => return Ok(0),
     };
-    let mut tree = prev_commit.tree()?;
+    let mut tree = objects::CommitData::read(&odb, prev_commit)?.tree_id()?;
 
     let mut removed = 0usize;
     for user in users {
         let path = std::path::Path::new("outbox/votes")
             .join(&encoded)
             .join(user);
-        if tree.get_path(&path).is_ok() {
-            tree = josh_core::filter::tree::insert(repo, &tree, &path, git2::Oid::ZERO_SHA1, 0)?;
+        if matches!(
+            tree::get_path_entry(transaction, &odb, tree, &path),
+            Ok(Some(_))
+        ) {
+            tree = tree::insert_oid(&odb, tree, &path, git2::Oid::ZERO_SHA1, 0)?;
             removed += 1;
         }
     }
@@ -261,8 +267,8 @@ pub fn delete_outbox_votes(
 
     let sig = repo.signature()?;
     let msg = format!("delete outbox votes on {}\n", ref_name);
-    let new_oid = repo.commit(None, &sig, &sig, &msg, &tree, &[&prev_commit])?;
-    transaction.update_ref(&ref_name, Expected::At(prev_commit.id()), new_oid, &msg)?;
+    let new_oid = objects::write_commit(&odb, tree, &[prev_commit], &sig, &sig, &msg)?;
+    transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;
 
     Ok(removed)
 }

--- a/josh-cli/src/commands/pull.rs
+++ b/josh-cli/src/commands/pull.rs
@@ -228,10 +228,12 @@ fn resolve_upstream_ref(
 /// Walks all parents (not just first-parent) so changes landed via merge
 /// commits (e.g. by a merge queue) are detected as well.
 fn upstream_change_ids(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<std::collections::HashSet<String>> {
+    let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let mut ids = std::collections::HashSet::new();
     let mut walk = repo.revwalk()?;
     walk.push(tip)?;
@@ -240,7 +242,7 @@ fn upstream_change_ids(
     }
 
     for oid in walk {
-        let commit = repo.find_commit(oid?)?;
+        let commit = josh_core::objects::CommitData::read(&odb, oid?)?;
         if let (Some(id), _) = commit_change_meta(&commit) {
             ids.insert(id);
         }
@@ -281,6 +283,8 @@ fn restack_commits(
             continue;
         }
 
+        // PORT: the rebased tree comes out of a libgit2 index merge, so this commit
+        // stays on the repository handle with it.
         let tree = repo.find_tree(tree_oid)?;
         let new_oid = repo.commit(
             None,
@@ -377,12 +381,12 @@ pub fn integrate(
             local_commits.push(oid);
         }
 
-        let applied = upstream_change_ids(repo, new, merge_base)?;
+        let applied = upstream_change_ids(transaction, new, merge_base)?;
 
         let mut skipped = Vec::new();
         let mut remaining = Vec::new();
         for &oid in &local_commits {
-            let commit = repo.find_commit(oid)?;
+            let commit = josh_core::objects::CommitData::read(&transaction.odb()?, oid)?;
             match commit_change_meta(&commit) {
                 (Some(id), _) if applied.contains(&id) => skipped.push(id),
                 // A commit with a Change-Id not yet applied upstream, or one

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -119,7 +119,7 @@ impl DistributedCacheBackend {
             };
             let tree = match &base {
                 Some(commit) => commit.tree()?,
-                None => crate::filter::tree::empty(&repo),
+                None => repo.find_tree(crate::filter::tree::empty_id())?,
             };
             let updated = builder.create_updated(&repo, &tree)?;
 

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -894,22 +894,6 @@ pub fn insert_oid(
     insert_oid(odb, full_tree, parent, subtree, 0o0040000)
 }
 
-// PORT: retained pub API for the leaf crates (josh-proxy, josh-changes, josh-link,
-// josh-cq); its `Git2Odb` reads and writes resolve through the registered backend, so it
-// must be facade-backed or gone before the backend can be unregistered (the writes would
-// otherwise land loose on disk).
-pub fn insert<'a>(
-    repo: &'a git2::Repository,
-    full_tree: &git2::Tree,
-    path: &Path,
-    oid: git2::Oid,
-    mode: i32,
-) -> anyhow::Result<git2::Tree<'a>> {
-    let odb = repo.odb()?;
-    let result = insert_oid(&objects::Git2Odb(&odb), full_tree.id(), path, oid, mode)?;
-    Ok(repo.find_tree(result)?)
-}
-
 /// Kind of `oid`, or `None` when the object is missing (the zero oid included) or the
 /// header unreadable -- both read as an ordinary miss.
 fn kind_of(src: &impl gix_object::FindHeader, oid: git2::Oid) -> Option<gix_object::Kind> {
@@ -1339,13 +1323,6 @@ pub fn empty_id() -> git2::Oid {
     git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap()
 }
 
-// PORT: retained pub API for the leaf crates (in-core callers compare against
-// `empty_id()` instead); the lookup resolves through the registered backend's disk
-// fallback, which virtualizes the empty tree.
-pub fn empty(repo: &git2::Repository) -> git2::Tree<'_> {
-    repo.find_tree(empty_id()).unwrap()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1548,16 +1525,13 @@ mod tests {
         let out = remove_pred(&t, &mut String::new(), input, &|_, isblob| isblob, key).unwrap();
         assert_eq!(out, input, ".git in input passes through verbatim");
 
-        let base = t.repo().find_tree(input).unwrap();
-        let inserted = insert(t.repo(), &base, Path::new("sub/.git"), blob, 0o100644).unwrap();
+        let odb = t.odb().unwrap();
+        let inserted = insert_oid(&odb, input, Path::new("sub/.git"), blob, 0o100644).unwrap();
         assert_eq!(
-            t.repo()
-                .find_tree(inserted.id())
+            get_path_entry(&t, &odb, inserted, Path::new("sub/.git"))
                 .unwrap()
-                .get_path(Path::new("sub/.git"))
-                .unwrap()
-                .id(),
-            blob,
+                .map(|e| objects::git2_oid(&e.oid)),
+            Some(blob),
             "inserted names are written as given"
         );
     }

--- a/josh-core/src/trailers.rs
+++ b/josh-core/src/trailers.rs
@@ -9,14 +9,20 @@ pub fn is_trailer_line(line: &str) -> bool {
 /// Extract change-id metadata from a commit, preferring jj/gitbutler's custom
 /// `change-id` commit-object header over any `Change:` / `Change-Id:` trailer
 /// in the message body. The series list comes from message trailers regardless.
-pub fn commit_change_meta(commit: &git2::Commit) -> (Option<String>, Vec<String>) {
-    let (mut id, series) = parse_change_meta(commit.message().unwrap_or(""));
-    if let Ok(buf) = commit.header_field_bytes("change-id") {
-        if let Ok(s) = std::str::from_utf8(&buf) {
-            let s = s.trim();
-            if !s.is_empty() {
-                id = Some(s.to_string());
-            }
+pub fn commit_change_meta(commit: &crate::objects::CommitData) -> (Option<String>, Vec<String>) {
+    let message = commit
+        .message()
+        .ok()
+        .and_then(|m| std::str::from_utf8(m).ok())
+        .unwrap_or("");
+    let (mut id, series) = parse_change_meta(message);
+    if let Ok(parsed) = commit.parsed()
+        && let Some(header) = parsed.extra_headers().find("change-id")
+        && let Ok(s) = std::str::from_utf8(header)
+    {
+        let s = s.trim();
+        if !s.is_empty() {
+            id = Some(s.to_string());
         }
     }
     (id, series)

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -195,6 +195,33 @@ pub fn write_commit(
     Ok(git2_oid(&id))
 }
 
+/// Serialize a new commit whose author and committer are taken from `base`, and write it to
+/// `out`. Only those two fields carry over -- any extra headers of `base` are dropped.
+pub fn write_commit_with_signatures_of(
+    out: &impl gix_object::Write,
+    base: &CommitData,
+    tree: git2::Oid,
+    parents: &[git2::Oid],
+    message: &str,
+) -> anyhow::Result<git2::Oid> {
+    let parsed = base.parsed()?;
+    let commit = gix_object::Commit {
+        tree: gix_oid(tree),
+        parents: parents.iter().map(|p| gix_oid(*p)).collect(),
+        author: parsed.author()?.into(),
+        committer: parsed.committer()?.into(),
+        encoding: None,
+        message: message.into(),
+        extra_headers: vec![],
+    };
+    let mut buffer = Vec::with_capacity(commit.size() as usize);
+    gix_object::WriteTo::write_to(&commit, &mut buffer)?;
+    let id = out
+        .write_buf(gix_object::Kind::Commit, &buffer)
+        .map_err(|e| anyhow::anyhow!("write_commit: {e}"))?;
+    Ok(git2_oid(&id))
+}
+
 fn gix_signature(sig: &git2::Signature<'_>) -> anyhow::Result<gix_actor::Signature> {
     let when = sig.when();
     Ok(gix_actor::Signature {
@@ -628,6 +655,19 @@ mod tests {
                     message,
                     parent_ids.len()
                 );
+
+                // The signature-copying variant reproduces the same commit when the
+                // signatures it copies are the ones git2 was given.
+                let base = CommitData::read(&Git2Odb(&odb), want).unwrap();
+                let copied = write_commit_with_signatures_of(
+                    &Git2Odb(&odb),
+                    &base,
+                    *tree,
+                    &parent_ids,
+                    message,
+                )
+                .unwrap();
+                assert_eq!(want, copied, "signature-copying writer diverged");
             }
         }
     }


### PR DESCRIPTION
Port josh-changes and josh-cq onto the memodb facade

Every changes-ref write -- comments, votes, diff data, PR data, the
anchor and merge commits, and the outbox cleanups -- now builds its
blobs, trees and commits through the transaction facade, as do the
reads and history walks behind them. `commit_change_meta` takes a
CommitData, so the custom `change-id` header comes from the parsed
commit.

josh-gix-ext gains `write_commit_with_signatures_of` for commits that
carry another commit's author and committer; the existing parity test
covers it.

With no callers left, the typed `tree::insert` and `tree::empty`
wrappers are gone.

Rebase and cherry-pick commits in josh-cli stay on the repository
handle, next to the libgit2 index merges that produce their trees.

Change: changes-cq-facade
Assisted-By: anthropic/claude-fable-5