### PR TITLE
Merge trees and commits through the object source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,6 +1891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-bitmap"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd1d118d0f5d88b96e6f6e13b566475fef4797ead4a02c26fed36c1375066f7"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
 name = "gix-chunk"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,8 +1986,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fee7d89a3c507491cdfc57a1d1e0e300214720b4f7709ebc253e422f99822bfc"
 dependencies = [
  "bstr",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
  "gix-hash",
+ "gix-imara-diff",
  "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
  "thiserror 2.0.19",
 ]
 
@@ -2095,6 +2113,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-ignore"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cff8e8aa125e39377456073e63df3334d9e5741372ddcc226198015076dda2"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
+dependencies = [
+ "bstr",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5009c4e7e9f9b4cfaaab1153e49133eb04d79c015b5702d6c3d2ab94271a89c6"
+dependencies = [
+ "bitflags 2.13.1",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.17.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "gix-lock"
 version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2171,32 @@ checksum = "d4c69157820343bf1c6e4b88b9808e920900de02e18aaf5862b30ada43814848"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7b2e202fa474a3dd0bbd551be35adf199be0bf5c925fd7707fff2fdb520f651"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "nonempty",
  "thiserror 2.0.19",
 ]
 
@@ -2355,6 +2450,7 @@ version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b675b920bd5a61d17ad542772f03ec34c60feb8ff683e1560c03ae967363731e"
 dependencies = [
+ "dashmap",
  "gix-fs",
  "libc",
  "parking_lot 0.12.5",
@@ -2433,6 +2529,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a034e84d1e04e1b1f20f51f12491da230b6ac8b925d0c8e1b89bcd87a7c5ccc"
 dependencies = [
  "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31eb8e675122e83585e461fe28f68ff8c5ed55b49017b697e7e76423ff973424"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
 ]
 
 [[package]]
@@ -3484,9 +3598,16 @@ dependencies = [
  "anyhow",
  "git2",
  "gix-actor",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-glob",
  "gix-hash",
+ "gix-merge",
  "gix-object",
  "gix-revision",
+ "gix-revwalk",
+ "gix-worktree",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,13 @@ gix-hash = { version = "^0.26", features = ["sha1"] }
 gix-object = "0.63.0"
 gix-odb = "0.83"
 gix-pack = { version = "0.73", features = ["sha1"] }
+gix-command = "0.9.1"
+gix-diff = { version = "0.66.0", default-features = false, features = ["blob"] }
+gix-filter = "0.33.0"
+gix-glob = "0.27.0"
+gix-merge = { version = "0.19.0", default-features = false, features = ["sha1"] }
+gix-revwalk = "0.34.0"
+gix-worktree = { version = "0.55.0", default-features = false, features = ["attributes"] }
 gix-revision = { version = "0.48.0", default-features = false, features = ["merge_base"] }
 gix-zlib = "0.1"
 gix-config = "0.59.0"

--- a/josh-cli/src/commands/pull.rs
+++ b/josh-cli/src/commands/pull.rs
@@ -254,47 +254,45 @@ fn upstream_change_ids(
 /// Cherry-pick `commits` (oldest first) on top of `tip`, in memory.
 /// Bails out on conflicts without writing any refs.
 fn restack_commits(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     tip: git2::Oid,
     commits: &[git2::Oid],
 ) -> anyhow::Result<(git2::Oid, usize)> {
-    let mut acc = repo.find_commit(tip)?;
+    use josh_core::objects::CommitData;
+
+    let odb = transaction.odb()?;
+    let mut acc = CommitData::read(&odb, tip)?;
     let mut kept = 0usize;
 
     for &oid in commits {
-        let commit = repo.find_commit(oid)?;
+        let commit = CommitData::read(&odb, oid)?;
         let parent = commit
-            .parent(0)
+            .first_parent_id()
             .with_context(|| format!("cannot restack root commit {}", short_oid(oid)))?;
+        let parent_tree = CommitData::read(&odb, parent)?.tree_id()?;
 
-        let mut index = repo.merge_trees(&parent.tree()?, &acc.tree()?, &commit.tree()?, None)?;
-
-        if index.has_conflicts() {
-            anyhow::bail!(
-                "conflict while restacking change commit {} onto upstream; resolve manually",
-                short_oid(oid)
-            );
-        }
-
-        let tree_oid = index.write_tree_to(repo)?;
-        if tree_oid == acc.tree_id() {
+        let tree_oid =
+            josh_core::objects::merge_trees(&odb, parent_tree, acc.tree_id()?, commit.tree_id()?)
+                .with_context(|| {
+                format!(
+                    "conflict while restacking change commit {} onto upstream; resolve manually",
+                    short_oid(oid)
+                )
+            })?;
+        if tree_oid == acc.tree_id()? {
             // The change became empty on top of the new base (e.g. its content
             // already landed upstream without a matching Change-Id).
             continue;
         }
 
-        // PORT: the rebased tree comes out of a libgit2 index merge, so this commit
-        // stays on the repository handle with it.
-        let tree = repo.find_tree(tree_oid)?;
-        let new_oid = repo.commit(
-            None,
-            &commit.author(),
-            &commit.committer(),
-            commit.message().unwrap_or_default(),
-            &tree,
-            &[&acc],
+        let new_oid = josh_core::objects::write_commit_with_signatures_of(
+            &odb,
+            &commit,
+            tree_oid,
+            &[acc.id()],
+            std::str::from_utf8(commit.message_raw()?).unwrap_or_default(),
         )?;
-        acc = repo.find_commit(new_oid)?;
+        acc = CommitData::read(&odb, new_oid)?;
         kept += 1;
     }
 
@@ -351,7 +349,7 @@ pub fn integrate(
         return Ok(IntegrateReport::UpToDate);
     }
 
-    let merge_base = repo.merge_base(old, new)?;
+    let merge_base = josh_core::objects::merge_base(&transaction.odb()?, old, new)?;
 
     // Upstream is already contained in the local branch: nothing to integrate.
     if merge_base == new {
@@ -401,7 +399,7 @@ pub fn integrate(
         if remaining.is_empty() {
             (new, IntegrateReport::Rewound { branch, skipped })
         } else {
-            let (tip, kept) = restack_commits(repo, new, &remaining)?;
+            let (tip, kept) = restack_commits(transaction, new, &remaining)?;
             (
                 tip,
                 IntegrateReport::Restacked {

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -188,19 +188,17 @@ fn prepare_push(
                 "--merge requires --base=<ref> or an existing destination ref"
             ));
         }
-        let base_commit = repo.find_commit(original_target)?;
-        let backward_commit = repo.find_commit(unfiltered_oid)?;
-        let merged_tree = repo
-            .merge_commits(&base_commit, &backward_commit, None)?
-            .write_tree_to(repo)?;
+        let odb = transaction.odb()?;
+        let merged_tree =
+            josh_core::objects::merge_commits(&odb, original_target, unfiltered_oid, None)?;
         let signature = josh_core::git::josh_commit_signature()?;
-        repo.commit(
-            None,
+        josh_core::objects::write_commit(
+            &odb,
+            merged_tree,
+            &[original_target, unfiltered_oid],
             &signature,
             &signature,
             &format!("Merge from {}", josh_core::filter::pretty(filter, 0)),
-            &repo.find_tree(merged_tree)?,
-            &[&base_commit, &backward_commit],
         )?
     } else {
         unfiltered_oid

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -400,8 +400,14 @@ impl GithubSyncCtx<'_> {
             let base = match parse_changes_target(&pr.head_ref_name)
                 .and_then(|t| self.target_branch_shas.get(&t))
             {
-                Some(tip) => self.repo.merge_base(*tip, pr_head.id())?,
-                None => self.repo.merge_base(target.id(), pr_head.id())?,
+                Some(tip) => {
+                    josh_core::objects::merge_base(&self.transaction.odb()?, *tip, pr_head.id())?
+                }
+                None => josh_core::objects::merge_base(
+                    &self.transaction.odb()?,
+                    target.id(),
+                    pr_head.id(),
+                )?,
             };
             change.set_base(base);
             change

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2556,14 +2556,7 @@ fn cached_merge_trees(
     if let Some(hit) = transaction.get_merge_trees(key) {
         return Ok(hit);
     }
-    // PORT: libgit2-internal merge compute -- the find_tree bridges read and
-    // `write_tree_to` writes possibly-unflushed objects through the registered backend.
-    let repo = transaction.repo();
-    let tree_a = repo.find_tree(a)?;
-    let tree_b = repo.find_tree(b)?;
-    let tree_c = repo.find_tree(c)?;
-    let mut index = repo.merge_trees(&tree_a, &tree_b, &tree_c, None)?;
-    let oid = index.write_tree_to(repo)?;
+    let oid = objects::merge_trees(&transaction.odb()?, a, b, c)?;
     transaction.insert_merge_trees(key, oid);
     Ok(oid)
 }

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -622,20 +622,12 @@ pub fn unapply_filter(
                     // If our assumption was correct and all conflicts were in filtered files,
                     // both resulting trees will be the same and we can pick the result to proceed.
 
-                    // PORT: libgit2-internal merge compute -- the find_commit bridges and
-                    // `write_tree_to` move possibly-unflushed objects through the
-                    // registered backend.
-                    let parent0 = transaction.repo().find_commit(original_parents[0].id())?;
-                    let parent1 = transaction.repo().find_commit(original_parents[1].id())?;
-
-                    let mut mergeopts = git2::MergeOptions::new();
-                    mergeopts.file_favor(git2::FileFavor::Ours);
-
-                    let mut merged_index =
-                        transaction
-                            .repo()
-                            .merge_commits(&parent0, &parent1, Some(&mergeopts))?;
-                    let base_tree = merged_index.write_tree_to(transaction.repo())?;
+                    let base_tree = objects::merge_commits(
+                        &odb,
+                        original_parents[0].id(),
+                        original_parents[1].id(),
+                        Some(objects::merge::Favor::Ours),
+                    )?;
                     // The base is a merge of both original parents; resolve any `:rev(...)` cutoff
                     // against the first parent (mirrors the descendant-pick preference above).
                     let tid_ours = filter::unapply(
@@ -646,13 +638,12 @@ pub fn unapply_filter(
                         Some((module_commit.id(), original_parents[0].id())),
                     )?;
 
-                    mergeopts.file_favor(git2::FileFavor::Theirs);
-
-                    let mut merged_index =
-                        transaction
-                            .repo()
-                            .merge_commits(&parent0, &parent1, Some(&mergeopts))?;
-                    let base_tree = merged_index.write_tree_to(transaction.repo())?;
+                    let base_tree = objects::merge_commits(
+                        &odb,
+                        original_parents[0].id(),
+                        original_parents[1].id(),
+                        Some(objects::merge::Favor::Theirs),
+                    )?;
                     let tid_theirs = filter::unapply(
                         transaction,
                         filter,

--- a/josh-gix-ext/Cargo.toml
+++ b/josh-gix-ext/Cargo.toml
@@ -14,6 +14,13 @@ anyhow.workspace = true
 git2.workspace = true
 gix-actor.workspace = true
 gix-hash.workspace = true
+gix-command.workspace = true
+gix-diff.workspace = true
+gix-filter.workspace = true
+gix-glob.workspace = true
+gix-merge.workspace = true
+gix-revwalk.workspace = true
+gix-worktree.workspace = true
 gix-object.workspace = true
 gix-revision.workspace = true
 

--- a/josh-gix-ext/src/graph.rs
+++ b/josh-gix-ext/src/graph.rs
@@ -45,6 +45,22 @@ pub fn is_descendant_of(
     Ok(bases.is_some_and(|bases| bases.iter().any(|base| *base == ancestor)))
 }
 
+/// The best common ancestor of `a` and `b`, erroring when they share no history. With
+/// several equally good candidates the choice among them is arbitrary.
+pub fn merge_base(
+    objects: &impl gix_object::Find,
+    a: git2::Oid,
+    b: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    ensure_commit(objects, a)?;
+    ensure_commit(objects, b)?;
+    let mut graph = gix_revision::Graph::new(objects, None);
+    gix_revision::merge_base(gix_oid(a), &[gix_oid(b)], &mut graph)
+        .map_err(|e| anyhow::anyhow!("merge_base: {e}"))?
+        .map(|bases| git2_oid(bases.first()))
+        .ok_or_else(|| anyhow::anyhow!("{a} and {b} share no history"))
+}
+
 /// The best common ancestor of every commit in `commits`, or `None` when they do not all
 /// share history.
 pub fn merge_base_octopus(
@@ -170,6 +186,23 @@ mod tests {
             merge_base_octopus(&objects, &[c, b, unrelated]).unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn merge_base_is_the_join_of_two_lineages() {
+        let t = TestRepo::new();
+        let root = t.commit(1000, &[]);
+        let a = t.commit(1001, &[root]);
+        let b = t.commit(1002, &[root]);
+        let odb = t.repo.odb().unwrap();
+        let objects = crate::Git2Odb(&odb);
+
+        assert_eq!(merge_base(&objects, a, b).unwrap(), root);
+        assert_eq!(merge_base(&objects, a, root).unwrap(), root);
+        assert_eq!(merge_base(&objects, a, a).unwrap(), a);
+
+        let unrelated = t.commit(1003, &[]);
+        assert!(merge_base(&objects, a, unrelated).is_err());
     }
 
     #[test]

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -24,9 +24,11 @@ use std::collections::HashMap;
 use gix_object::WriteTo;
 
 pub mod graph;
+pub mod merge;
 pub mod revwalk;
 
-pub use graph::{is_descendant_of, merge_base_octopus};
+pub use graph::{is_descendant_of, merge_base, merge_base_octopus};
+pub use merge::{merge_commits, merge_trees};
 pub use revwalk::{RangeWalk, RevWalk};
 
 /// Map the kind of a raw object between the two libraries. Infallible: both enums cover exactly

--- a/josh-gix-ext/src/merge.rs
+++ b/josh-gix-ext/src/merge.rs
@@ -1,0 +1,317 @@
+//! Three-way merges over an object source, so the merge reads and writes the same objects as
+//! the rest of a transaction -- including the trees it has not written out yet.
+//!
+//! josh merges bare trees: there is no worktree to read from, no attributes to consult and no
+//! external merge drivers to run, so the platforms below are the empty configuration of each.
+
+use crate::{git2_oid, gix_oid};
+
+/// Which side wins a conflicting hunk.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Favor {
+    Ours,
+    Theirs,
+}
+
+/// The scratch state a merge needs. Cheap to build and not worth caching: the merges josh
+/// runs are per-push, not per-commit.
+struct Platforms {
+    diff: gix_diff::blob::Platform,
+    blob: gix_merge::blob::Platform,
+}
+
+fn attributes() -> gix_worktree::Stack {
+    // No worktree root and no id mappings, so every attribute lookup misses and nothing
+    // touches the filesystem.
+    gix_worktree::Stack::new(
+        std::path::PathBuf::new(),
+        gix_worktree::stack::State::AttributesStack(gix_worktree::stack::state::Attributes::new(
+            Default::default(),
+            None,
+            gix_worktree::stack::state::attributes::Source::IdMapping,
+            Default::default(),
+        )),
+        gix_glob::pattern::Case::Sensitive,
+        Vec::new(),
+        Vec::new(),
+    )
+}
+
+fn platforms() -> Platforms {
+    let filter = || gix_filter::Pipeline::new(Default::default(), Default::default());
+    Platforms {
+        diff: gix_diff::blob::Platform::new(
+            Default::default(),
+            gix_diff::blob::Pipeline::new(
+                Default::default(),
+                filter(),
+                Vec::new(),
+                Default::default(),
+            ),
+            gix_diff::blob::pipeline::Mode::ToGit,
+            attributes(),
+        ),
+        blob: gix_merge::blob::Platform::new(
+            gix_merge::blob::Pipeline::new(Default::default(), filter(), Default::default()),
+            gix_merge::blob::pipeline::Mode::ToGit,
+            attributes(),
+            Vec::new(),
+            Default::default(),
+        ),
+    }
+}
+
+fn options(favor: Option<Favor>) -> gix_merge::tree::Options {
+    use gix_merge::blob::builtin_driver::{binary, text};
+    let (conflict, binary_conflict) = match favor {
+        None => (
+            text::Conflict::Keep {
+                style: Default::default(),
+                marker_size: text::Conflict::DEFAULT_MARKER_SIZE
+                    .try_into()
+                    .expect("non-zero"),
+            },
+            None,
+        ),
+        Some(Favor::Ours) => (
+            text::Conflict::ResolveWithOurs,
+            Some(binary::ResolveWith::Ours),
+        ),
+        Some(Favor::Theirs) => (
+            text::Conflict::ResolveWithTheirs,
+            Some(binary::ResolveWith::Theirs),
+        ),
+    };
+    gix_merge::tree::Options {
+        rewrites: Some(Default::default()),
+        blob_merge: gix_merge::blob::platform::merge::Options {
+            is_virtual_ancestor: false,
+            resolve_binary_with: binary_conflict,
+            text: text::Options {
+                diff_algorithm: gix_diff::blob::Algorithm::Histogram,
+                conflict,
+            },
+        },
+        blob_merge_command_ctx: Default::default(),
+        fail_on_conflict: None,
+        marker_size_multiplier: 0,
+        symlink_conflicts: None,
+        tree_conflicts: None,
+    }
+}
+
+/// Turn a merge result into the tree it produced, erroring on anything git would call a
+/// conflict. A side preference resolves conflicting content, so what remains unresolved are
+/// the conflicts no side preference can decide (a path deleted on one side and modified on
+/// the other, say).
+fn write_result(
+    objects: &impl gix_object::Write,
+    mut outcome: gix_merge::tree::Outcome<'_>,
+    labels: (git2::Oid, git2::Oid),
+) -> anyhow::Result<git2::Oid> {
+    let unresolved = gix_merge::tree::TreatAsUnresolved::default();
+    if outcome.has_unresolved_conflicts(unresolved) {
+        let paths: Vec<_> = outcome
+            .conflicts
+            .iter()
+            .filter(|c| c.is_unresolved(unresolved))
+            .map(|c| c.ours.location().to_string())
+            .collect();
+        return Err(anyhow::anyhow!(
+            "merge of {} and {} conflicts in {}",
+            labels.0,
+            labels.1,
+            paths.join(", ")
+        ));
+    }
+    let id = outcome
+        .tree
+        .write(|tree| gix_object::Write::write(objects, tree))
+        .map_err(|e| anyhow::anyhow!("writing merge result: {e}"))?;
+    Ok(git2_oid(&id))
+}
+
+/// Merge `ours` and `theirs` against their common ancestor `base`, all trees.
+pub fn merge_trees(
+    objects: &(impl gix_object::FindObjectOrHeader + gix_object::Write),
+    base: git2::Oid,
+    ours: git2::Oid,
+    theirs: git2::Oid,
+) -> anyhow::Result<git2::Oid> {
+    let mut platforms = platforms();
+    let outcome = gix_merge::tree(
+        &gix_oid(base),
+        &gix_oid(ours),
+        &gix_oid(theirs),
+        gix_merge::blob::builtin_driver::text::Labels::default(),
+        objects,
+        |buf| gix_object::Write::write_buf(objects, gix_object::Kind::Blob, buf),
+        &mut gix_diff::tree::State::default(),
+        &mut platforms.diff,
+        &mut platforms.blob,
+        options(None),
+    )?;
+    write_result(objects, outcome, (ours, theirs))
+}
+
+/// Merge two commits, finding their merge base the way git does -- several equally good bases
+/// are merged into a virtual one first. A `favor` decides conflicting hunks, leaving only the
+/// conflicts no side preference can resolve.
+pub fn merge_commits(
+    objects: &(impl gix_object::FindObjectOrHeader + gix_object::Write),
+    ours: git2::Oid,
+    theirs: git2::Oid,
+    favor: Option<Favor>,
+) -> anyhow::Result<git2::Oid> {
+    let mut platforms = platforms();
+    let mut graph = gix_revwalk::Graph::new(objects, None);
+    let outcome = gix_merge::commit(
+        gix_oid(ours),
+        gix_oid(theirs),
+        gix_merge::blob::builtin_driver::text::Labels::default(),
+        &mut graph,
+        &mut platforms.diff,
+        &mut platforms.blob,
+        objects,
+        &mut |id| id.to_string(),
+        gix_merge::commit::Options {
+            allow_missing_merge_base: true,
+            use_first_merge_base: false,
+            tree_merge: options(favor),
+        },
+    )?;
+    write_result(objects, outcome.tree_merge, (ours, theirs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestRepo {
+        _dir: tempfile::TempDir,
+        repo: git2::Repository,
+    }
+
+    impl TestRepo {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().unwrap();
+            let repo = git2::Repository::init_bare(dir.path()).unwrap();
+            TestRepo { _dir: dir, repo }
+        }
+
+        fn tree(&self, files: &[(&str, &str)]) -> git2::Oid {
+            let mut builder = self.repo.treebuilder(None).unwrap();
+            for (name, content) in files {
+                let blob = self.repo.blob(content.as_bytes()).unwrap();
+                builder.insert(name, blob, 0o100644).unwrap();
+            }
+            builder.write().unwrap()
+        }
+
+        fn commit(&self, tree: git2::Oid, parents: &[git2::Oid]) -> git2::Oid {
+            let sig = git2::Signature::new("Test", "test@example.com", &git2::Time::new(1000, 0))
+                .unwrap();
+            let tree = self.repo.find_tree(tree).unwrap();
+            let parents: Vec<_> = parents
+                .iter()
+                .map(|&p| self.repo.find_commit(p).unwrap())
+                .collect();
+            let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+            self.repo
+                .commit(None, &sig, &sig, "c", &tree, &parent_refs)
+                .unwrap()
+        }
+
+        fn file(&self, tree: git2::Oid, name: &str) -> String {
+            let entry = self
+                .repo
+                .find_tree(tree)
+                .unwrap()
+                .get_name(name)
+                .unwrap_or_else(|| panic!("{name} not in tree"))
+                .id();
+            String::from_utf8(self.repo.find_blob(entry).unwrap().content().to_vec()).unwrap()
+        }
+    }
+
+    /// Edits on different lines of one file merge into a single file holding both, and each
+    /// side's other changes carry over.
+    #[test]
+    fn non_overlapping_edits_merge_cleanly() {
+        let t = TestRepo::new();
+        let base = t.tree(&[("a", "1\n2\n3\n"), ("b", "keep\n")]);
+        let ours = t.tree(&[("a", "one\n2\n3\n"), ("b", "keep\n"), ("new", "ours\n")]);
+        let theirs = t.tree(&[("a", "1\n2\nthree\n"), ("b", "keep\n")]);
+        let odb = t.repo.odb().unwrap();
+        let objects = crate::Git2Odb(&odb);
+
+        let merged = merge_trees(&objects, base, ours, theirs).unwrap();
+
+        assert_eq!(t.file(merged, "a"), "one\n2\nthree\n");
+        assert_eq!(t.file(merged, "b"), "keep\n");
+        assert_eq!(t.file(merged, "new"), "ours\n");
+    }
+
+    #[test]
+    fn overlapping_edits_conflict() {
+        let t = TestRepo::new();
+        let base = t.tree(&[("a", "1\n")]);
+        let ours = t.tree(&[("a", "ours\n")]);
+        let theirs = t.tree(&[("a", "theirs\n")]);
+        let odb = t.repo.odb().unwrap();
+        let objects = crate::Git2Odb(&odb);
+
+        let err = merge_trees(&objects, base, ours, theirs)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("conflicts in a"), "{err}");
+    }
+
+    #[test]
+    fn a_favor_decides_conflicting_content() {
+        let t = TestRepo::new();
+        let base = t.commit(t.tree(&[("a", "1\n")]), &[]);
+        let ours = t.commit(t.tree(&[("a", "ours\n")]), &[base]);
+        let theirs = t.commit(t.tree(&[("a", "theirs\n")]), &[base]);
+        let odb = t.repo.odb().unwrap();
+        let objects = crate::Git2Odb(&odb);
+
+        let merged = merge_commits(&objects, ours, theirs, Some(Favor::Ours)).unwrap();
+        assert_eq!(t.file(merged, "a"), "ours\n");
+
+        let merged = merge_commits(&objects, ours, theirs, Some(Favor::Theirs)).unwrap();
+        assert_eq!(t.file(merged, "a"), "theirs\n");
+    }
+
+    /// The conflicts josh reports are the ones no side preference can decide, which is what
+    /// makes a favored merge fail at all.
+    #[test]
+    fn a_favor_cannot_decide_delete_against_modify() {
+        let t = TestRepo::new();
+        let base = t.commit(t.tree(&[("a", "1\n"), ("b", "1\n")]), &[]);
+        let ours = t.commit(t.tree(&[("b", "1\n")]), &[base]);
+        let theirs = t.commit(t.tree(&[("a", "modified\n"), ("b", "1\n")]), &[base]);
+        let odb = t.repo.odb().unwrap();
+        let objects = crate::Git2Odb(&odb);
+
+        let err = merge_commits(&objects, ours, theirs, Some(Favor::Ours))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("conflicts in a"), "{err}");
+    }
+
+    #[test]
+    fn commits_merge_across_their_common_ancestor() {
+        let t = TestRepo::new();
+        let base = t.commit(t.tree(&[("a", "1\n"), ("b", "1\n")]), &[]);
+        let ours = t.commit(t.tree(&[("a", "2\n"), ("b", "1\n")]), &[base]);
+        let ours = t.commit(t.tree(&[("a", "3\n"), ("b", "1\n")]), &[ours]);
+        let theirs = t.commit(t.tree(&[("a", "1\n"), ("b", "2\n")]), &[base]);
+        let odb = t.repo.odb().unwrap();
+        let objects = crate::Git2Odb(&odb);
+
+        let merged = merge_commits(&objects, ours, theirs, Some(Favor::Ours)).unwrap();
+        assert_eq!(t.file(merged, "a"), "3\n");
+        assert_eq!(t.file(merged, "b"), "2\n");
+    }
+}

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -448,15 +448,15 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
         let oid_to_push = if push_options.merge {
             if let Some(base_commit_id) = transaction_mirror.resolve_ref(&original_target_ref)? {
                 let signature = josh_core::git::josh_commit_signature()?;
-                // PORT: libgit2-internal merge compute over possibly-unflushed commits.
-                let backward_commit = transaction.repo().find_commit(backward_new_oid)?;
-                let base_commit = transaction.repo().find_commit(base_commit_id)?;
-                let merged_tree = transaction
-                    .repo()
-                    .merge_commits(&base_commit, &backward_commit, None)?
-                    .write_tree_to(transaction.repo())?;
+                let odb = transaction.odb()?;
+                let merged_tree = josh_core::objects::merge_commits(
+                    &odb,
+                    base_commit_id,
+                    backward_new_oid,
+                    None,
+                )?;
                 josh_core::objects::write_commit(
-                    &transaction.odb()?,
+                    &odb,
                     merged_tree,
                     &[base_commit_id, backward_new_oid],
                     &signature,


### PR DESCRIPTION
Merge trees and commits through the object source

`merge_trees` and `merge_commits` in josh-gix-ext run gix-merge over an
object source, so a merge reads its inputs and writes its result where
the rest of a transaction can see them. Bare trees mean the blob and
diff platforms are the empty configuration: no worktree, no attributes,
no external drivers. Rename detection stays on.

A merge fails on anything git calls a conflict. `merge_commits` takes an
optional side preference for conflicting hunks, leaving only the
conflicts no preference can decide, such as a path deleted on one side
and modified on the other.

Ported: `unapply_filter`'s ours/theirs merge pair, `cached_merge_trees`,
the `-o merge` push path in josh-proxy and josh-cli, and `josh pull`'s
restack. `merge_base` joins the reachability helpers and takes the two
remaining graph calls in josh-cli.

Change: merge-through-object-source
Assisted-By: anthropic/claude-fable-5