### PR TITLE
Port persist, josh-search, josh-compose and the cache backend onto the facade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3603,6 +3603,7 @@ dependencies = [
  "gix-hash",
  "gix-object",
  "josh-core",
+ "josh-gix-ext",
  "josh-test-support",
  "rand 0.10.2",
  "tempfile",

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -378,43 +378,41 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
         let commit = repo.revparse_single(&input_ref)?.peel_to_commit()?;
 
-        let tree = repo
-            .find_commit(josh_core::filter_commit(
-                &transaction,
-                filterobj,
-                commit.id(),
-            )?)?
-            .tree()?;
+        let odb = transaction.odb()?;
+        let tree = josh_core::objects::CommitData::read(
+            &odb,
+            josh_core::filter_commit(&transaction, filterobj, commit.id())?,
+        )?
+        .tree_id()?;
 
-        /* let start = std::time::Instant::now(); */
         // The trigram index is experimental; without it every file is a candidate and
         // search_matches does all the filtering, so results are identical, just slower.
         let candidates = if josh_core::filter::experimental_features_enabled() {
             let ifilterobj = filterobj.chain(josh_core::filter::parse(":SQUASH:INDEX")?);
             let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit.id())?;
-            let index_tree = repo.find_commit(index_commit)?.tree()?;
-            josh_search::search_candidates(&repo, &index_tree, &tree, searchstring)?
+            let index_tree = josh_core::objects::CommitData::read(&odb, index_commit)?.tree_id()?;
+            josh_search::search_candidates(&odb, index_tree, tree, searchstring)?
         } else {
             let mut scan = vec![];
-            tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
-                if entry.kind() == Some(git2::ObjectType::Blob)
-                    && let Ok(name) = entry.name()
+            josh_core::objects::walk_tree_preorder(&odb, tree, &mut |parent, entry| {
+                if !entry.mode.is_tree()
+                    && !entry.mode.is_commit()
+                    && let Ok(name) = std::str::from_utf8(entry.filename)
                 {
-                    scan.push(format!("{}{}", root, name));
+                    let separator = if parent.is_empty() { "" } else { "/" };
+                    scan.push(format!("{}{}{}", parent, separator, name));
                 }
-                0
+                Ok(())
             })?;
             scan
         };
-        let matches = josh_search::search_matches(&repo, &tree, searchstring, &candidates)?;
-        /* let duration = start.elapsed(); */
+        let matches = josh_search::search_matches(&odb, tree, searchstring, &candidates)?;
 
         for r in matches {
             for l in r.1 {
                 println!("{}:{}: {}", r.0, l.0, l.1);
             }
         }
