### PR TITLE
Render the test build's diagnostics when it fails

### DIFF
--- a/ws/cargo-test-build.sh
+++ b/ws/cargo-test-build.sh
@@ -3,8 +3,11 @@ set -e
 cp -a --reflink=auto /cargo-deps-build/target/. "${CARGO_TARGET_DIR}/"
 cp -a --reflink=auto /cargo-deps-build/build/. "${CARGO_BUILD_BUILD_DIR}/"
 
+# On failure the diagnostics are in the json, so render them before giving up: a build
+# that fails silently is unactionable from the run log.
 cargo test --workspace --offline --locked --no-run --message-format=json \
-    > /tmp/cargo.json
+    > /tmp/cargo.json \
+    || { jq -r 'select(.message.rendered != null) | .message.rendered' /tmp/cargo.json; exit 1; }
 
 sh check-sccache.sh
 


### PR DESCRIPTION
Render the test build's diagnostics when it fails

The build writes cargo's json to a file and exits on failure before
anything reads it, so a failed build reached the run log as "FAILED
with exit code 101" and nothing else -- the errors themselves, and the
disk-full linker failure behind them, were only visible by rerunning
with the redirect removed.

Change: render-test-build-diagnostics
Assisted-By: anthropic/claude-fable-5