### PR TITLE
Move the remaining object reads from git2 to gix_object::Find

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3760,7 +3760,9 @@ dependencies = [
  "allocative",
  "anyhow",
  "git2",
+ "gix-object",
  "josh-filter",
+ "josh-gix-ext",
  "starlark",
 ]
 

--- a/forges/josh-github-changes/src/ids.rs
+++ b/forges/josh-github-changes/src/ids.rs
@@ -16,7 +16,7 @@ pub fn store_github_id(
     github_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let blob_oid = transaction.repo().blob(github_id.as_bytes())?;
+    let blob_oid = josh_core::objects::write_blob(&transaction.odb()?, github_id.as_bytes())?;
     let path = std::path::Path::new("gh_ids")
         .join(encode_change_id_path(change_id))
         .join(local_hash);
@@ -47,7 +47,7 @@ pub fn store_github_vote_id(
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let json = serde_json::to_string(vote_data)?;
-    let blob_oid = transaction.repo().blob(json.as_bytes())?;
+    let blob_oid = josh_core::objects::write_blob(&transaction.odb()?, json.as_bytes())?;
     let path = std::path::Path::new("gh_vote_ids")
         .join(encode_change_id_path(change_id))
         .join(user);

--- a/forges/josh-github-changes/src/prs.rs
+++ b/forges/josh-github-changes/src/prs.rs
@@ -64,8 +64,12 @@ pub fn collect_pr_infos(
                 entry.head_oid?,
                 entry.base_oid?,
             );
-            let commit = transaction.repo().find_commit(head_oid).ok()?;
-            let raw_message = commit.message().unwrap_or("");
+            let odb = transaction.odb().ok()?;
+            let commit = josh_core::objects::CommitData::read(&odb, head_oid).ok()?;
+            let raw_message = commit
+                .message()
+                .ok()
+                .and_then(|m| std::str::from_utf8(m).ok())?;
             let message = raw_message.trim_end();
             let title = message.lines().next().unwrap_or("").trim().to_string();
             let title = if title.is_empty() {

--- a/josh-changes/src/forges/gerrit.rs
+++ b/josh-changes/src/forges/gerrit.rs
@@ -168,7 +168,7 @@ pub fn build_gerrit_independent_push(
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<Vec<PushRef>> {
-    let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let changes = get_changes(transaction, tip, base)?;
     let changes = split_changes(transaction, changes)?;
 
@@ -185,7 +185,9 @@ pub fn build_gerrit_independent_push(
 
         // A change has no dependencies when its split commit sits directly on
         // the target base (nothing else was pulled in below it by `downstack`).
-        let parent = repo.find_commit(change.commit)?.parent_ids().next();
+        let parent = josh_core::objects::CommitData::read(&odb, change.commit)?
+            .parent_ids()
+            .next();
         let has_no_deps = if base == git2::Oid::ZERO_SHA1 {
             parent.is_none()
         } else {

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -331,7 +331,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
         let r = repo.revparse_single(&input_ref)?;
         let hs = josh_core::housekeeping::find_all_workspaces_and_subdirectories(
-            &josh_core::objects::Git2Odb(&repo.odb()?),
+            &transaction.odb()?,
             r.peel_to_tree()?.id(),
         )?;
         for i in hs {

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -40,7 +40,7 @@ pub fn handle_list(
     args: &ListArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let scope = args.scope.resolve(transaction)?;
     let changes = josh_changes::list_changes(transaction, &scope)?;
 
@@ -64,14 +64,8 @@ pub fn handle_list(
     let mut rows: Vec<Row> = Vec::with_capacity(changes.len());
     for change in &changes {
         let id = change.id().unwrap_or("<no-change-id>").to_string();
-        let commit = repo.find_commit(change.commit())?;
-        let subject = commit
-            .message()
-            .unwrap_or("")
-            .lines()
-            .next()
-            .unwrap_or("")
-            .to_string();
+        let commit = josh_core::objects::CommitData::read(&odb, change.commit())?;
+        let subject = commit.summary().unwrap_or_default();
 
         let deps_count = change
             .contributing(transaction)
@@ -141,15 +135,15 @@ pub fn handle_show(
     args: &ShowArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let scope = args.scope.resolve(transaction)?;
     let change = resolve_change_by_id(transaction, &scope, &args.change_id)?;
 
-    let commit = repo.find_commit(change.commit())?;
-    let msg = commit.message().unwrap_or("");
-    let subject = msg.lines().next().unwrap_or("");
-    let author = commit.author().email().unwrap_or("").to_string();
-    let date = chrono::DateTime::from_timestamp(commit.time().seconds(), 0)
+    let commit = josh_core::objects::CommitData::read(&odb, change.commit())?;
+    let subject = commit.summary().unwrap_or_default();
+    let parsed = commit.parsed()?;
+    let author = parsed.author()?.email.to_string();
+    let date = chrono::DateTime::from_timestamp(parsed.time()?.seconds, 0)
         .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
         .unwrap_or_default();
 
@@ -186,7 +180,10 @@ pub fn handle_show(
     println!("Subject:   {}", subject);
 
     println!();
-    let files = file_stats(repo, &commit)?;
+    // PORT: the per-file line stats come out of libgit2's patch machinery; the change
+    // commit is behind a ref, so it is on disk.
+    let repo = transaction.repo();
+    let files = file_stats(repo, &repo.find_commit(change.commit())?)?;
     let total_adds: usize = files.iter().map(|f| f.adds).sum();
     let total_dels: usize = files.iter().map(|f| f.dels).sum();
     println!(
@@ -217,7 +214,7 @@ pub fn handle_deps(
     args: &DepsArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
+    let odb = transaction.odb()?;
     let scope = args.scope.resolve(transaction)?;
     let changes = josh_changes::list_changes(transaction, &scope)?;
     let oid_to_change_id = build_oid_to_change_id(&changes);
@@ -240,14 +237,9 @@ pub fn handle_deps(
             Some(d) if d != &args.change_id => d.clone(),
             _ => continue,
         };
-        let subject = repo
-            .find_commit(oid)
+        let subject = josh_core::objects::CommitData::read(&odb, oid)
             .ok()
-            .and_then(|c| {
-                c.message()
-                    .ok()
-                    .map(|m| m.lines().next().unwrap_or("").to_string())
-            })
+            .and_then(|c| c.summary())
             .unwrap_or_default();
         deps.push((dep_id, subject));
     }

--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -298,19 +298,16 @@ fn handle_link_update(
         if filtered_oid == git2::Oid::ZERO_SHA1 {
             vec![]
         } else {
-            let filtered_tree = repo
-                .find_commit(filtered_oid)
+            let odb = transaction.odb()?;
+            let filtered_tree = josh_core::objects::CommitData::read(&odb, filtered_oid)
                 .context("Failed to find filtered commit")?
-                .tree()
+                .tree_id()
                 .context("Failed to get filtered tree")?;
-            josh_core::link::find_link_files(
-                &josh_core::objects::Git2Odb(&repo.odb()?),
-                filtered_tree.id(),
-            )
-            .context("Failed to find link files in filtered tree")?
+            josh_core::link::find_link_files(&odb, filtered_tree)
+                .context("Failed to find link files in filtered tree")?
         }
     } else {
-        josh_core::link::find_link_files(&josh_core::objects::Git2Odb(&repo.odb()?), head_tree.id())
+        josh_core::link::find_link_files(&transaction.odb()?, head_tree.id())
             .context("Failed to find link files")?
     };
 
@@ -397,11 +394,8 @@ fn handle_link_push(
     }
 
     // Find the .link.josh file at the given path
-    let link_files = josh_core::link::find_link_files(
-        &josh_core::objects::Git2Odb(&repo.odb()?),
-        head_tree.id(),
-    )
-    .context("Failed to find link files")?;
+    let link_files = josh_core::link::find_link_files(&transaction.odb()?, head_tree.id())
+        .context("Failed to find link files")?;
 
     let link_path = std::path::PathBuf::from(normalized_path);
     let (_, link_file) = link_files

--- a/josh-cli/src/commands/pull.rs
+++ b/josh-cli/src/commands/pull.rs
@@ -369,8 +369,8 @@ pub fn integrate(
         let mut local_commits = Vec::new();
         for oid in walk {
             let oid = oid?;
-            let commit = repo.find_commit(oid)?;
-            if commit.parent_count() > 1 {
+            let commit = josh_core::objects::CommitData::read(&transaction.odb()?, oid)?;
+            if commit.parent_ids().count() > 1 {
                 anyhow::bail!(
                     "local branch '{}' contains merge commits; cannot integrate automatically",
                     branch

--- a/josh-cli/src/forge/github/changes.rs
+++ b/josh-cli/src/forge/github/changes.rs
@@ -63,7 +63,6 @@ async fn run_sync(
 
     let ctx = GithubSyncCtx {
         transaction,
-        repo,
         api: &api,
         owner,
         repo_name,
@@ -265,7 +264,6 @@ impl SyncStats {
 /// target-branch tips. Per-phase behavior is documented on the methods.
 struct GithubSyncCtx<'a> {
     transaction: &'a josh_core::cache::Transaction,
-    repo: &'a git2::Repository,
     api: &'a GithubApiConnection,
     owner: &'a str,
     repo_name: &'a str,
@@ -283,14 +281,13 @@ impl GithubSyncCtx<'_> {
 
         let head_oid =
             git2::Oid::from_str(&pr.head_oid).map_err(|e| anyhow!("bad head OID: {}", e))?;
-        self.repo
-            .find_commit(head_oid)
+        let odb = self.transaction.odb()?;
+        josh_core::objects::CommitData::read(&odb, head_oid)
             .map_err(|_| anyhow!("head commit {} not available from GitHub", pr.head_oid))?;
 
         let base_oid =
             git2::Oid::from_str(&pr.base_ref_oid).map_err(|e| anyhow!("bad base OID: {}", e))?;
-        self.repo
-            .find_commit(base_oid)
+        josh_core::objects::CommitData::read(&odb, base_oid)
             .map_err(|_| anyhow!("base commit {} not available from GitHub", pr.base_ref_oid))?;
 
         // For stacked changes the base is the merge-base against the ultimate

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -458,8 +458,7 @@ fn get_starlark(
         Ok(rw) => rw.tree_id(),
         Err(_) => return to_filter(Op::Empty),
     };
-    // PORT: josh-starlark reads the filtered tree through the repo handle.
-    match josh_starlark::evaluate(&script, filtered_tree, transaction.repo()) {
+    match josh_starlark::evaluate(&script, filtered_tree, odb) {
         Ok(f) => {
             let star_file = Filter::new().file(star_path);
             compose(&[star_file, subfilter, f])

--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -123,7 +123,7 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
     let trace_s = span!(Level::TRACE, "discover_filter_candidates");
     let _e = trace_s.enter();
 
-    let odb = repo.odb()?;
+    let odb = transaction.odb()?;
     transaction.for_each_ref_prefixed("refs/josh/upstream/", |name, target| {
         if !name.ends_with(".git/HEAD") {
             return Ok(());
@@ -145,7 +145,7 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
             let tree = repo
                 .find_object(target, None)?
                 .peel(git2::ObjectType::Tree)?;
-            let hs = find_all_workspaces_and_subdirectories(&objects::Git2Odb(&odb), tree.id())?;
+            let hs = find_all_workspaces_and_subdirectories(&odb, tree.id())?;
             known_f.0 = target;
             for i in hs {
                 known_f.1.insert(i);

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -71,6 +71,74 @@ pub fn hash_blob(data: &[u8]) -> git2::Oid {
     )
 }
 
+/// The entries of the tree `oid`, owned so several trees can be walked side by side.
+/// Errors when the object is missing or is not a tree.
+pub fn read_tree_entries(
+    src: &(impl gix_object::Find + ?Sized),
+    oid: git2::Oid,
+) -> anyhow::Result<Vec<gix_object::tree::Entry>> {
+    let mut buffer = Vec::new();
+    let data = src
+        .try_find(&gix_oid(oid), &mut buffer)
+        .map_err(|e| anyhow::anyhow!("read tree {}: {}", oid, e))?
+        .ok_or_else(|| anyhow::anyhow!("object {} not found", oid))?;
+    if data.kind != gix_object::Kind::Tree {
+        return Err(anyhow::anyhow!("object {} is not a tree", oid));
+    }
+    Ok(
+        gix_object::TreeRef::from_bytes(&buffer, gix_hash::Kind::Sha1)?
+            .into_owned()
+            .entries,
+    )
+}
+
+/// Descend `path` from the tree `oid`. `None` covers a missing component and a non-tree
+/// entry on the way; the final entry may be of any kind.
+pub fn path_entry(
+    src: &(impl gix_object::Find + ?Sized),
+    oid: git2::Oid,
+    path: &std::path::Path,
+) -> anyhow::Result<Option<gix_object::tree::Entry>> {
+    let mut current = oid;
+    let mut components = path.components().peekable();
+    while let Some(component) = components.next() {
+        let mut buffer = Vec::new();
+        let Some(data) = src
+            .try_find(&gix_oid(current), &mut buffer)
+            .map_err(|e| anyhow::anyhow!("read tree {}: {}", current, e))?
+        else {
+            return Ok(None);
+        };
+        if data.kind != gix_object::Kind::Tree {
+            return Ok(None);
+        }
+        let parsed = gix_object::TreeRef::from_bytes(&buffer, gix_hash::Kind::Sha1)?;
+        let name = std::os::unix::ffi::OsStrExt::as_bytes(component.as_os_str());
+        let Some(entry) = parsed.entries.iter().find(|e| e.filename == name) else {
+            return Ok(None);
+        };
+        if components.peek().is_none() {
+            return Ok(Some((*entry).into()));
+        }
+        current = git2_oid(entry.oid);
+    }
+    Ok(None)
+}
+
+/// The text of the blob `oid`, or `""` when it is missing, is not a blob, holds a NUL byte or
+/// is not valid UTF-8 -- the tolerance the display and script paths want, where a file that
+/// cannot be shown is the same as a file that is not there.
+pub fn blob_text(src: &(impl gix_object::Find + ?Sized), oid: git2::Oid) -> String {
+    let mut buffer = Vec::new();
+    let Ok(Some(data)) = src.try_find(&gix_oid(oid), &mut buffer) else {
+        return String::new();
+    };
+    if data.kind != gix_object::Kind::Blob || buffer.contains(&0) {
+        return String::new();
+    }
+    String::from_utf8(buffer).unwrap_or_default()
+}
+
 /// Preorder tree walk: entries in stored tree order, the callback firing for a tree entry
 /// before its descent, `parent` being the slash-separated path of the containing directory
 /// (`""` at the root level). Non-tree entry objects are never loaded. Descending into a tree

--- a/josh-starlark/Cargo.toml
+++ b/josh-starlark/Cargo.toml
@@ -17,4 +17,7 @@ anyhow.workspace = true
 git2.workspace = true
 
 josh-filter.workspace = true
+josh-gix-ext.workspace = true
+
+gix-object.workspace = true
 

--- a/josh-starlark/src/evaluate.rs
+++ b/josh-starlark/src/evaluate.rs
@@ -19,12 +19,12 @@ use starlark::{
 /// The `tree_oid` parameter is made available as a global variable named "tree"
 /// in the Starlark script, allowing access to the git tree via methods.
 ///
-/// SAFETY contract: `repo` must remain valid for the entire duration of this call.
+/// SAFETY contract: `objects` must remain valid for the entire duration of this call.
 /// The evaluation is synchronous; no threads are spawned and no values escape.
 pub fn evaluate(
     script: &str,
     tree_oid: git2::Oid,
-    repo: &git2::Repository,
+    objects: &dyn gix_object::Find,
 ) -> anyhow::Result<Filter> {
     // Parse the starlark script
     let ast = AstModule::parse("script.star", script.to_owned(), &Dialect::Standard)
@@ -40,7 +40,7 @@ pub fn evaluate(
         module.set("filter", filter_value);
 
         // Add a global "tree" value (the git tree) to the module
-        let tree_value = module.heap().alloc(StarlarkTree::new(tree_oid, repo));
+        let tree_value = module.heap().alloc(StarlarkTree::new(tree_oid, objects));
         module.set("tree", tree_value);
 
         // Create an evaluator

--- a/josh-starlark/src/tests.rs
+++ b/josh-starlark/src/tests.rs
@@ -11,7 +11,8 @@ fn test_simple_filter() -> anyhow::Result<()> {
     let script = r#"
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, empty_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, empty_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -27,7 +28,8 @@ fn test_chain_filter() -> anyhow::Result<()> {
     let script = r#"
 filter = filter.subdir("src").prefix("lib")
 "#;
-    let filter = evaluate(script, empty_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, empty_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src:prefix=lib");
     Ok(())
@@ -43,7 +45,8 @@ fn test_file_filter() -> anyhow::Result<()> {
     let script = r#"
 filter = filter.file("README.md")
 "#;
-    let filter = evaluate(script, empty_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, empty_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     // file() creates a rename from the same path to itself, which is represented as ::README.md
     assert_eq!(filter_spec, "::README.md");
@@ -62,7 +65,8 @@ f1 = filter.subdir("src")
 f2 = filter.subdir("lib")
 filter = compose([f1, f2])
 "#;
-    let filter = evaluate(script, empty_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, empty_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     // compose formats as :[filter1,filter2]
     assert_eq!(filter_spec, ":[:/src,:/lib]");
@@ -126,7 +130,8 @@ fn test_tree_file() -> anyhow::Result<()> {
 content = tree.file("README.md")
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, root_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -141,7 +146,8 @@ content = tree.file("nonexistent.txt")
 # Should return empty string, not error
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, root_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -156,7 +162,8 @@ src_tree = tree.tree("src")
 main_content = src_tree.file("main.rs")
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, root_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -171,7 +178,8 @@ nonexistent_tree = tree.tree("nonexistent")
 # Should return empty tree, not error
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, root_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -186,7 +194,8 @@ dirs_list = tree.dirs("")
 # Should contain "src"
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, root_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -201,7 +210,8 @@ files_list = tree.files("")
 # Should contain "README.md"
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, root_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -216,7 +226,8 @@ src_tree = tree.tree("src")
 main_content = src_tree.file("main.rs")
 filter = filter.subdir("src")
 "#;
-    let filter = evaluate(script, root_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, root_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
     assert_eq!(filter_spec, ":/src");
     Ok(())
@@ -242,7 +253,8 @@ def collect_all_files(dir_path=""):
 all_file_filters = collect_all_files("")
 filter = compose(all_file_filters)
 "#;
-    let filter = evaluate(script, root_tree_oid, &repo)?;
+    let odb = repo.odb()?;
+    let filter = evaluate(script, root_tree_oid, &josh_gix_ext::Git2Odb(&odb))?;
     let filter_spec = spec(filter);
 
     // The filter should contain all files: README.md, src/main.rs, src/lib/utils.rs.

--- a/josh-starlark/src/tree.rs
+++ b/josh-starlark/src/tree.rs
@@ -10,24 +10,24 @@ use std::fmt::{self, Display};
 use std::path::PathBuf;
 
 /// Opaque Tree type for Starlark
-/// We wrap git2::Tree by storing its OID and a raw pointer to the repository.
+/// We wrap a git tree by storing its OID and a raw pointer to the object source it came from.
 #[derive(Clone, ProvidesStaticType, NoSerialize)]
 pub(crate) struct StarlarkTree {
     pub tree_oid: git2::Oid,
     // SAFETY: StarlarkTree is only constructed inside `evaluate()`, which is
-    // synchronous and spawns no threads. The referenced `git2::Repository` must
+    // synchronous and spawns no threads. The referenced object source must
     // remain alive and at a stable address for that entire duration so this raw
     // pointer stays valid.
-    repo: *const git2::Repository,
+    objects: *const dyn gix_object::Find,
 }
 
-// SAFETY: See the `repo` field documentation above.
+// SAFETY: See the `objects` field documentation above.
 unsafe impl Send for StarlarkTree {}
 unsafe impl Sync for StarlarkTree {}
 
 impl Allocative for StarlarkTree {
     fn visit<'a, 'b: 'a>(&self, _visitor: &'a mut allocative::Visitor<'b>) {
-        // Tree OID is Copy and small; repo is a raw pointer we do not own.
+        // Tree OID is Copy and small; the object source is a raw pointer we do not own.
     }
 }
 
@@ -61,23 +61,27 @@ impl<'v> StarlarkValue<'v> for StarlarkTree {
 }
 
 impl StarlarkTree {
-    /// Create a new StarlarkTree from a git2::Oid and a repository reference.
+    /// Create a new StarlarkTree from a tree OID and the object source to read it from.
     ///
-    /// This constructor is crate-private because the returned value stores `repo`
+    /// This constructor is crate-private because the returned value stores `objects`
     /// as a raw pointer without carrying a lifetime. The crate must therefore only
-    /// construct `StarlarkTree` values in contexts that guarantee the repository
+    /// construct `StarlarkTree` values in contexts that guarantee the object source
     /// outlives the tree and all of its clones, such as the synchronous
     /// `evaluate()` flow described in the struct-level safety comments.
-    pub(crate) fn new(tree_oid: git2::Oid, repo: &git2::Repository) -> Self {
+    pub(crate) fn new(tree_oid: git2::Oid, objects: &dyn gix_object::Find) -> Self {
+        let objects: *const (dyn gix_object::Find + '_) = objects;
         Self {
             tree_oid,
-            repo: repo as *const _,
+            // SAFETY: erasing the borrow's lifetime is sound under the same contract that
+            // makes the raw pointer sound -- the object source outlives this value and every
+            // clone of it.
+            objects: unsafe { std::mem::transmute(objects) },
         }
     }
 
-    fn repo(&self) -> &git2::Repository {
-        // SAFETY: See the `repo` field documentation on the struct.
-        unsafe { &*self.repo }
+    fn objects(&self) -> &dyn gix_object::Find {
+        // SAFETY: See the `objects` field documentation on the struct.
+        unsafe { &*self.objects }
     }
 
     /// Get empty tree OID
@@ -85,13 +89,8 @@ impl StarlarkTree {
         git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap()
     }
 
-    /// Navigate to a path in the tree, returning the OID of the tree at that path.
-    /// Caller must hold repo lock when using navigate_to_path_oid_with_repo.
-    fn navigate_to_path_oid_with_repo(
-        &self,
-        path: &str,
-        repo: &git2::Repository,
-    ) -> anyhow::Result<git2::Oid> {
+    /// Navigate to a path in the tree, returning the OID of the tree at that path
+    fn navigate_to_path_oid(&self, path: &str) -> anyhow::Result<git2::Oid> {
         if path.is_empty() {
             return Ok(self.tree_oid);
         }
@@ -104,59 +103,56 @@ impl StarlarkTree {
 
         let mut current_tree_oid = self.tree_oid;
         for component in components {
-            let current_tree = repo
-                .find_tree(current_tree_oid)
-                .context("Failed to find tree")?;
-
-            let entry = current_tree
-                .get_name(component)
+            let entry = josh_gix_ext::read_tree_entries(self.objects(), current_tree_oid)
+                .context("Failed to find tree")?
+                .into_iter()
+                .find(|e| e.filename == component.as_bytes())
                 .ok_or_else(|| anyhow!("Path component '{}' not found", component))?;
 
-            if entry.kind() != Some(git2::ObjectType::Tree) {
+            if !entry.mode.is_tree() {
                 return Err(anyhow!("Path component '{}' is not a directory", component));
             }
 
-            current_tree_oid = entry.id();
+            current_tree_oid = josh_gix_ext::git2_oid(&entry.oid);
         }
 
         Ok(current_tree_oid)
     }
 
-    /// Navigate to a path in the tree, returning the OID of the tree at that path
-    fn navigate_to_path_oid(&self, path: &str) -> anyhow::Result<git2::Oid> {
-        self.navigate_to_path_oid_with_repo(path, self.repo())
-    }
-
     /// Get blob content at path, returning empty string if not found or binary
     fn get_file_content(&self, path: &str) -> String {
-        let repo = self.repo();
-
-        let tree = match repo.find_tree(self.tree_oid) {
-            Ok(t) => t,
-            Err(_) => return String::new(),
+        let objects = self.objects();
+        let Ok(Some(entry)) =
+            josh_gix_ext::path_entry(objects, self.tree_oid, PathBuf::from(path).as_path())
+        else {
+            return String::new();
         };
-
-        let entry = match tree.get_path(PathBuf::from(path).as_path()) {
-            Ok(e) => e,
-            Err(_) => return String::new(),
-        };
-
-        if entry.kind() != Some(git2::ObjectType::Blob) {
+        if !entry.mode.is_blob() {
             return String::new();
         }
+        josh_gix_ext::blob_text(objects, josh_gix_ext::git2_oid(&entry.oid))
+    }
 
-        let blob = match repo.find_blob(entry.id()) {
-            Ok(b) => b,
-            Err(_) => return String::new(),
+    /// The full paths of the entries at `path` that satisfy `keep`, in stored tree order.
+    /// An unreadable path yields no entries, so a script can probe freely.
+    fn child_paths(&self, path: &str, keep: fn(&gix_object::tree::Entry) -> bool) -> Vec<String> {
+        let Ok(target_tree_oid) = self.navigate_to_path_oid(path) else {
+            return Vec::new();
         };
-
-        if blob.is_binary() {
-            return String::new();
-        }
-
-        std::str::from_utf8(blob.content())
-            .map(|s| s.to_string())
-            .unwrap_or_default()
+        let Ok(entries) = josh_gix_ext::read_tree_entries(self.objects(), target_tree_oid) else {
+            return Vec::new();
+        };
+        let base_path = if path.is_empty() {
+            String::new()
+        } else {
+            format!("{}/", path)
+        };
+        entries
+            .iter()
+            .filter(|entry| keep(entry))
+            .filter_map(|entry| std::str::from_utf8(&entry.filename).ok())
+            .map(|name| format!("{}{}", base_path, name))
+            .collect()
     }
 }
 
@@ -175,42 +171,11 @@ fn tree_methods(_builder: &mut MethodsBuilder) {
         path: StringValue,
         heap: starlark::values::Heap<'v>,
     ) -> anyhow::Result<Vec<Value<'v>>> {
-        let repo = this.repo();
-
-        let target_tree_oid = if path.as_str().is_empty() {
-            this.tree_oid
-        } else {
-            match this.navigate_to_path_oid_with_repo(path.as_str(), repo) {
-                Ok(oid) => oid,
-                Err(_) => return Ok(Vec::new()), // Path doesn't exist, return empty list
-            }
-        };
-
-        let target_tree = repo
-            .find_tree(target_tree_oid)
-            .context("Failed to find tree")?;
-
-        let mut dirs = Vec::new();
-        let base_path = if path.as_str().is_empty() {
-            String::new()
-        } else {
-            format!("{}/", path.as_str())
-        };
-
-        for entry in target_tree.iter() {
-            if let Ok(name) = entry.name() {
-                if entry.kind() == Some(git2::ObjectType::Tree) {
-                    let full_path = if base_path.is_empty() {
-                        name.to_string()
-                    } else {
-                        format!("{}{}", base_path, name)
-                    };
-                    dirs.push(heap.alloc_str(&full_path).to_value());
-                }
-            }
-        }
-
-        Ok(dirs)
+        Ok(this
+            .child_paths(path.as_str(), |entry| entry.mode.is_tree())
+            .iter()
+            .map(|path| heap.alloc_str(path).to_value())
+            .collect())
     }
 
     /// Get a list of full paths to child files (blobs) at the given path
@@ -220,42 +185,11 @@ fn tree_methods(_builder: &mut MethodsBuilder) {
         path: StringValue,
         heap: starlark::values::Heap<'v>,
     ) -> anyhow::Result<Vec<Value<'v>>> {
-        let repo = this.repo();
-
-        let target_tree_oid = if path.as_str().is_empty() {
-            this.tree_oid
-        } else {
-            match this.navigate_to_path_oid_with_repo(path.as_str(), repo) {
-                Ok(oid) => oid,
-                Err(_) => return Ok(Vec::new()), // Path doesn't exist, return empty list
-            }
-        };
-
-        let target_tree = repo
-            .find_tree(target_tree_oid)
-            .context("Failed to find tree")?;
-
-        let mut files = Vec::new();
-        let base_path = if path.as_str().is_empty() {
-            String::new()
-        } else {
-            format!("{}/", path.as_str())
-        };
-
-        for entry in target_tree.iter() {
-            if let Ok(name) = entry.name() {
-                if entry.kind() == Some(git2::ObjectType::Blob) {
-                    let full_path = if base_path.is_empty() {
-                        name.to_string()
-                    } else {
-                        format!("{}{}", base_path, name)
-                    };
-                    files.push(heap.alloc_str(&full_path).to_value());
-                }
-            }
-        }
-
-        Ok(files)
+        Ok(this
+            .child_paths(path.as_str(), |entry| entry.mode.is_blob())
+            .iter()
+            .map(|path| heap.alloc_str(path).to_value())
+            .collect())
     }
 
     /// Get the tree at the given path
@@ -268,7 +202,7 @@ fn tree_methods(_builder: &mut MethodsBuilder) {
 
         Ok(StarlarkTree {
             tree_oid,
-            repo: this.repo,
+            objects: this.objects,
         })
     }
 }

--- a/josh-templates/src/templates.rs
+++ b/josh-templates/src/templates.rs
@@ -49,15 +49,11 @@ impl GraphQLHelper {
             self.transaction_context(&self.repo_path).open()?
         };
 
-        let tree = transaction.repo().find_commit(self.commit_id)?.tree()?;
-
-        let blob = tree
-            .get_path(&path)?
-            .to_object(transaction.repo())?
-            .peel_to_blob()
-            .map(|x| x.content().to_vec())
-            .unwrap_or_default();
-        let query = String::from_utf8(blob)?;
+        let odb = transaction.odb()?;
+        let tree = josh_core::objects::CommitData::read(&odb, self.commit_id)?.tree_id()?;
+        let entry = josh_core::objects::path_entry(&odb, tree, &path)?
+            .ok_or_else(|| anyhow!("no such path: {}", path.display()))?;
+        let query = josh_core::objects::blob_text(&odb, josh_core::objects::git2_oid(&entry.oid));
 
         let mut variables = juniper::Variables::new();
 
@@ -154,19 +150,19 @@ pub fn render(
         return Err(anyhow!("no command"));
     };
 
-    let tree = transaction.repo().find_commit(commit_id)?.tree()?;
-    let obj = tree
-        .get_path(&std::path::PathBuf::from(path))?
-        .to_object(transaction.repo());
+    let odb = transaction.odb()?;
+    let tree = josh_core::objects::CommitData::read(&odb, commit_id)?.tree_id()?;
+    let entry = josh_core::objects::path_entry(&odb, tree, &std::path::PathBuf::from(path))?;
 
-    let obj = if let Ok(obj) = obj {
-        obj
+    let entry = if let Some(entry) = entry {
+        entry
     } else {
         return Ok(None);
     };
 
-    let template = if let Ok(blob) = obj.peel_to_blob() {
-        let file = std::str::from_utf8(blob.content())?;
+    let template = if entry.mode.is_blob() {
+        let content = josh_core::objects::blob_text(&odb, josh_core::objects::git2_oid(&entry.oid));
+        let file = content.as_str();
         if cmd == "get" {
             return Ok(Some((file.to_string(), params)));
         }
@@ -219,9 +215,6 @@ pub fn render(
     } else {
         return Ok(Some(("".to_string(), params)));
     };
-
-    drop(obj);
-    drop(tree);
 
     let repo_path = if split_odb {
         transaction


### PR DESCRIPTION
Move the remaining object reads from git2 to gix_object::Find

Filtering produces trees and commits in memory, and they are not always
written to the on-disk object database. Lookups through
`git2::Repository` only see objects on disk and can miss them; lookups
through the `gix_object::Find` interface see in-memory and on-disk
objects through one handle. This converts the callers that still used
the repository handle:

- josh-starlark's `Tree` value, so a script sees the filtered tree it
  is evaluated against,
- the template and query blobs rendered by josh-templates,
- the GitHub id and vote blobs, and PR head commits,
- the Gerrit dependency check,
- the commit reads behind `josh changes list`, `show` and `deps`,
  `josh pull` and `josh sync`.

The operations these callers share -- listing a tree's entries,
resolving a path to an entry, reading a blob as text -- are now three
josh-gix-ext helpers: `read_tree_entries`, `path_entry` and
`blob_text`.

Reads that only touch objects already on disk keep the repository
handle: rev-parse and peeling, the worktree checkout, and the per-file
line stats of `josh changes show`.

Change: last-object-consumers
Assisted-By: anthropic/claude-fable-5