-        /* eprintln!("\n Search took {:?}", duration); */
     }
 
     if reverse {

--- a/josh-compose/src/archive.rs
+++ b/josh-compose/src/archive.rs
@@ -1,41 +1,45 @@
 use anyhow::Context;
+use josh_core::cache;
+use josh_core::filter::tree;
+use josh_core::memodb;
 
-/// Produce a tar archive (as bytes) from a git tree, using git2 to walk the tree.
-/// Works with in-memory objects (e.g. mempack backend) as well as on-disk objects.
-pub fn tree_to_tar(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Vec<u8>> {
+/// Produce a tar archive (as bytes) from a git tree.
+pub fn tree_to_tar(
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
+    tree_oid: git2::Oid,
+) -> anyhow::Result<Vec<u8>> {
     let mut buf = Vec::new();
     {
         let mut builder = tar::Builder::new(&mut buf);
-        let tree = repo
-            .find_tree(tree_oid)
-            .with_context(|| format!("tree not found: {tree_oid}"))?;
-        append_tree(repo, &tree, "", &mut builder)?;
+        append_tree(transaction, odb, tree_oid, "", &mut builder)?;
         builder.finish()?;
     }
     Ok(buf)
 }
 
 fn append_tree(
-    repo: &git2::Repository,
-    tree: &git2::Tree,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
+    tree_oid: git2::Oid,
     prefix: &str,
     builder: &mut tar::Builder<impl std::io::Write>,
 ) -> anyhow::Result<()> {
-    for entry in tree {
-        let name = entry.name().unwrap_or("");
+    let reader = tree::read_tree(transaction, odb, tree_oid)?;
+    for entry in reader.entries() {
+        let name = String::from_utf8_lossy(entry.filename);
         let path = if prefix.is_empty() {
             name.to_string()
         } else {
             format!("{prefix}/{name}")
         };
+        let id = josh_core::objects::git2_oid(entry.oid);
 
-        let filemode = entry.filemode();
-
-        if filemode == 0o120000 {
-            // Symlink: stored as blob, content is the link target
-            let blob = repo.find_blob(entry.id())?;
+        if entry.mode.is_link() {
+            let content = tree::blob_bytes(odb, id)
+                .with_context(|| format!("symlink target not found: {path}"))?;
             let target =
-                std::str::from_utf8(blob.content()).context("symlink target is not valid UTF-8")?;
+                std::str::from_utf8(&content).context("symlink target is not valid UTF-8")?;
             let mut header = tar::Header::new_gnu();
             header.set_entry_type(tar::EntryType::Symlink);
             header.set_path(&path)?;
@@ -43,7 +47,7 @@ fn append_tree(
             header.set_size(0);
             header.set_cksum();
             builder.append(&header, std::io::empty())?;
-        } else if let Some(git2::ObjectType::Tree) = entry.kind() {
+        } else if entry.mode.is_tree() {
             let mut header = tar::Header::new_gnu();
             header.set_entry_type(tar::EntryType::Directory);
             header.set_path(format!("{path}/"))?;
@@ -52,18 +56,21 @@ fn append_tree(
             header.set_cksum();
             builder.append(&header, std::io::empty())?;
 
-            let subtree = repo.find_tree(entry.id())?;
-            append_tree(repo, &subtree, &path, builder)?;
-        } else if let Some(git2::ObjectType::Blob) = entry.kind() {
-            let blob = repo.find_blob(entry.id())?;
-            let is_exec = filemode & 0o111 != 0;
+            append_tree(transaction, odb, id, &path, builder)?;
+        } else if entry.mode.is_blob() {
+            let content =
+                tree::blob_bytes(odb, id).with_context(|| format!("blob not found: {path}"))?;
             let mut header = tar::Header::new_gnu();
             header.set_entry_type(tar::EntryType::Regular);
             header.set_path(&path)?;
-            header.set_mode(if is_exec { 0o755 } else { 0o644 });
-            header.set_size(blob.content().len() as u64);
+            header.set_mode(if entry.mode.is_executable() {
+                0o755
+            } else {
+                0o644
+            });
+            header.set_size(content.len() as u64);
             header.set_cksum();
-            builder.append(&header, blob.content())?;
+            builder.append(&header, &content[..])?;
         }
         // Skip other types (submodules etc.)
     }

--- a/josh-compose/src/container.rs
+++ b/josh-compose/src/container.rs
@@ -1,6 +1,9 @@
 use std::collections::HashSet;
 use std::path::Path;
 
+use josh_core::cache;
+use josh_core::memodb;
+
 use josh_compose_backend::{Mount, RunArgs, Runtime, SidecarArgs, SidecarHandle};
 
 use crate::OutputMode;
@@ -42,11 +45,12 @@ fn resolve_passthrough(
 /// start, or readiness timeout — is a hard error surfaced by the runtime; there is
 /// no soft-skip path.
 fn start_sidecar(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     spec: &SidecarSpec,
     runtime: &dyn Runtime,
 ) -> anyhow::Result<SidecarHandle> {
-    let env_key = image::ensure_image(repo, spec.image, runtime)?;
+    let env_key = image::ensure_image(transaction, odb, spec.image, runtime)?;
 
     let passthrough_env = resolve_passthrough(&spec.name, &spec.passthrough)?;
 
@@ -72,13 +76,14 @@ fn start_sidecar(
 /// `attempted` tracks ws_trees already visited in this invocation to avoid redundant
 /// re-runs; the output cache may also short-circuit re-runs across invocations.
 pub fn run_container(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     ws_tree: git2::Oid,
     attempted: &mut HashSet<git2::Oid>,
     extract_to_workdir: bool,
     runtime: &dyn Runtime,
 ) -> anyhow::Result<()> {
-    let workspace_meta = meta::read_meta(repo, ws_tree)?;
+    let workspace_meta = meta::read_meta(transaction, odb, ws_tree)?;
 
     // Cache check: skip only if a previous successful run is recorded AND its
     // output volume is still present (when one is expected). Mirrors
@@ -108,7 +113,7 @@ pub fn run_container(
     eprintln!("[{}] Running ({})", workspace_meta.label, ws_tree);
 
     // Run all dependencies, collecting failures so sibling jobs still get a chance to run.
-    let input_entries = meta::read_blob_entries(repo, ws_tree, "inputs");
+    let input_entries = meta::read_blob_entries(transaction, odb, ws_tree, "inputs");
     let mut dep_volumes: Vec<(String, String, bool)> = vec![];
     let mut dep_errors: Vec<String> = vec![];
     for (dep_name, dep_sha) in &input_entries {
@@ -119,11 +124,18 @@ pub fn run_container(
                 continue;
             }
         };
-        if let Err(e) = run_container(repo, dep_tree, attempted, extract_to_workdir, runtime) {
+        if let Err(e) = run_container(
+            transaction,
+            odb,
+            dep_tree,
+            attempted,
+            extract_to_workdir,
+            runtime,
+        ) {
             dep_errors.push(format!("dependency {dep_name} failed: {e}"));
             continue;
         }
-        let dep_meta = meta::read_meta(repo, dep_tree)?;
+        let dep_meta = meta::read_meta(transaction, odb, dep_tree)?;
         if dep_meta.output == OutputMode::None {
             continue;
         }
@@ -151,7 +163,7 @@ pub fn run_container(
     };
 
     // Resolve the environment (cache-or-build).
-    let image_name = image::ensure_image(repo, image_oid, runtime)?;
+    let image_name = image::ensure_image(transaction, odb, image_oid, runtime)?;
 
     let mut cache_volume: Option<String> = None;
     if let Some(cache_name) = &workspace_meta.cache {
@@ -161,7 +173,7 @@ pub fn run_container(
     }
 
     // Read env vars from env/ subtree
-    let mut env_vars = meta::read_blob_entries(repo, ws_tree, "env");
+    let mut env_vars = meta::read_blob_entries(transaction, odb, ws_tree, "env");
 
     // Start any declared sidecars and inject their addresses into the main container's env.
     // Any sidecar failure (missing creds, start error, readiness timeout) is fatal: tear
@@ -170,7 +182,7 @@ pub fn run_container(
     let mut started_sidecars: Vec<SidecarHandle> = vec![];
     if !workspace_meta.sidecars.is_empty() {
         for spec in &workspace_meta.sidecars {
-            match start_sidecar(repo, spec, runtime) {
+            match start_sidecar(transaction, odb, spec, runtime) {
                 Ok(handle) => {
                     for (k, v) in &spec.inject {
                         env_vars.push((
@@ -202,7 +214,7 @@ pub fn run_container(
 
     // Create an ephemeral scratch artifact seeded with the worktree contents. The
     // runtime owns its naming and ownership; we just hold the opaque name.
-    let worktree_tar = crate::archive::tree_to_tar(repo, worktree_oid)?;
+    let worktree_tar = crate::archive::tree_to_tar(transaction, odb, worktree_oid)?;
     let snapshot_vol = runtime.create_scratch_artifact(&worktree_tar)?;
 
     let snapshot_vol_clone = snapshot_vol.clone();

--- a/josh-compose/src/filter.rs
+++ b/josh-compose/src/filter.rs
@@ -17,8 +17,6 @@ pub fn compute_ws_tree(
     filter_spec: &str,
     source_commit: git2::Oid,
 ) -> anyhow::Result<(git2::Oid, String)> {
-    let repo = transaction.repo();
-
     let full_filter = format!(":SQUASH{filter_spec}");
 
     let filterobj = josh_core::filter::parse(&full_filter)
@@ -27,10 +25,10 @@ pub fn compute_ws_tree(
     let filtered_commit = josh_core::filter_commit(transaction, filterobj, source_commit)
         .context("failed to apply filter")?;
 
-    let ws_tree = repo
-        .find_commit(filtered_commit)
+    let odb = transaction.odb()?;
+    let ws_tree = josh_core::objects::CommitData::read(&odb, filtered_commit)
         .context("filtered result is not a commit")?
-        .tree_id();
+        .tree_id()?;
 
     let safe_name = josh_core::filter::as_tree(transaction, filterobj)
         .context("failed to compute filter id")?

--- a/josh-compose/src/image.rs
+++ b/josh-compose/src/image.rs
@@ -1,6 +1,10 @@
 use anyhow::Context;
 
 use josh_compose_backend::{EnvRecipe, EnvironmentBackend};
+use josh_core::cache;
+use josh_core::filter::tree;
+use josh_core::memodb;
+use josh_core::objects;
 
 use crate::meta;
 use crate::naming;
@@ -8,7 +12,8 @@ use crate::naming;
 /// Ensure the environment for the given build tree exists, building it if needed.
 /// Returns the environment key (image name).
 pub fn ensure_image(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     build_tree: git2::Oid,
     runtime: &dyn EnvironmentBackend,
 ) -> anyhow::Result<String> {
@@ -25,25 +30,24 @@ pub fn ensure_image(
 
     // Build each base environment and pass its key as a build arg so the
     // Containerfile can reference it (e.g. ARG my_base; FROM $my_base).
-    let base_entries = meta::read_blob_entries(repo, build_tree, "bases");
+    let base_entries = meta::read_blob_entries(transaction, odb, build_tree, "bases");
     for (base_name, base_sha) in &base_entries {
         let base_oid = git2::Oid::from_str(base_sha.trim())
             .with_context(|| format!("invalid base SHA for {base_name}: {base_sha}"))?;
-        let base_env = ensure_image(repo, base_oid, runtime)?;
+        let base_env = ensure_image(transaction, odb, base_oid, runtime)?;
         build_args.push((base_name.clone(), base_env));
     }
 
-    for (k, v) in meta::read_blob_entries(repo, build_tree, "args") {
+    for (k, v) in meta::read_blob_entries(transaction, odb, build_tree, "args") {
         build_args.push((k, v));
     }
 
-    let tree = repo.find_tree(build_tree)?;
-    let context_entry = tree
-        .get_path(std::path::Path::new("context"))
+    let context_entry = tree::read_tree(transaction, odb, build_tree)?
+        .entry(b"context")
+        .map(|e| objects::git2_oid(e.oid))
         .context("workspace image tree missing 'context' subtree")?;
-    let context_oid = context_entry.id();
 
-    let context = crate::archive::tree_to_tar(repo, context_oid)?;
+    let context = crate::archive::tree_to_tar(transaction, odb, context_entry)?;
 
     runtime.prepare_env(
         &image_name,

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -63,7 +63,15 @@ pub fn run(
     // uncommitted changes (input_ref == "."). For committed refs there is no
     // working tree to write back to.
     let extract_to_workdir = opts.input_ref == ".";
-    container::run_container(repo, ws_tree, &mut attempted, extract_to_workdir, runtime)?;
+    let odb = transaction.odb()?;
+    container::run_container(
+        transaction,
+        &odb,
+        ws_tree,
+        &mut attempted,
+        extract_to_workdir,
+        runtime,
+    )?;
 
     Ok(())
 }
@@ -90,7 +98,8 @@ pub fn plan_images(
 
     let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
-    plan::collect_image_oids(repo, ws_tree, ignore_cache, runtime)
+    let odb = transaction.odb()?;
+    plan::collect_image_oids(transaction, &odb, ws_tree, ignore_cache, runtime)
 }
 
 /// Enumerate every job hash (workspace tree OID) that a `run` with the same options
@@ -115,5 +124,6 @@ pub fn plan_jobs(
 
     let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
-    plan::collect_job_hashes(repo, ws_tree, ignore_cache, runtime)
+    let odb = transaction.odb()?;
+    plan::collect_job_hashes(transaction, &odb, ws_tree, ignore_cache, runtime)
 }

--- a/josh-compose/src/meta.rs
+++ b/josh-compose/src/meta.rs
@@ -9,6 +9,10 @@ use std::path::Path;
 
 use crate::OutputMode;
 use josh_compose_backend::NetworkPolicy;
+use josh_core::cache;
+use josh_core::filter::tree;
+use josh_core::memodb;
+use josh_core::objects;
 
 /// Specification for a sidecar service that runs alongside a workspace step.
 ///
@@ -49,47 +53,54 @@ pub struct WorkspaceMeta {
 }
 
 /// Read a blob from a git tree at the given path. Returns None if not found.
-pub fn read_blob(repo: &git2::Repository, tree_oid: git2::Oid, path: &str) -> Option<String> {
-    let tree = repo.find_tree(tree_oid).ok()?;
-    let entry = tree.get_path(Path::new(path)).ok()?;
-    let blob = repo.find_blob(entry.id()).ok()?;
-    let content = std::str::from_utf8(blob.content()).ok()?.trim().to_string();
-    Some(content)
+pub fn read_blob(
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
+    tree_oid: git2::Oid,
+    path: &str,
+) -> Option<String> {
+    let entry = tree::get_path_entry(transaction, odb, tree_oid, Path::new(path)).ok()??;
+    let content = tree::blob_bytes(odb, objects::git2_oid(&entry.oid))?;
+    Some(std::str::from_utf8(&content).ok()?.trim().to_string())
 }
 
 /// Read all entries from a subtree at `prefix`. Returns (name, oid) pairs.
 pub fn read_tree_entries(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     tree_oid: git2::Oid,
     prefix: &str,
 ) -> Vec<(String, git2::Oid)> {
-    let Ok(tree) = repo.find_tree(tree_oid) else {
+    let Ok(Some(entry)) = tree::get_path_entry(transaction, odb, tree_oid, Path::new(prefix))
+    else {
         return vec![];
     };
-    let Ok(entry) = tree.get_path(Path::new(prefix)) else {
-        return vec![];
-    };
-    let Ok(subtree) = repo.find_tree(entry.id()) else {
+    let Ok(subtree) = tree::read_tree(transaction, odb, objects::git2_oid(&entry.oid)) else {
         return vec![];
     };
     subtree
-        .iter()
-        .map(|e| (e.name().unwrap_or("").to_string(), e.id()))
+        .entries()
+        .map(|e| {
+            (
+                String::from_utf8_lossy(e.filename).into_owned(),
+                objects::git2_oid(e.oid),
+            )
+        })
         .collect()
 }
 
 /// Read all blob entries from a subtree and return (name, content) pairs.
 pub fn read_blob_entries(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     tree_oid: git2::Oid,
     prefix: &str,
 ) -> Vec<(String, String)> {
-    read_tree_entries(repo, tree_oid, prefix)
+    read_tree_entries(transaction, odb, tree_oid, prefix)
         .into_iter()
         .filter_map(|(name, oid)| {
-            let blob = repo.find_blob(oid).ok()?;
-            let content = std::str::from_utf8(blob.content()).ok()?.trim().to_string();
-            Some((name, content))
+            let content = tree::blob_bytes(odb, oid)?;
+            Some((name, std::str::from_utf8(&content).ok()?.trim().to_string()))
         })
         .collect()
 }
@@ -100,29 +111,33 @@ pub fn read_blob_entries(
 /// optionally `worktree` (falling back to `run` for backward compatibility) from the
 /// tree. Returns `None` for `image` and `worktree` when the workspace is
 /// orchestrator-only (no image to build and no files to mount).
-pub fn read_meta(repo: &git2::Repository, ws_tree: git2::Oid) -> anyhow::Result<WorkspaceMeta> {
-    let label = read_blob(repo, ws_tree, "label")
+pub fn read_meta(
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
+    ws_tree: git2::Oid,
+) -> anyhow::Result<WorkspaceMeta> {
+    let label = read_blob(transaction, odb, ws_tree, "label")
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| ws_tree.to_string());
 
-    let output = match read_blob(repo, ws_tree, "output").as_deref() {
+    let output = match read_blob(transaction, odb, ws_tree, "output").as_deref() {
         Some("none") => OutputMode::None,
         Some("workdir") => OutputMode::Workdir,
         _ => OutputMode::Keep,
     };
 
-    let cmd = read_blob(repo, ws_tree, "cmd")
+    let cmd = read_blob(transaction, odb, ws_tree, "cmd")
         .filter(|s| !s.is_empty())
         .unwrap_or_else(|| "bash run.sh".to_string());
 
-    let cache = read_blob(repo, ws_tree, "cache").filter(|s| !s.is_empty());
+    let cache = read_blob(transaction, odb, ws_tree, "cache").filter(|s| !s.is_empty());
 
-    let network = match read_blob(repo, ws_tree, "network").as_deref() {
+    let network = match read_blob(transaction, odb, ws_tree, "network").as_deref() {
         Some("host") => NetworkPolicy::Host,
         _ => NetworkPolicy::None,
     };
 
-    let image = read_blob(repo, ws_tree, "image")
+    let image = read_blob(transaction, odb, ws_tree, "image")
         .filter(|s| !s.is_empty())
         .map(|sha| {
             git2::Oid::from_str(&sha)
@@ -130,16 +145,15 @@ pub fn read_meta(repo: &git2::Repository, ws_tree: git2::Oid) -> anyhow::Result<
         })
         .transpose()?;
 
-    let tree = repo.find_tree(ws_tree)?;
+    let tree = tree::read_tree(transaction, odb, ws_tree)?;
     // Prefer "worktree"; fall back to "run" for backward compatibility with
     // workspaces authored before the rename.
     let worktree = tree
-        .get_path(Path::new("worktree"))
-        .map(|e| e.id())
-        .or_else(|_| tree.get_path(Path::new("run")).map(|e| e.id()))
-        .ok();
+        .entry(b"worktree")
+        .or_else(|| tree.entry(b"run"))
+        .map(|e| objects::git2_oid(e.oid));
 
-    let sidecars = read_sidecars(repo, ws_tree)?;
+    let sidecars = read_sidecars(transaction, odb, ws_tree)?;
 
     Ok(WorkspaceMeta {
         label,
@@ -154,19 +168,20 @@ pub fn read_meta(repo: &git2::Repository, ws_tree: git2::Oid) -> anyhow::Result<
 }
 
 pub fn read_sidecars(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     ws_tree: git2::Oid,
 ) -> anyhow::Result<Vec<SidecarSpec>> {
     let mut out = vec![];
-    for (name, content) in read_blob_entries(repo, ws_tree, "sidecars") {
+    for (name, content) in read_blob_entries(transaction, odb, ws_tree, "sidecars") {
         let sidecar_tree = git2::Oid::from_str(content.trim())
             .map_err(|_| anyhow::anyhow!("sidecar {name}: invalid tree SHA {content:?}"))?;
-        let image_sha = read_blob(repo, sidecar_tree, "image")
+        let image_sha = read_blob(transaction, odb, sidecar_tree, "image")
             .filter(|s| !s.is_empty())
             .ok_or_else(|| anyhow::anyhow!("sidecar {name}: missing image"))?;
         let image = git2::Oid::from_str(&image_sha)
             .map_err(|_| anyhow::anyhow!("sidecar {name}: invalid image SHA {image_sha:?}"))?;
-        let port_str = read_blob(repo, sidecar_tree, "port")
+        let port_str = read_blob(transaction, odb, sidecar_tree, "port")
             .filter(|s| !s.is_empty())
             .ok_or_else(|| anyhow::anyhow!("sidecar {name}: missing port"))?;
         let port: u16 = port_str
@@ -175,9 +190,9 @@ pub fn read_sidecars(
         out.push(SidecarSpec {
             name,
             image,
-            env: read_blob_entries(repo, sidecar_tree, "env"),
-            passthrough: read_blob_entries(repo, sidecar_tree, "passthrough"),
-            inject: read_blob_entries(repo, sidecar_tree, "inject"),
+            env: read_blob_entries(transaction, odb, sidecar_tree, "env"),
+            passthrough: read_blob_entries(transaction, odb, sidecar_tree, "passthrough"),
+            inject: read_blob_entries(transaction, odb, sidecar_tree, "inject"),
             port,
         });
     }

--- a/josh-compose/src/plan.rs
+++ b/josh-compose/src/plan.rs
@@ -1,5 +1,8 @@
 use std::collections::HashSet;
 
+use josh_core::cache;
+use josh_core::memodb;
+
 use josh_compose_backend::ArtifactBackend;
 
 use crate::OutputMode;
@@ -18,7 +21,8 @@ use crate::naming;
 /// early-return path in `container::run_container`. When `ignore_cache` is true, every
 /// image a fresh-cache run would build is reported.
 pub fn collect_image_oids(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     ws_tree: git2::Oid,
     ignore_cache: bool,
     runtime: &dyn ArtifactBackend,
@@ -27,7 +31,8 @@ pub fn collect_image_oids(
     let mut image_seen: HashSet<git2::Oid> = HashSet::new();
     let mut ws_seen: HashSet<git2::Oid> = HashSet::new();
     walk_workspace(
-        repo,
+        transaction,
+        odb,
         ws_tree,
         ignore_cache,
         runtime,
@@ -47,19 +52,29 @@ pub fn collect_image_oids(
 /// present is pruned from the walk. When true, every job a fresh-cache run would
 /// touch is reported.
 pub fn collect_job_hashes(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     ws_tree: git2::Oid,
     ignore_cache: bool,
     runtime: &dyn ArtifactBackend,
 ) -> anyhow::Result<Vec<git2::Oid>> {
     let mut out: Vec<git2::Oid> = vec![];
     let mut ws_seen: HashSet<git2::Oid> = HashSet::new();
-    walk_workspace_jobs(repo, ws_tree, ignore_cache, runtime, &mut out, &mut ws_seen)?;
+    walk_workspace_jobs(
+        transaction,
+        odb,
+        ws_tree,
+        ignore_cache,
+        runtime,
+        &mut out,
+        &mut ws_seen,
+    )?;
     Ok(out)
 }
 
 fn walk_workspace(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     ws_tree: git2::Oid,
     ignore_cache: bool,
     runtime: &dyn ArtifactBackend,
@@ -71,7 +86,7 @@ fn walk_workspace(
         return Ok(());
     }
 
-    let workspace_meta = meta::read_meta(repo, ws_tree)?;
+    let workspace_meta = meta::read_meta(transaction, odb, ws_tree)?;
 
     if !ignore_cache && workspace_is_skippable(ws_tree, &workspace_meta, runtime)? {
         eprintln!(
@@ -81,11 +96,12 @@ fn walk_workspace(
         return Ok(());
     }
 
-    for (dep_name, dep_sha) in meta::read_blob_entries(repo, ws_tree, "inputs") {
+    for (dep_name, dep_sha) in meta::read_blob_entries(transaction, odb, ws_tree, "inputs") {
         let dep_tree = git2::Oid::from_str(dep_sha.trim())
             .map_err(|_| anyhow::anyhow!("dependency {dep_name}: invalid tree SHA {dep_sha:?}"))?;
         walk_workspace(
-            repo,
+            transaction,
+            odb,
             dep_tree,
             ignore_cache,
             runtime,
@@ -96,17 +112,18 @@ fn walk_workspace(
     }
 
     if let Some(image_oid) = workspace_meta.image {
-        collect_image_with_bases(repo, image_oid, out, image_seen)?;
+        collect_image_with_bases(transaction, odb, image_oid, out, image_seen)?;
     }
     for spec in &workspace_meta.sidecars {
-        collect_image_with_bases(repo, spec.image, out, image_seen)?;
+        collect_image_with_bases(transaction, odb, spec.image, out, image_seen)?;
     }
 
     Ok(())
 }
 
 fn walk_workspace_jobs(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     ws_tree: git2::Oid,
     ignore_cache: bool,
     runtime: &dyn ArtifactBackend,
@@ -117,16 +134,24 @@ fn walk_workspace_jobs(
         return Ok(());
     }
 
-    let workspace_meta = meta::read_meta(repo, ws_tree)?;
+    let workspace_meta = meta::read_meta(transaction, odb, ws_tree)?;
 
     if !ignore_cache && workspace_is_skippable(ws_tree, &workspace_meta, runtime)? {
         return Ok(());
     }
 
-    for (dep_name, dep_sha) in meta::read_blob_entries(repo, ws_tree, "inputs") {
+    for (dep_name, dep_sha) in meta::read_blob_entries(transaction, odb, ws_tree, "inputs") {
         let dep_tree = git2::Oid::from_str(dep_sha.trim())
             .map_err(|_| anyhow::anyhow!("dependency {dep_name}: invalid tree SHA {dep_sha:?}"))?;
-        walk_workspace_jobs(repo, dep_tree, ignore_cache, runtime, out, ws_seen)?;
+        walk_workspace_jobs(
+            transaction,
+            odb,
+            dep_tree,
+            ignore_cache,
+            runtime,
+            out,
+            ws_seen,
+        )?;
     }
 
     out.push(ws_tree);
@@ -158,7 +183,8 @@ fn workspace_is_skippable(
 /// (post-order traversal). This ensures a base image's OID always appears before any
 /// image that uses it as a base — the ordering `collect_image_oids` guarantees.
 fn collect_image_with_bases(
-    repo: &git2::Repository,
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
     image_oid: git2::Oid,
     out: &mut Vec<git2::Oid>,
     image_seen: &mut HashSet<git2::Oid>,
@@ -167,10 +193,10 @@ fn collect_image_with_bases(
         return Ok(());
     }
 
-    for (base_name, base_sha) in meta::read_blob_entries(repo, image_oid, "bases") {
+    for (base_name, base_sha) in meta::read_blob_entries(transaction, odb, image_oid, "bases") {
         let base_oid = git2::Oid::from_str(base_sha.trim())
             .map_err(|_| anyhow::anyhow!("invalid base SHA for {base_name}: {base_sha:?}"))?;
-        collect_image_with_bases(repo, base_oid, out, image_seen)?;
+        collect_image_with_bases(transaction, odb, base_oid, out, image_seen)?;
     }
 
     if image_seen.insert(image_oid) {

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -2,6 +2,7 @@ use super::CACHE_VERSION;
 use super::backend::{CacheBackend, HistoryGraphHint};
 use crate::filter;
 use crate::filter::Filter;
+use crate::objects;
 use std::collections::HashMap;
 
 // Only flush shards after they gained enough new entries. Mid-run flushes enqueue their pack
@@ -67,18 +68,23 @@ impl DistributedCacheBackend {
         })
     }
 
-    fn tree_id(&self, repo: &git2::Repository, filter: Filter) -> anyhow::Result<git2::Oid> {
+    /// The object store of this backend's own repository, with its buffered objects in front.
+    fn odb<'a>(&self, repo: &'a git2::Repository) -> anyhow::Result<josh_memodb::Odb<'a>> {
+        Ok(josh_memodb::Odb::new(self.mem_odb.clone(), repo.odb()?))
+    }
+
+    fn tree_id(&self, odb: &josh_memodb::Odb, filter: Filter) -> anyhow::Result<git2::Oid> {
         if let Some(oid) = self.tree_ids.lock().unwrap().get(&filter) {
             return Ok(*oid);
         }
-        let odb = repo.odb()?;
-        let oid = josh_filter::persist::as_tree(repo, &josh_gix_ext::Git2Odb(&odb), filter)?;
+        let oid = josh_filter::persist::as_tree(odb, filter)?;
         self.tree_ids.lock().unwrap().insert(filter, oid);
         Ok(oid)
     }
 
     pub fn flush(&self, force: bool) -> anyhow::Result<()> {
         let repo = self.repo.lock().unwrap();
+        let odb = self.odb(&repo)?;
 
         let mut guard = self.new_entries.lock().unwrap();
         let mut pending = self.pending_refs.lock().unwrap();
@@ -89,8 +95,29 @@ impl DistributedCacheBackend {
             if m.is_empty() || !(force || m.len() >= FLUSH_AFTER) {
                 continue;
             }
-            let rp = ref_path(self.tree_id(&repo, *filter)?, *shard);
-            let mut builder = git2::build::TreeUpdateBuilder::new();
+            let rp = ref_path(self.tree_id(&odb, *filter)?, *shard);
+
+            // Base the update on the newest unpublished commit for this ref when one exists:
+            // basing on the published tip would drop the entries of earlier unpublished
+            // batches.
+            let base = if let Some(oid) = pending.get(&rp) {
+                Some(*oid)
+            } else if let Ok(r) = repo.revparse_single(&rp) {
+                // PORT: resolves a ref -- stays on git2 until flag day.
+                Some(r.peel_to_commit()?.id())
+            } else {
+                None
+            };
+
+            let mut buf = Vec::new();
+            let root = match base {
+                Some(commit) => {
+                    let tree = objects::CommitData::read(&odb, commit)?.tree_id()?;
+                    gix_object::FindExt::find_tree(&odb, &objects::gix_oid(tree), &mut buf)?.into()
+                }
+                None => gix_object::Tree::default(),
+            };
+            let mut editor = gix_object::tree::Editor::new(root, &odb, gix_hash::Kind::Sha1);
 
             // Each entry is a gitlink: the tree entry stores the target oid directly, and git
             // never requires a gitlink target to be present, so no blob objects are needed and
@@ -99,40 +126,30 @@ impl DistributedCacheBackend {
             // in tree entries -- so it is encoded as a blob entry pointing at the empty blob;
             // the entry mode disambiguates on read.
             for (from, to) in &mut *m {
-                if *to == git2::Oid::ZERO_SHA1 {
-                    let blob = repo.blob(&[])?;
-                    builder.upsert(fanout(*from), blob, git2::FileMode::Blob.into());
+                let (kind, target) = if *to == git2::Oid::ZERO_SHA1 {
+                    (
+                        gix_object::tree::EntryKind::Blob,
+                        objects::write_blob(&odb, &[])?,
+                    )
                 } else {
-                    builder.upsert(fanout(*from), *to, git2::FileMode::Commit.into());
-                }
+                    (gix_object::tree::EntryKind::Commit, *to)
+                };
+                editor.upsert(fanout(*from), kind, objects::gix_oid(target))?;
             }
 
-            // Base the update on the newest unpublished commit for this ref when one exists:
-            // basing on the published tip would drop the entries of earlier unpublished
-            // batches.
-            let base = if let Some(oid) = pending.get(&rp) {
-                Some(repo.find_commit(*oid)?)
-            } else if let Ok(r) = repo.revparse_single(&rp) {
-                Some(r.peel_to_commit()?)
-            } else {
-                None
-            };
-            let tree = match &base {
-                Some(commit) => commit.tree()?,
-                None => repo.find_tree(crate::filter::tree::empty_id())?,
-            };
-            let updated = builder.create_updated(&repo, &tree)?;
+            let updated = editor.write(|tree| {
+                gix_object::Write::write(&odb, tree)
+                    .map_err(|e| anyhow::anyhow!("write cache tree: {e}"))
+            })?;
 
             let signature = crate::git::josh_commit_signature()?;
-            let parent_refs = base.iter().collect::<Vec<_>>();
-
-            let commit = repo.commit(
-                None,
+            let commit = objects::write_commit(
+                &odb,
+                objects::git2_oid(&updated),
+                base.as_slice(),
                 &signature,
                 &signature,
                 "cache",
-                &repo.find_tree(updated)?,
-                &parent_refs,
             )?;
             log::info!("CACHE flush {} {}", m.len(), rp);
             m.clear();
@@ -218,11 +235,9 @@ fn ref_path(filter_tree_id: git2::Oid, shard: u64) -> String {
 // rewrites subtrees that grow with the accumulated shard. A single 2-hex level goes quadratic on
 // dense shards for exactly that reason, while a third level only adds one more tree write per
 // entry without making any subtree meaningfully smaller.
-fn fanout(commit: git2::Oid) -> std::path::PathBuf {
+fn fanout(commit: git2::Oid) -> [gix_object::bstr::BString; 3] {
     let commit = commit.to_string();
-    std::path::Path::new(&commit[..2])
-        .join(&commit[2..5])
-        .join(&commit[5..])
+    [commit[..2].into(), commit[2..5].into(), commit[5..].into()]
 }
 
 impl CacheBackend for DistributedCacheBackend {
@@ -256,34 +271,42 @@ impl CacheBackend for DistributedCacheBackend {
 
         std::mem::drop(guard);
 
-        let rp = ref_path(self.tree_id(&repo, filter)?, shard);
+        let odb = self.odb(&repo)?;
+        let rp = ref_path(self.tree_id(&odb, filter)?, shard);
         // Flushed-but-unpublished entries live in a pending commit (see `flush`), not behind
         // the ref yet; prefer it so in-process reads keep seeing everything ever flushed.
         let pending = self.pending_refs.lock().unwrap();
         let tree = if let Some(oid) = pending.get(&rp) {
-            repo.find_commit(*oid)?.tree()?
+            objects::CommitData::read(&odb, *oid)?.tree_id()?
         } else if let Ok(r) = repo.revparse_single(&rp) {
-            r.peel_to_tree()?
+            // PORT: resolves a ref -- stays on git2 until flag day.
+            r.peel_to_tree()?.id()
         } else {
             return Ok(None);
         };
         std::mem::drop(pending);
 
-        if let Ok(e) = tree.get_path(&fanout(from)) {
-            log::debug!(
-                "DistributedCacheBackend: HIT {:?} {}",
-                from,
-                filter::spec(filter)
-            );
-            // Gitlink entries carry the target oid directly; any other mode is the empty-blob
-            // encoding of `Oid::ZERO_SHA1` (see `flush`).
-            if e.filemode() == i32::from(git2::FileMode::Commit) {
-                return Ok(Some(e.id()));
-            }
-            return Ok(Some(git2::Oid::ZERO_SHA1));
-        } else {
+        let mut buf = Vec::new();
+        let root = gix_object::FindExt::find_tree_iter(&odb, &objects::gix_oid(tree), &mut buf)?;
+        let mut entry_buf = Vec::new();
+        let entry = root
+            .lookup_entry(&odb, &mut entry_buf, fanout(from))
+            .map_err(|e| anyhow::anyhow!("cache lookup: {e}"))?;
+        let Some(e) = entry else {
             return Ok(None);
         };
+
+        log::debug!(
+            "DistributedCacheBackend: HIT {:?} {}",
+            from,
+            filter::spec(filter)
+        );
+        // Gitlink entries carry the target oid directly; any other mode is the empty-blob
+        // encoding of `Oid::ZERO_SHA1` (see `flush`).
+        if e.mode.kind() == gix_object::tree::EntryKind::Commit {
+            return Ok(Some(objects::git2_oid(&e.oid)));
+        }
+        Ok(Some(git2::Oid::ZERO_SHA1))
     }
 
     fn write(

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -24,13 +24,11 @@ pub mod text;
 pub mod tree;
 
 pub fn as_tree(transaction: &cache::Transaction, filter: Filter) -> anyhow::Result<git2::Oid> {
-    josh_filter::persist::as_tree(transaction.repo(), &transaction.odb()?, filter)
+    josh_filter::persist::as_tree(&transaction.odb()?, filter)
 }
 
-// PORT: persist::from_tree reads possibly-unflushed filter trees through the registered
-// libgit2 backend; it must move to the facade before the backend can be unregistered.
 pub fn from_tree(transaction: &cache::Transaction, tree_oid: git2::Oid) -> anyhow::Result<Filter> {
-    josh_filter::persist::from_tree(transaction.repo(), tree_oid)
+    josh_filter::persist::from_tree(&transaction.odb()?, tree_oid)
 }
 
 static WORKSPACES: LazyLock<std::sync::Mutex<std::collections::HashMap<git2::Oid, Filter>>> =
@@ -1579,18 +1577,13 @@ fn apply_impl(
         }
         Op::Index => {
             let index_cache = transaction.trigram_index_cache(x.commit);
-            // PORT: josh_search::trigram_index takes a git2::Tree; the bridge read
-            // resolves fresh filtered trees through the registered backend.
-            let input_tree = transaction.repo().find_tree(x.tree_id())?;
-            Ok(x.with_tree(
-                josh_search::trigram_index(
-                    transaction.repo(),
-                    &index_cache,
-                    &mut transaction.trigram_indexer(),
-                    input_tree,
-                )?
-                .id(),
-            ))
+            let tree = x.tree_id();
+            Ok(x.with_tree(josh_search::trigram_index(
+                odb,
+                &index_cache,
+                &mut transaction.trigram_indexer(),
+                tree,
+            )?))
         }
 
         Op::Invert => {
@@ -2785,10 +2778,11 @@ mod tests {
 
         // Serialize to tree
         let odb = repo.odb().unwrap();
-        let tree_oid = as_tree(&repo, &objects::Git2Odb(&odb), meta_filter).unwrap();
+        let objects = objects::Git2Odb(&odb);
+        let tree_oid = as_tree(&objects, meta_filter).unwrap();
 
         // Deserialize from tree
-        let deserialized_filter = from_tree(&repo, tree_oid).unwrap();
+        let deserialized_filter = from_tree(&objects, tree_oid).unwrap();
 
         // Verify the specs match
         let original_spec = spec(meta_filter);

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -100,17 +100,17 @@ struct InMemoryBuilder<'a> {
     /// Present when building for persistence (`as_tree`): used to resolve the object kind of
     /// `InsertContent::Oid` so the object can be referenced as a tree entry with the correct
     /// mode. Absent when computing `Filter::id`, which must stay repository-independent.
-    repo: Option<&'a git2::Repository>,
+    src: Option<&'a dyn gix_object::FindHeader>,
     /// Persist-time tree id per node, filled by `build_persist`. Diverges from `Filter::id`
     /// only for nodes whose subtree contains an unresolved insert OID.
     persist_ids: HashMap<Filter, gix_hash::ObjectId>,
 }
 
 impl<'a> InMemoryBuilder<'a> {
-    fn new(repo: Option<&'a git2::Repository>) -> Self {
+    fn new(src: Option<&'a dyn gix_object::FindHeader>) -> Self {
         Self {
             staging: josh_gix_ext::StagingOdb::new(),
-            repo,
+            src,
             persist_ids: HashMap::new(),
         }
     }
@@ -397,17 +397,18 @@ impl<'a> InMemoryBuilder<'a> {
                     // In persist mode (repo present), resolve the object kind and reference
                     // the object as an actual tree entry ("o") with the matching mode, so it
                     // is reachable from the filter tree in normal git terms and gets
-                    // transferred along with it. Without a repo (`Filter::id`), the kind is
-                    // unknown and the entry mode would be a guess, so the OID is hashed as a
-                    // string; that form is never persisted (`as_tree` always has a repo).
+                    // transferred along with it. Without an object source (`Filter::id`), the
+                    // kind is unknown and the entry mode would be a guess, so the OID is hashed
+                    // as a string; that form is never persisted (`as_tree` always has one).
                     InsertContent::Oid(oid) => {
-                        if let Some(repo) = self.repo {
-                            let object = repo
-                                .find_object(*oid, None)
-                                .with_context(|| format!("insert: object {} not found", oid))?;
-                            let mode = match object.kind() {
-                                Some(git2::ObjectType::Blob) => gix_object::tree::EntryKind::Blob,
-                                Some(git2::ObjectType::Tree) => gix_object::tree::EntryKind::Tree,
+                        if let Some(src) = self.src {
+                            let kind = src
+                                .try_header(&josh_gix_ext::gix_oid(*oid))
+                                .map_err(|e| anyhow!("insert: object {}: {}", oid, e))?
+                                .map(|header| header.kind);
+                            let mode = match kind {
+                                Some(gix_object::Kind::Blob) => gix_object::tree::EntryKind::Blob,
+                                Some(gix_object::Kind::Tree) => gix_object::tree::EntryKind::Tree,
                                 _ => {
                                     return Err(anyhow!(
                                         "insert: {} is neither a blob nor a tree",
@@ -647,13 +648,12 @@ impl<'a> InMemoryBuilder<'a> {
 }
 
 pub fn as_tree(
-    repo: &git2::Repository,
-    out: &(impl gix_object::Exists + gix_object::Write),
+    out: &(impl gix_object::FindHeader + gix_object::Exists + gix_object::Write),
     filter: Filter,
 ) -> anyhow::Result<git2::Oid> {
     let filter = crate::opt::optimize(filter);
 
-    let mut builder = InMemoryBuilder::new(Some(repo));
+    let mut builder = InMemoryBuilder::new(Some(out));
     let root_oid = builder.build_persist(out, filter)?;
     let root_oid = git2::Oid::from_bytes(root_oid.as_bytes())?;
 
@@ -663,12 +663,104 @@ pub fn as_tree(
     Ok(root_oid)
 }
 
-pub fn from_tree(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Filter> {
-    Ok(to_filter(from_tree2(repo, tree_oid)?))
+/// One entry of a persisted filter tree.
+struct PersistedEntry {
+    name: BString,
+    oid: gix_hash::ObjectId,
+    is_tree: bool,
 }
 
-fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op> {
-    let tree = repo.find_tree(tree_oid)?;
+impl PersistedEntry {
+    fn id(&self) -> gix_hash::ObjectId {
+        self.oid
+    }
+
+    fn name(&self) -> anyhow::Result<&str> {
+        Ok(std::str::from_utf8(&self.name)?)
+    }
+}
+
+/// A persisted filter tree, read in full so nested reads can nest.
+struct PersistedTree {
+    oid: gix_hash::ObjectId,
+    entries: Vec<PersistedEntry>,
+}
+
+impl PersistedTree {
+    fn read(src: &impl gix_object::Find, oid: gix_hash::ObjectId) -> anyhow::Result<PersistedTree> {
+        let mut buffer = Vec::new();
+        let kind = src
+            .try_find(&oid, &mut buffer)
+            .map_err(|e| anyhow!("read tree {}: {}", oid, e))?
+            .ok_or_else(|| anyhow!("object {} not found", oid))?
+            .kind;
+        if kind != gix_object::Kind::Tree {
+            return Err(anyhow!("object {} is not a tree", oid));
+        }
+        let tree = gix_object::TreeRef::from_bytes(&buffer, gix_hash::Kind::Sha1)?;
+        Ok(PersistedTree {
+            oid,
+            entries: tree
+                .entries
+                .iter()
+                .map(|e| PersistedEntry {
+                    name: e.filename.into(),
+                    oid: e.oid.to_owned(),
+                    is_tree: e.mode.is_tree(),
+                })
+                .collect(),
+        })
+    }
+
+    fn id(&self) -> gix_hash::ObjectId {
+        self.oid
+    }
+
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn get(&self, index: usize) -> Option<&PersistedEntry> {
+        self.entries.get(index)
+    }
+
+    fn get_name(&self, name: &str) -> Option<&PersistedEntry> {
+        self.entries.iter().find(|e| e.name == name)
+    }
+}
+
+/// A persisted blob.
+struct Blob(Vec<u8>);
+
+impl Blob {
+    fn read(src: &impl gix_object::Find, oid: gix_hash::ObjectId) -> anyhow::Result<Blob> {
+        let mut buffer = Vec::new();
+        let kind = src
+            .try_find(&oid, &mut buffer)
+            .map_err(|e| anyhow!("read blob {}: {}", oid, e))?
+            .ok_or_else(|| anyhow!("object {} not found", oid))?
+            .kind;
+        if kind != gix_object::Kind::Blob {
+            return Err(anyhow!("object {} is not a blob", oid));
+        }
+        Ok(Blob(buffer))
+    }
+
+    fn content(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+pub fn from_tree(src: &impl gix_object::Find, tree_oid: git2::Oid) -> anyhow::Result<Filter> {
+    Ok(to_filter(from_tree2(src, josh_gix_ext::gix_oid(tree_oid))?))
+}
+
+fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyhow::Result<Op> {
+    let tree = PersistedTree::read(src, tree_oid)?;
 
     // Assume there's only one entry and get it directly
     let entry = tree.get(0).context("Empty tree")?;
@@ -676,25 +768,25 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
 
     match name {
         "nop" => {
-            let _ = repo.find_blob(entry.id())?;
+            let _ = Blob::read(src, entry.id())?;
             Ok(Op::Nop)
         }
         "empty" => {
-            let _ = repo.find_blob(entry.id())?;
+            let _ = Blob::read(src, entry.id())?;
             Ok(Op::Empty)
         }
         "paths" => {
-            let _ = repo.find_blob(entry.id())?;
+            let _ = Blob::read(src, entry.id())?;
             Ok(Op::Paths)
         }
         "export" => {
-            let _ = repo.find_blob(entry.id())?;
+            let _ = Blob::read(src, entry.id())?;
             Ok(Op::Export)
         }
         "link" => {
-            let inner = repo.find_tree(entry.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
             let mode_blob =
-                repo.find_blob(inner.get_name("0").context("link: missing mode")?.id())?;
+                Blob::read(src, inner.get_name("0").context("link: missing mode")?.id())?;
             let mode_str = std::str::from_utf8(mode_blob.content())?;
             let mode = if mode_str.is_empty() {
                 None
@@ -704,31 +796,33 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             Ok(Op::Link(mode))
         }
         "adapt" => {
-            let inner = repo.find_tree(entry.id())?;
-            let mode_blob =
-                repo.find_blob(inner.get_name("0").context("adapt: missing mode")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let mode_blob = Blob::read(
+                src,
+                inner.get_name("0").context("adapt: missing mode")?.id(),
+            )?;
             Ok(Op::Adapt(
                 std::str::from_utf8(mode_blob.content())?.to_string(),
             ))
         }
         "unlink" => {
-            let _ = repo.find_blob(entry.id())?;
+            let _ = Blob::read(src, entry.id())?;
             Ok(Op::Unlink)
         }
         "invert" => {
-            let _ = repo.find_blob(entry.id())?;
+            let _ = Blob::read(src, entry.id())?;
             Ok(Op::Invert)
         }
         "index" => {
-            let _ = repo.find_blob(entry.id())?;
+            let _ = Blob::read(src, entry.id())?;
             Ok(Op::Index)
         }
         "fold" => {
-            let _ = repo.find_blob(entry.id())?;
+            let _ = Blob::read(src, entry.id())?;
             Ok(Op::Fold)
         }
         "prune" => {
-            let blob = repo.find_blob(entry.id())?;
+            let blob = Blob::read(src, entry.id())?;
             let content = std::str::from_utf8(blob.content())?;
             if content == "trivial-merge" {
                 Ok(Op::Prune)
@@ -737,27 +831,36 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             }
         }
         "hook" => {
-            let inner = repo.find_tree(entry.id())?;
-            let hook_blob =
-                repo.find_blob(inner.get_name("0").context("hook: missing hook name")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let hook_blob = Blob::read(
+                src,
+                inner.get_name("0").context("hook: missing hook name")?.id(),
+            )?;
             let hook_name = std::str::from_utf8(hook_blob.content())?.to_string();
             Ok(Op::Hook(hook_name))
         }
         "author" => {
-            let inner = repo.find_tree(entry.id())?;
-            let name_blob =
-                repo.find_blob(inner.get_name("0").context("author: missing name")?.id())?;
-            let email_blob =
-                repo.find_blob(inner.get_name("1").context("author: missing email")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let name_blob = Blob::read(
+                src,
+                inner.get_name("0").context("author: missing name")?.id(),
+            )?;
+            let email_blob = Blob::read(
+                src,
+                inner.get_name("1").context("author: missing email")?.id(),
+            )?;
             let name = std::str::from_utf8(name_blob.content())?.to_string();
             let email = std::str::from_utf8(email_blob.content())?.to_string();
             Ok(Op::Author(name, email))
         }
         "committer" => {
-            let inner = repo.find_tree(entry.id())?;
-            let name_blob =
-                repo.find_blob(inner.get_name("0").context("committer: missing name")?.id())?;
-            let email_blob = repo.find_blob(
+            let inner = PersistedTree::read(src, entry.id())?;
+            let name_blob = Blob::read(
+                src,
+                inner.get_name("0").context("committer: missing name")?.id(),
+            )?;
+            let email_blob = Blob::read(
+                src,
                 inner
                     .get_name("1")
                     .context("committer: missing email")?
@@ -768,51 +871,64 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             Ok(Op::Committer(name, email))
         }
         "message" => {
-            let inner = repo.find_tree(entry.id())?;
-            let fmt_blob = repo.find_blob(
+            let inner = PersistedTree::read(src, entry.id())?;
+            let fmt_blob = Blob::read(
+                src,
                 inner
                     .get_name("0")
                     .context("message: missing fmt string")?
                     .id(),
             )?;
-            let regex_blob =
-                repo.find_blob(inner.get_name("1").context("message: missing regex")?.id())?;
+            let regex_blob = Blob::read(
+                src,
+                inner.get_name("1").context("message: missing regex")?.id(),
+            )?;
             let fmt = std::str::from_utf8(fmt_blob.content())?.to_string();
             let regex_str = std::str::from_utf8(regex_blob.content())?;
             let regex = regex::Regex::new(regex_str).context("invalid regex")?;
             Ok(Op::Message(fmt, Regex(regex)))
         }
         "subdir" => {
-            let inner = repo.find_tree(entry.id())?;
-            let path_blob =
-                repo.find_blob(inner.get_name("0").context("subdir: missing path")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let path_blob = Blob::read(
+                src,
+                inner.get_name("0").context("subdir: missing path")?.id(),
+            )?;
             let path = std::str::from_utf8(path_blob.content())?;
             Ok(Op::Subdir(std::path::PathBuf::from(path)))
         }
         "prefix" => {
-            let inner = repo.find_tree(entry.id())?;
-            let path_blob =
-                repo.find_blob(inner.get_name("0").context("prefix: missing path")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let path_blob = Blob::read(
+                src,
+                inner.get_name("0").context("prefix: missing path")?.id(),
+            )?;
             let path = std::str::from_utf8(path_blob.content())?;
             Ok(Op::Prefix(std::path::PathBuf::from(path)))
         }
         "insert" => {
-            let inner = repo.find_tree(entry.id())?;
-            let path_blob =
-                repo.find_blob(inner.get_name("0").context("insert: missing path")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let path_blob = Blob::read(
+                src,
+                inner.get_name("0").context("insert: missing path")?.id(),
+            )?;
             let path = std::str::from_utf8(path_blob.content())?;
             // An "o" entry references the inserted object directly (the kind is re-derived
             // from the repository when the filter is applied or persisted again).
             if let Some(obj_entry) = inner.get_name("o") {
                 return Ok(Op::Insert(
                     std::path::PathBuf::from(path),
-                    InsertContent::Oid(obj_entry.id()),
+                    InsertContent::Oid(josh_gix_ext::git2_oid(&obj_entry.id())),
                 ));
             }
-            let kind_blob =
-                repo.find_blob(inner.get_name("1").context("insert: missing kind")?.id())?;
-            let value_blob =
-                repo.find_blob(inner.get_name("2").context("insert: missing value")?.id())?;
+            let kind_blob = Blob::read(
+                src,
+                inner.get_name("1").context("insert: missing kind")?.id(),
+            )?;
+            let value_blob = Blob::read(
+                src,
+                inner.get_name("2").context("insert: missing value")?.id(),
+            )?;
             let kind = std::str::from_utf8(kind_blob.content())?;
             let value = std::str::from_utf8(value_blob.content())?;
             let content = match kind {
@@ -822,14 +938,16 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             Ok(Op::Insert(std::path::PathBuf::from(path), content))
         }
         "file" => {
-            let inner = repo.find_tree(entry.id())?;
-            let dest_blob = repo.find_blob(
+            let inner = PersistedTree::read(src, entry.id())?;
+            let dest_blob = Blob::read(
+                src,
                 inner
                     .get_name("0")
                     .context("file: missing destination path")?
                     .id(),
             )?;
-            let source_blob = repo.find_blob(
+            let source_blob = Blob::read(
+                src,
                 inner
                     .get_name("1")
                     .context("file: missing source path")?
@@ -843,15 +961,18 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             ))
         }
         "embed" => {
-            let inner = repo.find_tree(entry.id())?;
-            let path_blob =
-                repo.find_blob(inner.get_name("0").context("embed: missing path")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let path_blob = Blob::read(
+                src,
+                inner.get_name("0").context("embed: missing path")?.id(),
+            )?;
             let path = std::str::from_utf8(path_blob.content())?;
             Ok(Op::Embed(std::path::PathBuf::from(path)))
         }
         "pattern" => {
-            let inner = repo.find_tree(entry.id())?;
-            let pattern_blob = repo.find_blob(
+            let inner = PersistedTree::read(src, entry.id())?;
+            let pattern_blob = Blob::read(
+                src,
                 inner
                     .get_name("0")
                     .context("pattern: missing pattern")?
@@ -860,118 +981,134 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             Op::pattern(std::str::from_utf8(pattern_blob.content())?)
         }
         "workspace" => {
-            let inner = repo.find_tree(entry.id())?;
-            let path_blob =
-                repo.find_blob(inner.get_name("0").context("workspace: missing path")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let path_blob = Blob::read(
+                src,
+                inner.get_name("0").context("workspace: missing path")?.id(),
+            )?;
             let path = std::str::from_utf8(path_blob.content())?;
             Ok(Op::Workspace(std::path::PathBuf::from(path)))
         }
         "stored" => {
-            let inner = repo.find_tree(entry.id())?;
-            let path_blob =
-                repo.find_blob(inner.get_name("0").context("stored: missing path")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let path_blob = Blob::read(
+                src,
+                inner.get_name("0").context("stored: missing path")?.id(),
+            )?;
             let path = std::str::from_utf8(path_blob.content())?;
             Ok(Op::Stored(std::path::PathBuf::from(path)))
         }
         "starlark" => {
-            let inner = repo.find_tree(entry.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
             let path_tree = inner.get_name("0").context("starlark: missing path")?;
-            let path_blob = repo.find_blob(
-                repo.find_tree(path_tree.id())?
+            let path_blob = Blob::read(
+                src,
+                PersistedTree::read(src, path_tree.id())?
                     .get_name("0")
                     .context("starlark: missing path blob")?
                     .id(),
             )?;
             let path = std::str::from_utf8(path_blob.content())?;
-            let filter_tree = repo.find_tree(
+            let filter_tree = PersistedTree::read(
+                src,
                 inner
                     .get_name("1")
                     .context("starlark: missing filter")?
                     .id(),
             )?;
-            let filter = from_tree2(repo, filter_tree.id())?;
+            let filter = from_tree2(src, filter_tree.id())?;
             Ok(Op::Starlark(
                 std::path::PathBuf::from(path),
                 to_filter(filter),
             ))
         }
         "treederef" => {
-            let inner = repo.find_tree(entry.id())?;
-            let path_blob =
-                repo.find_blob(inner.get_name("0").context("treederef: missing path")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let path_blob = Blob::read(
+                src,
+                inner.get_name("0").context("treederef: missing path")?.id(),
+            )?;
             let path = std::str::from_utf8(path_blob.content())?;
             Ok(Op::ObjectDeref(std::path::PathBuf::from(path)))
         }
         "treeref" => {
-            let inner = repo.find_tree(entry.id())?;
-            let path_blob =
-                repo.find_blob(inner.get_name("0").context("treeref: missing path")?.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
+            let path_blob = Blob::read(
+                src,
+                inner.get_name("0").context("treeref: missing path")?.id(),
+            )?;
             let path = std::str::from_utf8(path_blob.content())?;
             Ok(Op::ObjectRef(std::path::PathBuf::from(path)))
         }
         "treeid" => {
-            let inner = repo.find_tree(entry.id())?;
+            let inner = PersistedTree::read(src, entry.id())?;
             let path_tree = inner.get_name("0").context("treeid: missing path")?;
-            let path_blob = repo.find_blob(
-                repo.find_tree(path_tree.id())?
+            let path_blob = Blob::read(
+                src,
+                PersistedTree::read(src, path_tree.id())?
                     .get_name("0")
                     .context("treeid: missing path blob")?
                     .id(),
             )?;
             let path = std::str::from_utf8(path_blob.content())?;
-            let filter_tree =
-                repo.find_tree(inner.get_name("1").context("treeid: missing filter")?.id())?;
-            let filter = from_tree2(repo, filter_tree.id())?;
+            let filter_tree = PersistedTree::read(
+                src,
+                inner.get_name("1").context("treeid: missing filter")?.id(),
+            )?;
+            let filter = from_tree2(src, filter_tree.id())?;
             Ok(Op::TreeId(
                 std::path::PathBuf::from(path),
                 to_filter(filter),
             ))
         }
         "compose" => {
-            let compose_tree = repo.find_tree(entry.id())?;
+            let compose_tree = PersistedTree::read(src, entry.id())?;
             let mut filters = Vec::new();
             for i in 0..compose_tree.len() {
                 let compose_entry = compose_tree.get(i).context("compose: missing entry")?;
-                let filter_tree = repo.find_tree(compose_entry.id())?;
-                let filter = from_tree2(repo, filter_tree.id())?;
+                let filter_tree = PersistedTree::read(src, compose_entry.id())?;
+                let filter = from_tree2(src, filter_tree.id())?;
                 filters.push(to_filter(filter));
             }
             Ok(Op::Compose(filters))
         }
         "subtract" => {
-            let subtract_tree = repo.find_tree(entry.id())?;
+            let subtract_tree = PersistedTree::read(src, entry.id())?;
             if subtract_tree.len() == 2 {
-                let a_tree = repo.find_tree(
+                let a_tree = PersistedTree::read(
+                    src,
                     subtract_tree
                         .get_name("0")
                         .context("subtract: missing 0")?
                         .id(),
                 )?;
-                let b_tree = repo.find_tree(
+                let b_tree = PersistedTree::read(
+                    src,
                     subtract_tree
                         .get_name("1")
                         .context("subtract: missing 1")?
                         .id(),
                 )?;
-                let a = from_tree2(repo, a_tree.id())?;
-                let b = from_tree2(repo, b_tree.id())?;
+                let a = from_tree2(src, a_tree.id())?;
+                let b = from_tree2(src, b_tree.id())?;
                 Ok(Op::Subtract(to_filter(a), to_filter(b)))
             } else {
                 Err(anyhow!("subtract: expected 2 entries"))
             }
         }
         "chain" => {
-            let chain_tree = repo.find_tree(entry.id())?;
+            let chain_tree = PersistedTree::read(src, entry.id())?;
             if !chain_tree.is_empty() {
                 let mut filters = vec![];
                 for i in 0..chain_tree.len() {
-                    let filter_tree = repo.find_tree(
+                    let filter_tree = PersistedTree::read(
+                        src,
                         chain_tree
                             .get_name(&i.to_string())
                             .with_context(|| format!("chain: missing {}", i))?
                             .id(),
                     )?;
-                    let filter = from_tree2(repo, filter_tree.id())?;
+                    let filter = from_tree2(src, filter_tree.id())?;
                     filters.push(to_filter(filter));
                 }
                 Ok(Op::Chain(filters))
@@ -980,53 +1117,61 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             }
         }
         "exclude" => {
-            let exclude_tree = repo.find_tree(entry.id())?;
+            let exclude_tree = PersistedTree::read(src, entry.id())?;
             if exclude_tree.len() == 1 {
-                let filter_tree = repo.find_tree(
+                let filter_tree = PersistedTree::read(
+                    src,
                     exclude_tree
                         .get_name("0")
                         .context("exclude: missing 0")?
                         .id(),
                 )?;
-                let filter = from_tree2(repo, filter_tree.id())?;
+                let filter = from_tree2(src, filter_tree.id())?;
                 Ok(Op::Exclude(to_filter(filter)))
             } else {
                 Err(anyhow!("exclude: expected 1 entry"))
             }
         }
         "select" => {
-            let select_tree = repo.find_tree(entry.id())?;
+            let select_tree = PersistedTree::read(src, entry.id())?;
             if select_tree.len() == 1 {
-                let filter_tree =
-                    repo.find_tree(select_tree.get_name("0").context("select: missing 0")?.id())?;
-                let filter = from_tree2(repo, filter_tree.id())?;
+                let filter_tree = PersistedTree::read(
+                    src,
+                    select_tree.get_name("0").context("select: missing 0")?.id(),
+                )?;
+                let filter = from_tree2(src, filter_tree.id())?;
                 Ok(Op::Select(to_filter(filter)))
             } else {
                 Err(anyhow!("select: expected 1 entry"))
             }
         }
         "pin" => {
-            let pin_tree = repo.find_tree(entry.id())?;
+            let pin_tree = PersistedTree::read(src, entry.id())?;
             if pin_tree.len() == 1 {
-                let filter_tree =
-                    repo.find_tree(pin_tree.get_name("0").context("pin: missing 0")?.id())?;
-                let filter = from_tree2(repo, filter_tree.id())?;
+                let filter_tree = PersistedTree::read(
+                    src,
+                    pin_tree.get_name("0").context("pin: missing 0")?.id(),
+                )?;
+                let filter = from_tree2(src, filter_tree.id())?;
                 Ok(Op::Pin(to_filter(filter)))
             } else {
                 Err(anyhow!("pin: expected 1 entry"))
             }
         }
         "rev" => {
-            let rev_tree = repo.find_tree(entry.id())?;
+            let rev_tree = PersistedTree::read(src, entry.id())?;
             let mut filters = Vec::new();
             for i in 0..rev_tree.len() {
                 let rev_entry = rev_tree
                     .get_name(&i.to_string())
                     .context("rev: missing entry")?;
-                let inner_tree = repo.find_tree(rev_entry.id())?;
-                let key_blob =
-                    repo.find_blob(inner_tree.get_name("o").context("rev: missing key")?.id())?;
-                let filter_tree = repo.find_tree(
+                let inner_tree = PersistedTree::read(src, rev_entry.id())?;
+                let key_blob = Blob::read(
+                    src,
+                    inner_tree.get_name("o").context("rev: missing key")?.id(),
+                )?;
+                let filter_tree = PersistedTree::read(
+                    src,
                     inner_tree
                         .get_name("f")
                         .context("rev: missing filter")?
@@ -1051,77 +1196,81 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
                     ));
                 };
 
-                let filter = from_tree2(repo, filter_tree.id())?;
+                let filter = from_tree2(src, filter_tree.id())?;
                 filters.push((match_op, lazy_ref, to_filter(filter)));
             }
             Ok(Op::Rev(filters))
         }
         "unapply" => {
-            let concat_tree = repo.find_tree(entry.id())?;
+            let concat_tree = PersistedTree::read(src, entry.id())?;
             let unapply_entry = concat_tree.get(0).context("concat: missing entry")?;
-            let inner_tree = repo.find_tree(unapply_entry.id())?;
-            let key_blob = repo.find_blob(
+            let inner_tree = PersistedTree::read(src, unapply_entry.id())?;
+            let key_blob = Blob::read(
+                src,
                 inner_tree
                     .get_name("o")
                     .context("concat: missing key")?
                     .id(),
             )?;
-            let filter_tree = repo.find_tree(
+            let filter_tree = PersistedTree::read(
+                src,
                 inner_tree
                     .get_name("f")
                     .context("concat: missing filter")?
                     .id(),
             )?;
             let key = std::str::from_utf8(key_blob.content())?;
-            let filter = from_tree2(repo, filter_tree.id())?;
+            let filter = from_tree2(src, filter_tree.id())?;
             Ok(Op::Unapply(LazyRef::parse(&key)?, to_filter(filter)))
         }
         "squash" => {
             // blob -> Squash(None), tree -> Squash(Some(...))
-            if let Some(kind) = entry.kind()
-                && kind == git2::ObjectType::Blob
-            {
-                let _ = repo.find_blob(entry.id())?;
+            if !entry.is_tree {
+                let _ = Blob::read(src, entry.id())?;
                 return Ok(Op::Squash(None));
             }
-            let squash_tree = repo.find_tree(entry.id())?;
+            let squash_tree = PersistedTree::read(src, entry.id())?;
             let mut filters = std::collections::BTreeMap::new();
             for i in 0..squash_tree.len() {
                 let squash_entry = squash_tree.get(i).context("squash: missing entry")?;
-                let inner_tree = repo.find_tree(squash_entry.id())?;
-                let key_blob = repo.find_blob(
+                let inner_tree = PersistedTree::read(src, squash_entry.id())?;
+                let key_blob = Blob::read(
+                    src,
                     inner_tree
                         .get_name("o")
                         .context("squash: missing key")?
                         .id(),
                 )?;
-                let filter_tree = repo.find_tree(
+                let filter_tree = PersistedTree::read(
+                    src,
                     inner_tree
                         .get_name("f")
                         .context("squash: missing filter")?
                         .id(),
                 )?;
                 let key = std::str::from_utf8(key_blob.content())?;
-                let filter = from_tree2(repo, filter_tree.id())?;
+                let filter = from_tree2(src, filter_tree.id())?;
                 filters.insert(LazyRef::parse(&key)?, to_filter(filter));
             }
             Ok(Op::Squash(Some(filters)))
         }
         "regex_replace" => {
-            let regex_replace_tree = repo.find_tree(entry.id())?;
+            let regex_replace_tree = PersistedTree::read(src, entry.id())?;
             let mut replacements = Vec::new();
             for i in 0..regex_replace_tree.len() {
                 let regex_entry = regex_replace_tree
                     .get(i)
                     .context("regex_replace: missing entry")?;
-                let inner_tree = repo.find_tree(regex_entry.id())?;
-                let regex_blob = repo.find_blob(
+                let inner_tree = PersistedTree::read(src, regex_entry.id())?;
+                let regex_blob = Blob::read(
+                    src,
                     inner_tree
                         .get_name("p")
                         .context("regex_replace: missing pattern")?
                         .id(),
                 )?;
-                let replacement_blob = repo.find_blob(
+                let replacement_blob = Blob::read(
+                    src,
                     inner_tree
                         .get_name("r")
                         .context("regex_replace: missing replacement")?
@@ -1135,8 +1284,9 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             Ok(Op::RegexReplace(replacements))
         }
         "downstack" => {
-            let inner = repo.find_tree(entry.id())?;
-            let key_blob = repo.find_blob(
+            let inner = PersistedTree::read(src, entry.id())?;
+            let key_blob = Blob::read(
+                src,
                 inner
                     .get_name("0")
                     .context("downstack: missing base ref")?
@@ -1146,8 +1296,9 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
             Ok(Op::Downstack(LazyRef::parse(key)?))
         }
         "meta" => {
-            let meta_tree = repo.find_tree(entry.id())?;
-            let filter_tree = repo.find_tree(
+            let meta_tree = PersistedTree::read(src, entry.id())?;
+            let filter_tree = PersistedTree::read(
+                src,
                 meta_tree
                     .get_name("0")
                     .context("meta: missing filter tree")?
@@ -1166,13 +1317,13 @@ fn from_tree2(repo: &git2::Repository, tree_oid: git2::Oid) -> anyhow::Result<Op
                 }
 
                 // The entry should be a blob with the value as content
-                let value_blob = repo.find_blob(meta_entry.id())?;
+                let value_blob = Blob::read(src, meta_entry.id())?;
                 let value = std::str::from_utf8(value_blob.content())?.to_string();
                 meta.insert(meta_key.to_string(), value);
             }
 
             // Deserialize filter
-            let filter = from_tree2(repo, filter_tree.id())?;
+            let filter = from_tree2(src, filter_tree.id())?;
             Ok(Op::Meta(meta, to_filter(filter)))
         }
         _ => Err(anyhow!("Unknown tree structure")),

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -445,20 +445,12 @@ impl Revision {
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
 
-        // PORT: josh-search takes a git2::Tree, so these reads stay on the repo handle.
-        let filtered_tree = transaction.repo().find_tree(x.tree_id())?;
         // The trigram index is experimental; without it every file is a candidate and
         // search_matches does all the filtering, so results are identical, just slower.
         let candidates = if filter::experimental_features_enabled() {
             let ifilterobj = filter::parse(":SQUASH:INDEX")?;
             let index_tree = filter::apply(&transaction, ifilterobj, x.clone())?;
-            let index_tree = transaction.repo().find_tree(index_tree.tree_id())?;
-            josh_search::search_candidates(
-                transaction.repo(),
-                &index_tree,
-                &filtered_tree,
-                &string,
-            )?
+            josh_search::search_candidates(&odb, index_tree.tree_id(), x.tree_id(), &string)?
         } else {
             let mut scan = vec![];
             objects::walk_tree_preorder(&odb, x.tree_id(), &mut |parent, entry| {
@@ -473,8 +465,7 @@ impl Revision {
             })?;
             scan
         };
-        let results =
-            josh_search::search_matches(transaction.repo(), &filtered_tree, &string, &candidates)?;
+        let results = josh_search::search_matches(&odb, x.tree_id(), &string, &candidates)?;
 
         let mut r = vec![];
         for m in results {

--- a/josh-search/Cargo.toml
+++ b/josh-search/Cargo.toml
@@ -20,6 +20,7 @@ gix-hash.workspace = true
 gix-object.workspace = true
 
 [dev-dependencies]
+josh-gix-ext.workspace = true
 criterion2 = { version = "3.0.4" }
 rand = "0.10.2"
 tempfile.workspace = true

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -278,13 +278,13 @@ fn recover_chain(repo: &git2::Repository, n_files: usize) -> anyhow::Result<Vec<
 /// End-to-end search exactly as `josh-filter --search` performs it: candidate selection over
 /// the index tree, then exact matching over the source tree.
 fn search(
-    repo: &git2::Repository,
-    index_tree: &git2::Tree,
-    source_tree: &git2::Tree,
+    src: &dyn josh_search::Objects,
+    index_tree: git2::Oid,
+    source_tree: git2::Oid,
     needle: &str,
 ) -> anyhow::Result<(Vec<String>, Vec<(String, Vec<(usize, String)>)>)> {
-    let candidates = josh_search::search_candidates(repo, index_tree, source_tree, needle)?;
-    let matches = josh_search::search_matches(repo, source_tree, needle, &candidates)?;
+    let candidates = josh_search::search_candidates(src, index_tree, source_tree, needle)?;
+    let matches = josh_search::search_matches(src, source_tree, needle, &candidates)?;
     Ok((candidates, matches))
 }
 
@@ -336,17 +336,16 @@ impl TrigramBench {
             let repo = transaction.repo();
             let tip_tree = repo.find_commit(tip)?.tree()?;
             let total_bytes = tree_content_bytes(repo, &tip_tree)?;
+            let odb = transaction.odb()?;
 
-            // Cold-build the tip index, then flush: `trigram_search` opens fresh repository
-            // handles per directory, and those cannot see objects still sitting in this
-            // transaction's in-memory odb.
-            let index_tree = josh_search::trigram_index(
-                repo,
+            // Cold-build the tip index, then flush: the timed groups reopen the repository and
+            // read these index trees back, so they must be on disk by then.
+            let index_tree_oid = josh_search::trigram_index(
+                &odb,
                 &transaction.trigram_index_cache(tip),
                 &mut josh_search::Indexer::default(),
-                tip_tree.clone(),
+                tip_tree.id(),
             )?;
-            let index_tree_oid = index_tree.id();
             transaction.flush_mem_odb()?;
 
             // Gate: the rare needle is found in exactly its planted file, with a tight
@@ -354,7 +353,7 @@ impl TrigramBench {
             // degenerated and the search numbers would be meaningless. (The bound is kept at
             // the pre-rework value of 5; the exact index should always produce exactly 1.)
             let rare_path = path_for(n_files / 2).to_string_lossy().into_owned();
-            let (candidates, matches) = search(repo, &index_tree, &tip_tree, NEEDLE_RARE)?;
+            let (candidates, matches) = search(&odb, index_tree_oid, tip_tree.id(), NEEDLE_RARE)?;
             anyhow::ensure!(
                 matches.len() == 1 && matches[0].0 == rare_path,
                 "rare needle not found in exactly its planted file {rare_path}: {matches:?}"
@@ -367,13 +366,13 @@ impl TrigramBench {
 
             // Gate: the common needle is found in every planted file, the absent one nowhere.
             let common_count = n_files.div_ceil(COMMON_EVERY);
-            let (_, matches) = search(repo, &index_tree, &tip_tree, NEEDLE_COMMON)?;
+            let (_, matches) = search(&odb, index_tree_oid, tip_tree.id(), NEEDLE_COMMON)?;
             anyhow::ensure!(
                 matches.len() == common_count,
                 "common needle found in {} files, expected {common_count}",
                 matches.len()
             );
-            let (_, matches) = search(repo, &index_tree, &tip_tree, NEEDLE_ABSENT)?;
+            let (_, matches) = search(&odb, index_tree_oid, tip_tree.id(), NEEDLE_ABSENT)?;
             anyhow::ensure!(
                 matches.is_empty(),
                 "absent needle found in {} files",
@@ -387,6 +386,7 @@ impl TrigramBench {
             let transaction = context.open()?;
             let repo = transaction.repo();
             let root_tree = repo.find_commit(chain[0])?.tree()?;
+            let odb = transaction.odb()?;
             // One indexer state for the whole chain, matching how josh keeps one per
             // transaction. Collect the per-commit (source tree, index tree) pairs on the way:
             // the history search group iterates them.
@@ -394,23 +394,20 @@ impl TrigramBench {
             let mut chain_indexes = vec![(
                 root_tree.id(),
                 josh_search::trigram_index(
-                    repo,
+                    &odb,
                     &transaction.trigram_index_cache(chain[0]),
                     &mut indexer,
-                    root_tree,
-                )?
-                .id(),
+                    root_tree.id(),
+                )?,
             )];
             for &oid in &chain[1..] {
-                let tree = repo.find_commit(oid)?.tree()?;
-                let tree_oid = tree.id();
+                let tree_oid = repo.find_commit(oid)?.tree_id();
                 let index_oid = josh_search::trigram_index(
-                    repo,
+                    &odb,
                     &transaction.trigram_index_cache(oid),
                     &mut indexer,
-                    tree,
-                )?
-                .id();
+                    tree_oid,
+                )?;
                 chain_indexes.push((tree_oid, index_oid));
             }
             let root_index_oid = chain_indexes.first().expect("chain is never empty").1;
@@ -462,20 +459,17 @@ fn trigram_benches(c: &mut Criterion) {
                 josh_core::reset_caches().expect("reset caches");
                 let transaction = bench.context.open().expect("open transaction");
                 let repo = transaction.repo();
-                let tip_tree = repo
-                    .find_commit(case.tip())
-                    .expect("find tip")
-                    .tree()
-                    .expect("tip tree");
+                let tip_tree = repo.find_commit(case.tip()).expect("find tip").tree_id();
+                let odb = transaction.odb().expect("odb");
 
                 let mut indexer = josh_search::Indexer::default();
 
                 runner.run(|| {
                     josh_search::trigram_index(
-                        repo,
+                        &odb,
                         &transaction.trigram_index_cache(case.tip()),
                         &mut indexer,
-                        tip_tree.clone(),
+                        tip_tree,
                     )
                     .expect("index tree")
                 });
@@ -501,13 +495,13 @@ fn trigram_benches(c: &mut Criterion) {
                 let root_tree = repo
                     .find_commit(case.chain[0])
                     .expect("find root")
-                    .tree()
-                    .expect("root tree");
+                    .tree_id();
+                let odb = transaction.odb().expect("odb");
                 // One indexer state across the warm root and the whole chain, matching how
                 // josh keeps one per transaction.
                 let mut indexer = josh_search::Indexer::default();
                 josh_search::trigram_index(
-                    repo,
+                    &odb,
                     &transaction.trigram_index_cache(case.chain[0]),
                     &mut indexer,
                     root_tree,
@@ -516,13 +510,9 @@ fn trigram_benches(c: &mut Criterion) {
 
                 runner.run(|| {
                     for &oid in &case.chain[1..] {
-                        let tree = repo
-                            .find_commit(oid)
-                            .expect("find churn commit")
-                            .tree()
-                            .expect("churn tree");
+                        let tree = repo.find_commit(oid).expect("find churn commit").tree_id();
                         josh_search::trigram_index(
-                            repo,
+                            &odb,
                             &transaction.trigram_index_cache(oid),
                             &mut indexer,
                             tree,
@@ -553,16 +543,12 @@ fn trigram_benches(c: &mut Criterion) {
                     josh_core::reset_caches().expect("reset caches");
                     let transaction = bench.context.open().expect("open transaction");
                     let repo = transaction.repo();
-                    let index_tree = repo
-                        .find_tree(case.index_tree_oid)
-                        .expect("find prebuilt index tree");
-                    let source_tree = repo
-                        .find_commit(case.tip())
-                        .expect("find tip")
-                        .tree()
-                        .expect("tip tree");
+                    let source_tree = repo.find_commit(case.tip()).expect("find tip").tree_id();
+                    let odb = transaction.odb().expect("odb");
 
-                    runner.run(|| search(repo, &index_tree, &source_tree, needle).expect("search"));
+                    runner.run(|| {
+                        search(&odb, case.index_tree_oid, source_tree, needle).expect("search")
+                    });
                 });
             });
         }
@@ -586,15 +572,13 @@ fn trigram_benches(c: &mut Criterion) {
                 b.iter_with_setup_wrapper(|runner| {
                     josh_core::reset_caches().expect("reset caches");
                     let transaction = bench.context.open().expect("open transaction");
-                    let repo = transaction.repo();
+                    let odb = transaction.odb().expect("odb");
 
                     runner.run(|| {
                         let mut hits = 0;
                         for (tree_oid, index_oid) in &case.chain_indexes {
-                            let source = repo.find_tree(*tree_oid).expect("find source tree");
-                            let index = repo.find_tree(*index_oid).expect("find index tree");
                             let (_, matches) =
-                                search(repo, &index, &source, needle).expect("search");
+                                search(&odb, *index_oid, *tree_oid, needle).expect("search");
                             hits += matches.len();
                         }
                         hits

--- a/josh-search/src/lib.rs
+++ b/josh-search/src/lib.rs
@@ -84,21 +84,20 @@ fn distinct_trigrams(content: &str) -> BTreeSet<[u8; 3]> {
         .collect()
 }
 
-/// Read the blob at `name` in `tree` as text, or "" if it is absent, binary or not UTF-8.
-fn get_blob(repo: &git2::Repository, tree: &git2::Tree, name: &str) -> String {
-    let Some(entry) = tree.get_name(name) else {
+/// Read the blob `oid` as text, or "" if it is absent, contains a NUL byte, or is not UTF-8.
+fn read_blob_text(src: &dyn Objects, oid: gix_hash::ObjectId) -> String {
+    let mut buffer = Vec::new();
+    let Ok(Some(data)) = src.try_find(&oid, &mut buffer) else {
         return "".to_owned();
     };
-
-    let Ok(blob) = repo.find_blob(entry.id()) else {
+    if data.kind != gix_object::Kind::Blob {
         return "".to_owned();
-    };
-
-    if blob.is_binary() {
+    }
+    if buffer.contains(&0) {
         return "".to_owned();
     }
 
-    let Ok(content) = std::str::from_utf8(blob.content()) else {
+    let Ok(content) = std::str::from_utf8(&buffer) else {
         return "".to_owned();
     };
 
@@ -140,10 +139,14 @@ pub struct Indexer {
     overlay_memo: HashMap<Vec<gix_hash::ObjectId>, gix_hash::ObjectId>,
 }
 
-/// One [`trigram_index`] call: the persistent [`Indexer`] state plus the per-call repository,
-/// cache and root bookkeeping.
+/// What an index run needs from the object database.
+pub trait Objects: gix_object::Find + gix_object::Exists + gix_object::Write {}
+impl<T: gix_object::Find + gix_object::Exists + gix_object::Write> Objects for T {}
+
+/// One [`trigram_index`] call: the persistent [`Indexer`] state plus the per-call object
+/// source, cache and root bookkeeping.
 struct Run<'a> {
-    repo: &'a git2::Repository,
+    src: &'a dyn Objects,
     cache: &'a dyn IndexCache,
     ix: &'a mut Indexer,
     /// `(source tree, index)` pairs of this call, memoized by [`flush`](Run::flush) only after
@@ -151,7 +154,7 @@ struct Run<'a> {
     roots: Vec<(git2::Oid, gix_hash::ObjectId)>,
 }
 
-impl<'a> Run<'a> {
+impl Run<'_> {
     /// Serialize `entries` as a tree into `pending` and return its hash. Entries are sorted
     /// into git's canonical order (directories compare with a trailing `/`), which differs
     /// from plain name order for the mixed blob/tree entries index trees contain.
@@ -186,9 +189,12 @@ impl<'a> Run<'a> {
         let tree = if let Some((_, data)) = self.ix.pending.get(&oid) {
             gix_object::TreeRef::from_bytes(data, gix_hash::Kind::Sha1)?.into_owned()
         } else {
-            let odb = self.repo.odb()?;
-            let obj = odb.read(to_git2(oid))?;
-            gix_object::TreeRef::from_bytes(obj.data(), gix_hash::Kind::Sha1)?.into_owned()
+            let mut buffer = Vec::new();
+            self.src
+                .try_find(&oid, &mut buffer)
+                .map_err(|e| anyhow::anyhow!("read tree {}: {}", oid, e))?
+                .ok_or_else(|| anyhow::anyhow!("object {} not found", oid))?;
+            gix_object::TreeRef::from_bytes(&buffer, gix_hash::Kind::Sha1)?.into_owned()
         };
         let tree = std::sync::Arc::new(tree);
         self.ix.trees.insert(oid, tree.clone());
@@ -352,37 +358,34 @@ impl<'a> Run<'a> {
     /// The index of a directory: the overlay of its children's wrapped indexes, memoized per
     /// source tree oid. The root is not special — incrementality is just this memo hitting on
     /// unchanged subtrees.
-    fn index_tree(&mut self, tree: &git2::Tree) -> anyhow::Result<gix_hash::ObjectId> {
-        if let Some(id) = self.ix.tree_memo.get(&tree.id()) {
+    fn index_tree_oid(&mut self, tree_oid: git2::Oid) -> anyhow::Result<gix_hash::ObjectId> {
+        let tree = self.read_tree(to_gix(tree_oid))?;
+        if let Some(id) = self.ix.tree_memo.get(&tree_oid) {
             return Ok(*id);
         }
-        if let Some(cached) = self.cache.get_index(tree.id()) {
+        if let Some(cached) = self.cache.get_index(tree_oid) {
             let id = to_gix(cached);
-            self.ix.tree_memo.insert(tree.id(), id);
+            self.ix.tree_memo.insert(tree_oid, id);
             return Ok(id);
         }
 
-        let mut wrapped = Vec::with_capacity(tree.len());
-        for entry in tree.iter() {
-            let name = entry.name()?.to_owned();
-            match entry.kind() {
-                Some(git2::ObjectType::Blob) => {
-                    let content = get_blob(self.repo, tree, &name);
-                    wrapped.push(self.index_blob(entry.id(), &name, &content));
-                }
-                Some(git2::ObjectType::Tree) => {
-                    let child_tree = self.repo.find_tree(entry.id())?;
-                    let child = self.index_tree(&child_tree)?;
-                    wrapped.push(self.wrap(&name, child)?);
-                }
-                // Submodules etc. are not indexed.
-                _ => {}
-            };
+        let mut wrapped = Vec::with_capacity(tree.entries.len());
+        for entry in tree.entries.clone() {
+            let name = std::str::from_utf8(&entry.filename)?.to_owned();
+            let child_oid = to_git2(entry.oid);
+            if entry.mode.is_tree() {
+                let child = self.index_tree_oid(child_oid)?;
+                wrapped.push(self.wrap(&name, child)?);
+            } else if !entry.mode.is_commit() {
+                let content = read_blob_text(self.src, entry.oid);
+                wrapped.push(self.index_blob(child_oid, &name, &content));
+            }
+            // Submodules etc. are not indexed.
         }
         let index = self.overlay_many(wrapped)?;
 
-        self.ix.tree_memo.insert(tree.id(), index);
-        self.roots.push((tree.id(), index));
+        self.ix.tree_memo.insert(tree_oid, index);
+        self.roots.push((tree_oid, index));
         Ok(index)
     }
 
@@ -393,16 +396,16 @@ impl<'a> Run<'a> {
         if self.roots.is_empty() {
             return Ok(());
         }
-        let odb = self.repo.odb()?;
-
         // Index leaves are the empty blob, and an empty directory's index is the empty tree;
         // neither lives in `pending`, so make sure both exist before anything references them.
         for (kind, id) in [
-            (git2::ObjectType::Blob, empty_blob()),
-            (git2::ObjectType::Tree, empty_tree()),
+            (gix_object::Kind::Blob, empty_blob()),
+            (gix_object::Kind::Tree, empty_tree()),
         ] {
-            if !odb.exists(to_git2(id)) {
-                odb.write(kind, &[])?;
+            if !self.src.exists(&id) {
+                self.src
+                    .write_buf(kind, &[])
+                    .map_err(|e| anyhow::anyhow!("write index object: {}", e))?;
             }
         }
 
@@ -423,12 +426,10 @@ impl<'a> Run<'a> {
                     stack.push(entry.oid.to_owned());
                 }
             }
-            let git2_kind = match kind {
-                gix_object::Kind::Tree => git2::ObjectType::Tree,
-                _ => git2::ObjectType::Blob,
-            };
-            if !odb.exists(to_git2(id)) {
-                odb.write(git2_kind, data)?;
+            if !self.src.exists(&id) {
+                self.src
+                    .write_buf(*kind, data)
+                    .map_err(|e| anyhow::anyhow!("write index object: {}", e))?;
             }
             written.push(id);
         }
@@ -443,21 +444,21 @@ impl<'a> Run<'a> {
     }
 }
 
-pub fn trigram_index<'a>(
-    repo: &'a git2::Repository,
+pub fn trigram_index(
+    src: &dyn Objects,
     cache: &dyn IndexCache,
     indexer: &mut Indexer,
-    tree: git2::Tree<'a>,
-) -> anyhow::Result<git2::Tree<'a>> {
+    tree: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
     let mut run = Run {
-        repo,
+        src,
         cache,
         ix: indexer,
         roots: Vec::new(),
     };
-    let index = run.index_tree(&tree)?;
+    let index = run.index_tree_oid(tree)?;
     run.flush()?;
-    Ok(repo.find_tree(to_git2(index))?)
+    Ok(to_git2(index))
 }
 
 /// Exact candidate files for `searchstring`: files containing every trigram of the query.
@@ -465,26 +466,26 @@ pub fn trigram_index<'a>(
 /// Queries shorter than three bytes (or without any valid-UTF-8 window) have no trigrams; every
 /// file of `source_tree` is a candidate then, and [`search_matches`] does the filtering.
 pub fn search_candidates(
-    repo: &git2::Repository,
-    index_tree: &git2::Tree,
-    source_tree: &git2::Tree,
+    src: &dyn Objects,
+    index_tree: git2::Oid,
+    source_tree: git2::Oid,
     searchstring: &str,
 ) -> anyhow::Result<Vec<String>> {
     let trigrams = distinct_trigrams(searchstring);
 
     let mut results = vec![];
     if trigrams.is_empty() {
-        collect_paths(repo, source_tree.id(), "", &mut results)?;
+        collect_paths(src, source_tree, "", &mut results)?;
         return Ok(results);
     }
 
     let mut roots = vec![];
     for t in &trigrams {
         let path = format!("{:02x}/{:02x}/{:02x}", t[0], t[1], t[2]);
-        match index_tree.get_path(std::path::Path::new(&path)) {
-            Ok(entry) => roots.push(entry.id()),
+        match path_entry(src, index_tree, std::path::Path::new(&path))? {
+            Some(oid) => roots.push(oid),
             // A trigram absent from the index cannot occur in any file.
-            Err(_) => return Ok(vec![]),
+            None => return Ok(vec![]),
         }
     }
     roots.sort();
@@ -497,7 +498,7 @@ pub fn search_candidates(
     if roots.len() > MAX_INTERSECT {
         let mut sized = roots
             .iter()
-            .map(|&oid| anyhow::Ok((repo.find_tree(oid)?.len(), oid)))
+            .map(|&oid| anyhow::Ok((read_tree_entries(src, oid)?.len(), oid)))
             .collect::<Result<Vec<_>, _>>()?;
         sized.sort();
         roots = sized
@@ -507,13 +508,13 @@ pub fn search_candidates(
             .collect();
     }
 
-    intersect_walk(repo, &roots, "", &mut results)?;
+    intersect_walk(src, &roots, "", &mut results)?;
     Ok(results)
 }
 
 /// Emit every file path present in ALL of the mirror trees `roots`.
 fn intersect_walk(
-    repo: &git2::Repository,
+    src: &dyn Objects,
     roots: &[git2::Oid],
     prefix: &str,
     out: &mut Vec<String>,
@@ -521,54 +522,86 @@ fn intersect_walk(
     // Content addressing fast path: identical mirrors (trigrams with the same file set)
     // intersect to themselves.
     if roots.iter().all(|oid| *oid == roots[0]) {
-        return collect_paths(repo, roots[0], prefix, out);
+        return collect_paths(src, roots[0], prefix, out);
     }
 
     let trees = roots
         .iter()
-        .map(|oid| repo.find_tree(*oid))
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(|oid| read_tree_entries(src, *oid))
+        .collect::<anyhow::Result<Vec<_>>>()?;
     let smallest = trees
         .iter()
         .min_by_key(|t| t.len())
         .expect("roots is never empty");
 
-    'entry: for entry in smallest.iter() {
-        let name = entry.name()?;
+    'entry: for entry in smallest {
+        let name = std::str::from_utf8(&entry.filename)?;
 
         let mut child_roots = Vec::with_capacity(trees.len());
         for tree in &trees {
-            match tree.get_name(name) {
-                Some(other) if other.kind() == entry.kind() => child_roots.push(other.id()),
+            match tree.iter().find(|e| e.filename == entry.filename) {
+                Some(other) if other.mode.is_tree() == entry.mode.is_tree() => {
+                    child_roots.push(to_git2(other.oid))
+                }
                 _ => continue 'entry,
             }
         }
 
         let path = join_path(prefix, name);
-        match entry.kind() {
-            Some(git2::ObjectType::Tree) => intersect_walk(repo, &child_roots, &path, out)?,
-            Some(git2::ObjectType::Blob) => out.push(path),
-            _ => {}
+        if entry.mode.is_tree() {
+            intersect_walk(src, &child_roots, &path, out)?;
+        } else if !entry.mode.is_commit() {
+            out.push(path);
         }
     }
     Ok(())
 }
 
+/// The entries of the tree `oid`, owned so several trees can be walked side by side.
+fn read_tree_entries(
+    src: &dyn Objects,
+    oid: git2::Oid,
+) -> anyhow::Result<Vec<gix_object::tree::Entry>> {
+    let mut buffer = Vec::new();
+    let data = src
+        .try_find(&to_gix(oid), &mut buffer)
+        .map_err(|e| anyhow::anyhow!("read tree {}: {}", oid, e))?
+        .ok_or_else(|| anyhow::anyhow!("object {} not found", oid))?;
+    if data.kind != gix_object::Kind::Tree {
+        return Err(anyhow::anyhow!("object {} is not a tree", oid));
+    }
+    Ok(
+        gix_object::TreeRef::from_bytes(&buffer, gix_hash::Kind::Sha1)?
+            .into_owned()
+            .entries,
+    )
+}
+
 /// Emit every blob path under `oid` (a tree), prefixed with `prefix`.
 fn collect_paths(
-    repo: &git2::Repository,
+    src: &dyn Objects,
     oid: git2::Oid,
     prefix: &str,
     out: &mut Vec<String>,
 ) -> anyhow::Result<()> {
-    let tree = repo.find_tree(oid)?;
-    for entry in tree.iter() {
-        let name = entry.name()?;
+    let mut buffer = Vec::new();
+    let Some(data) = src
+        .try_find(&to_gix(oid), &mut buffer)
+        .map_err(|e| anyhow::anyhow!("read tree {}: {}", oid, e))?
+    else {
+        return Ok(());
+    };
+    if data.kind != gix_object::Kind::Tree {
+        return Ok(());
+    }
+    let tree = gix_object::TreeRef::from_bytes(&buffer, gix_hash::Kind::Sha1)?.into_owned();
+    for entry in tree.entries {
+        let name = std::str::from_utf8(&entry.filename)?;
         let path = join_path(prefix, name);
-        match entry.kind() {
-            Some(git2::ObjectType::Tree) => collect_paths(repo, entry.id(), &path, out)?,
-            Some(git2::ObjectType::Blob) => out.push(path),
-            _ => {}
+        if entry.mode.is_tree() {
+            collect_paths(src, to_git2(entry.oid), &path, out)?;
+        } else if !entry.mode.is_commit() {
+            out.push(path);
         }
     }
     Ok(())
@@ -585,15 +618,15 @@ fn join_path(prefix: &str, name: &str) -> String {
 type SearchMatchesResult = Vec<(String, Vec<(usize, String)>)>;
 
 pub fn search_matches(
-    repo: &git2::Repository,
-    tree: &git2::Tree,
+    src: &dyn Objects,
+    tree: git2::Oid,
     searchstring: &str,
     candidates: &Vec<String>,
 ) -> anyhow::Result<SearchMatchesResult> {
     let mut results = vec![];
 
     for c in candidates {
-        let b = get_blob_path(repo, tree, std::path::Path::new(&c));
+        let b = get_blob_path(src, tree, std::path::Path::new(&c));
 
         let mut bresults = vec![];
 
@@ -611,25 +644,44 @@ pub fn search_matches(
     Ok(results)
 }
 
-/// Like [`get_blob`], but for a (possibly nested) path instead of a root entry name.
-fn get_blob_path(repo: &git2::Repository, tree: &git2::Tree, path: &std::path::Path) -> String {
-    let Ok(entry) = tree.get_path(path) else {
-        return "".to_owned();
-    };
-
-    let Ok(blob) = repo.find_blob(entry.id()) else {
-        return "".to_owned();
-    };
-
-    if blob.is_binary() {
-        return "".to_owned();
+/// Like [`read_blob_text`], but for a path inside `tree`.
+fn get_blob_path(src: &dyn Objects, tree: git2::Oid, path: &std::path::Path) -> String {
+    match path_entry(src, tree, path) {
+        Ok(Some(oid)) => read_blob_text(src, to_gix(oid)),
+        _ => "".to_owned(),
     }
+}
 
-    let Ok(content) = std::str::from_utf8(blob.content()) else {
-        return "".to_owned();
-    };
-
-    content.to_owned()
+/// The oid at `path` inside `tree`, or `None` when any component is missing or not a tree.
+fn path_entry(
+    src: &dyn Objects,
+    tree: git2::Oid,
+    path: &std::path::Path,
+) -> anyhow::Result<Option<git2::Oid>> {
+    let mut current = tree;
+    let mut components = path.components().peekable();
+    while let Some(component) = components.next() {
+        let mut buffer = Vec::new();
+        let Some(data) = src
+            .try_find(&to_gix(current), &mut buffer)
+            .map_err(|e| anyhow::anyhow!("read tree {}: {}", current, e))?
+        else {
+            return Ok(None);
+        };
+        if data.kind != gix_object::Kind::Tree {
+            return Ok(None);
+        }
+        let parsed = gix_object::TreeRef::from_bytes(&buffer, gix_hash::Kind::Sha1)?;
+        let name = std::os::unix::ffi::OsStrExt::as_bytes(component.as_os_str());
+        let Some(entry) = parsed.entries.iter().find(|e| e.filename == name) else {
+            return Ok(None);
+        };
+        current = to_git2(entry.oid.to_owned());
+        if components.peek().is_some() && !entry.mode.is_tree() {
+            return Ok(None);
+        }
+    }
+    Ok(Some(current))
 }
 
 #[cfg(test)]
@@ -682,6 +734,11 @@ mod tests {
         (tmp, repo)
     }
 
+    /// Object access over a test repository's odb.
+    fn objects(repo: &git2::Repository) -> josh_gix_ext::Git2Odb<'_> {
+        josh_gix_ext::Git2Odb(Box::leak(Box::new(repo.odb().unwrap())))
+    }
+
     fn commit_tree<'a>(repo: &'a git2::Repository, files: &[(&str, &str)]) -> git2::Tree<'a> {
         let mut builder = git2::build::TreeUpdateBuilder::new();
         for (path, content) in files {
@@ -709,44 +766,51 @@ mod tests {
             ],
         );
 
-        let index = trigram_index(&repo, &cache, &mut Indexer::default(), tree.clone()).unwrap();
+        let index =
+            trigram_index(&objects(&repo), &cache, &mut Indexer::default(), tree.id()).unwrap();
 
         // The index format is pinned: cached indexes of older josh versions stay valid only as
         // long as this oid does not change.
         assert_eq!(
-            index.id().to_string(),
+            index.to_string(),
             "169f9d05072eb25e1f1e90b4f7f11f6cfc2d3222"
         );
 
         // "Tes" folds to "tes", which lives at 74/65/73 in the hex spine.
         assert!(
-            index
-                .get_path(std::path::Path::new("74/65/73/sub1/file1"))
-                .is_ok()
+            path_entry(
+                &objects(&repo),
+                index,
+                std::path::Path::new("74/65/73/sub1/file1")
+            )
+            .unwrap()
+            .is_some()
         );
 
-        let candidates = search_candidates(&repo, &index, &tree, "document").unwrap();
+        let candidates = search_candidates(&objects(&repo), index, tree.id(), "document").unwrap();
         assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
 
         // Trigrams are case-folded, so candidates are a case-insensitive superset ("Test" in
         // file1 makes it a candidate for "test") while match verification stays byte-exact.
-        let candidates = search_candidates(&repo, &index, &tree, "test").unwrap();
+        let candidates = search_candidates(&objects(&repo), index, tree.id(), "test").unwrap();
         assert_eq!(candidates, vec!["sub1/file1"]);
-        let matches = search_matches(&repo, &tree, "test", &candidates).unwrap();
+        let matches = search_matches(&objects(&repo), tree.id(), "test", &candidates).unwrap();
         assert!(matches.is_empty());
 
-        let candidates = search_candidates(&repo, &index, &tree, "missingword").unwrap();
+        let candidates =
+            search_candidates(&objects(&repo), index, tree.id(), "missingword").unwrap();
         assert!(candidates.is_empty());
 
         // Short query: every file is a candidate.
-        let candidates = search_candidates(&repo, &index, &tree, "e").unwrap();
+        let candidates = search_candidates(&objects(&repo), index, tree.id(), "e").unwrap();
         assert_eq!(candidates.len(), 3);
 
         // Indexing is deterministic and memoization-independent: a cold rebuild of the same
         // tree yields the same oid.
         let cold = MapCache::default();
-        let index2 = trigram_index(&repo, &cold, &mut Indexer::default(), tree).unwrap();
-        assert_eq!(index.id(), index2.id());
+        let index2 =
+            trigram_index(&objects(&repo), &cold, &mut Indexer::default(), tree.id()).unwrap();
+        assert_eq!(index, index2);
     }
 
     #[test]
@@ -766,7 +830,7 @@ mod tests {
                 ("sub2/mod", "alpha beta gamma"),
             ],
         );
-        trigram_index(&repo, &cache, &mut indexer, tree_a).unwrap();
+        trigram_index(&objects(&repo), &cache, &mut indexer, tree_a.id()).unwrap();
 
         // One file modified, one removed (its unique trigrams must vanish from the spine), one
         // added in a fresh directory.
@@ -778,7 +842,7 @@ mod tests {
                 ("sub3/new", "fresh addition here"),
             ],
         );
-        let index_b = trigram_index(&repo, &cache, &mut indexer, tree_b.clone()).unwrap();
+        let index_b = trigram_index(&objects(&repo), &cache, &mut indexer, tree_b.id()).unwrap();
 
         // Every subtree is memoized, including the fresh one — incrementality has no special
         // path that could skip it.
@@ -788,15 +852,15 @@ mod tests {
         // Warm (incremental) and cold-built indexes agree bit for bit.
         let cold = MapCache::default();
         let index_b_cold =
-            trigram_index(&repo, &cold, &mut Indexer::default(), tree_b.clone()).unwrap();
-        assert_eq!(index_b.id(), index_b_cold.id());
+            trigram_index(&objects(&repo), &cold, &mut Indexer::default(), tree_b.id()).unwrap();
+        assert_eq!(index_b, index_b_cold);
 
         // The incremental index searches correctly.
-        let hits = search_candidates(&repo, &index_b, &tree_b, "delta").unwrap();
+        let hits = search_candidates(&objects(&repo), index_b, tree_b.id(), "delta").unwrap();
         assert_eq!(hits, vec!["sub2/mod"]);
-        let hits = search_candidates(&repo, &index_b, &tree_b, "zebra").unwrap();
+        let hits = search_candidates(&objects(&repo), index_b, tree_b.id(), "zebra").unwrap();
         assert!(hits.is_empty());
-        let hits = search_candidates(&repo, &index_b, &tree_b, "addition").unwrap();
+        let hits = search_candidates(&objects(&repo), index_b, tree_b.id(), "addition").unwrap();
         assert_eq!(hits, vec!["sub3/new"]);
     }
 }


### PR DESCRIPTION
Port persist, josh-search, josh-compose and the cache backend onto the facade

Filter persistence reads its trees and blobs through an object source,
so `from_tree` no longer needs a repository handle and `as_tree` takes
only the store it writes to.

josh-search takes an object source as well: `trigram_index`,
`search_candidates` and `search_matches` are oid-in, oid-out, which
retires the bridges their callers kept in josh-core, josh-graphql and
josh-cli.

josh-compose reads workspace metadata, image contexts and tar archives
through the transaction facade.

The distributed cache backend gets a facade over its own store. Shard
trees are built with a gix tree editor and entries are looked up with
`TreeRefIter::lookup_entry`. Resolving the shard refs stays on git2.

Change: persist-search-compose-facade
Assisted-By: anthropic/claude-fable-5