### PR TITLE
Give the transaction the reads that are not object reads

### DIFF
--- a/cq/josh-cq/src/cq.rs
+++ b/cq/josh-cq/src/cq.rs
@@ -38,7 +38,7 @@ pub fn handle_track(
     mode: &str,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<String> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
 
     let refs = crate::remote::list_refs(url)?;
 
@@ -54,17 +54,7 @@ pub fn handle_track(
         .context("Failed to peel FETCH_HEAD to commit")?
         .id();
 
-    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
-    // Transaction helper at flag day (gix head_name()).
-    let head_ref = repo.head().context("Failed to get HEAD")?;
-    let head_refname = head_ref
-        .name()
-        .context("HEAD ref name is not valid UTF-8")?
-        .to_string();
-    let head_target = head_ref.target().context("HEAD does not point at an oid")?;
-    let head_commit = head_ref
-        .peel_to_commit()
-        .context("Failed to peel HEAD to commit")?;
+    let head = transaction.head().context("Failed to get HEAD")?;
 
     let signature = make_signature(transaction)?;
 
@@ -79,7 +69,7 @@ pub fn handle_track(
         None,
         "HEAD",
         fetched_commit,
-        head_commit.tree_id(),
+        josh_core::objects::CommitData::read(&transaction.odb()?, head.commit)?.tree_id()?,
         link_mode,
     )?
     .into_tree_oid();
@@ -112,7 +102,7 @@ pub fn handle_track(
     let final_commit = josh_core::objects::write_commit(
         &odb,
         final_tree,
-        &[head_commit.id()],
+        &[head.commit],
         &signature,
         &signature,
         &format!("Track remote: {}", id),
@@ -121,8 +111,8 @@ pub fn handle_track(
 
     transaction
         .update_ref(
-            &head_refname,
-            josh_core::cache::Expected::At(head_target),
+            &head.reference,
+            josh_core::cache::Expected::At(head.target),
             final_commit,
             "josh-cq track",
         )

--- a/forges/josh-github-changes/src/cache.rs
+++ b/forges/josh-github-changes/src/cache.rs
@@ -72,7 +72,7 @@ pub fn store_sync_fingerprint(
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let json = serde_json::to_string(fingerprint)?;
-    let blob_oid = transaction.repo().blob(json.as_bytes())?;
+    let blob_oid = josh_core::objects::write_blob(&transaction.odb()?, json.as_bytes())?;
     let path = std::path::Path::new("gh_cache")
         .join(encode_change_id_path(change_id))
         .join(LEAF);

--- a/josh-changes/src/change.rs
+++ b/josh-changes/src/change.rs
@@ -246,7 +246,6 @@ pub fn resolve_change(
     head: git2::Oid,
     spec: &str,
 ) -> anyhow::Result<Change> {
-    let repo = transaction.repo();
     let odb = transaction.odb()?;
     // Try as a full OID first.
     if let Ok(oid) = git2::Oid::from_str(spec) {
@@ -255,14 +254,14 @@ pub fn resolve_change(
         }
     }
 
-    // Try as a revparse (branch, tag, short SHA).
-    // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
-    if let Ok(obj) = repo.revparse_single(spec) {
-        if let Ok(commit) = obj.peel_to_commit()
-            && let Ok(commit) = objects::CommitData::read(&odb, commit.id())
-        {
-            return Ok(Change::from_commit(&commit));
-        }
+    // Try as a revparse (branch, tag, short SHA). An error -- a spec that looks
+    // like a too-short oid prefix, say -- only means this is not a revision; the
+    // spec may still name a change-id, so fall through to the walk below.
+    if let Some(oid) = transaction.rev_parse(spec).ok().flatten()
+        && let Ok(oid) = objects::peel_to_commit(&odb, oid)
+        && let Ok(commit) = objects::CommitData::read(&odb, oid)
+    {
+        return Ok(Change::from_commit(&commit));
     }
 
     // Walk from head to find a commit with matching Change-Id.

--- a/josh-changes/src/comments.rs
+++ b/josh-changes/src/comments.rs
@@ -494,7 +494,6 @@ pub fn delete_outbox_comments(
     if content_hashes.is_empty() {
         return Ok(0);
     }
-    let repo = transaction.repo();
     let odb = transaction.odb()?;
     let want: std::collections::HashSet<&str> = content_hashes.iter().map(|s| s.as_str()).collect();
 
@@ -546,7 +545,7 @@ pub fn delete_outbox_comments(
         }
     }
 
-    let sig = repo.signature()?;
+    let sig = transaction.signature()?;
     let msg = format!("cleanup posted outbox comments on {}\n", ref_name);
     let new_oid = objects::write_commit(&odb, tree, &[prev_commit], &sig, &sig, &msg)?;
     transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;

--- a/josh-changes/src/refs.rs
+++ b/josh-changes/src/refs.rs
@@ -257,19 +257,14 @@ impl ChangesRef {
 
 /// Read HEAD and return the current branch shorthand. Errors on a
 /// detached HEAD with a message asking the caller to pass an explicit branch.
-// PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
-// Transaction helper at flag day (gix head_name()).
 pub fn head_branch(transaction: &josh_core::cache::Transaction) -> anyhow::Result<String> {
     let head = transaction
-        .repo()
         .head()
         .map_err(|e| anyhow!("failed to read HEAD: {}", e))?;
-    if !head.is_branch() {
-        return Err(anyhow!(
-            "HEAD is detached -- pass --branch to select a target branch explicitly"
-        ));
-    }
-    Ok(head.shorthand()?.to_string())
+    let branch = head.short_branch().ok_or_else(|| {
+        anyhow!("HEAD is detached -- pass --branch to select a target branch explicitly")
+    })?;
+    Ok(branch.to_string())
 }
 
 /// Return every changes ref that currently exists, as `ChangesRef` values.

--- a/josh-changes/src/store.rs
+++ b/josh-changes/src/store.rs
@@ -55,7 +55,6 @@ pub fn write_changes_tree(
     timestamp: Option<&str>,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
     let odb = transaction.odb()?;
     let ref_name = scope.ref_name();
     let prev_commit = transaction.resolve_ref(&ref_name)?;
@@ -79,7 +78,7 @@ pub fn write_changes_tree(
             let time = parse_timestamp(timestamp);
             git2::Signature::new(name, &email, &time)?
         }
-        None => josh_core::git::user_signature(repo)?,
+        None => josh_core::git::user_signature(transaction)?,
     };
     let msg = format!("update {}\n", ref_name);
     let new_oid = objects::write_commit(&odb, tree, prev_commit.as_slice(), &sig, &sig, &msg)?;
@@ -125,7 +124,6 @@ pub fn store_diff_data(
     change: &Change,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
     let odb = transaction.odb()?;
     let change_id = change
         .id()
@@ -162,7 +160,7 @@ pub fn store_diff_data(
 
     let tree = tree::insert_oid(&odb, base_tree, &path, tree_oid, 0o0040000)?;
 
-    let sig = repo.signature()?;
+    let sig = transaction.signature()?;
 
     let anchor_sig = git2::Signature::new("JOSH", "josh@josh-project.dev", &git2::Time::new(0, 0))?;
     let anchor_oid = objects::write_commit(
@@ -196,7 +194,6 @@ pub fn store_pr_data<T: serde::Serialize>(
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let json = serde_json::to_string(data)?;
-    let repo = transaction.repo();
     let odb = transaction.odb()?;
     let blob_oid = objects::write_blob(&odb, json.as_bytes())?;
 
@@ -225,7 +222,7 @@ pub fn store_pr_data<T: serde::Serialize>(
 
     let tree = tree::insert_oid(&odb, base_tree, &path, tree_oid, 0o0040000)?;
 
-    let sig = repo.signature()?;
+    let sig = transaction.signature()?;
     let msg = format!("update {}\n", ref_name);
     let new_oid = objects::write_commit(&odb, tree, prev_tip.as_slice(), &sig, &sig, &msg)?;
     transaction.update_ref(
@@ -274,7 +271,6 @@ pub fn delete_change(
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
     let odb = transaction.odb()?;
     let encoded = encode_change_id_path(change_id);
 
@@ -306,7 +302,7 @@ pub fn delete_change(
         }
     }
 
-    let sig = repo.signature()?;
+    let sig = transaction.signature()?;
     let msg = format!("update {}\n", ref_name);
     let new_oid = objects::write_commit(&odb, tree, &[prev_commit], &sig, &sig, &msg)?;
     transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;

--- a/josh-changes/src/votes.rs
+++ b/josh-changes/src/votes.rs
@@ -68,7 +68,6 @@ fn write_vote_inner(
     scope: &ChangesRef,
     path_prefix: &str,
 ) -> anyhow::Result<String> {
-    let repo = transaction.repo();
     let change_id = change
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
@@ -90,7 +89,11 @@ fn write_vote_inner(
 
     let user = match author {
         Some(name) => name.to_string(),
-        None => repo.signature()?.email().unwrap_or("unknown").to_string(),
+        None => transaction
+            .signature()?
+            .email()
+            .unwrap_or("unknown")
+            .to_string(),
     };
 
     let path = std::path::Path::new(path_prefix)
@@ -118,7 +121,7 @@ fn write_vote_inner(
             let time = parse_timestamp(timestamp);
             git2::Signature::new(name, &email, &time)?
         }
-        None => repo.signature()?,
+        None => transaction.signature()?,
     };
     let msg = format!("update {}\n", ref_name);
     let new_oid = objects::write_commit(&odb, tree, prev_commit.as_slice(), &sig, &sig, &msg)?;
@@ -138,7 +141,6 @@ pub fn read_vote(
     user: Option<&str>,
     scope: &ChangesRef,
 ) -> anyhow::Result<Option<VoteData>> {
-    let repo = transaction.repo();
     let odb = transaction.odb()?;
     let tree = match transaction.resolve_ref(&scope.ref_name())? {
         Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
@@ -147,7 +149,11 @@ pub fn read_vote(
 
     let user = match user {
         Some(name) => name.to_string(),
-        None => repo.signature()?.email().unwrap_or("unknown").to_string(),
+        None => transaction
+            .signature()?
+            .email()
+            .unwrap_or("unknown")
+            .to_string(),
     };
 
     let path = std::path::Path::new("votes")
@@ -237,7 +243,6 @@ pub fn delete_outbox_votes(
         return Ok(0);
     }
 
-    let repo = transaction.repo();
     let odb = transaction.odb()?;
     let encoded = encode_change_id_path(change_id);
     let ref_name = scope.ref_name();
@@ -265,7 +270,7 @@ pub fn delete_outbox_votes(
         return Ok(0);
     }
 
-    let sig = repo.signature()?;
+    let sig = transaction.signature()?;
     let msg = format!("delete outbox votes on {}\n", ref_name);
     let new_oid = objects::write_commit(&odb, tree, &[prev_commit], &sig, &sig, &msg)?;
     transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -7,16 +7,13 @@ fn resolve_input_ref(
     transaction: &josh_core::cache::Transaction,
     input_ref: &str,
 ) -> anyhow::Result<(String, git2::Oid)> {
-    let repo = transaction.repo();
-    let oid = josh_core::git::resolve_snapshot_input(repo, input_ref)?;
+    let oid = josh_core::git::resolve_snapshot_input(transaction, input_ref)?;
     let ref_string = if input_ref == "+" || input_ref == "." {
         oid.to_string()
     } else if git2::Oid::from_str(input_ref).is_ok() {
         input_ref.to_string()
-    // PORT: DWIM short-name resolution stays on the git2 handle until flag day (gix
-    // partial-name find_reference then).
-    } else if let Ok(reference) = repo.resolve_reference_from_short_name(input_ref) {
-        reference.name().unwrap().to_string()
+    } else if let Some(name) = transaction.expand_ref_name(input_ref)? {
+        name
     } else {
         oid.to_string()
     };
@@ -200,7 +197,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         .open()?;
 
     let repo_for_hook = git2::Repository::open_ext(
-        transaction.repo().path(),
+        transaction.path(),
         git2::RepositoryOpenFlags::NO_SEARCH,
         &[] as &[&std::ffi::OsStr],
     )?;
@@ -209,7 +206,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     };
     transaction = transaction.with_filter_hook(std::sync::Arc::new(hook));
 
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
 
     // If the filter spec doesn't contain a colon and it's not from a file,
     // treat it as a SHA and read from tree
@@ -304,17 +301,17 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     });
 
     if args.get_flag("discover") {
-        // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
-        let r = repo.revparse_single(&input_ref)?;
-        let hs = josh_core::housekeeping::find_all_workspaces_and_subdirectories(
-            &transaction.odb()?,
-            r.peel_to_tree()?.id(),
-        )?;
+        let odb = transaction.odb()?;
+        let head = transaction
+            .rev_parse(&input_ref)?
+            .ok_or_else(|| anyhow!("no such revision: {}", input_ref))?;
+        let tree = josh_core::objects::CommitData::read(&odb, head)?.tree_id()?;
+        let hs = josh_core::housekeeping::find_all_workspaces_and_subdirectories(&odb, tree)?;
         for i in hs {
             let (mut updated_refs, _) = josh_core::filter_refs(
                 &transaction,
                 josh_core::filter::parse(&i)?,
-                &[(input_ref.to_string(), r.id())],
+                &[(input_ref.to_string(), head)],
             );
             updated_refs[0].0 = "refs/JOSH_TMP".to_string();
             josh_core::update_refs(&transaction, updated_refs);
@@ -351,13 +348,14 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     josh_core::update_refs(&transaction, updated_refs.clone());
 
     if let Some(searchstring) = args.get_one::<String>("search") {
-        // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
-        let commit = repo.revparse_single(&input_ref)?.peel_to_commit()?;
+        let commit = transaction
+            .rev_parse(&input_ref)?
+            .ok_or_else(|| anyhow!("no such revision: {}", input_ref))?;
 
         let odb = transaction.odb()?;
         let tree = josh_core::objects::CommitData::read(
             &odb,
-            josh_core::filter_commit(&transaction, filterobj, commit.id())?,
+            josh_core::filter_commit(&transaction, filterobj, commit)?,
         )?
         .tree_id()?;
 
@@ -365,7 +363,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         // search_matches does all the filtering, so results are identical, just slower.
         let candidates = if josh_core::filter::experimental_features_enabled() {
             let ifilterobj = filterobj.chain(josh_core::filter::parse(":SQUASH:INDEX")?);
-            let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit.id())?;
+            let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit)?;
             let index_tree = josh_core::objects::CommitData::read(&odb, index_commit)?.tree_id()?;
             josh_search::search_candidates(&odb, index_tree, tree, searchstring)?
         } else {
@@ -396,10 +394,14 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         // rev-parse reads them through the repository handle, which only sees disk.
         transaction.flush_mem_odb()?;
 
-        // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
-        let new = repo.revparse_single(target).unwrap().id();
-        let old = repo.revparse_single("JOSH_TMP").unwrap().id();
-        let unfiltered_old = repo.revparse_single(&input_ref).unwrap().id();
+        let rev = |spec: &str| -> anyhow::Result<git2::Oid> {
+            transaction
+                .rev_parse(spec)?
+                .ok_or_else(|| anyhow!("no such revision: {}", spec))
+        };
+        let new = rev(target)?;
+        let old = rev("JOSH_TMP")?;
+        let unfiltered_old = rev(&input_ref)?;
 
         let ret = match josh_core::history::unapply_filter(
             &transaction,

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -374,7 +374,7 @@ fn handle_clone(
     transaction: &josh_core::cache::Transaction,
     distributed_cache: bool,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
 
     // Create FetchArgs from CloneArgs
     let fetch_args = FetchArgs {
@@ -455,7 +455,7 @@ fn handle_remote(
 ) -> anyhow::Result<()> {
     match &args.command {
         RemoteCommand::Add(add_args) => {
-            let repo_path = normalize_repo_path(transaction.repo().path());
+            let repo_path = normalize_repo_path(transaction.path());
             handle_remote_add_repo(add_args, &repo_path)
         }
     }
@@ -542,8 +542,7 @@ fn handle_filter(
     args: &FilterArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
-    let repo_path = normalize_repo_path(repo.path());
+    let repo_path = normalize_repo_path(transaction.path());
 
     let config = read_remote_config(&repo_path, &args.remote)
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;

--- a/josh-cli/src/commands/cache.rs
+++ b/josh-cli/src/commands/cache.rs
@@ -57,8 +57,7 @@ pub fn handle_cache(args: &CacheArgs, transaction: &Transaction) -> anyhow::Resu
 }
 
 fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyhow::Result<()> {
-    let repo = transaction.repo();
-    let repo_path = normalize_repo_path(repo.path());
+    let repo_path = normalize_repo_path(transaction.path());
 
     let default_branch = remote_ops::resolve_default_branch(transaction, &args.remote)?;
 
@@ -220,8 +219,7 @@ fn handle_cache_build(args: &CacheBuildArgs, transaction: &Transaction) -> anyho
 }
 
 fn handle_cache_push(args: &CachePushArgs, transaction: &Transaction) -> anyhow::Result<()> {
-    let repo = transaction.repo();
-    let repo_path = normalize_repo_path(repo.path());
+    let repo_path = normalize_repo_path(transaction.path());
 
     let config = read_remote_config(&repo_path, &args.remote)
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
@@ -303,8 +301,7 @@ pub fn fetch_remote_cache(
 }
 
 fn handle_cache_fetch(args: &CacheFetchArgs, transaction: &Transaction) -> anyhow::Result<()> {
-    let repo = transaction.repo();
-    let repo_path = normalize_repo_path(repo.path());
+    let repo_path = normalize_repo_path(transaction.path());
 
     let config = read_remote_config(&repo_path, &args.remote)
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -182,7 +182,7 @@ pub fn handle_show(
     println!();
     // PORT: the per-file line stats come out of libgit2's patch machinery; the change
     // commit is behind a ref, so it is on disk.
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
     let files = file_stats(repo, &repo.find_commit(change.commit())?)?;
     let total_adds: usize = files.iter().map(|f| f.adds).sum();
     let total_dels: usize = files.iter().map(|f| f.dels).sum();

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -55,10 +55,7 @@ pub fn handle_comment(
     args: &CommentArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
-    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
-    // Transaction helper at flag day (gix head_name()).
-    let head = repo.head()?.peel_to_commit()?.id();
+    let head = transaction.head()?.commit;
 
     let (short_file, short_location) = args
         .location

--- a/josh-cli/src/commands/fetch.rs
+++ b/josh-cli/src/commands/fetch.rs
@@ -25,7 +25,7 @@ pub fn handle_fetch(
     transaction: &josh_core::cache::Transaction,
     distributed_cache: bool,
 ) -> anyhow::Result<Vec<RefUpdate>> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
     let repo_path = normalize_repo_path(repo.path());
 
     let config = read_remote_config(&repo_path, &args.remote)

--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -85,7 +85,7 @@ fn handle_link_add(
     args: &LinkAddArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
 
     // Validate the path (should not be empty and should be a valid path)
     if args.path.is_empty() {
@@ -98,13 +98,7 @@ fn handle_link_add(
     // Get the target branch (default to "HEAD" if not provided)
     let target = args.target.as_deref().unwrap_or("HEAD");
 
-    // Get the current HEAD commit
-    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
-    // Transaction helper at flag day (gix head_name()).
-    let head_ref = repo.head().context("Failed to get HEAD")?;
-    let head_commit = head_ref
-        .peel_to_commit()
-        .context("Failed to get HEAD commit")?;
+    let head_commit = transaction.head().context("Failed to get HEAD")?.commit;
 
     let mode = josh_core::filter::LinkMode::parse(&args.mode)
         .with_context(|| format!("Invalid link mode: '{}'", args.mode))?;
@@ -119,7 +113,7 @@ fn handle_link_add(
         josh_core::filter::invert(filter_obj)
             .with_context(|| format!("Filter '{}' has no inverse", filter))?,
     );
-    let export_oid = josh_core::filter_commit(transaction, combined_filter, head_commit.id())
+    let export_oid = josh_core::filter_commit(transaction, combined_filter, head_commit)
         .context("Failed to apply export filter")?;
 
     // If the export filter found no local content, fall back to fetching the remote.
@@ -162,10 +156,10 @@ fn handle_link_add(
         args.filter.as_deref(),
         target,
         initial_oid,
-        head_commit.tree_id(),
+        josh_core::objects::CommitData::read(&transaction.odb()?, head_commit)?.tree_id()?,
         mode,
     )?
-    .into_commit(transaction, head_commit.id(), &signature)?;
+    .into_commit(transaction, head_commit, &signature)?;
 
     // Create the fixed branch name
     let branch_name = "refs/heads/josh-link";
@@ -193,15 +187,9 @@ fn handle_link_fetch(
     args: &LinkFetchArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
 
-    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
-    // Transaction helper at flag day (gix head_name()).
-    let head_commit = repo
-        .head()
-        .context("Failed to get HEAD")?
-        .peel_to_commit()
-        .context("Failed to get HEAD commit")?;
+    let head_commit = transaction.head().context("Failed to get HEAD")?.commit;
 
     let commit_oid = if let Some(filter_str) = &args.filter {
         let filter = josh_core::filter::parse(filter_str)
@@ -210,10 +198,10 @@ fn handle_link_fetch(
             josh_core::filter::invert(filter)
                 .with_context(|| format!("Filter '{}' has no inverse", filter_str))?,
         );
-        josh_core::filter_commit(transaction, roundtrip, head_commit.id())
+        josh_core::filter_commit(transaction, roundtrip, head_commit)
             .context("Failed to apply filter")?
     } else {
-        head_commit.id()
+        head_commit
     };
 
     let link_refs = josh_link::collect_all_link_refs(transaction, commit_oid)
@@ -276,15 +264,12 @@ fn handle_link_update(
     args: &LinkUpdateArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
 
-    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
-    // Transaction helper at flag day (gix head_name()).
-    let head_ref = repo.head().context("Failed to get HEAD")?;
-    let head_commit = head_ref
-        .peel_to_commit()
-        .context("Failed to get HEAD commit")?;
-    let head_tree = head_commit.tree().context("Failed to get HEAD tree")?;
+    let head_commit = transaction.head().context("Failed to get HEAD")?.commit;
+    let head_tree = josh_core::objects::CommitData::read(&transaction.odb()?, head_commit)?
+        .tree_id()
+        .context("Failed to get HEAD tree")?;
 
     let link_files = if let Some(filter_str) = &args.filter {
         let filter = josh_core::filter::parse(filter_str)
@@ -293,7 +278,7 @@ fn handle_link_update(
             josh_core::filter::invert(filter)
                 .with_context(|| format!("Filter '{}' has no inverse", filter_str))?,
         );
-        let filtered_oid = josh_core::filter_commit(transaction, roundtrip, head_commit.id())
+        let filtered_oid = josh_core::filter_commit(transaction, roundtrip, head_commit)
             .context("Failed to apply filter")?;
         if filtered_oid == git2::Oid::ZERO_SHA1 {
             vec![]
@@ -307,7 +292,7 @@ fn handle_link_update(
                 .context("Failed to find link files in filtered tree")?
         }
     } else {
-        josh_core::link::find_link_files(&transaction.odb()?, head_tree.id())
+        josh_core::link::find_link_files(&transaction.odb()?, head_tree)
             .context("Failed to find link files")?
     };
 
@@ -349,7 +334,7 @@ fn handle_link_update(
 
     let signature = make_signature(transaction)?;
     let Some(result) =
-        josh_link::update_links(transaction, head_commit.id(), links_to_update, &signature)?
+        josh_link::update_links(transaction, head_commit, links_to_update, &signature)?
     else {
         eprintln!("All {} link file(s) already up to date", link_files.len());
         return Ok(());
@@ -375,17 +360,11 @@ fn handle_link_push(
     args: &LinkPushArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
-
     // Get current HEAD commit
-    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
-    // Transaction helper at flag day (gix head_name()).
-    let head_commit = repo
-        .head()
-        .context("Failed to get HEAD")?
-        .peel_to_commit()
-        .context("Failed to get HEAD commit")?;
-    let head_tree = head_commit.tree().context("Failed to get HEAD tree")?;
+    let head_commit = transaction.head().context("Failed to get HEAD")?.commit;
+    let head_tree = josh_core::objects::CommitData::read(&transaction.odb()?, head_commit)?
+        .tree_id()
+        .context("Failed to get HEAD tree")?;
 
     // Normalize path: strip slash(es)
     let normalized_path = args.path.trim_matches('/');
@@ -394,7 +373,7 @@ fn handle_link_push(
     }
 
     // Find the .link.josh file at the given path
-    let link_files = josh_core::link::find_link_files(&transaction.odb()?, head_tree.id())
+    let link_files = josh_core::link::find_link_files(&transaction.odb()?, head_tree)
         .context("Failed to find link files")?;
 
     let link_path = std::path::PathBuf::from(normalized_path);
@@ -415,7 +394,7 @@ fn handle_link_push(
     let combined_filter = path_filter.chain(josh_core::filter::invert(*link_file)?);
 
     // Apply the filter to get the commit suitable for pushing
-    let exported_commit = josh_core::filter_commit(transaction, combined_filter, head_commit.id())
+    let exported_commit = josh_core::filter_commit(transaction, combined_filter, head_commit)
         .context("Failed to apply export filter")?;
 
     if exported_commit == git2::Oid::ZERO_SHA1 {

--- a/josh-cli/src/commands/pull.rs
+++ b/josh-cli/src/commands/pull.rs
@@ -203,10 +203,9 @@ fn resolve_upstream_ref(
 ) -> anyhow::Result<String> {
     let expected_prefix = format!("refs/remotes/{}/", remote);
 
-    // PORT: config-based upstream resolution stays on the git2 handle until flag day
-    // (gix branch_remote_tracking_ref_name then).
-    if let Ok(upstream_buf) = transaction.repo().branch_upstream_name(branch_ref) {
-        if let Ok(upstream) = upstream_buf.as_str() {
+    if let Some(upstream) = transaction.upstream_ref(branch_ref)? {
+        {
+            let upstream = upstream.as_str();
             if !upstream.starts_with(&expected_prefix) {
                 return Err(anyhow::anyhow!(
                     "the current branch tracks '{}', which does not belong to remote '{}'",
@@ -232,7 +231,7 @@ fn upstream_change_ids(
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<std::collections::HashSet<String>> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
     let odb = transaction.odb()?;
     let mut ids = std::collections::HashSet::new();
     let mut walk = repo.revwalk()?;
@@ -311,17 +310,12 @@ pub fn integrate(
     transaction: &josh_core::cache::Transaction,
     remote: &str,
 ) -> anyhow::Result<IntegrateReport> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
 
-    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
-    // Transaction helper at flag day (gix head_name()).
-    let head = repo.head().context("Failed to resolve HEAD")?;
-    if !head.is_branch() {
-        anyhow::bail!("HEAD is detached; cannot integrate pull");
-    }
+    let head = transaction.head().context("Failed to resolve HEAD")?;
     let branch_ref = head
-        .name()
-        .map_err(|_| anyhow::anyhow!("HEAD ref name is not valid UTF-8"))?
+        .branch()
+        .ok_or_else(|| anyhow::anyhow!("HEAD is detached; cannot integrate pull"))?
         .to_string();
     let branch = branch_ref
         .strip_prefix("refs/heads/")
@@ -332,18 +326,12 @@ pub fn integrate(
     let new = transaction
         .resolve_ref(&upstream_refname)?
         .ok_or_else(|| anyhow::anyhow!("failed to resolve upstream ref '{}'", upstream_refname))?;
-    let new = repo
-        .find_object(new, None)?
-        .peel_to_commit()
-        .with_context(|| format!("failed to resolve upstream ref '{}'", upstream_refname))?
-        .id();
-    let old = head
-        .peel_to_commit()
-        .context("failed to resolve HEAD commit")?
-        .id();
+    let new = josh_core::objects::peel_to_commit(&transaction.odb()?, new)
+        .with_context(|| format!("failed to resolve upstream ref '{}'", upstream_refname))?;
+    let old = head.commit;
     // The ref's stored target, which the CAS guard on the write below compares against;
     // differs from the peeled `old` only if the branch points at an annotated tag.
-    let old_target = head.target().context("HEAD branch has no direct target")?;
+    let old_target = head.target;
 
     if old == new {
         return Ok(IntegrateReport::UpToDate);
@@ -436,7 +424,7 @@ pub fn integrate(
 /// Stash uncommitted changes to tracked files so the worktree update in
 /// `integrate` cannot conflict with them. Returns true if a stash was created.
 fn autostash_push(transaction: &josh_core::cache::Transaction) -> anyhow::Result<bool> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
     let mut opts = git2::StatusOptions::new();
     opts.include_untracked(false);
     if repo.statuses(Some(&mut opts))?.is_empty() {

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -110,8 +110,6 @@ fn prepare_push(
     gerrit_mode: GerritMode,
     dry_run: bool,
 ) -> anyhow::Result<PreparedPush> {
-    let repo = transaction.repo();
-
     let (local_ref, remote_ref) = if let Some(colon_pos) = refspec.find(':') {
         let local = &refspec[..colon_pos];
         let remote = &refspec[colon_pos + 1..];
@@ -124,12 +122,11 @@ fn prepare_push(
         .strip_prefix("refs/heads/")
         .unwrap_or(&remote_ref);
 
-    // PORT: DWIM short-name resolution stays on the git2 handle until flag day (gix
-    // partial-name find_reference then).
-    let local_commit = repo
-        .resolve_reference_from_short_name(&local_ref)
-        .with_context(|| format!("Failed to resolve local ref '{}'", local_ref))?
-        .target()
+    let local_ref_name = transaction
+        .expand_ref_name(&local_ref)?
+        .with_context(|| format!("Failed to resolve local ref '{}'", local_ref))?;
+    let local_commit = transaction
+        .resolve_ref(&local_ref_name)?
         .context("Failed to get target of local ref")?;
 
     let dest_remote_ref = format!("refs/josh/remotes/{}/{}", remote_name, remote_ref);
@@ -499,7 +496,7 @@ fn orchestrate_push(
     push_mode: PushMode,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
     let repo_path = normalize_repo_path(repo.path());
 
     let remote_name = remote.unwrap_or("origin");
@@ -520,11 +517,9 @@ fn orchestrate_push(
     let push_target = push_url.as_deref().unwrap_or(&url);
 
     let refspecs = if refspecs_arg.is_empty() {
-        // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
-        // Transaction helper at flag day (gix head_name()).
-        let head = repo.head().context("Failed to get HEAD")?;
+        let head = transaction.head().context("Failed to get HEAD")?;
         let current_branch = head
-            .shorthand()
+            .short_branch()
             .context("Failed to get current branch name")?;
         vec![current_branch.to_string()]
     } else {
@@ -626,9 +621,7 @@ pub fn handle_publish(
     args: &PublishArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
-    let config = repo.config().context("Failed to get git config")?;
-    let push_mode = PushMode::Publish(config.get_string("user.email").unwrap_or_default());
+    let push_mode = PushMode::Publish(transaction.config_string("user.email")?.unwrap_or_default());
 
     orchestrate_push(
         args.remote.as_deref(),

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -30,16 +30,14 @@ pub fn handle_sync(
     args: &SyncArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
 
-    // PORT: symbolic-HEAD read is not expressible via resolve_ref; move to a
-    // Transaction helper at flag day (gix head_name()).
-    let head = repo.head()?.peel_to_commit()?;
-    let branch = repo.head()?.shorthand().ok().map(|s| s.to_string());
+    let head = transaction.head()?;
+    let branch = head.short_branch().map(|s| s.to_string());
 
     let base_oid = if let Some(b) = &branch {
         match transaction.resolve_ref(&format!("refs/remotes/origin/{}", b))? {
-            Some(oid) => repo.find_object(oid, None)?.peel_to_commit()?.id(),
+            Some(oid) => josh_core::objects::peel_to_commit(&transaction.odb()?, oid)?,
             None => git2::Oid::ZERO_SHA1,
         }
     } else {
@@ -61,7 +59,7 @@ pub fn handle_sync(
             sync_remote(args, transaction, repo, remote)
         }
         josh_changes::ChangesRef::Local { branch } => {
-            sync_local(args, transaction, branch, head.id(), base_oid)
+            sync_local(args, transaction, branch, head.commit, base_oid)
         }
     }
 }

--- a/josh-cli/src/remote_ops.rs
+++ b/josh-cli/src/remote_ops.rs
@@ -53,7 +53,7 @@ pub fn resolve_default_branch(
     // expressible via resolve_ref; stays on the git2 handle until flag day (gix
     // try_find_reference then).
     transaction
-        .repo()
+        .git2_repo()
         .find_reference(&head_symref)
         .ok()
         .and_then(|r| r.symbolic_target().ok().flatten().map(|s| s.to_string()))

--- a/josh-compose/src/filter.rs
+++ b/josh-compose/src/filter.rs
@@ -2,8 +2,11 @@ use anyhow::Context;
 
 /// Resolve an input ref to a commit OID.
 /// Delegates to josh_core::git::resolve_snapshot_input.
-pub fn resolve_input(repo: &git2::Repository, input_ref: &str) -> anyhow::Result<git2::Oid> {
-    josh_core::git::resolve_snapshot_input(repo, input_ref)
+pub fn resolve_input(
+    transaction: &josh_core::cache::Transaction,
+    input_ref: &str,
+) -> anyhow::Result<git2::Oid> {
+    josh_core::git::resolve_snapshot_input(transaction, input_ref)
         .with_context(|| format!("failed to resolve input ref: {input_ref:?}"))
 }
 

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -52,9 +52,7 @@ pub fn run(
     }
 
     let filter_spec = opts.filter_spec.trim().to_string();
-    let repo = transaction.repo();
-
-    let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
+    let source_commit = filter::resolve_input(transaction, &opts.input_ref)?;
 
     let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
@@ -92,9 +90,7 @@ pub fn plan_images(
     josh_filter::check_experimental_features_enabled("josh compose images")?;
 
     let filter_spec = opts.filter_spec.trim().to_string();
-    let repo = transaction.repo();
-
-    let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
+    let source_commit = filter::resolve_input(transaction, &opts.input_ref)?;
 
     let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
@@ -118,9 +114,7 @@ pub fn plan_jobs(
     josh_filter::check_experimental_features_enabled("josh compose jobs")?;
 
     let filter_spec = opts.filter_spec.trim().to_string();
-    let repo = transaction.repo();
-
-    let source_commit = filter::resolve_input(repo, &opts.input_ref)?;
+    let source_commit = filter::resolve_input(transaction, &opts.input_ref)?;
 
     let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 

--- a/josh-core/benches/deephistory_glob.rs
+++ b/josh-core/benches/deephistory_glob.rs
@@ -161,7 +161,7 @@ impl GlobBench {
         {
             let transaction = context.open()?;
             let case = cases.first().expect("at least one case");
-            let repo = transaction.repo();
+            let repo = transaction.git2_repo();
 
             // The tripwire only means something if the dotfiles actually exist in the raw tree.
             let raw_tree = repo.find_commit(case.head)?.tree()?;
@@ -478,8 +478,8 @@ fn deephistory_glob(c: &mut Criterion) {
                 .unwrap()
                 .tree_id()
                 .unwrap();
-            let (want, _) =
-                expected_tree(transaction.repo(), probe, &glob_pred(pattern)).expect("expected");
+            let (want, _) = expected_tree(transaction.git2_repo(), probe, &glob_pred(pattern))
+                .expect("expected");
             assert_eq!(
                 got, want,
                 "incremental `::{pattern}` diverged from the independent expectation"

--- a/josh-core/benches/deephistory_subdir.rs
+++ b/josh-core/benches/deephistory_subdir.rs
@@ -124,7 +124,7 @@ impl SubdirBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = transaction.repo();
+            let repo = transaction.git2_repo();
             let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
             let raw_subdir_tree = repo
                 .find_commit(case.head)?

--- a/josh-core/benches/deephistory_subdir_distributed.rs
+++ b/josh-core/benches/deephistory_subdir_distributed.rs
@@ -114,7 +114,7 @@ impl SubdirBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = transaction.repo();
+            let repo = transaction.git2_repo();
             let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
             let raw_subdir_tree = repo
                 .find_commit(case.head)?

--- a/josh-core/benches/deephistory_subdir_sparse.rs
+++ b/josh-core/benches/deephistory_subdir_sparse.rs
@@ -123,7 +123,7 @@ impl SubdirBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = transaction.repo();
+            let repo = transaction.git2_repo();
             let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
             let raw_subdir_tree = repo
                 .find_commit(case.head)?

--- a/josh-core/benches/refs_filter_update.rs
+++ b/josh-core/benches/refs_filter_update.rs
@@ -133,7 +133,7 @@ impl RefsBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = transaction.repo();
+            let repo = transaction.git2_repo();
             let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
             let raw_subdir_tree = repo
                 .find_commit(case.head)?

--- a/josh-core/benches/unapply.rs
+++ b/josh-core/benches/unapply.rs
@@ -98,7 +98,7 @@ impl UnapplyBench {
         let mut cases = vec![];
         {
             let transaction = context.open()?;
-            let repo = transaction.repo();
+            let repo = transaction.git2_repo();
             for &n_commits in HISTORY_SIZES {
                 let head = repo.refname_to_id(&format!("refs/heads/case_{n_commits}"))?;
                 let filtered_head = josh_core::filter_commit(&transaction, filter, head)?;
@@ -264,7 +264,7 @@ fn unapply_extend(c: &mut Criterion) {
     {
         let case = bench.cases.first().expect("at least one case");
         let transaction = bench.context.open().expect("open transaction");
-        let tip = extend_filtered(transaction.repo(), case.filtered_head, usize::MAX)
+        let tip = extend_filtered(transaction.git2_repo(), case.filtered_head, usize::MAX)
             .expect("extend filtered");
         let unapplied = unapply_filter(
             &transaction,
@@ -295,7 +295,7 @@ fn unapply_extend(c: &mut Criterion) {
                 || {
                     let transaction = bench.context.open().expect("open transaction");
                     let tip = extend_filtered(
-                        transaction.repo(),
+                        transaction.git2_repo(),
                         case.filtered_head,
                         salt.fetch_add(1, Ordering::Relaxed),
                     )

--- a/josh-core/benches/widetree_glob.rs
+++ b/josh-core/benches/widetree_glob.rs
@@ -139,7 +139,7 @@ impl GlobBench {
         // runs.
         {
             let transaction = context.open()?;
-            let repo = transaction.repo();
+            let repo = transaction.git2_repo();
             for case in &cases {
                 // Recursive pattern: keeps exactly the `.rs` blobs everywhere (string predicate is
                 // exact -- see the no-dot-component invariant above).

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -15,6 +15,33 @@ pub trait FilterHook {
     ) -> anyhow::Result<crate::filter::Filter>;
 }
 
+/// Where a repository's HEAD points, as [`Transaction::head`] reports it.
+pub struct Head {
+    /// The ref HEAD resolves to: a fully qualified `refs/heads/...` on a branch, and `HEAD`
+    /// itself when detached. Either way, this is the ref to update to move HEAD.
+    pub reference: String,
+    /// The unpeeled target of [`Head::reference`], for guarding an update against it.
+    pub target: git2::Oid,
+    /// The commit HEAD resolves to, annotated tags peeled.
+    pub commit: git2::Oid,
+}
+
+impl Head {
+    /// The branch HEAD is on, fully qualified; `None` when HEAD is detached.
+    pub fn branch(&self) -> Option<&str> {
+        self.reference
+            .starts_with("refs/heads/")
+            .then_some(&*self.reference)
+    }
+
+    /// [`Head::branch`] without its `refs/heads/` prefix, for the places that show it to a
+    /// user or match it against a remote's branch names.
+    pub fn short_branch(&self) -> Option<&str> {
+        self.branch()
+            .map(|name| name.strip_prefix("refs/heads/").unwrap_or(name))
+    }
+}
+
 /// What [`Transaction::update_ref`] requires the ref to currently be before it is
 /// repointed at the new target.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -264,7 +291,12 @@ impl Transaction {
         context.open()
     }
 
-    pub fn repo(&self) -> &git2::Repository {
+    /// The libgit2 handle on this repository, for the porcelain josh has not moved to gix:
+    /// worktree and index operations, `FETCH_HEAD`'s multi-entry semantics, notes, and
+    /// git's DWIM name resolution. It must never read or write objects josh produces --
+    /// those live in this transaction's store until it flushes, and this handle cannot see
+    /// them (use [`Transaction::odb`]).
+    pub fn git2_repo(&self) -> &git2::Repository {
         &self.repo
     }
 
@@ -360,6 +392,90 @@ impl Transaction {
             Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
             Err(e) => Err(e.into()),
         }
+    }
+
+    /// The repository's git directory, for the callers that build paths beside it or hand
+    /// it to a `git` subprocess.
+    pub fn path(&self) -> &std::path::Path {
+        self.repo.path()
+    }
+
+    /// Where HEAD points. Errors when HEAD is unborn (a repository whose HEAD names a
+    /// branch that does not exist yet) or detached at an object that is not a commit;
+    /// annotated tags are peeled. The commit is resolved through the transaction's objects,
+    /// so a HEAD moved to a commit this transaction produced resolves. (gix mapping:
+    /// `Repository::head()` + `head_id()`.)
+    pub fn head(&self) -> anyhow::Result<Head> {
+        let head = self.repo.head()?;
+        let reference = if head.is_branch() {
+            head.name()
+                .map_err(|e| anyhow!("HEAD ref name is not valid UTF-8: {}", e))?
+                .to_string()
+        } else {
+            "HEAD".to_string()
+        };
+        let target = head
+            .target()
+            .ok_or_else(|| anyhow!("HEAD does not point at an object"))?;
+        Ok(Head {
+            reference,
+            target,
+            commit: crate::objects::peel_to_commit(&self.odb()?, target)?,
+        })
+    }
+
+    /// Resolve a user-supplied revision -- a ref name, a short or full oid, or rev syntax
+    /// like `master~2` -- to the object it names, unpeeled. `Ok(None)` when it resolves to
+    /// nothing, which covers both a malformed spec and one naming something absent: a
+    /// revision a user typed is input, not a contract. (gix mapping: `rev_parse_single`.)
+    pub fn rev_parse(&self, spec: &str) -> anyhow::Result<Option<git2::Oid>> {
+        match self.repo.revparse_single(spec) {
+            Ok(object) => Ok(Some(object.id())),
+            Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+            Err(e) if e.code() == git2::ErrorCode::InvalidSpec => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// The fully qualified name of the ref a short name refers to, resolved the way git
+    /// resolves an argument that could name several things (`master` ->
+    /// `refs/heads/master`). `Ok(None)` when no ref matches. (gix mapping:
+    /// `find_reference` with a partial name.)
+    pub fn expand_ref_name(&self, short_name: &str) -> anyhow::Result<Option<String>> {
+        match self.repo.resolve_reference_from_short_name(short_name) {
+            Ok(reference) => Ok(reference.name().ok().map(|name| name.to_string())),
+            Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+            Err(e) if e.code() == git2::ErrorCode::InvalidSpec => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// The remote-tracking ref that `branch_ref` is configured to track, from
+    /// `branch.<name>.remote` and `branch.<name>.merge`. `Ok(None)` when the branch has no
+    /// upstream configured. (gix mapping: `branch_remote_tracking_ref_name`.)
+    pub fn upstream_ref(&self, branch_ref: &str) -> anyhow::Result<Option<String>> {
+        match self.repo.branch_upstream_name(branch_ref) {
+            Ok(buf) => Ok(buf.as_str().ok().map(|name| name.to_string())),
+            Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// A string value from the repository's configuration, `None` when the key is unset.
+    /// (gix mapping: `config_snapshot().string()`.)
+    pub fn config_string(&self, key: &str) -> anyhow::Result<Option<String>> {
+        match self.repo.config()?.get_string(key) {
+            Ok(value) => Ok(Some(value)),
+            Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// The identity to record as author and committer, from the repository's configuration
+    /// with the usual environment overrides. Errors when no identity is configured.
+    /// (gix mapping: `committer()`.)
+    pub fn signature(&self) -> anyhow::Result<git2::Signature<'static>> {
+        Ok(self.repo.signature()?)
     }
 
     /// Create or update the direct ref `refname` to point at `target`, guarded by
@@ -885,7 +1001,7 @@ mod tests {
     }
 
     fn commit(transaction: &Transaction, msg: &str) -> git2::Oid {
-        let repo = transaction.repo();
+        let repo = transaction.git2_repo();
         let tree = repo
             .find_tree(repo.treebuilder(None).unwrap().write().unwrap())
             .unwrap();
@@ -907,7 +1023,7 @@ mod tests {
             .update_ref("refs/heads/main", Expected::Any, oid, "test")
             .unwrap();
         transaction
-            .repo()
+            .git2_repo()
             .reference_symbolic("refs/josh/sym", "refs/heads/main", true, "test")
             .unwrap();
 
@@ -922,7 +1038,7 @@ mod tests {
     fn resolve_ref_dangling_symref_is_none() {
         let (_dir, transaction) = test_transaction();
         transaction
-            .repo()
+            .git2_repo()
             .reference_symbolic("refs/josh/dangling", "refs/heads/missing", true, "test")
             .unwrap();
         assert_eq!(transaction.resolve_ref("refs/josh/dangling").unwrap(), None);
@@ -1059,7 +1175,7 @@ mod tests {
             .update_ref("refs/josh-x/c", Expected::Any, oid, "test")
             .unwrap();
         transaction
-            .repo()
+            .git2_repo()
             .reference_symbolic("refs/josh/aa", "refs/josh/a", true, "test")
             .unwrap();
 
@@ -1281,7 +1397,12 @@ mod tests {
             .delete_ref("refs/josh/sym", Expected::Any)
             .unwrap();
         // The symref entry is gone; the branch it pointed at survives.
-        assert!(transaction.repo().find_reference("refs/josh/sym").is_err());
+        assert!(
+            transaction
+                .git2_repo()
+                .find_reference("refs/josh/sym")
+                .is_err()
+        );
         assert_eq!(
             transaction.resolve_ref("refs/heads/main").unwrap(),
             Some(oid)

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -1742,7 +1742,7 @@ mod tests {
             assert!(!cp.fallback, "`{pattern}` must not need the fallback");
             let got =
                 remove_pattern(&t, input, &cp, key, CompiledPattern::initial_state()).unwrap();
-            let want = ground_truth_tree(t.repo(), input, pattern);
+            let want = ground_truth_tree(t.git2_repo(), input, pattern);
             assert_eq!(
                 got, want,
                 "`{pattern}` diverged from full-path glob matching"
@@ -1819,7 +1819,7 @@ mod tests {
             key,
         )
         .unwrap();
-        let want = ground_truth_tree(t.repo(), input, "a/*.txt");
+        let want = ground_truth_tree(t.git2_repo(), input, "a/*.txt");
         assert_eq!(out, want, "b/f.txt must not be kept via the a/ cache entry");
     }
 

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -11,9 +11,10 @@ use std::path::PathBuf;
 /// - A raw SHA hex string: resolves the object and peels to its commit.
 /// - Anything else: treated as a ref name.
 pub fn resolve_snapshot_input(
-    repo: &git2::Repository,
+    transaction: &crate::cache::Transaction,
     input_ref: &str,
 ) -> anyhow::Result<git2::Oid> {
+    let repo = transaction.git2_repo();
     if input_ref == "+" || input_ref == "." {
         let mut index = repo.index()?;
         let tree_oid = if input_ref == "+" {
@@ -85,8 +86,10 @@ fn parse_git_env_date(s: &str) -> Option<git2::Time> {
 /// Like `repo.signature()` but honors `GIT_COMMITTER_*` / `GIT_AUTHOR_*` env vars
 /// the way `git` itself does. git2's `Repository::signature` ignores the date
 /// env vars, which breaks reproducibility in tests.
-pub fn user_signature(repo: &git2::Repository) -> anyhow::Result<git2::Signature<'static>> {
-    let default = repo.signature()?;
+pub fn user_signature(
+    transaction: &crate::cache::Transaction,
+) -> anyhow::Result<git2::Signature<'static>> {
+    let default = transaction.signature()?;
     let name = std::env::var("GIT_COMMITTER_NAME")
         .or_else(|_| std::env::var("GIT_AUTHOR_NAME"))
         .ok();

--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -118,7 +118,7 @@ regex_parsed!(
  * expensive to build from scratch using heuristics.
  */
 pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::Result<()> {
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
     let mut known_filters = KNOWN_FILTERS.lock().unwrap();
     let trace_s = span!(Level::TRACE, "discover_filter_candidates");
     let _e = trace_s.enter();

--- a/josh-core/tests/cache_lock.rs
+++ b/josh-core/tests/cache_lock.rs
@@ -32,7 +32,7 @@ fn sled_lock_follows_transaction_lifetime() {
     // holds the exclusive lock on the cache directory. Scoped so the git borrows of `transaction`
     // end before it is dropped below.
     {
-        let git = transaction.repo();
+        let git = transaction.git2_repo();
         let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
         let tree = git
             .find_tree(git.treebuilder(None).unwrap().write().unwrap())

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -1052,7 +1052,7 @@ impl Repository {
         let transaction_mirror = context.transaction_mirror.lock().unwrap();
         let commit_id = {
             let oid = if let Ok(id) = git2::Oid::from_str(&at) {
-                Some((id, transaction_mirror.repo().odb()?.exists(id)))
+                Some((id, transaction_mirror.odb()?.contains(id)))
             } else {
                 None
             };
@@ -1071,8 +1071,9 @@ impl Repository {
             if let Some((oid, _)) = oid {
                 oid
             } else {
-                // PORT: rev-parse stays on the git2 handle until flag day (gix rev_parse then).
-                transaction_mirror.repo().revparse_single(&rev)?.id()
+                transaction_mirror
+                    .rev_parse(&rev)?
+                    .ok_or_else(|| anyhow::anyhow!("no such revision: {}", rev))?
             }
         };
 

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -307,7 +307,7 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
 pub fn load_detail(sha: &str, scope: &josh_changes::ChangesRef) -> anyhow::Result<DetailData> {
     let transaction = crate::common::open_transaction()?;
     let oid = git2::Oid::from_str(sha)?;
-    let repo = transaction.repo();
+    let repo = transaction.git2_repo();
     let commit = repo.find_commit(oid)?;
 
     let msg = commit.message().unwrap_or("");

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -315,7 +315,7 @@ pub fn load_rows(scope: &josh_changes::ChangesRef) -> anyhow::Result<ListData> {
     let mut dependencies: HashMap<String, Vec<String>> = HashMap::new();
 
     for change in &changes {
-        let commit = transaction.repo().find_commit(change.commit())?;
+        let commit = transaction.git2_repo().find_commit(change.commit())?;
         let subject = commit
             .message()
             .unwrap_or("")

--- a/josh-link/src/lib.rs
+++ b/josh-link/src/lib.rs
@@ -110,10 +110,7 @@ pub fn make_signature(
         )
         .context("Failed to create signature")
     } else {
-        let sig = transaction
-            .repo()
-            .signature()
-            .context("Failed to get signature")?;
+        let sig = transaction.signature().context("Failed to get signature")?;
         Ok(sig.to_owned())
     }
 }

--- a/josh-proxy/src/housekeeping.rs
+++ b/josh-proxy/src/housekeeping.rs
@@ -150,19 +150,13 @@ pub fn run(
     transaction_overlay
         .add_disk_alternate(repo_path.join("mirror").join("objects").to_str().unwrap())?;
 
-    let mirror_object_count: ParsedCommandResult<CountObjectsOutput> = run_command(
-        transaction_mirror.repo().path(),
-        &["git", "count-objects", "-v"],
-    )
-    .into();
+    let mirror_object_count: ParsedCommandResult<CountObjectsOutput> =
+        run_command(transaction_mirror.path(), &["git", "count-objects", "-v"]).into();
 
     trace_object_count!(mirror_object_count, "mirror");
 
-    let overlay_object_count: ParsedCommandResult<CountObjectsOutput> = run_command(
-        transaction_overlay.repo().path(),
-        &["git", "count-objects", "-v"],
-    )
-    .into();
+    let overlay_object_count: ParsedCommandResult<CountObjectsOutput> =
+        run_command(transaction_overlay.path(), &["git", "count-objects", "-v"]).into();
 
     trace_object_count!(overlay_object_count, "overlay");
 
@@ -177,7 +171,7 @@ pub fn run(
     if do_gc {
         trace_command_result!(
             run_command(
-                transaction_mirror.repo().path(),
+                transaction_mirror.path(),
                 &[
                     "git",
                     "repack",
@@ -194,7 +188,7 @@ pub fn run(
 
         trace_command_result!(
             run_command(
-                transaction_mirror.repo().path(),
+                transaction_mirror.path(),
                 &["git", "multi-pack-index", "write", "--bitmap"]
             ),
             "mirror",
@@ -203,7 +197,7 @@ pub fn run(
 
         trace_command_result!(
             run_command(
-                transaction_overlay.repo().path(),
+                transaction_overlay.path(),
                 &[
                     "git",
                     "repack",
@@ -221,18 +215,15 @@ pub fn run(
 
         trace_command_result!(
             run_command(
-                transaction_overlay.repo().path(),
+                transaction_overlay.path(),
                 &["git", "multi-pack-index", "write", "--bitmap"]
             ),
             "overlay",
             "multi_pack_index"
         );
 
-        let final_object_count: ParsedCommandResult<CountObjectsOutput> = run_command(
-            transaction_mirror.repo().path(),
-            &["git", "count-objects", "-v"],
-        )
-        .into();
+        let final_object_count: ParsedCommandResult<CountObjectsOutput> =
+            run_command(transaction_mirror.path(), &["git", "count-objects", "-v"]).into();
 
         trace_object_count!(final_object_count, "mirror");
     }

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -336,14 +336,8 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
         let transaction = transaction_ctx.open()?;
         let transaction_mirror = transaction_mirror_ctx.open()?;
 
-        transaction.add_disk_alternate(
-            transaction_mirror
-                .repo()
-                .path()
-                .join("objects")
-                .to_str()
-                .unwrap(),
-        )?;
+        transaction
+            .add_disk_alternate(transaction_mirror.path().join("objects").to_str().unwrap())?;
 
         let old = git2::Oid::from_str(old)?;
         let author = push_options.author.as_deref().unwrap_or("");
@@ -565,7 +559,6 @@ pub fn push_head_url(
     display_name: &str,
     force: bool,
 ) -> anyhow::Result<(String, i32)> {
-    let repo = transaction.repo();
     let push_temp_ref = format!("refs/{}", &namespace);
     let push_refspec = format!("{}:{}", &push_temp_ref, &refname);
 
@@ -584,8 +577,12 @@ pub fn push_head_url(
     )?;
     // Flush before the external `git push` below reads these objects from disk.
     transaction.flush_mem_odb()?;
-    let (stdout, stderr, status) =
-        run_git_with_auth(repo.path(), &cmd, remote_auth, Some(alternate.to_owned()))?;
+    let (stdout, stderr, status) = run_git_with_auth(
+        transaction.path(),
+        &cmd,
+        remote_auth,
+        Some(alternate.to_owned()),
+    )?;
     transaction.delete_ref(&push_temp_ref, josh_core::cache::Expected::Any)?;
 
     tracing::debug!(

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -333,7 +333,7 @@ impl TrigramBench {
 
             josh_core::reset_caches()?;
             let transaction = context.open()?;
-            let repo = transaction.repo();
+            let repo = transaction.git2_repo();
             let tip_tree = repo.find_commit(tip)?.tree()?;
             let total_bytes = tree_content_bytes(repo, &tip_tree)?;
             let odb = transaction.odb()?;
@@ -384,7 +384,7 @@ impl TrigramBench {
             // have changed the index. This is the property the planned rework must preserve.
             josh_core::reset_caches()?;
             let transaction = context.open()?;
-            let repo = transaction.repo();
+            let repo = transaction.git2_repo();
             let root_tree = repo.find_commit(chain[0])?.tree()?;
             let odb = transaction.odb()?;
             // One indexer state for the whole chain, matching how josh keeps one per
@@ -458,7 +458,7 @@ fn trigram_benches(c: &mut Criterion) {
             b.iter_with_setup_wrapper(|runner| {
                 josh_core::reset_caches().expect("reset caches");
                 let transaction = bench.context.open().expect("open transaction");
-                let repo = transaction.repo();
+                let repo = transaction.git2_repo();
                 let tip_tree = repo.find_commit(case.tip()).expect("find tip").tree_id();
                 let odb = transaction.odb().expect("odb");
 
@@ -491,7 +491,7 @@ fn trigram_benches(c: &mut Criterion) {
             b.iter_with_setup_wrapper(|runner| {
                 josh_core::reset_caches().expect("reset caches");
                 let transaction = bench.context.open().expect("open transaction");
-                let repo = transaction.repo();
+                let repo = transaction.git2_repo();
                 let root_tree = repo
                     .find_commit(case.chain[0])
                     .expect("find root")
@@ -542,7 +542,7 @@ fn trigram_benches(c: &mut Criterion) {
                 b.iter_with_setup_wrapper(|runner| {
                     josh_core::reset_caches().expect("reset caches");
                     let transaction = bench.context.open().expect("open transaction");
-                    let repo = transaction.repo();
+                    let repo = transaction.git2_repo();
                     let source_tree = repo.find_commit(case.tip()).expect("find tip").tree_id();
                     let odb = transaction.odb().expect("odb");
 

--- a/josh-templates/src/templates.rs
+++ b/josh-templates/src/templates.rs
@@ -129,9 +129,8 @@ pub fn render(
     query_and_params: &str,
     split_odb: bool,
 ) -> anyhow::Result<Option<(String, std::collections::BTreeMap<String, String>)>> {
-    let repo_path = transaction.repo().path();
+    let repo_path = transaction.path();
     let overlay_path = transaction
-        .repo()
         .path()
         .parent()
         .ok_or(anyhow!("parent"))?
@@ -177,7 +176,6 @@ pub fn render(
                 if let Ok(to) = TransactionContext::new(&overlay_path, cache.clone()).open() {
                     to.add_disk_alternate(
                         transaction
-                            .repo()
                             .path()
                             .parent()
                             .ok_or(anyhow!("parent"))?
@@ -218,13 +216,12 @@ pub fn render(
 
     let repo_path = if split_odb {
         transaction
-            .repo()
             .path()
             .parent()
             .ok_or(anyhow!("parent"))?
             .to_owned()
     } else {
-        transaction.repo().path().to_owned()
+        transaction.path().to_owned()
     };
 
     let mut handlebars = handlebars::Handlebars::new();


### PR DESCRIPTION
Give the transaction the reads that are not object reads

`head`, `rev_parse`, `expand_ref_name`, `upstream_ref`, `config_string`,
`signature` and `path` join the ref API, each documented with the gix
call that will implement it, so the flag day changes their internals
rather than their call sites. `Head` carries the ref HEAD resolves to
(`HEAD` itself when detached, so it is always the ref to update), that
ref's unpeeled target for a CAS guard, and the commit -- peeled through
the transaction's objects, so a HEAD the transaction just moved
resolves.

With those in place, josh-changes, josh-graphql, josh-templates,
josh-link, josh-compose and josh-proxy no longer reach for the
repository handle at all.

`Transaction::repo` becomes `git2_repo`, and says what it is for: the
porcelain josh has not moved to gix -- worktree and index operations,
FETCH_HEAD's multi-entry semantics, notes -- and never the objects the
transaction holds.

Change: transaction-non-object-reads
Assisted-By: anthropic/claude-fable-5