### PR TITLE
Share object stores and defer ref publication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3659,6 +3659,7 @@ dependencies = [
  "gix-zlib",
  "josh-gix-ext",
  "log",
+ "parking_lot 0.12.5",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ defer = "0.2.1"
 env_logger = "0.11.11"
 log = "0.4.33"
 mime = "0.3"
+parking_lot = "0.12.5"
 form_urlencoded = "1.2.2"
 futures = "0.3.33"
 gix = { version = "0.86.0", default-features = false, features = ["sha1", "parallel"] }

--- a/cq/josh-cq/src/bin/josh-cq.rs
+++ b/cq/josh-cq/src/bin/josh-cq.rs
@@ -119,6 +119,8 @@ async fn run_serve(args: ServeArgs, data_dir: Option<&std::path::Path>) -> anyho
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let _flush_guard = josh_core::memodb::FlushGuard::new();
+
     let cli = Cli::parse();
 
     match cli.command {

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -517,7 +517,8 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     Ok(0)
 }
 
-fn main() {
+fn main() -> std::process::ExitCode {
+    let _flush_guard = josh_core::memodb::FlushGuard::new();
     env_logger::init();
     let args = {
         let mut args = vec![];
@@ -527,12 +528,14 @@ fn main() {
         args
     };
 
-    std::process::exit(if let Err(e) = run_filter(args) {
+    let code = if let Err(e) = run_filter(args) {
         eprintln!("ERROR: {}", e);
         1
     } else {
         0
-    })
+    };
+
+    std::process::ExitCode::from(code as u8)
 }
 
 #[test]

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -194,7 +194,8 @@ pub struct FilterArgs {
     pub remote: String,
 }
 
-fn main() {
+fn main() -> std::process::ExitCode {
+    let _flush_guard = josh_core::memodb::FlushGuard::new();
     env_logger::init();
     let cli = Cli::parse();
 
@@ -209,8 +210,9 @@ fn main() {
         for e in e.chain() {
             eprintln!("{e}");
         }
-
-        std::process::exit(1);
+        std::process::ExitCode::FAILURE
+    } else {
+        std::process::ExitCode::SUCCESS
     }
 }
 

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -54,6 +54,34 @@ pub enum Expected {
     At(git2::Oid),
 }
 
+#[derive(Debug, Clone)]
+struct PendingRef {
+    name: String,
+    change: PendingRefChange,
+}
+
+#[derive(Debug, Clone)]
+enum PendingRefChange {
+    Update {
+        expected: Expected,
+        target: git2::Oid,
+        log_message: String,
+    },
+    Delete {
+        expected: Expected,
+    },
+    Symbolic {
+        target: String,
+        log_message: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+enum PendingTarget {
+    Object(git2::Oid),
+    Symbolic(String),
+}
+
 static REF_CACHE: LazyLock<RwLock<HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>>> =
     LazyLock::new(Default::default);
 
@@ -236,10 +264,17 @@ pub struct Transaction {
     /// transaction crosses threads (josh-graphql requires `Send`) while a `gix::Repository`
     /// holds `Rc` snapshots of packed-refs and shallow state and does not.
     gix_repo: std::sync::Arc<gix::ThreadSafeRepository>,
-    /// Per-transaction in-memory object store, flushed to a packfile when the transaction drops, at
-    /// an explicit boundary, or mid-transaction when it exceeds its size limit. Never shared with
-    /// another transaction.
+    /// The in-memory object store of this transaction's repository, shared with every other
+    /// transaction on the same objects directory and outliving them all, so packing is the
+    /// store's business rather than a transaction's (see [`josh_memodb::registry`]). An
+    /// ephemeral transaction gets a private store instead, reading through to the shared one.
     mem_odb: std::sync::Arc<josh_memodb::MemOdb>,
+    /// The runtime alternates of this transaction's repository handle, mirrored for the object
+    /// facade's write gate (see [`josh_memodb::Alternates`]).
+    alternates: josh_memodb::Alternates,
+    /// Ref edits accepted by this transaction but not yet visible on disk. Reads overlay this
+    /// queue, and disk boundaries flush objects before applying it.
+    pending_refs: std::cell::RefCell<Vec<PendingRef>>,
     mem_odb_limit: Option<usize>,
     ephemeral: bool,
     ref_prefix: Option<String>,
@@ -252,13 +287,24 @@ impl Drop for Transaction {
         // locking backend can release once the last transaction ends.
         self.t2.borrow().cache.end();
 
-        // Skip flushing to disk, the mem odb will be lost, as requested.
+        // Ephemeral transactions discard both their private object store and every ref edit.
         if self.ephemeral {
             return;
         }
 
-        if let Err(e) = self.mem_odb.flush() {
+        // Objects first, refs second: a ref that reaches disk must never point at an object
+        // only memory holds. A flush error is logged and the refs written anyway -- the same
+        // end state as before, where refs were already on disk by the time the flush ran.
+        let publishes_object = self
+            .pending_refs
+            .borrow()
+            .iter()
+            .any(|edit| matches!(&edit.change, PendingRefChange::Update { .. }));
+        if publishes_object && let Err(e) = self.mem_odb.flush() {
             log::error!("failed to flush in-memory object store: {e}");
+        }
+        if let Err(e) = self.apply_pending_refs() {
+            log::error!("failed to write pending ref updates: {e}");
         }
     }
 }
@@ -287,7 +333,15 @@ impl Transaction {
             git2::opts::strict_hash_verification(false);
         });
 
-        let mem_odb = josh_memodb::MemOdb::new(mem_odb_limit, josh_memodb::objects_dir(&repo));
+        // An ephemeral transaction must not contribute to a store that outlives it, so it
+        // buffers privately and reads through to the shared one.
+        let objects_dir = josh_memodb::objects_dir(&repo);
+        let shared = josh_memodb::registry::shared(mem_odb_limit, &objects_dir);
+        let mem_odb = if ephemeral {
+            josh_memodb::MemOdb::chained(mem_odb_limit, objects_dir, shared)
+        } else {
+            shared
+        };
 
         // Balanced in `Drop`; lets a locking backend (sled) hold its lock only while a
         // transaction is live.
@@ -318,6 +372,8 @@ impl Transaction {
             repo,
             gix_repo,
             mem_odb,
+            alternates: Default::default(),
+            pending_refs: std::cell::RefCell::new(Vec::new()),
             mem_odb_limit,
             ephemeral,
             ref_prefix: ref_prefix.map(|prefix| prefix.to_owned()),
@@ -356,17 +412,18 @@ impl Transaction {
     /// The transaction's object-database facade: memory store first, repository odb
     /// fallback (see [`josh_memodb::Odb`]).
     pub fn odb(&self) -> anyhow::Result<josh_memodb::Odb<'_>> {
-        Ok(josh_memodb::Odb::new(
+        Ok(josh_memodb::Odb::with_alternates(
             self.mem_odb.clone(),
             self.repo.odb()?,
+            &self.alternates,
         ))
     }
 
     /// Add `path` (an objects directory) as a runtime alternate of both the repository odb
-    /// and the memory store's write-dedup probe (see [`josh_memodb::Odb::write`]).
+    /// and this transaction's write-dedup probe (see [`josh_memodb::Odb::write`]).
     pub fn add_disk_alternate(&self, path: &str) -> anyhow::Result<()> {
         self.repo.odb()?.add_disk_alternate(path)?;
-        self.mem_odb.add_alternate(path)?;
+        self.alternates.add(path)?;
         Ok(())
     }
 
@@ -402,16 +459,22 @@ impl Transaction {
         Ok(Some(TreeBytes::Odb(obj)))
     }
 
+    /// Pack the repository's buffered objects and block until they are durable, then publish
+    /// every ref update a persistent transaction has accepted. Ephemeral transactions keep
+    /// their pending refs private. The shared store covers everything buffered for the
+    /// repository, not only what this transaction wrote.
     // TODO: remove and rework proxy git launch path to use spawn_git
     pub fn flush_mem_odb(&self) -> anyhow::Result<()> {
         self.mem_odb.flush()?;
+        if !self.ephemeral {
+            self.apply_pending_refs()?;
+        }
         Ok(())
     }
 
-    /// Flush this transaction's in-memory objects, then build a `git` subprocess against its repo.
-    /// Use this in place of [`crate::git::GitCommand::new`] whenever a transaction is in scope: the
-    /// spawned `git` reads objects from disk and cannot see the in-memory backend, so the store must
-    /// be flushed first.
+    /// Flush this transaction's in-memory objects and publish its pending ref updates, then build
+    /// a `git` subprocess against its repo. Use this in place of [`crate::git::GitCommand::new`]
+    /// whenever a transaction is in scope: the spawned `git` reads objects and refs from disk.
     pub fn git_command(
         &self,
         args: &[&str],
@@ -439,14 +502,150 @@ impl Transaction {
     /// partial-name DWIM. `Ok(None)` if the ref (or the end of a symbolic chain) does not
     /// exist. The target is not peeled: for an annotated tag ref this is the tag oid,
     /// peeling is an object-store concern.
-    pub fn resolve_ref(&self, refname: &str) -> anyhow::Result<Option<git2::Oid>> {
-        match self.repo.refname_to_id(refname) {
-            Ok(oid) => Ok(Some(oid)),
+
+    fn pending_target(&self, refname: &str) -> Option<Option<PendingTarget>> {
+        self.pending_refs
+            .borrow()
+            .iter()
+            .rev()
+            .find(|edit| edit.name == refname)
+            .map(|edit| match &edit.change {
+                PendingRefChange::Update { target, .. } => Some(PendingTarget::Object(*target)),
+                PendingRefChange::Delete { .. } => None,
+                PendingRefChange::Symbolic { target, .. } => {
+                    Some(PendingTarget::Symbolic(target.clone()))
+                }
+            })
+    }
+
+    fn ref_target(&self, refname: &str) -> anyhow::Result<Option<PendingTarget>> {
+        if let Some(target) = self.pending_target(refname) {
+            return Ok(target);
+        }
+        match self.repo.find_reference(refname) {
+            Ok(reference) => {
+                if let Some(target) = reference.symbolic_target()? {
+                    Ok(Some(PendingTarget::Symbolic(target.to_owned())))
+                } else {
+                    Ok(reference.target().map(PendingTarget::Object))
+                }
+            }
             Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
             Err(e) => Err(e.into()),
         }
     }
 
+    fn resolve_ref_target(&self, refname: &str) -> anyhow::Result<Option<(String, git2::Oid)>> {
+        let mut name = refname.to_owned();
+        for _ in 0..5 {
+            match self.ref_target(&name)? {
+                Some(PendingTarget::Object(target)) => return Ok(Some((name, target))),
+                Some(PendingTarget::Symbolic(target)) => name = target,
+                None => return Ok(None),
+            }
+        }
+        Err(anyhow!("symbolic ref '{}' is nested too deeply", name))
+    }
+
+    fn pending_partial(&self, partial: &str) -> Option<Option<String>> {
+        let mut candidates = vec![partial.to_owned()];
+        if !partial.starts_with("refs/") {
+            candidates.extend([
+                format!("refs/{partial}"),
+                format!("refs/tags/{partial}"),
+                format!("refs/heads/{partial}"),
+                format!("refs/remotes/{partial}"),
+            ]);
+            if partial != "HEAD" {
+                candidates.push(format!("refs/remotes/{partial}/HEAD"));
+            }
+        }
+        let pending = self.pending_refs.borrow();
+        for candidate in candidates {
+            if let Some(edit) = pending.iter().rev().find(|edit| edit.name == candidate) {
+                return Some(match edit.change {
+                    PendingRefChange::Delete { .. } => None,
+                    _ => Some(edit.name.clone()),
+                });
+            }
+        }
+        None
+    }
+
+    fn apply_pending_refs(&self) -> anyhow::Result<()> {
+        let edits = std::mem::take(&mut *self.pending_refs.borrow_mut());
+        for edit in edits {
+            match edit.change {
+                PendingRefChange::Update {
+                    expected,
+                    target,
+                    log_message,
+                } => self.write_ref(&edit.name, expected, target, &log_message)?,
+                PendingRefChange::Delete { expected } => {
+                    self.delete_ref_now(&edit.name, expected)?
+                }
+                PendingRefChange::Symbolic {
+                    target,
+                    log_message,
+                } => {
+                    self.repo
+                        .reference_symbolic(&edit.name, &target, true, &log_message)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn write_ref(
+        &self,
+        refname: &str,
+        expected: Expected,
+        target: git2::Oid,
+        log_message: &str,
+    ) -> anyhow::Result<()> {
+        match expected {
+            Expected::Any => {
+                self.repo.reference(refname, target, true, log_message)?;
+            }
+            Expected::At(old) => {
+                self.repo
+                    .reference_matching(refname, target, true, old, log_message)?;
+            }
+            Expected::Absent => {
+                self.repo.reference(refname, target, false, log_message)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn delete_ref_now(&self, refname: &str, expected: Expected) -> anyhow::Result<()> {
+        match expected {
+            Expected::Absent => Err(anyhow!("delete_ref: Expected::Absent is not a valid guard")),
+            Expected::Any => match self.repo.find_reference(refname) {
+                Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(()),
+                Err(e) => Err(e.into()),
+                Ok(mut reference) => match reference.delete() {
+                    Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(()),
+                    other => Ok(other?),
+                },
+            },
+            Expected::At(old) => {
+                let mut reference = self.repo.find_reference(refname)?;
+                if reference.target() != Some(old) {
+                    return Err(anyhow!(
+                        "delete_ref: '{}' does not point at {}",
+                        refname,
+                        old
+                    ));
+                }
+                Ok(reference.delete()?)
+            }
+        }
+    }
+    /// Resolve a fully qualified refname through this transaction's pending overlay.
+    pub fn resolve_ref(&self, refname: &str) -> anyhow::Result<Option<git2::Oid>> {
+        Ok(self.resolve_ref_target(refname)?.map(|(_, target)| target))
+    }
     /// The repository's git directory, for the callers that build paths beside it or hand
     /// it to a `git` subprocess.
     pub fn path(&self) -> &std::path::Path {
@@ -459,17 +658,14 @@ impl Transaction {
     /// so a HEAD moved to a commit this transaction produced resolves. (gix mapping:
     /// `Repository::head()` + `head_id()`.)
     pub fn head(&self) -> anyhow::Result<Head> {
-        let head = self.repo.head()?;
-        let reference = if head.is_branch() {
-            head.name()
-                .map_err(|e| anyhow!("HEAD ref name is not valid UTF-8: {}", e))?
-                .to_string()
+        let (name, target) = self
+            .resolve_ref_target("HEAD")?
+            .ok_or_else(|| anyhow!("HEAD does not point at an object"))?;
+        let reference = if name.starts_with("refs/heads/") {
+            name
         } else {
             "HEAD".to_string()
         };
-        let target = head
-            .target()
-            .ok_or_else(|| anyhow!("HEAD does not point at an object"))?;
         Ok(Head {
             reference,
             target,
@@ -495,8 +691,18 @@ impl Transaction {
     /// `refs/heads/master`). `Ok(None)` when no ref matches. (gix mapping:
     /// `find_reference` with a partial name.)
     pub fn expand_ref_name(&self, short_name: &str) -> anyhow::Result<Option<String>> {
+        if let Some(pending) = self.pending_partial(short_name) {
+            return match pending {
+                Some(name) => Ok(self.resolve_ref_target(&name)?.map(|(name, _)| name)),
+                None => Ok(None),
+            };
+        }
         match self.repo.resolve_reference_from_short_name(short_name) {
-            Ok(reference) => Ok(reference.name().ok().map(|name| name.to_string())),
+            Ok(reference) => Ok(reference
+                .resolve()?
+                .name()
+                .ok()
+                .map(|name| name.to_string())),
             Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(None),
             Err(e) if e.code() == git2::ErrorCode::InvalidSpec => Ok(None),
             Err(e) => Err(e.into()),
@@ -531,15 +737,8 @@ impl Transaction {
         Ok(self.repo.signature()?)
     }
 
-    /// Create or update the direct ref `refname` to point at `target`, guarded by
-    /// `expected`: with `Expected::Any` an existing ref is overwritten unconditionally
-    /// (updating to the value a ref already has is a no-op); `Expected::At(oid)` asserts
-    /// the ref currently points at `oid`; `Expected::Absent` asserts it does not exist.
-    /// On a failed assertion — including a ref that appeared or disappeared
-    /// concurrently — an error is returned and the ref is unchanged. Writers that derive
-    /// `target` from the ref's old value pass `At`/`Absent` so they never overwrite a
-    /// concurrent update. (gix mapping: `PreviousValue::Any` / `MustExistAndMatch` /
-    /// `MustNotExist`.)
+    /// Collect a direct ref update. Transaction reads see it immediately; disk sees it only
+    /// after the object store has been flushed at a boundary or on drop.
     pub fn update_ref(
         &self,
         refname: &str,
@@ -547,21 +746,45 @@ impl Transaction {
         target: git2::Oid,
         log_message: &str,
     ) -> anyhow::Result<()> {
+        let current = self.ref_target(refname)?;
+        let guard_allows_unchanged = match expected {
+            Expected::Any => true,
+            Expected::At(old) => old == target,
+            Expected::Absent => false,
+        };
+        if guard_allows_unchanged
+            && matches!(current, Some(PendingTarget::Object(current)) if current == target)
+        {
+            return Ok(());
+        }
         match expected {
-            Expected::Any => {
-                self.repo.reference(refname, target, true, log_message)?;
+            Expected::Any => {}
+            Expected::Absent if current.is_none() => {}
+            Expected::At(old) if matches!(current, Some(PendingTarget::Object(current)) if current == old) =>
+                {}
+            Expected::Absent => {
+                return Err(anyhow!(
+                    "ref '{}' exists but was expected to be absent",
+                    refname
+                ));
             }
             Expected::At(old) => {
-                self.repo
-                    .reference_matching(refname, target, true, old, log_message)?;
-            }
-            Expected::Absent => {
-                self.repo.reference(refname, target, false, log_message)?;
+                return Err(anyhow!(
+                    "ref '{}' does not point at the expected value {old}",
+                    refname
+                ));
             }
         }
+        self.pending_refs.borrow_mut().push(PendingRef {
+            name: refname.to_owned(),
+            change: PendingRefChange::Update {
+                expected,
+                target,
+                log_message: log_message.to_owned(),
+            },
+        });
         Ok(())
     }
-
     /// Delete the ref `refname`, guarded by `expected`: `Expected::Any` deletes whatever
     /// is there and treats an absent ref as a no-op; `Expected::At(oid)` asserts the ref
     /// currently points at `oid` and errors, leaving the ref in place, on mismatch or
@@ -572,28 +795,23 @@ impl Transaction {
     /// gix's Any-delete succeeds -- acceptable widening at flag day. (gix mapping: RefEdit
     /// Change::Delete with PreviousValue::Any / MustExistAndMatch, RefLog::AndReference.)
     pub fn delete_ref(&self, refname: &str, expected: Expected) -> anyhow::Result<()> {
-        match expected {
-            Expected::Absent => Err(anyhow!("delete_ref: Expected::Absent is not a valid guard")),
-            Expected::Any => match self.repo.find_reference(refname) {
-                Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(()),
-                Err(e) => Err(e.into()),
-                Ok(mut reference) => match reference.delete() {
-                    Err(e) if e.code() == git2::ErrorCode::NotFound => Ok(()),
-                    other => Ok(other?),
-                },
-            },
-            Expected::At(old) => {
-                let mut reference = self.repo.find_reference(refname)?;
-                if reference.target() != Some(old) {
-                    return Err(anyhow!(
-                        "delete_ref: '{}' does not point at {}",
-                        refname,
-                        old
-                    ));
-                }
-                Ok(reference.delete()?)
-            }
+        if expected == Expected::Absent {
+            return Err(anyhow!("delete_ref: Expected::Absent is not a valid guard"));
         }
+        if let Expected::At(old) = expected
+            && !matches!(self.ref_target(refname)?, Some(PendingTarget::Object(target)) if target == old)
+        {
+            return Err(anyhow!(
+                "delete_ref: '{}' does not point at {}",
+                refname,
+                old
+            ));
+        }
+        self.pending_refs.borrow_mut().push(PendingRef {
+            name: refname.to_owned(),
+            change: PendingRefChange::Delete { expected },
+        });
+        Ok(())
     }
 
     /// Force-create or update the symbolic ref `refname` to point at the ref named
@@ -607,8 +825,13 @@ impl Transaction {
         target: &str,
         log_message: &str,
     ) -> anyhow::Result<()> {
-        self.repo
-            .reference_symbolic(refname, target, true, log_message)?;
+        self.pending_refs.borrow_mut().push(PendingRef {
+            name: refname.to_owned(),
+            change: PendingRefChange::Symbolic {
+                target: target.to_owned(),
+                log_message: log_message.to_owned(),
+            },
+        });
         Ok(())
     }
 
@@ -626,15 +849,27 @@ impl Transaction {
             !prefix.contains(['*', '?', '[', '\\']),
             "prefix must consist of refname-valid characters"
         );
-        let mut refs = vec![];
+        let mut refs = HashMap::new();
         for reference in self.repo.references_glob(&format!("{}*", prefix))? {
             let reference = reference?;
             if let (Ok(name), Some(target)) = (reference.name(), reference.target()) {
-                refs.push((name.to_owned(), target));
+                refs.insert(name.to_owned(), target);
             }
         }
-        // git2 yields loose refs in filesystem order followed by packed ones; sorting makes
-        // the order part of the API contract instead of an artifact of the backend.
+        for edit in self.pending_refs.borrow().iter() {
+            if !edit.name.starts_with(prefix) {
+                continue;
+            }
+            match edit.change {
+                PendingRefChange::Update { target, .. } => {
+                    refs.insert(edit.name.clone(), target);
+                }
+                PendingRefChange::Delete { .. } | PendingRefChange::Symbolic { .. } => {
+                    refs.remove(&edit.name);
+                }
+            }
+        }
+        let mut refs: Vec<_> = refs.into_iter().collect();
         refs.sort();
         for (name, target) in refs {
             cb(&name, target)?;
@@ -1194,6 +1429,7 @@ mod tests {
         transaction
             .update_ref("refs/josh/a", Expected::Any, a, "test")
             .unwrap();
+        transaction.apply_pending_refs().unwrap();
         // Pack the ref by hand (git2 exposes no pack-refs API): the CAS must see the
         // packed value, not conclude the ref is absent.
         std::fs::write(
@@ -1227,6 +1463,8 @@ mod tests {
         transaction
             .update_ref("refs/josh-x/c", Expected::Any, oid, "test")
             .unwrap();
+        transaction.apply_pending_refs().unwrap();
+
         transaction
             .git2_repo()
             .reference_symbolic("refs/josh/aa", "refs/josh/a", true, "test")
@@ -1277,6 +1515,7 @@ mod tests {
     }
 
     #[test]
+
     fn delete_ref_any_deletes_existing() {
         let (_dir, transaction) = test_transaction();
         let oid = commit(&transaction, "a");
@@ -1355,6 +1594,7 @@ mod tests {
         transaction
             .update_ref("refs/josh/a", Expected::Any, a, "test")
             .unwrap();
+        transaction.apply_pending_refs().unwrap();
         // Pack the ref by hand (git2 exposes no pack-refs API): delete must remove the
         // packed entry, not conclude the ref is absent.
         std::fs::write(
@@ -1460,5 +1700,182 @@ mod tests {
             transaction.resolve_ref("refs/heads/main").unwrap(),
             Some(oid)
         );
+    }
+
+    /// A context the store-lifetime tests below open several transactions from in turn.
+    fn test_context() -> (tempfile::TempDir, TransactionContext) {
+        let dir = tempfile::tempdir().unwrap();
+        git2::Repository::init_bare(dir.path()).unwrap();
+        let context = TransactionContext::new(
+            dir.path(),
+            std::sync::Arc::new(crate::cache::CacheStack::new()),
+        );
+        (dir, context)
+    }
+
+    fn packs(dir: &std::path::Path) -> usize {
+        std::fs::read_dir(dir.join("objects").join("pack"))
+            .map(|entries| {
+                entries
+                    .filter(|e| {
+                        e.as_ref()
+                            .is_ok_and(|e| e.file_name().to_string_lossy().ends_with(".pack"))
+                    })
+                    .count()
+            })
+            .unwrap_or(0)
+    }
+
+    /// The store outlives the transaction that filled it: a transaction that publishes nothing
+    /// leaves no packfile behind, and the objects it produced are still there for the next
+    /// transaction to read.
+    #[test]
+    fn objects_outlive_a_transaction_that_published_nothing() {
+        let (dir, context) = test_context();
+
+        let oid = {
+            let transaction = context.open().unwrap();
+            transaction
+                .odb()
+                .unwrap()
+                .write(gix_object::Kind::Blob, b"unpublished")
+        };
+
+        assert_eq!(packs(dir.path()), 0, "nothing was published, nothing packs");
+
+        let transaction = context.open().unwrap();
+        let odb = transaction.odb().unwrap();
+        assert!(odb.contains(oid));
+        assert_eq!(&*odb.read(oid).unwrap().1, b"unpublished");
+    }
+
+    /// A publishing transaction keeps its ref private until drop, then flushes the object
+    /// before making the ref visible to disk-only readers.
+    #[test]
+    fn publishing_a_ref_flushes_before_ref_reaches_disk() {
+        let (dir, context) = test_context();
+
+        let oid = {
+            let transaction = context.open().unwrap();
+            let oid = transaction
+                .odb()
+                .unwrap()
+                .write(gix_object::Kind::Blob, b"published");
+            transaction
+                .update_ref("refs/josh/blob", Expected::Absent, oid, "test")
+                .unwrap();
+
+            // Transaction reads see their pending state; disk-only readers see neither half.
+            assert_eq!(
+                transaction.resolve_ref("refs/josh/blob").unwrap(),
+                Some(oid)
+            );
+            let on_disk = git2::Repository::open(dir.path()).unwrap();
+            assert!(on_disk.find_reference("refs/josh/blob").is_err());
+            assert!(on_disk.find_blob(oid).is_err());
+            oid
+        };
+
+        let on_disk = git2::Repository::open(dir.path()).unwrap();
+        assert_eq!(
+            on_disk.find_reference("refs/josh/blob").unwrap().target(),
+            Some(oid)
+        );
+        assert_eq!(on_disk.find_blob(oid).unwrap().content(), b"published");
+    }
+
+    /// An explicit disk-reader boundary has the same ordering as drop: object first, ref second.
+    #[test]
+    fn flush_mem_odb_publishes_pending_refs_after_objects() {
+        let (dir, context) = test_context();
+        let transaction = context.open().unwrap();
+        let oid = transaction
+            .odb()
+            .unwrap()
+            .write(gix_object::Kind::Blob, b"boundary");
+        transaction
+            .update_ref("refs/josh/blob", Expected::Absent, oid, "test")
+            .unwrap();
+
+        transaction.flush_mem_odb().unwrap();
+
+        let on_disk = git2::Repository::open(dir.path()).unwrap();
+        assert_eq!(
+            on_disk.find_reference("refs/josh/blob").unwrap().target(),
+            Some(oid)
+        );
+        assert_eq!(on_disk.find_blob(oid).unwrap().content(), b"boundary");
+    }
+
+    #[test]
+    fn ephemeral_transaction_never_publishes_refs() {
+        let (dir, _) = test_context();
+        {
+            let transaction = TransactionContext::new(
+                dir.path(),
+                std::sync::Arc::new(crate::cache::CacheStack::new()),
+            )
+            .ephemeral()
+            .open()
+            .unwrap();
+            let target = commit(&transaction, "a");
+            transaction
+                .update_ref("refs/josh/ephemeral", Expected::Absent, target, "test")
+                .unwrap();
+
+            assert_eq!(
+                transaction.resolve_ref("refs/josh/ephemeral").unwrap(),
+                Some(target)
+            );
+            transaction.flush_mem_odb().unwrap();
+            assert!(
+                git2::Repository::open(dir.path())
+                    .unwrap()
+                    .find_reference("refs/josh/ephemeral")
+                    .is_err()
+            );
+        }
+
+        assert!(
+            git2::Repository::open(dir.path())
+                .unwrap()
+                .find_reference("refs/josh/ephemeral")
+                .is_err()
+        );
+    }
+
+    /// An ephemeral transaction discards what it writes, but still reads what the repository's
+    /// store holds in memory.
+    #[test]
+    fn ephemeral_reads_the_shared_store_and_discards_its_own() {
+        let (dir, context) = test_context();
+
+        let shared = {
+            let transaction = context.open().unwrap();
+            transaction
+                .odb()
+                .unwrap()
+                .write(gix_object::Kind::Blob, b"shared")
+        };
+
+        let own = {
+            let ephemeral = TransactionContext::new(
+                dir.path(),
+                std::sync::Arc::new(crate::cache::CacheStack::new()),
+            )
+            .ephemeral()
+            .open()
+            .unwrap();
+            let odb = ephemeral.odb().unwrap();
+            assert_eq!(&*odb.read(shared).unwrap().1, b"shared");
+            odb.write(gix_object::Kind::Blob, b"ephemeral")
+        };
+
+        // What the ephemeral transaction wrote is gone; what it read is still buffered.
+        let transaction = context.open().unwrap();
+        let odb = transaction.odb().unwrap();
+        assert!(odb.contains(shared));
+        assert!(!odb.contains(own));
+        assert_eq!(packs(dir.path()), 0);
     }
 }

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -26,6 +26,7 @@ struct Cli {
 }
 
 fn main() {
+    let _flush_guard = josh_core::memodb::FlushGuard::new();
     let cli = Cli::parse();
     let scope = resolve_initial_scope(&cli);
 
@@ -36,6 +37,7 @@ fn main() {
         )
         .with_context(scope)
         .launch(app);
+
 }
 
 fn resolve_initial_scope(cli: &Cli) -> josh_changes::ChangesRef {

--- a/josh-memodb/Cargo.toml
+++ b/josh-memodb/Cargo.toml
@@ -19,4 +19,5 @@ gix-pack.workspace = true
 gix-zlib.workspace = true
 josh-gix-ext.workspace = true
 log.workspace = true
+parking_lot.workspace = true
 tempfile.workspace = true

--- a/josh-memodb/src/flusher.rs
+++ b/josh-memodb/src/flusher.rs
@@ -7,9 +7,9 @@
 //!
 //! * [`enqueue_chunk`] hands the worker a store to pack and returns immediately. It is best-effort
 //!   (fire-and-forget), used from the write path when a store overflows its size limit.
-//! * [`drain`] hands the worker a store and blocks until it is packed and evicted, used at
-//!   transaction and external-git boundaries where the objects must be durable on disk before the
-//!   caller proceeds.
+//! * [`drain`] hands the worker a store and blocks until it is packed and evicted, used at the
+//!   boundaries where the objects must be durable on disk before the caller proceeds: an external
+//!   `git`, and the end of a transaction that published a ref.
 //!
 //! A single worker processes jobs FIFO, so a store's queued overflow chunks always complete before
 //! its drain — and no two packs are ever written from the same store concurrently. A job carries
@@ -52,12 +52,14 @@ impl Flusher {
                 while let Ok(job) = receiver.recv() {
                     match job {
                         Job::Chunk { store } => {
-                            if let Err(e) = store.pack_to_disk() {
-                                log::error!("background chunk flush failed: {e}");
-                            }
-                            // Cleared only now (after packing + eviction), so the write path does
-                            // not enqueue a fresh chunk until this store's size reflects the drain.
-                            store.clear_chunk_in_flight();
+                            let packed = match store.pack_to_disk() {
+                                Ok(()) => true,
+                                Err(e) => {
+                                    log::error!("background chunk flush failed: {e}");
+                                    false
+                                }
+                            };
+                            store.finish_chunk(packed);
                         }
                         Job::Drain { store, ack } => {
                             let _ = ack.send(store.pack_to_disk().map_err(|e| e.to_string()));

--- a/josh-memodb/src/lib.rs
+++ b/josh-memodb/src/lib.rs
@@ -1,16 +1,19 @@
 //! josh's object store.
 //!
-//! [`MemOdb`] is a per-operation in-memory store that buffers the objects josh produces and
-//! flushes them to a packfile at transaction and external-git boundaries. [`Odb`] is the facade
-//! every reader and writer goes through: memory first, then the repository's objects on disk.
+//! [`MemOdb`] is an in-memory store that buffers the objects josh produces and packs them to disk
+//! on its own schedule. There is one per objects directory (see [`registry`]), so it outlives the
+//! transactions writing to it. [`Odb`] is the facade every reader and writer goes through: memory
+//! first, then the repository's objects on disk.
 
 mod flusher;
 pub mod hash;
 pub mod mem_odb;
 pub mod odb;
 pub mod pack;
+pub mod registry;
 
 pub use hash::PassthroughHasher;
 pub use mem_odb::MemOdb;
-pub use odb::{Bytes, Odb};
+pub use odb::{Alternates, Bytes, Odb};
 pub use pack::objects_dir;
+pub use registry::FlushGuard;

--- a/josh-memodb/src/mem_odb.rs
+++ b/josh-memodb/src/mem_odb.rs
@@ -1,19 +1,24 @@
-//! A per-operation in-memory ODB store buffering the objects josh produces while filtering, instead
-//! of writing each as a loose object. Packed to a packfile at transaction and external-git
-//! boundaries, and additionally packed mid-transaction once the buffered object data exceeds the
-//! configured size limit (so a single transaction may write several packfiles). One [`MemOdb`] per
-//! operation (not process-global), so flushes are isolated and deterministic.
+//! An in-memory ODB store buffering the objects josh produces while filtering, instead of writing
+//! each as a loose object. There is one store per objects directory (see [`crate::registry`]), so a
+//! store outlives the transactions that write to it and the next transaction on the same repository
+//! reads their objects from memory rather than from a pack.
+//!
+//! Packing is therefore not tied to a transaction. A store packs when its buffered data exceeds the
+//! configured size limit, when a transaction that published a ref ends, at an explicit boundary
+//! ([`MemOdb::flush`]), and at process exit ([`crate::FlushGuard`]).
 //!
 //! Packing itself runs on a background thread (see [`crate::flusher`]): the write path enqueues the
 //! work and keeps filtering, and a boundary flush blocks only until the pack is durable. The store's
-//! `Mutex` therefore guards concurrent access from the filter thread (writes and reads through
-//! the facade) and the flusher thread (which snapshots the buffered objects to pack them, then evicts
-//! them); it is `Send + Sync` so its `Arc` can cross to the flusher.
+//! locks therefore guard concurrent access from every thread holding a transaction on the repository
+//! and from the flusher thread (which snapshots the buffered objects to pack them, then evicts
+//! them); the store is `Send + Sync` so its `Arc` can cross to the flusher.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use parking_lot::{Mutex, RwLock};
 
 use gix_hash::ObjectId;
 use gix_object::Kind;
@@ -27,6 +32,9 @@ type ObjectMap = BTreeMap<ObjectId, (Kind, Arc<[u8]>)>;
 /// which keeps the resulting packfile — and hence its checksum-derived name — deterministic.
 pub(crate) type Snapshot = Vec<(ObjectId, Kind, Arc<[u8]>)>;
 
+/// `limit` sentinel for an unbounded store, so the limit can be tightened atomically.
+const UNBOUNDED: usize = usize::MAX;
+
 /// The buffered objects plus a running total of their data size, guarded by one lock so that an
 /// insert and the overflow check following it are observed atomically.
 struct Inner {
@@ -34,71 +42,78 @@ struct Inner {
     size: usize,
 }
 
-/// A per-operation in-memory object store. Create one with [`MemOdb::new`], attach it to a
-/// repository's object database with [`MemOdb::register`], and drain it to disk with
-/// [`MemOdb::flush`]. When `limit` is set, the store also enqueues a background pack from the write
-/// path as soon as the buffered data exceeds it (see [`MemOdb::enqueue_chunk`]).
+/// An in-memory object store. Obtain the store of a repository with
+/// [`crate::registry::shared`], or an unregistered one with [`MemOdb::new`] /
+/// [`MemOdb::chained`]; drain it to disk with [`MemOdb::flush`]. When a limit is set, the store
+/// also enqueues a background pack from the write path as soon as the buffered data exceeds it
+/// (see [`MemOdb::enqueue_chunk`]).
 pub struct MemOdb {
-    inner: Mutex<Inner>,
-    limit: Option<usize>,
-    /// The registered repository's resolved object directory (`<commondir>/objects`, see
-    /// [`crate::pack::objects_dir`]), captured at construction while the caller holds a repository
-    /// handle; the background flusher packs straight into it without opening one.
+    inner: RwLock<Inner>,
+    /// The tightest buffered-data bound any attacher asked for, [`UNBOUNDED`] when none did. A
+    /// shared store serves transactions opened with different limits, so the bound is a budget
+    /// for the objects directory and only ever tightens (see [`MemOdb::tighten_limit`]).
+    limit: AtomicUsize,
+    /// The store's resolved object directory (`<commondir>/objects`, see
+    /// [`crate::pack::objects_dir`]), captured while the caller holds a repository handle; the
+    /// background flusher packs straight into it without opening one.
     objects_dir: PathBuf,
     /// Set while an overflow chunk is queued on or running in the background flusher, so the write
     /// path does not pile up redundant chunk requests every time the store crosses its limit.
     /// Cleared by the flusher once the chunk has packed and evicted.
     chunk_in_flight: AtomicBool,
-    /// A mirror of the runtime alternates registered on the owning repository
-    /// (see [`MemOdb::add_alternate`]): an odb over ONLY the alternate object directories, no
-    /// repository attached. The direct write path probes it so alternate-resident objects
-    /// (the proxy overlay's mirror) are never buffered — flushed packs must not contain
-    /// duplicates of mirror objects, and the pack-time disk filter cannot see runtime
-    /// alternates. Deliberately excludes the repository's own odb: locally-durable objects
-    /// are dropped at pack time instead, and with no alternates registered the probe is a
-    /// `None` check, no filesystem I/O.
-    alternates: Mutex<Option<git2::Odb<'static>>>,
+    /// Held for the duration of a pack, so two packers never snapshot and evict the same store
+    /// concurrently. The flusher thread serialises its own jobs, but [`crate::FlushGuard`] packs
+    /// inline at process exit and would otherwise race it.
+    pack_lock: Mutex<()>,
+    /// Consulted on a read miss, for stores that must not contribute their own objects to the
+    /// repository's registered store but must still see what it holds (see [`MemOdb::chained`]).
+    read_through: Option<Arc<MemOdb>>,
 }
 
 impl MemOdb {
-    /// Create an empty store. Returned as an [`Arc`] because the store is shared between the owning
-    /// transaction and the libgit2 backend registered on its repository. `limit` bounds the total
-    /// buffered object data: once exceeded the store flushes itself to a packfile (`None` = unbounded).
-    /// `objects_dir` is where flushes land; pass [`crate::pack::objects_dir`] of the repository the
-    /// store is about to be registered on.
+    /// Create an empty, unregistered store: its objects are visible only through this handle.
+    /// Prefer [`crate::registry::shared`] for a repository josh filters into; this is for stores
+    /// with a lifetime of their own (the distributed cache backend's repository, tests). `limit`
+    /// bounds the total buffered object data, above which the store packs itself in the
+    /// background (`None` = unbounded); `objects_dir` is where flushes land.
     pub fn new(limit: Option<usize>, objects_dir: PathBuf) -> Arc<MemOdb> {
+        Self::build(limit, objects_dir, None)
+    }
+
+    /// [`MemOdb::new`] plus a store to read through on a miss. Used for ephemeral transactions:
+    /// their objects are discarded, so they must not land in the repository's registered store,
+    /// but they must still see the objects it buffers.
+    pub fn chained(
+        limit: Option<usize>,
+        objects_dir: PathBuf,
+        read_through: Arc<MemOdb>,
+    ) -> Arc<MemOdb> {
+        Self::build(limit, objects_dir, Some(read_through))
+    }
+
+    pub(crate) fn build(
+        limit: Option<usize>,
+        objects_dir: PathBuf,
+        read_through: Option<Arc<MemOdb>>,
+    ) -> Arc<MemOdb> {
         Arc::new(MemOdb {
-            inner: Mutex::new(Inner {
+            inner: RwLock::new(Inner {
                 map: Default::default(),
                 size: 0,
             }),
-            limit,
+            limit: AtomicUsize::new(limit.unwrap_or(UNBOUNDED)),
             objects_dir,
             chunk_in_flight: AtomicBool::new(false),
-            alternates: Mutex::new(None),
+            pack_lock: Mutex::new(()),
+            read_through,
         })
     }
 
-    /// Record `path` (an objects directory) as a runtime alternate of the owning repository.
-    /// Callers add the alternate to the repository odb themselves (`Odb::add_disk_alternate`);
-    /// this mirror only feeds the direct write path's dedup probe (see [`Self::alternates`]).
-    pub fn add_alternate(&self, path: &str) -> Result<(), git2::Error> {
-        let mut alternates = self.alternates.lock().unwrap();
-        let odb = match alternates.as_mut() {
-            Some(odb) => odb,
-            None => alternates.insert(git2::Odb::new()?),
-        };
-        odb.add_disk_alternate(path)
-    }
-
-    /// Whether `oid` exists in one of the registered alternates. `false` without filesystem
-    /// I/O when no alternates are registered.
-    pub(crate) fn exists_in_alternates(&self, oid: git2::Oid) -> bool {
-        self.alternates
-            .lock()
-            .unwrap()
-            .as_ref()
-            .is_some_and(|odb| odb.exists(oid))
+    /// Lower the bound to `limit` if that is tighter. Called on every attach: honouring the
+    /// tightest request is the safe direction, and the bound never loosens.
+    pub(crate) fn tighten_limit(&self, limit: Option<usize>) {
+        self.limit
+            .fetch_min(limit.unwrap_or(UNBOUNDED), Ordering::AcqRel);
     }
 
     /// Buffer `oid` and return whether the store has now exceeded its size limit, so the caller
@@ -106,12 +121,12 @@ impl MemOdb {
     /// no bytes, so it must not trigger a pack.
     fn insert(&self, oid: ObjectId, kind: Kind, data: Arc<[u8]>) -> bool {
         let len = data.len();
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.write();
         if inner.map.insert(oid, (kind, data)).is_some() {
             return false;
         }
         inner.size += len;
-        self.limit.is_some_and(|limit| inner.size > limit)
+        inner.size > self.limit.load(Ordering::Acquire)
     }
 
     /// Hash `data` and buffer it, enqueueing a background pack if the store overflows its
@@ -133,34 +148,54 @@ impl MemOdb {
 
     /// The buffered object `id`, as a zero-copy clone of the store's shared buffer.
     pub fn get(&self, id: &gix_hash::oid) -> Option<(Kind, Arc<[u8]>)> {
-        self.inner
-            .lock()
-            .unwrap()
+        if let Some(hit) = self
+            .inner
+            .read()
             .map
             .get(id)
             .map(|(kind, data)| (*kind, data.clone()))
+        {
+            return Some(hit);
+        }
+        self.read_through.as_ref()?.get(id)
     }
 
     /// Kind and size of the buffered object `id`, without touching its bytes.
     pub fn header(&self, id: &gix_hash::oid) -> Option<(Kind, u64)> {
-        self.inner
-            .lock()
-            .unwrap()
+        if let Some(hit) = self
+            .inner
+            .read()
             .map
             .get(id)
             .map(|(kind, data)| (*kind, data.len() as u64))
+        {
+            return Some(hit);
+        }
+        self.read_through.as_ref()?.header(id)
     }
 
     pub fn contains(&self, id: &gix_hash::oid) -> bool {
-        self.inner.lock().unwrap().map.contains_key(id)
+        self.inner.read().map.contains_key(id)
+            || self.read_through.as_ref().is_some_and(|s| s.contains(id))
     }
 
-    /// Drain every in-memory object into a packfile on disk and evict it from the store, blocking
-    /// until done. Called when the owning transaction completes (or at an explicit external-git
-    /// boundary) so the on-disk repository is left whole for any subsequent process that expects the
-    /// objects on disk. Packing runs on the background flusher, behind any overflow chunks already
-    /// queued for this store, so it returns only once every buffered object is durable.
+    /// Whether this store holds nothing of its own to pack.
+    fn is_empty(&self) -> bool {
+        self.inner.read().map.is_empty()
+    }
+
+    /// Drain every in-memory object this store can see into a packfile on disk and evict it,
+    /// blocking until done: at an external-git boundary, and when a transaction that published a
+    /// ref ends. Everything *readable* through the store has to become durable, so a chained
+    /// store drains what it reads through too. Runs on the background flusher behind any queued
+    /// overflow chunks; a store holding nothing skips the round trip.
     pub fn flush(self: &Arc<Self>) -> Result<(), git2::Error> {
+        if let Some(behind) = &self.read_through {
+            behind.flush()?;
+        }
+        if self.is_empty() {
+            return Ok(());
+        }
         crate::flusher::drain(self.clone())
     }
 
@@ -174,8 +209,7 @@ impl MemOdb {
 
     /// Enqueue a best-effort background pack of this store, called from the ODB `write` path when the
     /// store overflows its size limit. `chunk_in_flight` collapses the burst of overflowing writes
-    /// that follow into a single queued chunk; the flusher clears it once the chunk has packed and
-    /// evicted (so `size` reflects the drain before another chunk can be enqueued).
+    /// that follow into a single queued chunk.
     fn enqueue_chunk(self: &Arc<Self>) {
         if self.chunk_in_flight.swap(true, Ordering::AcqRel) {
             return;
@@ -183,26 +217,36 @@ impl MemOdb {
         crate::flusher::enqueue_chunk(self.clone());
     }
 
-    /// Clear the [`Self::chunk_in_flight`] guard. Called by the background flusher after a chunk.
-    pub(crate) fn clear_chunk_in_flight(&self) {
+    /// Release the in-flight guard after a background chunk. A write can overflow after the worker
+    /// snapshots the store but before it releases the guard; check the remaining size after the
+    /// release so that write still schedules the next chunk. Failed packs wait for a later write or
+    /// explicit drain instead of retrying in a hot loop.
+    pub(crate) fn finish_chunk(self: &Arc<Self>, packed: bool) {
         self.chunk_in_flight.store(false, Ordering::Release);
+        if packed && self.inner.read().size > self.limit.load(Ordering::Acquire) {
+            self.enqueue_chunk();
+        }
     }
 
-    /// Pack this store's currently-buffered objects into a packfile and evict them. Runs only on
-    /// the background flusher, which packs a snapshot of the buffers straight into the object
-    /// directory captured at construction (see [`crate::pack::write_snapshot`]) — no repository
-    /// handle involved. The snapshot shares the object buffers (`Arc`), and the objects stay in the
-    /// map while the pack is written, so concurrent reads through the backend keep resolving until
+    /// Pack this store's currently-buffered objects into a packfile and evict them. Runs on the
+    /// background flusher, or inline at process exit, packing a snapshot of the buffers straight
+    /// into the object directory captured at construction (see [`crate::pack::write_snapshot`]) —
+    /// no repository handle involved. The snapshot shares the object buffers (`Arc`), and the
+    /// objects stay in the map while the pack is written, so concurrent reads keep resolving until
     /// eviction — which happens only once the pack is on disk.
     pub(crate) fn pack_to_disk(self: &Arc<Self>) -> Result<(), git2::Error> {
+        // One packer per store at a time: the flusher's own jobs are already serialised, but the
+        // process-exit flush packs inline and would otherwise snapshot and evict concurrently.
+        let _packing = self.pack_lock.lock();
+
         // Snapshot under the lock, then release it: `write_snapshot` filters against the on-disk
-        // store and compresses every object, which must not stall the filter thread's reads and
-        // writes. Objects already on disk may have been re-buffered (the memory-only freshen does
-        // not deduplicate against disk, see `odb_backend`); `write_snapshot` packs only the
-        // genuinely-new ones, in the map's sorted oid order, keeping the packfile — and its
-        // checksum-derived name — deterministic.
+        // store and compresses every object, which must not stall the filter threads' reads and
+        // writes. Objects already on disk may have been re-buffered (the write gate does not
+        // deduplicate against the repository's own disk, see `crate::odb::Odb::write`);
+        // `write_snapshot` packs only the genuinely-new ones, in the map's sorted oid order,
+        // keeping the packfile — and its checksum-derived name — deterministic.
         let snapshot: Snapshot = {
-            let inner = self.inner.lock().unwrap();
+            let inner = self.inner.read();
             if inner.map.is_empty() {
                 return Ok(());
             }
@@ -218,7 +262,7 @@ impl MemOdb {
         // Evict exactly the snapshotted oids (now durable: packed just above, or already on disk).
         // Writes that landed after the snapshot stay buffered for the next chunk or the drain, so a
         // background chunk running concurrently with the write path never drops a live object.
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.inner.write();
         for (oid, _, _) in &snapshot {
             if let Some((_, data)) = inner.map.remove(oid) {
                 inner.size = inner.size.saturating_sub(data.len());
@@ -255,7 +299,7 @@ mod tests {
 
         store.flush().unwrap();
 
-        // A fresh repo with no backend can only see objects that made it to disk.
+        // A fresh repo can only see objects that made it to disk.
         let on_disk = git2::Repository::open(dir.path()).unwrap();
         for (i, id) in ids.iter().enumerate() {
             let blob = on_disk.find_blob(josh_gix_ext::git2_oid(id)).unwrap();
@@ -303,7 +347,7 @@ mod tests {
 
     /// When `limit` is set, writing enough data to exceed it enqueues a background pack from inside
     /// the write path, which lands the objects on disk asynchronously (leaving the store to drain
-    /// the rest at the transaction boundary). Each further overflow enqueues another pack.
+    /// the rest at the next barrier). Each further overflow enqueues another pack.
     #[test]
     fn flushes_on_overflow_during_writes() {
         let dir = tempfile::tempdir().unwrap();
@@ -352,7 +396,59 @@ mod tests {
         assert_eq!(exts, ["idx", "pack"]);
     }
 
-    /// Poll a freshly-opened (backend-less) view of the repository until `id` is readable from disk,
+    /// A chained store reads what the store behind it holds and never adopts its objects, so
+    /// packing it leaves that store untouched -- the contract ephemeral transactions rely on.
+    /// An explicit flush is a durability barrier for everything readable, so it drains the chain.
+    #[test]
+    fn chained_store_reads_through_and_packs_separately() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        let shared = MemOdb::new(None, crate::pack::objects_dir(&repo));
+        let behind = shared.write(Kind::Blob, b"shared blob");
+
+        let private = MemOdb::chained(None, crate::pack::objects_dir(&repo), shared.clone());
+        let own = private.write(Kind::Blob, b"private blob");
+
+        assert!(private.contains(&behind));
+        assert_eq!(&*private.get(&behind).unwrap().1, b"shared blob");
+        assert_eq!(private.header(&behind).unwrap().0, Kind::Blob);
+        assert!(!shared.contains(&own));
+
+        // Packing the private store writes only its own objects.
+        private.pack_to_disk().unwrap();
+        let on_disk = git2::Repository::open(dir.path()).unwrap();
+        assert!(on_disk.find_blob(josh_gix_ext::git2_oid(&own)).is_ok());
+        assert!(on_disk.find_blob(josh_gix_ext::git2_oid(&behind)).is_err());
+        assert!(shared.contains(&behind));
+
+        // A flush is a barrier for everything the store can see, chain included.
+        private.flush().unwrap();
+        assert!(!shared.contains(&behind));
+        let on_disk = git2::Repository::open(dir.path()).unwrap();
+        assert!(on_disk.find_blob(josh_gix_ext::git2_oid(&behind)).is_ok());
+    }
+
+    /// The limit only ever tightens, whatever order attachers ask in, so a shared store honours
+    /// the smallest budget requested for its objects directory.
+    #[test]
+    fn limit_only_tightens() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
+
+        assert_eq!(store.limit.load(Ordering::Acquire), UNBOUNDED);
+        store.tighten_limit(Some(64));
+        assert_eq!(store.limit.load(Ordering::Acquire), 64);
+        store.tighten_limit(Some(128));
+        assert_eq!(store.limit.load(Ordering::Acquire), 64);
+        store.tighten_limit(None);
+        assert_eq!(store.limit.load(Ordering::Acquire), 64);
+        store.tighten_limit(Some(16));
+        assert_eq!(store.limit.load(Ordering::Acquire), 16);
+    }
+
+    /// Poll a freshly-opened view of the repository until `id` is readable from disk,
     /// up to ~2s. Used to observe asynchronous background packs without racing the flusher thread.
     fn wait_on_disk(repo_path: &std::path::Path, id: git2::Oid) -> bool {
         for _ in 0..200 {

--- a/josh-memodb/src/odb.rs
+++ b/josh-memodb/src/odb.rs
@@ -3,22 +3,56 @@
 //!
 //! Implements the [`gix_object`] object-access traits (memory-first, disk fallback) plus
 //! inherent helpers in `git2::Oid` currency; memory hits hand out zero-copy `Arc` buffers.
-//! The `disk` side is deliberately `repo.odb()` after [`MemOdb::register`]: it starts with
-//! the registered memory backend and includes any runtime alternates added later (josh-proxy
-//! overlays add the mirror), so the facade and plain git2 calls resolve exactly the same
-//! objects. Write dedup goes through the store's own alternate mirror instead (see
-//! [`Odb::write`]) and never touches `disk`.
-//!
-//! Lock discipline: never call into `disk` while holding the store mutex — the git2 path
-//! locks `disk` first and the store second (inside the backend trampolines), so the facade
-//! always probes the store and the disk sequentially, holding at most one lock at a time.
+//! The `disk` side is `repo.odb()`, including any runtime alternates added to that repository
+//! handle (josh-proxy overlays add the mirror), so the facade and plain git2 calls resolve
+//! exactly the same objects. Write dedup goes through the caller's [`Alternates`] mirror
+//! instead (see [`Odb::write`]) and never touches `disk`.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use gix_hash::ObjectId;
 use gix_object::Kind;
 
 use crate::MemOdb;
+
+/// A mirror of the runtime alternates registered on a repository handle: an odb over ONLY the
+/// alternate object directories, no repository attached. The facade's write path probes it so
+/// alternate-resident objects (the proxy overlay's mirror) are never buffered — flushed packs
+/// must not contain duplicates of mirror objects, and the pack-time disk filter cannot see
+/// runtime alternates. Deliberately excludes the repository's own odb: locally-durable objects
+/// are dropped at pack time instead, and with no alternates registered the probe is a `None`
+/// check, no filesystem I/O.
+///
+/// Owned by the holder of the repository handle rather than by the store, because what an
+/// alternate makes reachable is a property of the handle: josh-templates registers the overlay
+/// as an alternate of a mirror repository and the reverse elsewhere, and a store shared by both
+/// must not mix them.
+#[derive(Default)]
+pub struct Alternates(Mutex<Option<git2::Odb<'static>>>);
+
+impl Alternates {
+    /// Record `path` (an objects directory) as a runtime alternate. Callers add the alternate to
+    /// their repository odb themselves (`git2::Odb::add_disk_alternate`); this mirror only feeds
+    /// the write-dedup probe.
+    pub fn add(&self, path: &str) -> Result<(), git2::Error> {
+        let mut alternates = self.0.lock().unwrap();
+        let odb = match alternates.as_mut() {
+            Some(odb) => odb,
+            None => alternates.insert(git2::Odb::new()?),
+        };
+        odb.add_disk_alternate(path)
+    }
+
+    /// Whether `oid` exists in one of the recorded alternates. `false` without filesystem I/O
+    /// when none are recorded.
+    fn contains(&self, oid: git2::Oid) -> bool {
+        self.0
+            .lock()
+            .unwrap()
+            .as_ref()
+            .is_some_and(|o| o.exists(oid))
+    }
+}
 
 /// Raw object bytes from a facade read: zero-copy shared buffer for memory hits, a libgit2
 /// odb object for disk hits. Derefs to the raw serialized object bytes either way.
@@ -42,11 +76,30 @@ impl std::ops::Deref for Bytes<'_> {
 pub struct Odb<'repo> {
     mem: Arc<MemOdb>,
     disk: git2::Odb<'repo>,
+    alternates: Option<&'repo Alternates>,
 }
 
 impl<'repo> Odb<'repo> {
+    /// A facade with no runtime alternates registered, for repositories that have none.
     pub fn new(mem: Arc<MemOdb>, disk: git2::Odb<'repo>) -> Self {
-        Odb { mem, disk }
+        Odb {
+            mem,
+            disk,
+            alternates: None,
+        }
+    }
+
+    /// A facade whose write gate skips objects reachable through `alternates` (see there).
+    pub fn with_alternates(
+        mem: Arc<MemOdb>,
+        disk: git2::Odb<'repo>,
+        alternates: &'repo Alternates,
+    ) -> Self {
+        Odb {
+            mem,
+            disk,
+            alternates: Some(alternates),
+        }
     }
 
     /// Read the raw bytes and kind of `oid`; memory hits are zero-copy. A missing object is an
@@ -104,11 +157,10 @@ impl<'repo> Odb<'repo> {
     /// Hash and buffer an object in the memory store, returning its content id. The buffer is
     /// skipped when the object is already in memory or in a runtime alternate: proxy overlays
     /// must never buffer mirror objects, or flushed packs would gain duplicates and change
-    /// names (the pack-time disk filter cannot see runtime alternates). The same rule governs
-    /// `git_odb__freshen` on the registered backend, so both write paths buffer the same
-    /// objects. The gate never probes the repository's own on-disk odb: objects already
-    /// durable there are buffered anyway and dropped at pack time, and a repository without
-    /// alternates writes with zero filesystem I/O.
+    /// names (the pack-time disk filter cannot see runtime alternates). The gate never probes
+    /// the repository's own on-disk odb: objects already durable there are buffered anyway and
+    /// dropped at pack time, and a repository without alternates writes with zero filesystem
+    /// I/O.
     pub fn write(&self, kind: Kind, data: &[u8]) -> git2::Oid {
         let id = gix_object::compute_hash(gix_hash::Kind::Sha1, kind, data)
             .expect("failed to compute hash");
@@ -118,7 +170,11 @@ impl<'repo> Odb<'repo> {
 
     /// [`Odb::write`] with a caller-computed content hash, trusted verbatim.
     fn write_with_id(&self, id: ObjectId, kind: Kind, data: &[u8]) {
-        if self.mem.contains(&id) || self.mem.exists_in_alternates(josh_gix_ext::git2_oid(&id)) {
+        if self.mem.contains(&id)
+            || self
+                .alternates
+                .is_some_and(|alts| alts.contains(josh_gix_ext::git2_oid(&id)))
+        {
             return;
         }
         self.mem.write_with_id(id, kind, data);
@@ -281,9 +337,10 @@ mod tests {
             .unwrap()
             .add_disk_alternate(alt.to_str().unwrap())
             .unwrap();
-        store.add_alternate(alt.to_str().unwrap()).unwrap();
+        let alternates = Alternates::default();
+        alternates.add(alt.to_str().unwrap()).unwrap();
 
-        let odb = facade(&store, &repo);
+        let odb = Odb::with_alternates(store.clone(), repo.odb().unwrap(), &alternates);
 
         // Alternate hit: skipped, still readable through the disk chain.
         let oid = odb.write(Kind::Blob, b"mirror blob");

--- a/josh-memodb/src/registry.rs
+++ b/josh-memodb/src/registry.rs
@@ -1,0 +1,64 @@
+//! The process-wide map from objects directory to [`MemOdb`].
+//!
+//! A store has to outlive the transactions writing to it, or packing is back on transaction
+//! lifetime. Keyed by objects directory rather than repository path because a linked worktree, a
+//! bare clone and a gitdir file all reach the same objects through different paths. Entries are
+//! held strongly and never removed; a drained store is two empty collections.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
+
+use crate::MemOdb;
+
+static STORES: LazyLock<Mutex<HashMap<PathBuf, Arc<MemOdb>>>> = LazyLock::new(Default::default);
+
+/// A registered store lives as long as the process, so it always has a ceiling even when the
+/// caller asks for none. Matches the limit josh-cli and josh-proxy ask for explicitly.
+const DEFAULT_LIMIT: usize = 128 * 1024 * 1024;
+
+/// The store for `objects_dir`, created on first use. `limit` is a budget for the objects
+/// directory, not for one transaction's buffer, so it only ever tightens (see
+/// [`MemOdb::tighten_limit`]).
+pub fn shared(limit: Option<usize>, objects_dir: &Path) -> Arc<MemOdb> {
+    let limit = Some(limit.unwrap_or(DEFAULT_LIMIT));
+    // Two handles can name the same objects directory differently (a relative path, a symlinked
+    // checkout); resolving keeps them on one store. An unresolvable path is used as given.
+    let key = std::fs::canonicalize(objects_dir).unwrap_or_else(|_| objects_dir.to_path_buf());
+
+    let mut stores = STORES.lock().unwrap();
+    let store = stores
+        .entry(key)
+        .or_insert_with(|| MemOdb::build(limit, objects_dir.to_path_buf(), None))
+        .clone();
+    store.tighten_limit(limit);
+    store
+}
+
+/// Flushes every registered store to disk when dropped. Keep one guard alive for the lifetime of
+/// a binary so every return path, including errors and unwinding panics, drains the process-wide
+/// stores.
+#[must_use = "dropping the guard immediately flushes all registered stores"]
+pub struct FlushGuard;
+
+impl FlushGuard {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Drop for FlushGuard {
+    fn drop(&mut self) {
+        flush_all();
+    }
+}
+
+/// Pack every registered store to disk, inline.
+fn flush_all() {
+    let stores: Vec<Arc<MemOdb>> = STORES.lock().unwrap().values().cloned().collect();
+    for store in stores {
+        if let Err(e) = store.pack_to_disk() {
+            log::error!("failed to flush in-memory object store at exit: {e}");
+        }
+    }
+}

--- a/josh-proxy/src/bin/josh-proxy.rs
+++ b/josh-proxy/src/bin/josh-proxy.rs
@@ -277,7 +277,8 @@ fn pre_receive_hook() -> anyhow::Result<i32> {
     Ok(0)
 }
 
-fn main() {
+fn main() -> std::process::ExitCode {
+    let _flush_guard = josh_core::memodb::FlushGuard::new();
     // josh-proxy creates a symlink to itself as a git update hook.
     // When it gets called by git as that hook, the binary name will end
     // end in "/update" and this will not be a new server.
@@ -287,22 +288,20 @@ fn main() {
     if let [a0, a1, a2, a3, ..] = &std::env::args().collect::<Vec<_>>().as_slice()
         && a0.ends_with("/update")
     {
-        std::process::exit(update_hook(a1, a2, a3).unwrap_or(1));
+        return std::process::ExitCode::from(update_hook(a1, a2, a3).unwrap_or(1) as u8);
     }
 
     if let [a0, ..] = &std::env::args().collect::<Vec<_>>().as_slice()
         && a0.ends_with("/pre-receive")
     {
         eprintln!("josh-proxy: pre-receive hook");
-        let code = match pre_receive_hook() {
+        return std::process::ExitCode::from(match pre_receive_hook() {
             Ok(code) => code,
             Err(e) => {
                 eprintln!("josh-proxy: pre-receive hook failed: {}", e);
-                std::process::exit(1);
+                1
             }
-        };
-
-        std::process::exit(code);
+        } as u8);
     }
 
     let args = josh_proxy::cli::Args::parse();
@@ -323,5 +322,5 @@ fn main() {
             exit_code
         });
 
-    std::process::exit(exit_code);
+    std::process::ExitCode::from(exit_code as u8)
 }

--- a/tests/proxy/destroy_test_env.sh
+++ b/tests/proxy/destroy_test_env.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 curl -s http://localhost:8002/filters/refresh
 killall -2 josh-proxy
+# Wait for the shutdown to finish before listing the repository: josh-proxy packs the objects it
+# still holds in memory on the way out, so listing while it is still exiting is a race.
+for _ in $(seq 100); do
+  killall -0 josh-proxy >/dev/null 2>&1 || break
+  sleep 0.1
+done
 cd ${TESTTMP}/remote/scratch
 tree -I hooks
 

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -258,20 +258,16 @@ Make sure all temporary namespace got removed
       |   |   `-- b2a5b9c65fae1d20c1b1fb777d1ea025456faa
       |   |-- info
       |   `-- pack
-      |       |-- pack-3a57e9cdc95400944f3e385ef9f2dd3e34214850.idx
-      |       |-- pack-3a57e9cdc95400944f3e385ef9f2dd3e34214850.pack
-      |       |-- pack-63a0eba9c29d8be4a080b31f7ae988c86dcf4f40.idx
-      |       |-- pack-63a0eba9c29d8be4a080b31f7ae988c86dcf4f40.pack
       |       |-- pack-73ff0b391af4bb8dff50f6070f8e6bd258d3d562.idx
       |       |-- pack-73ff0b391af4bb8dff50f6070f8e6bd258d3d562.pack
-      |       |-- pack-e56807bf90b581321239e94899e9a2bad8ea715c.idx
-      |       `-- pack-e56807bf90b581321239e94899e9a2bad8ea715c.pack
+      |       |-- pack-d678c97bc806ec389cf8d05321e018083799eab5.idx
+      |       `-- pack-d678c97bc806ec389cf8d05321e018083799eab5.pack
       `-- refs
           |-- heads
           |-- namespaces
           `-- tags
   
-  57 directories, 48 files
+  57 directories, 44 files
 
 $ cat ${TESTTMP}/josh-proxy.out
 $ cat ${TESTTMP}/josh-proxy.out | grep REPO_UPDATE


### PR DESCRIPTION
Share object stores and defer ref publication

Share each in-memory object store by objects directory so unpublished objects can outlive transactions without producing tiny packs. Queue ref edits and flush objects before publishing refs at transaction boundaries.

Change: pack-lifetime
Assisted-By: anthropic/claude-opus-5
Assisted-By: openrouter/openai/gpt-5.6-sol