### PR TITLE
Let the bench gates see the objects a filter just produced

### DIFF
--- a/josh-core/benches/deephistory_glob.rs
+++ b/josh-core/benches/deephistory_glob.rs
@@ -175,6 +175,9 @@ impl GlobBench {
             for pattern in [PATTERN_RECURSIVE, PATTERN_PREFIX, PATTERN_LITERAL] {
                 let filter = Filter::new().pattern(pattern).expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
+                // The gate compares against an independent git2 reference model, which only
+                // sees what is on disk.
+                transaction.flush_mem_odb()?;
                 let got = repo.find_commit(filtered)?.tree_id();
                 let (want, kept) = expected_tree(repo, case.head, &glob_pred(pattern))?;
                 anyhow::ensure!(
@@ -469,7 +472,12 @@ fn deephistory_glob(c: &mut Criterion) {
                 .expect("probe commit");
             let filtered =
                 josh_core::filter_commit(&transaction, filter, probe).expect("filter probe");
-            let got = transaction.repo().find_commit(filtered).unwrap().tree_id();
+            // The filtered commit is still buffered, so read it through the transaction's
+            // object source.
+            let got = josh_core::objects::CommitData::read(&transaction.odb().unwrap(), filtered)
+                .unwrap()
+                .tree_id()
+                .unwrap();
             let (want, _) =
                 expected_tree(transaction.repo(), probe, &glob_pred(pattern)).expect("expected");
             assert_eq!(

--- a/josh-core/benches/deephistory_prefix_flush.rs
+++ b/josh-core/benches/deephistory_prefix_flush.rs
@@ -142,13 +142,15 @@ impl PrefixFlushBench {
             let transaction = context.open()?;
             let case = cases.first().expect("at least one case");
             let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
-            let repo = transaction.repo();
-            let nested_tree = repo
-                .find_commit(filtered)?
-                .tree()?
-                .get_path(Path::new(PREFIX))?
-                .id();
-            let raw_tree = repo.find_commit(case.head)?.tree_id();
+            // The filtered commit is still buffered, so read it through the transaction's
+            // object source rather than the repository handle.
+            let odb = transaction.odb()?;
+            let filtered_tree = josh_core::objects::CommitData::read(&odb, filtered)?.tree_id()?;
+            let nested_tree =
+                josh_core::objects::path_entry(&odb, filtered_tree, Path::new(PREFIX))?
+                    .map(|entry| josh_core::objects::git2_oid(&entry.oid))
+                    .ok_or_else(|| anyhow::anyhow!("prefix filter produced no `{PREFIX}` entry"))?;
+            let raw_tree = josh_core::objects::CommitData::read(&odb, case.head)?.tree_id()?;
             anyhow::ensure!(
                 nested_tree == raw_tree,
                 "prefix filter did not nest the tree under `{PREFIX}` -- benchmark would measure \

--- a/josh-core/benches/deephistory_subdir.rs
+++ b/josh-core/benches/deephistory_subdir.rs
@@ -121,6 +121,9 @@ impl SubdirBench {
             let transaction = context.open()?;
             let case = cases.first().expect("at least one case");
             let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
+            // The gate reads the filtered result through the repository handle, which only
+            // sees what is on disk.
+            transaction.flush_mem_odb()?;
             let repo = transaction.repo();
             let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
             let raw_subdir_tree = repo
@@ -304,7 +307,13 @@ fn deephistory_rev(c: &mut Criterion) {
         let rev_head = josh_core::filter_commit(&transaction, rev_filter, case.head).expect("rev");
         let sub_head =
             josh_core::filter_commit(&transaction, bench.filter, case.head).expect("subdir");
-        let tree_of = |oid| transaction.repo().find_commit(oid).unwrap().tree_id();
+        // Both heads are freshly filtered, so read them through the transaction's objects.
+        let tree_of = |oid| {
+            josh_core::objects::CommitData::read(&transaction.odb().unwrap(), oid)
+                .unwrap()
+                .tree_id()
+                .unwrap()
+        };
         assert_eq!(
             tree_of(rev_head),
             tree_of(sub_head),

--- a/josh-core/benches/deephistory_subdir_distributed.rs
+++ b/josh-core/benches/deephistory_subdir_distributed.rs
@@ -111,6 +111,9 @@ impl SubdirBench {
             let transaction = context.open()?;
             let case = cases.last().expect("at least one case");
             let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
+            // The gate reads the filtered result through the repository handle, which only
+            // sees what is on disk.
+            transaction.flush_mem_odb()?;
             let repo = transaction.repo();
             let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
             let raw_subdir_tree = repo

--- a/josh-core/benches/deephistory_subdir_sparse.rs
+++ b/josh-core/benches/deephistory_subdir_sparse.rs
@@ -120,6 +120,9 @@ impl SubdirBench {
             let transaction = context.open()?;
             let case = cases.last().expect("at least one case");
             let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
+            // The gate reads the filtered result through the repository handle, which only
+            // sees what is on disk.
+            transaction.flush_mem_odb()?;
             let repo = transaction.repo();
             let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
             let raw_subdir_tree = repo

--- a/josh-core/benches/refs_filter_update.rs
+++ b/josh-core/benches/refs_filter_update.rs
@@ -130,6 +130,9 @@ impl RefsBench {
             let transaction = context.open()?;
             let case = cases.first().expect("at least one case");
             let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
+            // The gate reads the filtered result through the repository handle, which only
+            // sees what is on disk.
+            transaction.flush_mem_odb()?;
             let repo = transaction.repo();
             let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
             let raw_subdir_tree = repo

--- a/josh-core/benches/ultrawide_pin_hook.rs
+++ b/josh-core/benches/ultrawide_pin_hook.rs
@@ -195,9 +195,14 @@ impl PinBench {
             for case in cases.iter().filter(|c| c.size <= SANITY_GATE_MAX_SIZE) {
                 let per_path = josh_core::filter_commit(&transaction, filter_per_path, case.head)?;
                 let one_tree = josh_core::filter_commit(&transaction, filter_one_tree, case.head)?;
-                let per_path_tree = transaction.repo().find_commit(per_path)?.tree()?.id();
-                let one_tree_tree = transaction.repo().find_commit(one_tree)?.tree()?.id();
-                let raw_tree = transaction.repo().find_commit(case.head)?.tree()?.id();
+                // The filtered commits are still buffered, so read them through the
+                // transaction's object source.
+                let odb = transaction.odb()?;
+                let tree_of =
+                    |oid| josh_core::objects::CommitData::read(&odb, oid).and_then(|c| c.tree_id());
+                let per_path_tree = tree_of(per_path)?;
+                let one_tree_tree = tree_of(one_tree)?;
+                let raw_tree = tree_of(case.head)?;
                 anyhow::ensure!(
                     per_path_tree != raw_tree,
                     "pin had no visible effect for size {} -- benchmark would measure a no-op",

--- a/josh-core/benches/unapply.rs
+++ b/josh-core/benches/unapply.rs
@@ -102,6 +102,9 @@ impl UnapplyBench {
             for &n_commits in HISTORY_SIZES {
                 let head = repo.refname_to_id(&format!("refs/heads/case_{n_commits}"))?;
                 let filtered_head = josh_core::filter_commit(&transaction, filter, head)?;
+                // The first-parent chase below reads the filtered commits through the
+                // repository handle, which only sees what is on disk.
+                transaction.flush_mem_odb()?;
 
                 // First-parent chase to the middle of the filtered history.
                 let mut filtered_mid = filtered_head;

--- a/josh-core/benches/widetree_glob.rs
+++ b/josh-core/benches/widetree_glob.rs
@@ -147,6 +147,9 @@ impl GlobBench {
                     .pattern(PATTERN_RECURSIVE)
                     .expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
+                // The gate compares against an independent git2 reference model, which only
+                // sees what is on disk.
+                transaction.flush_mem_odb()?;
                 let got = repo.find_commit(filtered)?.tree_id();
                 let (want, kept) = expected_tree(repo, case.head, &|p| p.ends_with(".rs"))?;
                 anyhow::ensure!(kept > 0, "recursive gate kept no blobs -- would be a no-op");
@@ -162,6 +165,7 @@ impl GlobBench {
                 // (valid only absent dot-components).
                 let filter = Filter::new().pattern(PATTERN_PREFIX).expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
+                transaction.flush_mem_odb()?;
                 let got_tree = repo.find_commit(filtered)?.tree()?;
                 anyhow::ensure!(
                     got_tree.len() == 1,
@@ -180,6 +184,7 @@ impl GlobBench {
                 // Sparse pattern: keeps exactly the N_SPARSE planted `.toml` blobs.
                 let filter = Filter::new().pattern(PATTERN_SPARSE).expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
+                transaction.flush_mem_odb()?;
                 let got = repo.find_commit(filtered)?.tree_id();
                 let (want, kept) = expected_tree(repo, case.head, &|p| p.ends_with(".toml"))?;
                 anyhow::ensure!(


### PR DESCRIPTION
Let the bench gates see the objects a filter just produced

The correctness gates filter a commit and then inspect the result. The
gates that only need its tree read it through the transaction's object
source; the ones that compare against an independent git2 reference
model -- expected_tree, count_history, unapply's first-parent chase --
flush first, so the model keeps reading git objects rather than josh's
own object layer.

Change: bench-gates-see-filtered-objects
Assisted-By: anthropic/claude-fable-5