### PR TITLE
Open the repository with gitoxide too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,6 +1826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb3790fd8981cba7949f1ba924ef865d902df731627bc5998d14164063892fce"
 dependencies = [
  "gix-actor",
+ "gix-attributes",
  "gix-commitgraph",
  "gix-config",
  "gix-date",
@@ -1833,6 +1834,7 @@ dependencies = [
  "gix-discover",
  "gix-error",
  "gix-features",
+ "gix-filter",
  "gix-fs",
  "gix-glob",
  "gix-hash",
@@ -1842,6 +1844,7 @@ dependencies = [
  "gix-odb",
  "gix-pack",
  "gix-path",
+ "gix-pathspec",
  "gix-protocol",
  "gix-ref",
  "gix-refspec",
@@ -1855,6 +1858,7 @@ dependencies = [
  "gix-url",
  "gix-utils",
  "gix-validate",
+ "gix-worktree",
  "gix-worktree-stream",
  "gix-zlib",
  "nonempty",
@@ -2539,6 +2543,7 @@ checksum = "31eb8e675122e83585e461fe28f68ff8c5ed55b49017b697e7e76423ff973424"
 dependencies = [
  "bstr",
  "gix-attributes",
+ "gix-features",
  "gix-fs",
  "gix-glob",
  "gix-hash",
@@ -3400,6 +3405,7 @@ dependencies = [
  "criterion",
  "git-version",
  "git2",
+ "gix",
  "gix-actor",
  "gix-config",
  "gix-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ log = "0.4.33"
 mime = "0.3"
 form_urlencoded = "1.2.2"
 futures = "0.3.33"
-gix = { version = "0.86.0", default-features = false, features = ["sha1"] }
+gix = { version = "0.86.0", default-features = false, features = ["sha1", "parallel"] }
 gix-actor = "^0.41"
 gix-features = { version = "0.49", features = ["progress"] }
 gix-hash = { version = "^0.26", features = ["sha1"] }

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -66,6 +66,7 @@ smallvec = "1.15.2"
 anyhow.workspace = true
 chrono.workspace = true
 git2.workspace = true
+gix.workspace = true
 gix-actor.workspace = true
 gix-object.workspace = true
 gix-config.workspace = true

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -103,6 +103,42 @@ pub struct TransactionContext {
     ephemeral: bool,
 }
 
+/// The process's opened gitoxide repositories, keyed by repository path. Opening reads
+/// configuration and resolves alternates, and the pack indices a store discovers are worth
+/// keeping across transactions -- the proxy builds a context per request, which would pay for
+/// both every time. Sharing is safe across transactions: a store that misses an object
+/// rescans its objects directory once all its known indices come up empty (gix's default
+/// refresh mode), so a pack another transaction has just flushed is still found, and ref reads
+/// see the loose and packed files as they are. Entries live for the process; the proxy has a
+/// fixed pair of repositories and other processes see few paths each.
+static GIX_REPOS: LazyLock<
+    std::sync::RwLock<HashMap<std::path::PathBuf, std::sync::Arc<gix::ThreadSafeRepository>>>,
+> = LazyLock::new(Default::default);
+
+fn shared_gix_repo(
+    path: &std::path::Path,
+) -> anyhow::Result<std::sync::Arc<gix::ThreadSafeRepository>> {
+    if let Some(repo) = GIX_REPOS.read().unwrap().get(path) {
+        return Ok(repo.clone());
+    }
+
+    let mut repos = GIX_REPOS.write().unwrap();
+    if let Some(repo) = repos.get(path) {
+        return Ok(repo.clone());
+    }
+
+    // Isolated: the repository's own configuration only, no environment or system-wide
+    // overrides, so a transaction resolves the same objects and refs whatever the process it
+    // runs in.
+    let repo = std::sync::Arc::new(gix::ThreadSafeRepository::open_opts(
+        path,
+        gix::open::Options::isolated(),
+    )?);
+    repos.insert(path.to_owned(), repo.clone());
+
+    Ok(repo)
+}
+
 impl TransactionContext {
     pub fn from_env(cache: std::sync::Arc<CacheStack>) -> anyhow::Result<Self> {
         let repo = git2::Repository::open_from_env()?;
@@ -148,12 +184,15 @@ impl TransactionContext {
             return Err(anyhow!("path does not exist"));
         }
 
+        let gix_repo = shared_gix_repo(&self.path)?;
+
         Ok(Transaction::new(
             git2::Repository::open_ext(
                 &self.path,
                 git2::RepositoryOpenFlags::NO_SEARCH,
                 &[] as &[&std::ffi::OsStr],
             )?,
+            gix_repo,
             self.cache.clone(),
             self.ref_prefix.as_deref(),
             self.mem_odb_limit,
@@ -192,6 +231,11 @@ pub struct Transaction {
     /// borrows it for the entire call while also borrowing other caches through `t2`.
     trigram_indexer: std::cell::RefCell<josh_search::Indexer>,
     repo: git2::Repository,
+    /// The gitoxide view of the same repository, and the one josh reads objects and refs
+    /// through as each of those moves off libgit2. Held in its thread-safe form: a
+    /// transaction crosses threads (josh-graphql requires `Send`) while a `gix::Repository`
+    /// holds `Rc` snapshots of packed-refs and shallow state and does not.
+    gix_repo: std::sync::Arc<gix::ThreadSafeRepository>,
     /// Per-transaction in-memory object store, flushed to a packfile when the transaction drops, at
     /// an explicit boundary, or mid-transaction when it exceeds its size limit. Never shared with
     /// another transaction.
@@ -222,6 +266,7 @@ impl Drop for Transaction {
 impl Transaction {
     fn new(
         repo: git2::Repository,
+        gix_repo: std::sync::Arc<gix::ThreadSafeRepository>,
         cache: std::sync::Arc<CacheStack>,
         ref_prefix: Option<&str>,
         mem_odb_limit: Option<usize>,
@@ -271,6 +316,7 @@ impl Transaction {
             }),
             trigram_indexer: Default::default(),
             repo,
+            gix_repo,
             mem_odb,
             mem_odb_limit,
             ephemeral,
@@ -289,6 +335,13 @@ impl Transaction {
         };
 
         context.open()
+    }
+
+    /// A gitoxide handle on this repository. Made per call rather than held: the handle
+    /// itself is not `Send`, and building one is a matter of cloning `Arc`s and taking
+    /// snapshot references -- no filesystem access.
+    pub fn repo(&self) -> gix::Repository {
+        self.gix_repo.to_thread_local()
     }
 
     /// The libgit2 handle on this repository, for the porcelain josh has not moved to gix:


### PR DESCRIPTION
Open the repository with gitoxide too

A transaction now carries the gitoxide view of its repository beside
the libgit2 one, ready for the object and ref reads to move over.

It is held in thread-safe form and handed out per call as a
`gix::Repository`: a transaction crosses threads, which josh-graphql
requires, while the thread-local handle holds `Rc` snapshots of
packed-refs and shallow state and cannot. That also means the workspace
builds gix with `parallel`, without which even the thread-safe handle
is `Rc`-based.

The opened repositories are shared for the whole process, keyed by
repository path in the shape of josh-memodb's store registry, rather
than once per context: the proxy builds a context per request, and a
per-request open costs twice over -- opening reads configuration and
resolves alternates, and the pack indices a store discovers start
cold each time. Measured against a mirror-shaped repository of 200
small packs, open-and-drop cost 3.9ms per fresh context against
0.09ms shared, and twenty packed blob reads cost 13.3ms through a
cold store against 0.12ms warm. Sharing across transactions rests on
the same properties as sharing within one: a store that misses an
object rescans its objects directory once all its known indices come
up empty, so a pack another transaction has just flushed is still
found, and ref reads see loose and packed files as they are.

Change: open-repository-with-gitoxide
Assisted-By: anthropic/claude-fable-5
Assisted-By: openrouter/stealth/ox-alpha