### PR TITLE
Read objects that memory does not hold through gitoxide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3650,6 +3650,7 @@ dependencies = [
 name = "josh-memodb"
 version = "26.7.28"
 dependencies = [
+ "anyhow",
  "git2",
  "gix-features",
  "gix-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ gix-features = { version = "0.49", features = ["progress"] }
 gix-hash = { version = "^0.26", features = ["sha1"] }
 gix-object = "0.63.0"
 gix-odb = "0.83"
-gix-pack = { version = "0.73", features = ["sha1"] }
+gix-pack = { version = "0.73", features = ["sha1", "object-cache-dynamic"] }
 gix-command = "0.9.1"
 gix-diff = { version = "0.66.0", default-features = false, features = ["blob"] }
 gix-filter = "0.33.0"

--- a/cq/josh-cq/src/cq.rs
+++ b/cq/josh-cq/src/cq.rs
@@ -69,12 +69,12 @@ pub fn handle_track(
         None,
         "HEAD",
         fetched_commit,
-        josh_core::objects::CommitData::read(&transaction.odb()?, head.commit)?.tree_id()?,
+        josh_core::objects::CommitData::read(transaction.odb(), head.commit)?.tree_id()?,
         link_mode,
     )?
     .into_tree_oid();
 
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let refs_blob = {
         let refs_map: BTreeMap<String, String> = refs
             .iter()
@@ -84,14 +84,14 @@ pub fn handle_track(
         let refs_json =
             serde_json::to_string_pretty(&refs_map).context("Failed to serialize refs to JSON")?;
 
-        josh_core::objects::write_blob(&odb, refs_json.as_bytes())
+        josh_core::objects::write_blob(odb, refs_json.as_bytes())
             .context("Failed to create refs.json blob")?
     };
 
     let refs_path = std::path::Path::new("remotes").join(id).join("refs.json");
 
     let final_tree = tree::insert_oid(
-        &odb,
+        odb,
         tree_with_link_oid,
         &refs_path,
         refs_blob,
@@ -100,7 +100,7 @@ pub fn handle_track(
     .context("Failed to insert refs.json into tree")?;
 
     let final_commit = josh_core::objects::write_commit(
-        &odb,
+        odb,
         final_tree,
         &[head.commit],
         &signature,

--- a/forges/josh-github-changes/src/cache.rs
+++ b/forges/josh-github-changes/src/cache.rs
@@ -72,7 +72,7 @@ pub fn store_sync_fingerprint(
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let json = serde_json::to_string(fingerprint)?;
-    let blob_oid = josh_core::objects::write_blob(&transaction.odb()?, json.as_bytes())?;
+    let blob_oid = josh_core::objects::write_blob(transaction.odb(), json.as_bytes())?;
     let path = std::path::Path::new("gh_cache")
         .join(encode_change_id_path(change_id))
         .join(LEAF);

--- a/forges/josh-github-changes/src/ids.rs
+++ b/forges/josh-github-changes/src/ids.rs
@@ -16,7 +16,7 @@ pub fn store_github_id(
     github_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let blob_oid = josh_core::objects::write_blob(&transaction.odb()?, github_id.as_bytes())?;
+    let blob_oid = josh_core::objects::write_blob(transaction.odb(), github_id.as_bytes())?;
     let path = std::path::Path::new("gh_ids")
         .join(encode_change_id_path(change_id))
         .join(local_hash);
@@ -47,7 +47,7 @@ pub fn store_github_vote_id(
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let json = serde_json::to_string(vote_data)?;
-    let blob_oid = josh_core::objects::write_blob(&transaction.odb()?, json.as_bytes())?;
+    let blob_oid = josh_core::objects::write_blob(transaction.odb(), json.as_bytes())?;
     let path = std::path::Path::new("gh_vote_ids")
         .join(encode_change_id_path(change_id))
         .join(user);

--- a/forges/josh-github-changes/src/prs.rs
+++ b/forges/josh-github-changes/src/prs.rs
@@ -64,8 +64,8 @@ pub fn collect_pr_infos(
                 entry.head_oid?,
                 entry.base_oid?,
             );
-            let odb = transaction.odb().ok()?;
-            let commit = josh_core::objects::CommitData::read(&odb, head_oid).ok()?;
+            let odb = transaction.odb();
+            let commit = josh_core::objects::CommitData::read(odb, head_oid).ok()?;
             let raw_message = commit
                 .message()
                 .ok()

--- a/josh-changes/src/change.rs
+++ b/josh-changes/src/change.rs
@@ -20,7 +20,7 @@ impl Change {
         commit: git2::Oid,
     ) -> anyhow::Result<Self> {
         Ok(Self::from_commit(&objects::CommitData::read(
-            &transaction.odb()?,
+            transaction.odb(),
             commit,
         )?))
     }
@@ -74,8 +74,8 @@ impl Change {
         transaction: &josh_core::cache::Transaction,
     ) -> anyhow::Result<Vec<git2::Oid>> {
         // First-parent walk down to (but not including) the base.
-        let odb = transaction.odb()?;
-        let mut walk = objects::RevWalk::new(&odb);
+        let odb = transaction.odb();
+        let mut walk = objects::RevWalk::new(odb);
         walk.simplify_first_parent();
         walk.push(self.commit)?;
         let base = self.base;
@@ -101,12 +101,12 @@ pub fn create_synthetic_merge_commit(
     target_branch_tip: git2::Oid,
     message: &str,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
-    let head = objects::CommitData::read(&odb, pr_head)?;
+    let odb = transaction.odb();
+    let head = objects::CommitData::read(odb, pr_head)?;
     let tree = head.tree_id()?;
 
     objects::write_commit_with_signatures_of(
-        &odb,
+        odb,
         &head,
         tree,
         &[target_branch_tip, pr_head],
@@ -143,8 +143,8 @@ pub(crate) fn get_changes(
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<std::collections::HashMap<git2::Oid, Change>> {
-    let odb = transaction.odb()?;
-    let mut walk = objects::RevWalk::new(&odb);
+    let odb = transaction.odb();
+    let mut walk = objects::RevWalk::new(odb);
     walk.simplify_first_parent();
     walk.push(tip)?;
     let mut oids = walk.into_topo_vec(|oid| base != git2::Oid::ZERO_SHA1 && oid == base)?;
@@ -153,7 +153,7 @@ pub(crate) fn get_changes(
 
     let mut changes = std::collections::HashMap::new();
     for rev in oids {
-        let commit = objects::CommitData::read(&odb, rev)?;
+        let commit = objects::CommitData::read(odb, rev)?;
         let mut change = Change::from_commit(&commit);
         if change.id.is_none() {
             continue;
@@ -186,25 +186,25 @@ pub fn list_changes(
     transaction: &josh_core::cache::Transaction,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<Change>> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let tree = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        Some(oid) => objects::CommitData::read(odb, oid)?.tree_id()?,
         None => return Ok(Vec::new()),
     };
 
     let diffs_tree =
-        match crate::store::get_tree(transaction, &odb, tree, std::path::Path::new("diffs")) {
+        match crate::store::get_tree(transaction, odb, tree, std::path::Path::new("diffs")) {
             Some(t) => t,
             None => return Ok(Vec::new()),
         };
 
     let mut changes = Vec::new();
-    for entry in tree::read_tree(transaction, &odb, diffs_tree)?.entries() {
+    for entry in tree::read_tree(transaction, odb, diffs_tree)?.entries() {
         let change_id = decode_change_id_path(std::str::from_utf8(entry.filename).unwrap_or(""));
         if change_id.is_empty() || !entry.mode.is_tree() {
             continue;
         }
-        let subtree = match tree::read_tree(transaction, &odb, objects::git2_oid(&entry.oid)) {
+        let subtree = match tree::read_tree(transaction, odb, objects::git2_oid(&entry.oid)) {
             Ok(t) => t,
             Err(_) => continue,
         };
@@ -213,7 +213,7 @@ pub fn list_changes(
         let mut tip_oid = git2::Oid::ZERO_SHA1;
         let mut base_oid = git2::Oid::ZERO_SHA1;
         for se in subtree.entries() {
-            let blob = match tree::blob_bytes(&odb, objects::git2_oid(&se.oid)) {
+            let blob = match tree::blob_bytes(odb, objects::git2_oid(&se.oid)) {
                 Some(b) => b,
                 None => continue,
             };
@@ -227,7 +227,7 @@ pub fn list_changes(
         if tip_oid == git2::Oid::ZERO_SHA1 {
             continue;
         }
-        let commit = match objects::CommitData::read(&odb, tip_oid) {
+        let commit = match objects::CommitData::read(odb, tip_oid) {
             Ok(c) => c,
             Err(_) => continue,
         };
@@ -246,10 +246,10 @@ pub fn resolve_change(
     head: git2::Oid,
     spec: &str,
 ) -> anyhow::Result<Change> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     // Try as a full OID first.
     if let Ok(oid) = git2::Oid::from_str(spec) {
-        if let Ok(commit) = objects::CommitData::read(&odb, oid) {
+        if let Ok(commit) = objects::CommitData::read(odb, oid) {
             return Ok(Change::from_commit(&commit));
         }
     }
@@ -258,18 +258,18 @@ pub fn resolve_change(
     // like a too-short oid prefix, say -- only means this is not a revision; the
     // spec may still name a change-id, so fall through to the walk below.
     if let Some(oid) = transaction.rev_parse(spec).ok().flatten()
-        && let Ok(oid) = objects::peel_to_commit(&odb, oid)
-        && let Ok(commit) = objects::CommitData::read(&odb, oid)
+        && let Ok(oid) = objects::peel_to_commit(odb, oid)
+        && let Ok(commit) = objects::CommitData::read(odb, oid)
     {
         return Ok(Change::from_commit(&commit));
     }
 
     // Walk from head to find a commit with matching Change-Id.
-    let mut walk = objects::RevWalk::new(&odb);
+    let mut walk = objects::RevWalk::new(odb);
     walk.simplify_first_parent();
     walk.push(head)?;
     for oid in walk.into_topo_vec(|_| false)? {
-        if let Ok(c) = objects::CommitData::read(&odb, oid) {
+        if let Ok(c) = objects::CommitData::read(odb, oid) {
             let message = c
                 .message()
                 .ok()

--- a/josh-changes/src/comments.rs
+++ b/josh-changes/src/comments.rs
@@ -111,8 +111,8 @@ fn write_comment_inner(
     let content = serde_json::to_string(meta)?;
     let content_hash =
         git2::Oid::hash_object(git2::ObjectType::Blob, content.as_bytes())?.to_string();
-    let odb = transaction.odb()?;
-    let blob_oid = objects::write_blob(&odb, content.as_bytes())?;
+    let odb = transaction.odb();
+    let blob_oid = objects::write_blob(odb, content.as_bytes())?;
 
     let prefix = std::path::Path::new(path_prefix);
     let path = if let Some(ref file) = meta.file {
@@ -120,9 +120,9 @@ fn write_comment_inner(
             Some(s) => git2::Oid::from_str(s)?,
             None => change.commit(),
         };
-        let commit_tree = objects::CommitData::read(&odb, resolve_commit)?.tree_id()?;
+        let commit_tree = objects::CommitData::read(odb, resolve_commit)?.tree_id()?;
         let file_blob =
-            tree::get_path_entry(transaction, &odb, commit_tree, std::path::Path::new(file))?
+            tree::get_path_entry(transaction, odb, commit_tree, std::path::Path::new(file))?
                 .ok_or_else(|| anyhow!("no such path: {}", file))?
                 .oid
                 .to_string();
@@ -170,7 +170,7 @@ pub fn comment_author(
         None => return Err(anyhow!("change has no Change-Id")),
     };
 
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let ref_name = scope.ref_name();
     let head = match transaction.resolve_ref(&ref_name)? {
         Some(oid) => oid,
@@ -179,18 +179,18 @@ pub fn comment_author(
 
     let path = if let Some(f) = file {
         // Find the blob_id for this comment in the current tree.
-        let head_tree = objects::CommitData::read(&odb, head)?.tree_id()?;
+        let head_tree = objects::CommitData::read(odb, head)?.tree_id()?;
         let cid_path = std::path::Path::new("comments")
             .join("F")
             .join(encode_change_id_path(change_id));
         let mut found = None;
-        if let Some(cid_tree) = get_tree(transaction, &odb, head_tree, &cid_path) {
-            for blob_entry in tree::read_tree(transaction, &odb, cid_tree)?.entries() {
+        if let Some(cid_tree) = get_tree(transaction, odb, head_tree, &cid_path) {
+            for blob_entry in tree::read_tree(transaction, odb, cid_tree)?.entries() {
                 let blob_name = std::str::from_utf8(blob_entry.filename).unwrap_or("");
                 let sub = std::path::Path::new(f).join(comment_id);
                 let full = cid_path.join(blob_name).join(&sub);
                 if matches!(
-                    tree::get_path_entry(transaction, &odb, head_tree, &full),
+                    tree::get_path_entry(transaction, odb, head_tree, &full),
                     Ok(Some(_))
                 ) {
                     found = Some(full);
@@ -211,20 +211,20 @@ pub fn comment_author(
             .join(comment_id)
     };
 
-    let mut walk = objects::RevWalk::new(&odb);
+    let mut walk = objects::RevWalk::new(odb);
     walk.simplify_first_parent();
     walk.push(head)?;
 
     for oid in walk.into_topo_vec(|_| false)? {
-        let commit = objects::CommitData::read(&odb, oid)?;
+        let commit = objects::CommitData::read(odb, oid)?;
         let tree = commit.tree_id()?;
-        if let Ok(Some(entry)) = tree::get_path_entry(transaction, &odb, tree, &path) {
+        if let Ok(Some(entry)) = tree::get_path_entry(transaction, odb, tree, &path) {
             // The commit that introduced or last changed this blob authored the comment.
             let is_new = match commit.first_parent_id() {
-                Some(parent) => josh_core::git::read_tree_id(&odb, parent)
+                Some(parent) => josh_core::git::read_tree_id(odb, parent)
                     .ok()
                     .and_then(|pt| {
-                        tree::get_path_entry(transaction, &odb, pt, &path)
+                        tree::get_path_entry(transaction, odb, pt, &path)
                             .ok()
                             .flatten()
                     })
@@ -271,20 +271,20 @@ pub fn read_comments(
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<Comment>> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let ref_name = scope.ref_name();
     let head_commit = match transaction.resolve_ref(&ref_name)? {
         Some(oid) => oid,
         None => return Ok(Vec::new()),
     };
-    let tree = objects::CommitData::read(&odb, head_commit)?.tree_id()?;
+    let tree = objects::CommitData::read(odb, head_commit)?.tree_id()?;
 
     let mut comments = Vec::new();
 
     // Posted/fetched: comments/{C,F}/...
     collect_comments_at_prefix(
         transaction,
-        &odb,
+        odb,
         tree,
         change_id,
         "comments",
@@ -294,7 +294,7 @@ pub fn read_comments(
     // Pending outbox (only meaningful on Remote refs): outbox/comments/{C,F}/...
     collect_comments_at_prefix(
         transaction,
-        &odb,
+        odb,
         tree,
         change_id,
         "outbox/comments",
@@ -303,15 +303,15 @@ pub fn read_comments(
     )?;
 
     // Walk history once to resolve author/timestamp for all comments.
-    let mut walk = objects::RevWalk::new(&odb);
+    let mut walk = objects::RevWalk::new(odb);
     walk.simplify_first_parent();
     let _ = walk.push(head_commit);
     'outer: for oid in walk.into_topo_vec(|_| false)?.into_iter() {
-        if let Ok(commit) = objects::CommitData::read(&odb, oid) {
+        if let Ok(commit) = objects::CommitData::read(odb, oid) {
             let Ok(tree) = commit.tree_id() else { continue };
             let parent_tree = commit
                 .first_parent_id()
-                .and_then(|p| josh_core::git::read_tree_id(&odb, p).ok());
+                .and_then(|p| josh_core::git::read_tree_id(odb, p).ok());
             for c in &mut comments {
                 if c.author.is_some() {
                     continue;
@@ -326,10 +326,10 @@ pub fn read_comments(
                         .join("C")
                         .join(encode_change_id_path(change_id))
                         .join(&c.id);
-                    if let Ok(Some(entry)) = tree::get_path_entry(transaction, &odb, tree, &p) {
+                    if let Ok(Some(entry)) = tree::get_path_entry(transaction, odb, tree, &p) {
                         let is_new = parent_tree
                             .and_then(|pt| {
-                                tree::get_path_entry(transaction, &odb, pt, &p)
+                                tree::get_path_entry(transaction, odb, pt, &p)
                                     .ok()
                                     .flatten()
                             })
@@ -346,18 +346,18 @@ pub fn read_comments(
                     let cid_path = std::path::Path::new(prefix)
                         .join("F")
                         .join(encode_change_id_path(change_id));
-                    if let Some(cid_tree) = get_tree(transaction, &odb, tree, &cid_path)
-                        && let Ok(reader) = tree::read_tree(transaction, &odb, cid_tree)
+                    if let Some(cid_tree) = get_tree(transaction, odb, tree, &cid_path)
+                        && let Ok(reader) = tree::read_tree(transaction, odb, cid_tree)
                     {
                         for blob_entry in reader.entries() {
                             let blob_name = std::str::from_utf8(blob_entry.filename).unwrap_or("");
                             let sub = std::path::Path::new(c.file.as_ref().unwrap()).join(&c.id);
                             let full_path = cid_path.join(blob_name).join(&sub);
                             if let Ok(Some(entry)) =
-                                tree::get_path_entry(transaction, &odb, tree, &full_path)
+                                tree::get_path_entry(transaction, odb, tree, &full_path)
                             {
                                 let parent_entry = parent_tree.and_then(|pt| {
-                                    tree::get_path_entry(transaction, &odb, pt, &full_path)
+                                    tree::get_path_entry(transaction, odb, pt, &full_path)
                                         .ok()
                                         .flatten()
                                 });
@@ -494,7 +494,7 @@ pub fn delete_outbox_comments(
     if content_hashes.is_empty() {
         return Ok(0);
     }
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let want: std::collections::HashSet<&str> = content_hashes.iter().map(|s| s.as_str()).collect();
 
     let ref_name = scope.ref_name();
@@ -502,15 +502,15 @@ pub fn delete_outbox_comments(
         Some(oid) => oid,
         None => return Ok(0),
     };
-    let mut tree = objects::CommitData::read(&odb, prev_commit)?.tree_id()?;
+    let mut tree = objects::CommitData::read(odb, prev_commit)?.tree_id()?;
 
     let encoded = encode_change_id_path(change_id);
     let mut paths_to_remove: Vec<std::path::PathBuf> = Vec::new();
 
     // Non-file: outbox/comments/C/<change>/<hash>
     let c_prefix = std::path::Path::new("outbox/comments/C").join(&encoded);
-    if let Some(c_tree) = get_tree(transaction, &odb, tree, &c_prefix) {
-        for entry in tree::read_tree(transaction, &odb, c_tree)?.entries() {
+    if let Some(c_tree) = get_tree(transaction, odb, tree, &c_prefix) {
+        for entry in tree::read_tree(transaction, odb, c_tree)?.entries() {
             if let Ok(name) = std::str::from_utf8(entry.filename) {
                 if want.contains(name) {
                     paths_to_remove.push(c_prefix.join(name));
@@ -521,10 +521,10 @@ pub fn delete_outbox_comments(
 
     // File: outbox/comments/F/<change>/<blob_id>/<path>/<to>/<file>/<hash>
     let f_prefix = std::path::Path::new("outbox/comments/F").join(&encoded);
-    if let Some(f_tree) = get_tree(transaction, &odb, tree, &f_prefix) {
+    if let Some(f_tree) = get_tree(transaction, odb, tree, &f_prefix) {
         collect_outbox_file_paths(
             transaction,
-            &odb,
+            odb,
             f_tree,
             &f_prefix,
             &want,
@@ -538,16 +538,16 @@ pub fn delete_outbox_comments(
 
     for path in &paths_to_remove {
         if matches!(
-            tree::get_path_entry(transaction, &odb, tree, path),
+            tree::get_path_entry(transaction, odb, tree, path),
             Ok(Some(_))
         ) {
-            tree = tree::insert_oid(&odb, tree, path, git2::Oid::ZERO_SHA1, 0)?;
+            tree = tree::insert_oid(odb, tree, path, git2::Oid::ZERO_SHA1, 0)?;
         }
     }
 
     let sig = transaction.signature()?;
     let msg = format!("cleanup posted outbox comments on {}\n", ref_name);
-    let new_oid = objects::write_commit(&odb, tree, &[prev_commit], &sig, &sig, &msg)?;
+    let new_oid = objects::write_commit(odb, tree, &[prev_commit], &sig, &sig, &msg)?;
     transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;
 
     Ok(paths_to_remove.len())

--- a/josh-changes/src/forges/gerrit.rs
+++ b/josh-changes/src/forges/gerrit.rs
@@ -78,14 +78,14 @@ fn rewrite_chain_with_gerrit_ids(
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
 
     // Collect the chain from tip down to (but excluding) base, first parent only.
     let mut chain: Vec<git2::Oid> = Vec::new();
     let mut cur = tip;
     while cur != base {
         chain.push(cur);
-        match josh_core::objects::CommitData::read(&odb, cur)?.first_parent_id() {
+        match josh_core::objects::CommitData::read(odb, cur)?.first_parent_id() {
             Some(p) => cur = p,
             None => break,
         }
@@ -94,7 +94,7 @@ fn rewrite_chain_with_gerrit_ids(
 
     let mut new_parent = (base != git2::Oid::ZERO_SHA1).then_some(base);
     for oid in chain {
-        let commit = josh_core::objects::CommitData::read(&odb, oid)?;
+        let commit = josh_core::objects::CommitData::read(odb, oid)?;
         let (josh_id, _) = josh_core::trailers::commit_change_meta(&commit);
         // A commit with no josh change id gets one derived from its own oid: rare
         // for a change stack, but Gerrit requires a Change-Id on every commit.
@@ -107,7 +107,7 @@ fn rewrite_chain_with_gerrit_ids(
         let new_message = message_with_gerrit_change_id(message, &gerrit_id);
 
         new_parent = Some(josh_core::objects::write_commit_with_signatures_of(
-            &odb,
+            odb,
             &commit,
             commit.tree_id()?,
             new_parent.as_slice(),
@@ -168,7 +168,7 @@ pub fn build_gerrit_independent_push(
     tip: git2::Oid,
     base: git2::Oid,
 ) -> anyhow::Result<Vec<PushRef>> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let changes = get_changes(transaction, tip, base)?;
     let changes = split_changes(transaction, changes)?;
 
@@ -185,7 +185,7 @@ pub fn build_gerrit_independent_push(
 
         // A change has no dependencies when its split commit sits directly on
         // the target base (nothing else was pulled in below it by `downstack`).
-        let parent = josh_core::objects::CommitData::read(&odb, change.commit)?
+        let parent = josh_core::objects::CommitData::read(odb, change.commit)?
             .parent_ids()
             .next();
         let has_no_deps = if base == git2::Oid::ZERO_SHA1 {

--- a/josh-changes/src/revisions.rs
+++ b/josh-changes/src/revisions.rs
@@ -15,7 +15,7 @@ pub fn read_revisions(
     change: &Change,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<Revision>> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let change_id = match change.id() {
         Some(id) => id,
         None => return Ok(Vec::new()),
@@ -30,7 +30,7 @@ pub fn read_revisions(
     let diffs_of = |tree: git2::Oid| -> Option<git2::Oid> {
         crate::store::get_tree(
             transaction,
-            &odb,
+            odb,
             tree,
             &std::path::Path::new("diffs").join(encode_change_id_path(change_id)),
         )
@@ -38,12 +38,12 @@ pub fn read_revisions(
 
     let mut revs: Vec<Revision> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut walk = objects::RevWalk::new(&odb);
+    let mut walk = objects::RevWalk::new(odb);
     walk.simplify_first_parent();
     walk.push(head)?;
 
     for oid in walk.into_topo_vec(|_| false)? {
-        let commit = objects::CommitData::read(&odb, oid)?;
+        let commit = objects::CommitData::read(odb, oid)?;
         let Ok(cur_tree) = commit.tree_id() else {
             continue;
         };
@@ -53,11 +53,11 @@ pub fn read_revisions(
         };
         let parent_cid_tree = commit
             .first_parent_id()
-            .and_then(|p| josh_core::git::read_tree_id(&odb, p).ok())
+            .and_then(|p| josh_core::git::read_tree_id(odb, p).ok())
             .and_then(diffs_of)
-            .and_then(|t| tree::read_tree(transaction, &odb, t).ok());
+            .and_then(|t| tree::read_tree(transaction, odb, t).ok());
 
-        for entry in tree::read_tree(transaction, &odb, cid_tree)?.entries() {
+        for entry in tree::read_tree(transaction, odb, cid_tree)?.entries() {
             let commit_oid = String::from_utf8_lossy(entry.filename).into_owned();
             if commit_oid.is_empty() || seen.contains(&commit_oid) {
                 continue;

--- a/josh-changes/src/stacked.rs
+++ b/josh-changes/src/stacked.rs
@@ -96,7 +96,7 @@ pub(crate) fn changes_to_refs(
                 change_id: change_id.clone(),
             });
             if let Some(parent_sha) =
-                josh_core::objects::CommitData::read(&transaction.odb()?, change.commit)?
+                josh_core::objects::CommitData::read(transaction.odb(), change.commit)?
                     .first_parent_id()
             {
                 refs.push(PushRef {

--- a/josh-changes/src/store.rs
+++ b/josh-changes/src/store.rs
@@ -55,22 +55,22 @@ pub fn write_changes_tree(
     timestamp: Option<&str>,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let ref_name = scope.ref_name();
     let prev_commit = transaction.resolve_ref(&ref_name)?;
     let base_tree = match prev_commit {
-        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        Some(oid) => objects::CommitData::read(odb, oid)?.tree_id()?,
         None => tree::empty_id(),
     };
 
     // Skip if the blob already exists at this path.
-    if let Ok(Some(existing)) = tree::get_path_entry(transaction, &odb, base_tree, path) {
+    if let Ok(Some(existing)) = tree::get_path_entry(transaction, odb, base_tree, path) {
         if objects::git2_oid(&existing.oid) == blob_oid {
             return Ok(());
         }
     }
 
-    let tree = tree::insert_oid(&odb, base_tree, path, blob_oid, git2::FileMode::Blob.into())?;
+    let tree = tree::insert_oid(odb, base_tree, path, blob_oid, git2::FileMode::Blob.into())?;
 
     let sig = match author {
         Some(name) => {
@@ -81,7 +81,7 @@ pub fn write_changes_tree(
         None => josh_core::git::user_signature(transaction)?,
     };
     let msg = format!("update {}\n", ref_name);
-    let new_oid = objects::write_commit(&odb, tree, prev_commit.as_slice(), &sig, &sig, &msg)?;
+    let new_oid = objects::write_commit(odb, tree, prev_commit.as_slice(), &sig, &sig, &msg)?;
     transaction.update_ref(
         &ref_name,
         prev_commit.map_or(Expected::Absent, Expected::At),
@@ -99,19 +99,19 @@ pub fn read_blob_map(
     scope: &ChangesRef,
     path: &std::path::Path,
 ) -> anyhow::Result<std::collections::HashMap<String, String>> {
-    let odb = transaction.odb()?;
-    let tree = match scope_tree(transaction, &odb, scope)? {
+    let odb = transaction.odb();
+    let tree = match scope_tree(transaction, odb, scope)? {
         Some(tree) => tree,
         None => return Ok(Default::default()),
     };
-    let subtree = match get_tree(transaction, &odb, tree, path) {
+    let subtree = match get_tree(transaction, odb, tree, path) {
         Some(t) => t,
         None => return Ok(Default::default()),
     };
     let mut map = std::collections::HashMap::new();
-    for entry in tree::read_tree(transaction, &odb, subtree)?.entries() {
+    for entry in tree::read_tree(transaction, odb, subtree)?.entries() {
         if let Ok(name) = std::str::from_utf8(entry.filename) {
-            if let Some(blob) = tree::blob_bytes(&odb, objects::git2_oid(&entry.oid)) {
+            if let Some(blob) = tree::blob_bytes(odb, objects::git2_oid(&entry.oid)) {
                 map.insert(name.to_string(), String::from_utf8_lossy(&blob).to_string());
             }
         }
@@ -124,7 +124,7 @@ pub fn store_diff_data(
     change: &Change,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let change_id = change
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
@@ -132,11 +132,11 @@ pub fn store_diff_data(
     let commit_oid_str = change.commit().to_string();
     let base_str = change.base().to_string();
     let content = format!("{}\n{}", commit_oid_str, base_str);
-    let blob_oid = objects::write_blob(&odb, content.as_bytes())?;
+    let blob_oid = objects::write_blob(odb, content.as_bytes())?;
 
     let entry_name = blob_oid.to_string();
     let tree_oid = tree::insert_oid(
-        &odb,
+        odb,
         tree::empty_id(),
         std::path::Path::new(&entry_name),
         blob_oid,
@@ -146,25 +146,25 @@ pub fn store_diff_data(
     let ref_name = scope.ref_name();
     let prev_tip = transaction.resolve_ref(&ref_name)?;
     let base_tree = match prev_tip {
-        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        Some(oid) => objects::CommitData::read(odb, oid)?.tree_id()?,
         None => tree::empty_id(),
     };
 
     let path = std::path::Path::new("diffs").join(encode_change_id_path(&change_id));
 
-    if let Ok(Some(existing)) = tree::get_path_entry(transaction, &odb, base_tree, &path) {
+    if let Ok(Some(existing)) = tree::get_path_entry(transaction, odb, base_tree, &path) {
         if objects::git2_oid(&existing.oid) == tree_oid {
             return Ok(());
         }
     }
 
-    let tree = tree::insert_oid(&odb, base_tree, &path, tree_oid, 0o0040000)?;
+    let tree = tree::insert_oid(odb, base_tree, &path, tree_oid, 0o0040000)?;
 
     let sig = transaction.signature()?;
 
     let anchor_sig = git2::Signature::new("JOSH", "josh@josh-project.dev", &git2::Time::new(0, 0))?;
     let anchor_oid = objects::write_commit(
-        &odb,
+        odb,
         tree::empty_id(),
         &[change.commit()],
         &anchor_sig,
@@ -176,7 +176,7 @@ pub fn store_diff_data(
     parents.extend(prev_tip);
     parents.push(anchor_oid);
     let msg = format!("update {}\n", ref_name);
-    let new_oid = objects::write_commit(&odb, tree, &parents, &sig, &sig, &msg)?;
+    let new_oid = objects::write_commit(odb, tree, &parents, &sig, &sig, &msg)?;
     transaction.update_ref(
         &ref_name,
         prev_tip.map_or(Expected::Absent, Expected::At),
@@ -194,11 +194,11 @@ pub fn store_pr_data<T: serde::Serialize>(
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
     let json = serde_json::to_string(data)?;
-    let odb = transaction.odb()?;
-    let blob_oid = objects::write_blob(&odb, json.as_bytes())?;
+    let odb = transaction.odb();
+    let blob_oid = objects::write_blob(odb, json.as_bytes())?;
 
     let tree_oid = tree::insert_oid(
-        &odb,
+        odb,
         tree::empty_id(),
         std::path::Path::new(&blob_oid.to_string()),
         blob_oid,
@@ -208,23 +208,23 @@ pub fn store_pr_data<T: serde::Serialize>(
     let ref_name = scope.ref_name();
     let prev_tip = transaction.resolve_ref(&ref_name)?;
     let base_tree = match prev_tip {
-        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        Some(oid) => objects::CommitData::read(odb, oid)?.tree_id()?,
         None => tree::empty_id(),
     };
 
     let path = std::path::Path::new("gh").join(encode_change_id_path(change_id));
 
-    if let Ok(Some(existing)) = tree::get_path_entry(transaction, &odb, base_tree, &path) {
+    if let Ok(Some(existing)) = tree::get_path_entry(transaction, odb, base_tree, &path) {
         if objects::git2_oid(&existing.oid) == tree_oid {
             return Ok(());
         }
     }
 
-    let tree = tree::insert_oid(&odb, base_tree, &path, tree_oid, 0o0040000)?;
+    let tree = tree::insert_oid(odb, base_tree, &path, tree_oid, 0o0040000)?;
 
     let sig = transaction.signature()?;
     let msg = format!("update {}\n", ref_name);
-    let new_oid = objects::write_commit(&odb, tree, prev_tip.as_slice(), &sig, &sig, &msg)?;
+    let new_oid = objects::write_commit(odb, tree, prev_tip.as_slice(), &sig, &sig, &msg)?;
     transaction.update_ref(
         &ref_name,
         prev_tip.map_or(Expected::Absent, Expected::At),
@@ -242,18 +242,18 @@ pub fn read_pr_data<T: serde::de::DeserializeOwned>(
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Option<T>> {
-    let odb = transaction.odb()?;
-    let tree = match scope_tree(transaction, &odb, scope)? {
+    let odb = transaction.odb();
+    let tree = match scope_tree(transaction, odb, scope)? {
         Some(tree) => tree,
         None => return Ok(None),
     };
     let gh_path = std::path::Path::new("gh").join(encode_change_id_path(change_id));
-    let subtree = match get_tree(transaction, &odb, tree, &gh_path) {
+    let subtree = match get_tree(transaction, odb, tree, &gh_path) {
         Some(t) => t,
         None => return Ok(None),
     };
-    for entry in tree::read_tree(transaction, &odb, subtree)?.entries() {
-        if let Some(blob) = tree::blob_bytes(&odb, objects::git2_oid(&entry.oid)) {
+    for entry in tree::read_tree(transaction, odb, subtree)?.entries() {
+        if let Some(blob) = tree::blob_bytes(odb, objects::git2_oid(&entry.oid)) {
             let json = String::from_utf8_lossy(&blob);
             let data: T = serde_json::from_str(&json)
                 .with_context(|| format!("stored PR data for '{}' failed to parse", change_id))?;
@@ -271,7 +271,7 @@ pub fn delete_change(
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let encoded = encode_change_id_path(change_id);
 
     let ref_name = scope.ref_name();
@@ -279,7 +279,7 @@ pub fn delete_change(
         Some(oid) => oid,
         None => return Ok(()),
     };
-    let mut tree = objects::CommitData::read(&odb, prev_commit)?.tree_id()?;
+    let mut tree = objects::CommitData::read(odb, prev_commit)?.tree_id()?;
     for prefix in &[
         "diffs",
         "comments/C",
@@ -295,16 +295,16 @@ pub fn delete_change(
     ] {
         let path = std::path::Path::new(prefix).join(&encoded);
         if matches!(
-            tree::get_path_entry(transaction, &odb, tree, &path),
+            tree::get_path_entry(transaction, odb, tree, &path),
             Ok(Some(_))
         ) {
-            tree = tree::insert_oid(&odb, tree, &path, git2::Oid::ZERO_SHA1, 0)?;
+            tree = tree::insert_oid(odb, tree, &path, git2::Oid::ZERO_SHA1, 0)?;
         }
     }
 
     let sig = transaction.signature()?;
     let msg = format!("update {}\n", ref_name);
-    let new_oid = objects::write_commit(&odb, tree, &[prev_commit], &sig, &sig, &msg)?;
+    let new_oid = objects::write_commit(odb, tree, &[prev_commit], &sig, &sig, &msg)?;
     transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;
 
     Ok(())

--- a/josh-changes/src/votes.rs
+++ b/josh-changes/src/votes.rs
@@ -76,11 +76,11 @@ fn write_vote_inner(
     let content = json.to_string();
     let content_hash =
         git2::Oid::hash_object(git2::ObjectType::Blob, content.as_bytes())?.to_string();
-    let odb = transaction.odb()?;
-    let blob_oid = objects::write_blob(&odb, content.as_bytes())?;
+    let odb = transaction.odb();
+    let blob_oid = objects::write_blob(odb, content.as_bytes())?;
 
     let tree_oid = tree::insert_oid(
-        &odb,
+        odb,
         tree::empty_id(),
         std::path::Path::new(&blob_oid.to_string()),
         blob_oid,
@@ -103,17 +103,17 @@ fn write_vote_inner(
     let ref_name = scope.ref_name();
     let prev_commit = transaction.resolve_ref(&ref_name)?;
     let base_tree = match prev_commit {
-        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        Some(oid) => objects::CommitData::read(odb, oid)?.tree_id()?,
         None => tree::empty_id(),
     };
 
-    if let Ok(Some(existing)) = tree::get_path_entry(transaction, &odb, base_tree, &path) {
+    if let Ok(Some(existing)) = tree::get_path_entry(transaction, odb, base_tree, &path) {
         if objects::git2_oid(&existing.oid) == tree_oid {
             return Ok(content_hash);
         }
     }
 
-    let tree = tree::insert_oid(&odb, base_tree, &path, tree_oid, 0o0040000)?;
+    let tree = tree::insert_oid(odb, base_tree, &path, tree_oid, 0o0040000)?;
 
     let sig = match author {
         Some(name) => {
@@ -124,7 +124,7 @@ fn write_vote_inner(
         None => transaction.signature()?,
     };
     let msg = format!("update {}\n", ref_name);
-    let new_oid = objects::write_commit(&odb, tree, prev_commit.as_slice(), &sig, &sig, &msg)?;
+    let new_oid = objects::write_commit(odb, tree, prev_commit.as_slice(), &sig, &sig, &msg)?;
     transaction.update_ref(
         &ref_name,
         prev_commit.map_or(Expected::Absent, Expected::At),
@@ -141,9 +141,9 @@ pub fn read_vote(
     user: Option<&str>,
     scope: &ChangesRef,
 ) -> anyhow::Result<Option<VoteData>> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let tree = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        Some(oid) => objects::CommitData::read(odb, oid)?.tree_id()?,
         None => return Ok(None),
     };
 
@@ -160,12 +160,12 @@ pub fn read_vote(
         .join(encode_change_id_path(change_id))
         .join(&user);
 
-    let subtree = match get_tree(transaction, &odb, tree, &path) {
+    let subtree = match get_tree(transaction, odb, tree, &path) {
         Some(t) => t,
         None => return Ok(None),
     };
-    for entry in tree::read_tree(transaction, &odb, subtree)?.entries() {
-        if let Some(blob) = tree::blob_bytes(&odb, objects::git2_oid(&entry.oid)) {
+    for entry in tree::read_tree(transaction, odb, subtree)?.entries() {
+        if let Some(blob) = tree::blob_bytes(odb, objects::git2_oid(&entry.oid)) {
             let data: VoteData = serde_json::from_slice(&blob)?;
             return Ok(Some(data));
         }
@@ -197,18 +197,18 @@ fn list_votes_at_prefix(
     scope: &ChangesRef,
     path_prefix: &str,
 ) -> anyhow::Result<Vec<(String, VoteData)>> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let tree = match transaction.resolve_ref(&scope.ref_name())? {
-        Some(oid) => objects::CommitData::read(&odb, oid)?.tree_id()?,
+        Some(oid) => objects::CommitData::read(odb, oid)?.tree_id()?,
         None => return Ok(Default::default()),
     };
     let path = std::path::Path::new(path_prefix).join(encode_change_id_path(change_id));
-    let subtree = match get_tree(transaction, &odb, tree, &path) {
+    let subtree = match get_tree(transaction, odb, tree, &path) {
         Some(t) => t,
         None => return Ok(Default::default()),
     };
     let mut votes = Vec::new();
-    for entry in tree::read_tree(transaction, &odb, subtree)?.entries() {
+    for entry in tree::read_tree(transaction, odb, subtree)?.entries() {
         let user = match std::str::from_utf8(entry.filename) {
             Ok(name) => name.to_string(),
             Err(_) => continue,
@@ -216,12 +216,12 @@ fn list_votes_at_prefix(
         if !entry.mode.is_tree() {
             continue;
         }
-        let user_tree = match tree::read_tree(transaction, &odb, objects::git2_oid(&entry.oid)) {
+        let user_tree = match tree::read_tree(transaction, odb, objects::git2_oid(&entry.oid)) {
             Ok(t) => t,
             Err(_) => continue,
         };
         for child in user_tree.entries() {
-            if let Some(blob) = tree::blob_bytes(&odb, objects::git2_oid(&child.oid)) {
+            if let Some(blob) = tree::blob_bytes(odb, objects::git2_oid(&child.oid)) {
                 if let Ok(data) = serde_json::from_slice::<VoteData>(&blob) {
                     votes.push((user.clone(), data));
                 }
@@ -243,14 +243,14 @@ pub fn delete_outbox_votes(
         return Ok(0);
     }
 
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let encoded = encode_change_id_path(change_id);
     let ref_name = scope.ref_name();
     let prev_commit = match transaction.resolve_ref(&ref_name)? {
         Some(oid) => oid,
         None => return Ok(0),
     };
-    let mut tree = objects::CommitData::read(&odb, prev_commit)?.tree_id()?;
+    let mut tree = objects::CommitData::read(odb, prev_commit)?.tree_id()?;
 
     let mut removed = 0usize;
     for user in users {
@@ -258,10 +258,10 @@ pub fn delete_outbox_votes(
             .join(&encoded)
             .join(user);
         if matches!(
-            tree::get_path_entry(transaction, &odb, tree, &path),
+            tree::get_path_entry(transaction, odb, tree, &path),
             Ok(Some(_))
         ) {
-            tree = tree::insert_oid(&odb, tree, &path, git2::Oid::ZERO_SHA1, 0)?;
+            tree = tree::insert_oid(odb, tree, &path, git2::Oid::ZERO_SHA1, 0)?;
             removed += 1;
         }
     }
@@ -272,7 +272,7 @@ pub fn delete_outbox_votes(
 
     let sig = transaction.signature()?;
     let msg = format!("delete outbox votes on {}\n", ref_name);
-    let new_oid = objects::write_commit(&odb, tree, &[prev_commit], &sig, &sig, &msg)?;
+    let new_oid = objects::write_commit(odb, tree, &[prev_commit], &sig, &sig, &msg)?;
     transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;
 
     Ok(removed)

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -301,12 +301,12 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     });
 
     if args.get_flag("discover") {
-        let odb = transaction.odb()?;
+        let odb = transaction.odb();
         let head = transaction
             .rev_parse(&input_ref)?
             .ok_or_else(|| anyhow!("no such revision: {}", input_ref))?;
-        let tree = josh_core::objects::CommitData::read(&odb, head)?.tree_id()?;
-        let hs = josh_core::housekeeping::find_all_workspaces_and_subdirectories(&odb, tree)?;
+        let tree = josh_core::objects::CommitData::read(odb, head)?.tree_id()?;
+        let hs = josh_core::housekeeping::find_all_workspaces_and_subdirectories(odb, tree)?;
         for i in hs {
             let (mut updated_refs, _) = josh_core::filter_refs(
                 &transaction,
@@ -352,9 +352,9 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             .rev_parse(&input_ref)?
             .ok_or_else(|| anyhow!("no such revision: {}", input_ref))?;
 
-        let odb = transaction.odb()?;
+        let odb = transaction.odb();
         let tree = josh_core::objects::CommitData::read(
-            &odb,
+            odb,
             josh_core::filter_commit(&transaction, filterobj, commit)?,
         )?
         .tree_id()?;
@@ -364,11 +364,11 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         let candidates = if josh_core::filter::experimental_features_enabled() {
             let ifilterobj = filterobj.chain(josh_core::filter::parse(":SQUASH:INDEX")?);
             let index_commit = josh_core::filter_commit(&transaction, ifilterobj, commit)?;
-            let index_tree = josh_core::objects::CommitData::read(&odb, index_commit)?.tree_id()?;
-            josh_search::search_candidates(&odb, index_tree, tree, searchstring)?
+            let index_tree = josh_core::objects::CommitData::read(odb, index_commit)?.tree_id()?;
+            josh_search::search_candidates(odb, index_tree, tree, searchstring)?
         } else {
             let mut scan = vec![];
-            josh_core::objects::walk_tree_preorder(&odb, tree, &mut |parent, entry| {
+            josh_core::objects::walk_tree_preorder(odb, tree, &mut |parent, entry| {
                 if !entry.mode.is_tree()
                     && !entry.mode.is_commit()
                     && let Ok(name) = std::str::from_utf8(entry.filename)
@@ -380,7 +380,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             })?;
             scan
         };
-        let matches = josh_search::search_matches(&odb, tree, searchstring, &candidates)?;
+        let matches = josh_search::search_matches(odb, tree, searchstring, &candidates)?;
 
         for r in matches {
             for l in r.1 {
@@ -418,7 +418,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
                 // discarded by the ref update: require fast-forward like git.
                 if rewritten != unfiltered_old
                     && !josh_core::objects::is_descendant_of(
-                        &transaction.odb()?,
+                        transaction.odb(),
                         rewritten,
                         unfiltered_old,
                     )?

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -40,7 +40,7 @@ pub fn handle_list(
     args: &ListArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let scope = args.scope.resolve(transaction)?;
     let changes = josh_changes::list_changes(transaction, &scope)?;
 
@@ -64,7 +64,7 @@ pub fn handle_list(
     let mut rows: Vec<Row> = Vec::with_capacity(changes.len());
     for change in &changes {
         let id = change.id().unwrap_or("<no-change-id>").to_string();
-        let commit = josh_core::objects::CommitData::read(&odb, change.commit())?;
+        let commit = josh_core::objects::CommitData::read(odb, change.commit())?;
         let subject = commit.summary().unwrap_or_default();
 
         let deps_count = change
@@ -135,11 +135,11 @@ pub fn handle_show(
     args: &ShowArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let scope = args.scope.resolve(transaction)?;
     let change = resolve_change_by_id(transaction, &scope, &args.change_id)?;
 
-    let commit = josh_core::objects::CommitData::read(&odb, change.commit())?;
+    let commit = josh_core::objects::CommitData::read(odb, change.commit())?;
     let subject = commit.summary().unwrap_or_default();
     let parsed = commit.parsed()?;
     let author = parsed.author()?.email.to_string();
@@ -214,7 +214,7 @@ pub fn handle_deps(
     args: &DepsArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let scope = args.scope.resolve(transaction)?;
     let changes = josh_changes::list_changes(transaction, &scope)?;
     let oid_to_change_id = build_oid_to_change_id(&changes);
@@ -237,7 +237,7 @@ pub fn handle_deps(
             Some(d) if d != &args.change_id => d.clone(),
             _ => continue,
         };
-        let subject = josh_core::objects::CommitData::read(&odb, oid)
+        let subject = josh_core::objects::CommitData::read(odb, oid)
             .ok()
             .and_then(|c| c.summary())
             .unwrap_or_default();

--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -156,7 +156,7 @@ fn handle_link_add(
         args.filter.as_deref(),
         target,
         initial_oid,
-        josh_core::objects::CommitData::read(&transaction.odb()?, head_commit)?.tree_id()?,
+        josh_core::objects::CommitData::read(transaction.odb(), head_commit)?.tree_id()?,
         mode,
     )?
     .into_commit(transaction, head_commit, &signature)?;
@@ -267,7 +267,7 @@ fn handle_link_update(
     let repo = transaction.git2_repo();
 
     let head_commit = transaction.head().context("Failed to get HEAD")?.commit;
-    let head_tree = josh_core::objects::CommitData::read(&transaction.odb()?, head_commit)?
+    let head_tree = josh_core::objects::CommitData::read(transaction.odb(), head_commit)?
         .tree_id()
         .context("Failed to get HEAD tree")?;
 
@@ -283,16 +283,16 @@ fn handle_link_update(
         if filtered_oid == git2::Oid::ZERO_SHA1 {
             vec![]
         } else {
-            let odb = transaction.odb()?;
-            let filtered_tree = josh_core::objects::CommitData::read(&odb, filtered_oid)
+            let odb = transaction.odb();
+            let filtered_tree = josh_core::objects::CommitData::read(odb, filtered_oid)
                 .context("Failed to find filtered commit")?
                 .tree_id()
                 .context("Failed to get filtered tree")?;
-            josh_core::link::find_link_files(&odb, filtered_tree)
+            josh_core::link::find_link_files(odb, filtered_tree)
                 .context("Failed to find link files in filtered tree")?
         }
     } else {
-        josh_core::link::find_link_files(&transaction.odb()?, head_tree)
+        josh_core::link::find_link_files(transaction.odb(), head_tree)
             .context("Failed to find link files")?
     };
 
@@ -362,7 +362,7 @@ fn handle_link_push(
 ) -> anyhow::Result<()> {
     // Get current HEAD commit
     let head_commit = transaction.head().context("Failed to get HEAD")?.commit;
-    let head_tree = josh_core::objects::CommitData::read(&transaction.odb()?, head_commit)?
+    let head_tree = josh_core::objects::CommitData::read(transaction.odb(), head_commit)?
         .tree_id()
         .context("Failed to get HEAD tree")?;
 
@@ -373,7 +373,7 @@ fn handle_link_push(
     }
 
     // Find the .link.josh file at the given path
-    let link_files = josh_core::link::find_link_files(&transaction.odb()?, head_tree)
+    let link_files = josh_core::link::find_link_files(transaction.odb(), head_tree)
         .context("Failed to find link files")?;
 
     let link_path = std::path::PathBuf::from(normalized_path);

--- a/josh-cli/src/commands/pull.rs
+++ b/josh-cli/src/commands/pull.rs
@@ -232,7 +232,7 @@ fn upstream_change_ids(
     base: git2::Oid,
 ) -> anyhow::Result<std::collections::HashSet<String>> {
     let repo = transaction.git2_repo();
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let mut ids = std::collections::HashSet::new();
     let mut walk = repo.revwalk()?;
     walk.push(tip)?;
@@ -241,7 +241,7 @@ fn upstream_change_ids(
     }
 
     for oid in walk {
-        let commit = josh_core::objects::CommitData::read(&odb, oid?)?;
+        let commit = josh_core::objects::CommitData::read(odb, oid?)?;
         if let (Some(id), _) = commit_change_meta(&commit) {
             ids.insert(id);
         }
@@ -259,25 +259,29 @@ fn restack_commits(
 ) -> anyhow::Result<(git2::Oid, usize)> {
     use josh_core::objects::CommitData;
 
-    let odb = transaction.odb()?;
-    let mut acc = CommitData::read(&odb, tip)?;
+    let odb = transaction.odb();
+    let mut acc = CommitData::read(odb, tip)?;
     let mut kept = 0usize;
 
     for &oid in commits {
-        let commit = CommitData::read(&odb, oid)?;
+        let commit = CommitData::read(odb, oid)?;
         let parent = commit
             .first_parent_id()
             .with_context(|| format!("cannot restack root commit {}", short_oid(oid)))?;
-        let parent_tree = CommitData::read(&odb, parent)?.tree_id()?;
+        let parent_tree = CommitData::read(odb, parent)?.tree_id()?;
 
-        let tree_oid =
-            josh_core::objects::merge_trees(&odb, parent_tree, acc.tree_id()?, commit.tree_id()?)
-                .with_context(|| {
-                format!(
-                    "conflict while restacking change commit {} onto upstream; resolve manually",
-                    short_oid(oid)
-                )
-            })?;
+        let tree_oid = josh_core::objects::merge_trees(
+            odb,
+            parent_tree,
+            acc.tree_id()?,
+            commit.tree_id()?,
+        )
+        .with_context(|| {
+            format!(
+                "conflict while restacking change commit {} onto upstream; resolve manually",
+                short_oid(oid)
+            )
+        })?;
         if tree_oid == acc.tree_id()? {
             // The change became empty on top of the new base (e.g. its content
             // already landed upstream without a matching Change-Id).
@@ -285,13 +289,13 @@ fn restack_commits(
         }
 
         let new_oid = josh_core::objects::write_commit_with_signatures_of(
-            &odb,
+            odb,
             &commit,
             tree_oid,
             &[acc.id()],
             std::str::from_utf8(commit.message_raw()?).unwrap_or_default(),
         )?;
-        acc = CommitData::read(&odb, new_oid)?;
+        acc = CommitData::read(odb, new_oid)?;
         kept += 1;
     }
 
@@ -326,7 +330,7 @@ pub fn integrate(
     let new = transaction
         .resolve_ref(&upstream_refname)?
         .ok_or_else(|| anyhow::anyhow!("failed to resolve upstream ref '{}'", upstream_refname))?;
-    let new = josh_core::objects::peel_to_commit(&transaction.odb()?, new)
+    let new = josh_core::objects::peel_to_commit(transaction.odb(), new)
         .with_context(|| format!("failed to resolve upstream ref '{}'", upstream_refname))?;
     let old = head.commit;
     // The ref's stored target, which the CAS guard on the write below compares against;
@@ -337,7 +341,7 @@ pub fn integrate(
         return Ok(IntegrateReport::UpToDate);
     }
 
-    let merge_base = josh_core::objects::merge_base(&transaction.odb()?, old, new)?;
+    let merge_base = josh_core::objects::merge_base(transaction.odb(), old, new)?;
 
     // Upstream is already contained in the local branch: nothing to integrate.
     if merge_base == new {
@@ -357,7 +361,7 @@ pub fn integrate(
         let mut local_commits = Vec::new();
         for oid in walk {
             let oid = oid?;
-            let commit = josh_core::objects::CommitData::read(&transaction.odb()?, oid)?;
+            let commit = josh_core::objects::CommitData::read(transaction.odb(), oid)?;
             if commit.parent_ids().count() > 1 {
                 anyhow::bail!(
                     "local branch '{}' contains merge commits; cannot integrate automatically",
@@ -372,7 +376,7 @@ pub fn integrate(
         let mut skipped = Vec::new();
         let mut remaining = Vec::new();
         for &oid in &local_commits {
-            let commit = josh_core::objects::CommitData::read(&transaction.odb()?, oid)?;
+            let commit = josh_core::objects::CommitData::read(transaction.odb(), oid)?;
             match commit_change_meta(&commit) {
                 (Some(id), _) if applied.contains(&id) => skipped.push(id),
                 // A commit with a Change-Id not yet applied upstream, or one

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -185,12 +185,12 @@ fn prepare_push(
                 "--merge requires --base=<ref> or an existing destination ref"
             ));
         }
-        let odb = transaction.odb()?;
+        let odb = transaction.odb();
         let merged_tree =
-            josh_core::objects::merge_commits(&odb, original_target, unfiltered_oid, None)?;
+            josh_core::objects::merge_commits(odb, original_target, unfiltered_oid, None)?;
         let signature = josh_core::git::josh_commit_signature()?;
         josh_core::objects::write_commit(
-            &odb,
+            odb,
             merged_tree,
             &[original_target, unfiltered_oid],
             &signature,

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -37,7 +37,7 @@ pub fn handle_sync(
 
     let base_oid = if let Some(b) = &branch {
         match transaction.resolve_ref(&format!("refs/remotes/origin/{}", b))? {
-            Some(oid) => josh_core::objects::peel_to_commit(&transaction.odb()?, oid)?,
+            Some(oid) => josh_core::objects::peel_to_commit(transaction.odb(), oid)?,
             None => git2::Oid::ZERO_SHA1,
         }
     } else {

--- a/josh-cli/src/forge/github/changes.rs
+++ b/josh-cli/src/forge/github/changes.rs
@@ -281,13 +281,13 @@ impl GithubSyncCtx<'_> {
 
         let head_oid =
             git2::Oid::from_str(&pr.head_oid).map_err(|e| anyhow!("bad head OID: {}", e))?;
-        let odb = self.transaction.odb()?;
-        josh_core::objects::CommitData::read(&odb, head_oid)
+        let odb = self.transaction.odb();
+        josh_core::objects::CommitData::read(odb, head_oid)
             .map_err(|_| anyhow!("head commit {} not available from GitHub", pr.head_oid))?;
 
         let base_oid =
             git2::Oid::from_str(&pr.base_ref_oid).map_err(|e| anyhow!("bad base OID: {}", e))?;
-        josh_core::objects::CommitData::read(&odb, base_oid)
+        josh_core::objects::CommitData::read(odb, base_oid)
             .map_err(|_| anyhow!("base commit {} not available from GitHub", pr.base_ref_oid))?;
 
         // For stacked changes the base is the merge-base against the ultimate
@@ -301,7 +301,7 @@ impl GithubSyncCtx<'_> {
                 .unwrap_or(base_oid);
 
             Some(josh_core::objects::merge_base(
-                &self.transaction.odb()?,
+                self.transaction.odb(),
                 against,
                 head_oid,
             )?)

--- a/josh-compose/src/filter.rs
+++ b/josh-compose/src/filter.rs
@@ -28,8 +28,8 @@ pub fn compute_ws_tree(
     let filtered_commit = josh_core::filter_commit(transaction, filterobj, source_commit)
         .context("failed to apply filter")?;
 
-    let odb = transaction.odb()?;
-    let ws_tree = josh_core::objects::CommitData::read(&odb, filtered_commit)
+    let odb = transaction.odb();
+    let ws_tree = josh_core::objects::CommitData::read(odb, filtered_commit)
         .context("filtered result is not a commit")?
         .tree_id()?;
 

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -61,10 +61,10 @@ pub fn run(
     // uncommitted changes (input_ref == "."). For committed refs there is no
     // working tree to write back to.
     let extract_to_workdir = opts.input_ref == ".";
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     container::run_container(
         transaction,
-        &odb,
+        odb,
         ws_tree,
         &mut attempted,
         extract_to_workdir,
@@ -94,8 +94,8 @@ pub fn plan_images(
 
     let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
-    let odb = transaction.odb()?;
-    plan::collect_image_oids(transaction, &odb, ws_tree, ignore_cache, runtime)
+    let odb = transaction.odb();
+    plan::collect_image_oids(transaction, odb, ws_tree, ignore_cache, runtime)
 }
 
 /// Enumerate every job hash (workspace tree OID) that a `run` with the same options
@@ -118,6 +118,6 @@ pub fn plan_jobs(
 
     let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
-    let odb = transaction.odb()?;
-    plan::collect_job_hashes(transaction, &odb, ws_tree, ignore_cache, runtime)
+    let odb = transaction.odb();
+    plan::collect_job_hashes(transaction, odb, ws_tree, ignore_cache, runtime)
 }

--- a/josh-core/benches/deephistory_glob.rs
+++ b/josh-core/benches/deephistory_glob.rs
@@ -474,7 +474,7 @@ fn deephistory_glob(c: &mut Criterion) {
                 josh_core::filter_commit(&transaction, filter, probe).expect("filter probe");
             // The filtered commit is still buffered, so read it through the transaction's
             // object source.
-            let got = josh_core::objects::CommitData::read(&transaction.odb().unwrap(), filtered)
+            let got = josh_core::objects::CommitData::read(transaction.odb(), filtered)
                 .unwrap()
                 .tree_id()
                 .unwrap();

--- a/josh-core/benches/deephistory_prefix_flush.rs
+++ b/josh-core/benches/deephistory_prefix_flush.rs
@@ -144,13 +144,13 @@ impl PrefixFlushBench {
             let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
             // The filtered commit is still buffered, so read it through the transaction's
             // object source rather than the repository handle.
-            let odb = transaction.odb()?;
-            let filtered_tree = josh_core::objects::CommitData::read(&odb, filtered)?.tree_id()?;
+            let odb = transaction.odb();
+            let filtered_tree = josh_core::objects::CommitData::read(odb, filtered)?.tree_id()?;
             let nested_tree =
-                josh_core::objects::path_entry(&odb, filtered_tree, Path::new(PREFIX))?
+                josh_core::objects::path_entry(odb, filtered_tree, Path::new(PREFIX))?
                     .map(|entry| josh_core::objects::git2_oid(&entry.oid))
                     .ok_or_else(|| anyhow::anyhow!("prefix filter produced no `{PREFIX}` entry"))?;
-            let raw_tree = josh_core::objects::CommitData::read(&odb, case.head)?.tree_id()?;
+            let raw_tree = josh_core::objects::CommitData::read(odb, case.head)?.tree_id()?;
             anyhow::ensure!(
                 nested_tree == raw_tree,
                 "prefix filter did not nest the tree under `{PREFIX}` -- benchmark would measure \

--- a/josh-core/benches/deephistory_subdir.rs
+++ b/josh-core/benches/deephistory_subdir.rs
@@ -309,7 +309,7 @@ fn deephistory_rev(c: &mut Criterion) {
             josh_core::filter_commit(&transaction, bench.filter, case.head).expect("subdir");
         // Both heads are freshly filtered, so read them through the transaction's objects.
         let tree_of = |oid| {
-            josh_core::objects::CommitData::read(&transaction.odb().unwrap(), oid)
+            josh_core::objects::CommitData::read(transaction.odb(), oid)
                 .unwrap()
                 .tree_id()
                 .unwrap()

--- a/josh-core/benches/ultrawide_pin_hook.rs
+++ b/josh-core/benches/ultrawide_pin_hook.rs
@@ -197,9 +197,9 @@ impl PinBench {
                 let one_tree = josh_core::filter_commit(&transaction, filter_one_tree, case.head)?;
                 // The filtered commits are still buffered, so read them through the
                 // transaction's object source.
-                let odb = transaction.odb()?;
+                let odb = transaction.odb();
                 let tree_of =
-                    |oid| josh_core::objects::CommitData::read(&odb, oid).and_then(|c| c.tree_id());
+                    |oid| josh_core::objects::CommitData::read(odb, oid).and_then(|c| c.tree_id());
                 let per_path_tree = tree_of(per_path)?;
                 let one_tree_tree = tree_of(one_tree)?;
                 let raw_tree = tree_of(case.head)?;

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -19,9 +19,13 @@ pub struct DistributedCacheBackend {
     // covers those. Only intentional producers (`josh cache build`) open the backend
     // [`Self::writable`].
     writable: bool,
-    // In-memory object store registered on `repo`, so the trees and commits produced by
-    // `flush` are buffered and packed instead of being written synchronously as loose objects.
+    // In-memory object store, so the trees and commits produced by `flush` are buffered and
+    // packed instead of being written synchronously as loose objects.
     mem_odb: std::sync::Arc<josh_memodb::MemOdb>,
+    // The facade over `mem_odb` and this repository's objects, held rather than built per call
+    // so its store's pack indices are loaded once. Behind a mutex like `repo`: the backend is
+    // shared between threads, a facade is not.
+    odb: std::sync::Mutex<josh_memodb::Odb>,
     // Shard commits built by non-forced flushes, keyed by ref name. Their objects may still be
     // in `mem_odb` only, so the refs are published exclusively by a forced flush, after a drain
     // has made every buffered object durable: a ref on disk must never point to objects that
@@ -56,20 +60,18 @@ impl DistributedCacheBackend {
 
     fn open(repo_path: impl AsRef<std::path::Path>, writable: bool) -> anyhow::Result<Self> {
         let repo = git2::Repository::open(repo_path.as_ref())?;
-        let mem_odb = josh_memodb::MemOdb::new(None, josh_memodb::objects_dir(&repo));
+        let objects_dir = josh_memodb::objects_dir(&repo);
+        let mem_odb = josh_memodb::MemOdb::new(None, objects_dir.clone());
+        let odb = josh_memodb::Odb::at(mem_odb.clone(), &objects_dir)?;
         Ok(Self {
             repo: std::sync::Mutex::new(repo),
             mem_odb,
+            odb: std::sync::Mutex::new(odb),
             writable,
             new_entries: Default::default(),
             pending_refs: Default::default(),
             tree_ids: Default::default(),
         })
-    }
-
-    /// The object store of this backend's own repository, with its buffered objects in front.
-    fn odb<'a>(&self, repo: &'a git2::Repository) -> anyhow::Result<josh_memodb::Odb<'a>> {
-        Ok(josh_memodb::Odb::new(self.mem_odb.clone(), repo.odb()?))
     }
 
     fn tree_id(&self, odb: &josh_memodb::Odb, filter: Filter) -> anyhow::Result<git2::Oid> {
@@ -83,7 +85,8 @@ impl DistributedCacheBackend {
 
     pub fn flush(&self, force: bool) -> anyhow::Result<()> {
         let repo = self.repo.lock().unwrap();
-        let odb = self.odb(&repo)?;
+        let odb = self.odb.lock().unwrap();
+        let odb = &*odb;
 
         let mut guard = self.new_entries.lock().unwrap();
         let mut pending = self.pending_refs.lock().unwrap();
@@ -94,7 +97,7 @@ impl DistributedCacheBackend {
             if m.is_empty() || !(force || m.len() >= FLUSH_AFTER) {
                 continue;
             }
-            let rp = ref_path(self.tree_id(&odb, *filter)?, *shard);
+            let rp = ref_path(self.tree_id(odb, *filter)?, *shard);
 
             // Base the update on the newest unpublished commit for this ref when one exists:
             // basing on the published tip would drop the entries of earlier unpublished
@@ -111,12 +114,12 @@ impl DistributedCacheBackend {
             let mut buf = Vec::new();
             let root = match base {
                 Some(commit) => {
-                    let tree = objects::CommitData::read(&odb, commit)?.tree_id()?;
-                    gix_object::FindExt::find_tree(&odb, &objects::gix_oid(tree), &mut buf)?.into()
+                    let tree = objects::CommitData::read(odb, commit)?.tree_id()?;
+                    gix_object::FindExt::find_tree(odb, &objects::gix_oid(tree), &mut buf)?.into()
                 }
                 None => gix_object::Tree::default(),
             };
-            let mut editor = gix_object::tree::Editor::new(root, &odb, gix_hash::Kind::Sha1);
+            let mut editor = gix_object::tree::Editor::new(root, odb, gix_hash::Kind::Sha1);
 
             // Each entry is a gitlink: the tree entry stores the target oid directly, and git
             // never requires a gitlink target to be present, so no blob objects are needed and
@@ -128,7 +131,7 @@ impl DistributedCacheBackend {
                 let (kind, target) = if *to == git2::Oid::ZERO_SHA1 {
                     (
                         gix_object::tree::EntryKind::Blob,
-                        objects::write_blob(&odb, &[])?,
+                        objects::write_blob(odb, &[])?,
                     )
                 } else {
                     (gix_object::tree::EntryKind::Commit, *to)
@@ -137,13 +140,13 @@ impl DistributedCacheBackend {
             }
 
             let updated = editor.write(|tree| {
-                gix_object::Write::write(&odb, tree)
+                gix_object::Write::write(odb, tree)
                     .map_err(|e| anyhow::anyhow!("write cache tree: {e}"))
             })?;
 
             let signature = crate::git::josh_commit_signature()?;
             let commit = objects::write_commit(
-                &odb,
+                odb,
                 objects::git2_oid(&updated),
                 base.as_slice(),
                 &signature,
@@ -242,13 +245,14 @@ impl CacheBackend for DistributedCacheBackend {
 
         std::mem::drop(guard);
 
-        let odb = self.odb(&repo)?;
-        let rp = ref_path(self.tree_id(&odb, filter)?, shard);
+        let odb = self.odb.lock().unwrap();
+        let odb = &*odb;
+        let rp = ref_path(self.tree_id(odb, filter)?, shard);
         // Flushed-but-unpublished entries live in a pending commit (see `flush`), not behind
         // the ref yet; prefer it so in-process reads keep seeing everything ever flushed.
         let pending = self.pending_refs.lock().unwrap();
         let tree = if let Some(oid) = pending.get(&rp) {
-            objects::CommitData::read(&odb, *oid)?.tree_id()?
+            objects::CommitData::read(odb, *oid)?.tree_id()?
         } else if let Ok(r) = repo.revparse_single(&rp) {
             // PORT: resolves a ref -- stays on git2 until flag day.
             r.peel_to_tree()?.id()
@@ -258,10 +262,10 @@ impl CacheBackend for DistributedCacheBackend {
         std::mem::drop(pending);
 
         let mut buf = Vec::new();
-        let root = gix_object::FindExt::find_tree_iter(&odb, &objects::gix_oid(tree), &mut buf)?;
+        let root = gix_object::FindExt::find_tree_iter(odb, &objects::gix_oid(tree), &mut buf)?;
         let mut entry_buf = Vec::new();
         let entry = root
-            .lookup_entry(&odb, &mut entry_buf, fanout(from))
+            .lookup_entry(odb, &mut entry_buf, fanout(from))
             .map_err(|e| anyhow::anyhow!("cache lookup: {e}"))?;
         let Some(e) = entry else {
             return Ok(None);

--- a/josh-core/src/cache/history_graph.rs
+++ b/josh-core/src/cache/history_graph.rs
@@ -66,7 +66,7 @@ pub fn collect_history_graph_info(
 
     Ok(HistoryGraphInfo {
         sequence_number: hint.sequence_number,
-        reachable_roots: read_roots_blob(&transaction.odb()?, blob)?,
+        reachable_roots: read_roots_blob(transaction.odb(), blob)?,
     })
 }
 
@@ -99,14 +99,14 @@ pub fn parents_share_root(
 
     // Parents disagree on the roots blob: read each blob and intersect.
     let mut common: std::collections::BTreeSet<git2::Oid> =
-        read_roots_blob(&transaction.odb()?, first_blob)?
+        read_roots_blob(transaction.odb(), first_blob)?
             .into_iter()
             .collect();
     for blob_oid in &parent_blobs[1..] {
         if common.is_empty() {
             return Ok(false);
         }
-        let p_set: std::collections::BTreeSet<_> = read_roots_blob(&transaction.odb()?, *blob_oid)?
+        let p_set: std::collections::BTreeSet<_> = read_roots_blob(transaction.odb(), *blob_oid)?
             .into_iter()
             .collect();
         common = common.intersection(&p_set).copied().collect();
@@ -128,12 +128,12 @@ fn ensure_hint_cached(
         return Ok(hint);
     }
 
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     if !odb.contains(input) {
         return Err(anyhow!("ensure_hint_cached: input does not exist"));
     }
 
-    let parent_ids = crate::git::read_parent_ids(&odb, input)?;
+    let parent_ids = crate::git::read_parent_ids(odb, input)?;
 
     // Fast path: every parent already has both pieces cached.
     let parents_hint: Option<Vec<(u64, git2::Oid)>> = parent_ids
@@ -145,13 +145,13 @@ fn ensure_hint_cached(
         .collect::<anyhow::Result<_>>()?;
 
     if let Some(parents_hint) = parents_hint {
-        let hint = derive_from_parents(&odb, input, &parents_hint)?;
+        let hint = derive_from_parents(odb, input, &parents_hint)?;
         store_hint(transaction, input, hint)?;
         return Ok(hint);
     }
 
     log::info!("ensure_hint_cached: new_walk for {:?}", input);
-    let mut walk = crate::objects::RevWalk::new(&odb);
+    let mut walk = crate::objects::RevWalk::new(odb);
     walk.push(input)?;
 
     // Prune ancestors that already have *both* pieces cached. Pruning on seq#
@@ -170,7 +170,7 @@ fn ensure_hint_cached(
     })?;
 
     for &oid in sorted.iter().rev() {
-        let parents_hint: Vec<(u64, git2::Oid)> = crate::git::read_parent_ids(&odb, oid)?
+        let parents_hint: Vec<(u64, git2::Oid)> = crate::git::read_parent_ids(odb, oid)?
             .into_iter()
             .map(|p| {
                 try_read_cached_hint(transaction, p)?
@@ -178,7 +178,7 @@ fn ensure_hint_cached(
                     .ok_or_else(|| anyhow!("parent {} hint missing during walk for {}", p, oid))
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
-        let hint = derive_from_parents(&odb, oid, &parents_hint)?;
+        let hint = derive_from_parents(odb, oid, &parents_hint)?;
         store_hint(transaction, oid, hint)?;
     }
 

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -269,9 +269,10 @@ pub struct Transaction {
     /// store's business rather than a transaction's (see [`josh_memodb::registry`]). An
     /// ephemeral transaction gets a private store instead, reading through to the shared one.
     mem_odb: std::sync::Arc<josh_memodb::MemOdb>,
-    /// The runtime alternates of this transaction's repository handle, mirrored for the object
-    /// facade's write gate (see [`josh_memodb::Alternates`]).
-    alternates: josh_memodb::Alternates,
+    /// The object-database facade: this transaction's store in front of the repository's
+    /// objects, plus the runtime alternates registered on it. Built once per transaction so
+    /// its cache serves a whole filter run (see [`josh_memodb::Odb`]).
+    odb: josh_memodb::Odb,
     /// Ref edits accepted by this transaction but not yet visible on disk. Reads overlay this
     /// queue, and disk boundaries flush objects before applying it.
     pending_refs: std::cell::RefCell<Vec<PendingRef>>,
@@ -342,6 +343,9 @@ impl Transaction {
         } else {
             shared
         };
+        // The store the repository was opened with, so pack indices are loaded once for every
+        // transaction of this context.
+        let odb = josh_memodb::Odb::new(mem_odb.clone(), gix_repo.objects.clone());
 
         // Balanced in `Drop`; lets a locking backend (sled) hold its lock only while a
         // transaction is live.
@@ -372,7 +376,7 @@ impl Transaction {
             repo,
             gix_repo,
             mem_odb,
-            alternates: Default::default(),
+            odb,
             pending_refs: std::cell::RefCell::new(Vec::new()),
             mem_odb_limit,
             ephemeral,
@@ -409,21 +413,18 @@ impl Transaction {
         &self.repo
     }
 
-    /// The transaction's object-database facade: memory store first, repository odb
+    /// The transaction's object-database facade: memory store first, repository objects
     /// fallback (see [`josh_memodb::Odb`]).
-    pub fn odb(&self) -> anyhow::Result<josh_memodb::Odb<'_>> {
-        Ok(josh_memodb::Odb::with_alternates(
-            self.mem_odb.clone(),
-            self.repo.odb()?,
-            &self.alternates,
-        ))
+    pub fn odb(&self) -> &josh_memodb::Odb {
+        &self.odb
     }
 
-    /// Add `path` (an objects directory) as a runtime alternate of both the repository odb
-    /// and this transaction's write-dedup probe (see [`josh_memodb::Odb::write`]).
+    /// Add `path` (an objects directory) as a runtime alternate: the facade reads through it
+    /// and never buffers what it holds (see [`josh_memodb::Odb::write`]). The porcelain handle
+    /// is told separately, since it resolves objects of its own.
     pub fn add_disk_alternate(&self, path: &str) -> anyhow::Result<()> {
         self.repo.odb()?.add_disk_alternate(path)?;
-        self.alternates.add(path)?;
+        self.odb.add_alternate(std::path::Path::new(path))?;
         Ok(())
     }
 
@@ -434,11 +435,11 @@ impl Transaction {
     /// Trees still buffered in the memory store come back as zero-copy `Arc` clones of the
     /// store's own buffers and bypass the TreeCache promotion accounting -- caching them
     /// again would only duplicate memory the store already holds.
-    pub fn read_tree_bytes<'a>(
+    pub fn read_tree_bytes(
         &self,
-        odb: &'a josh_memodb::Odb,
+        odb: &josh_memodb::Odb,
         oid: git2::Oid,
-    ) -> anyhow::Result<Option<TreeBytes<'a>>> {
+    ) -> anyhow::Result<Option<TreeBytes>> {
         if let Some(bytes) = self.t2.borrow().tree_cache.get(oid) {
             return Ok(Some(TreeBytes::Cached(bytes)));
         }
@@ -452,7 +453,7 @@ impl Transaction {
         };
         let mut t2 = self.t2.borrow_mut();
         if t2.tree_cache.should_promote(oid) {
-            let bytes: std::sync::Arc<[u8]> = obj.data().into();
+            let bytes: std::sync::Arc<[u8]> = obj.into();
             t2.tree_cache.insert(oid, bytes.clone());
             return Ok(Some(TreeBytes::Cached(bytes)));
         }
@@ -669,7 +670,7 @@ impl Transaction {
         Ok(Head {
             reference,
             target,
-            commit: crate::objects::peel_to_commit(&self.odb()?, target)?,
+            commit: crate::objects::peel_to_commit(self.odb(), target)?,
         })
     }
 
@@ -1058,7 +1059,7 @@ impl Transaction {
         let oid = t2.cache.read_propagate(filter, tree, hint, true).ok()??;
         // Per-subtree index trees are anchored by no ref, so gc may have pruned a
         // cached one; treat a dangling hit as a miss and reindex.
-        if self.odb().ok()?.contains(oid) {
+        if self.odb().contains(oid) {
             Some(oid)
         } else {
             None
@@ -1093,7 +1094,7 @@ impl Transaction {
     pub fn get_ref(&self, filter: crate::filter::Filter, from: git2::Oid) -> Option<git2::Oid> {
         if let Some(m) = REF_CACHE.read().unwrap().get(&filter.id())
             && let Some(oid) = m.get(&from)
-            && self.odb().unwrap().contains(*oid)
+            && self.odb().contains(*oid)
         {
             return Some(*oid);
         }
@@ -1232,7 +1233,7 @@ impl Transaction {
                 return Ok(Some(oid));
             }
 
-            if self.odb()?.contains(oid) {
+            if self.odb().contains(oid) {
                 // Only report an object as cached if it exists in the object database.
                 // This forces a rebuild in case the object was garbage collected.
                 return Ok(Some(oid));
@@ -1737,14 +1738,13 @@ mod tests {
             let transaction = context.open().unwrap();
             transaction
                 .odb()
-                .unwrap()
                 .write(gix_object::Kind::Blob, b"unpublished")
         };
 
         assert_eq!(packs(dir.path()), 0, "nothing was published, nothing packs");
 
         let transaction = context.open().unwrap();
-        let odb = transaction.odb().unwrap();
+        let odb = transaction.odb();
         assert!(odb.contains(oid));
         assert_eq!(&*odb.read(oid).unwrap().1, b"unpublished");
     }
@@ -1759,7 +1759,6 @@ mod tests {
             let transaction = context.open().unwrap();
             let oid = transaction
                 .odb()
-                .unwrap()
                 .write(gix_object::Kind::Blob, b"published");
             transaction
                 .update_ref("refs/josh/blob", Expected::Absent, oid, "test")
@@ -1789,10 +1788,7 @@ mod tests {
     fn flush_mem_odb_publishes_pending_refs_after_objects() {
         let (dir, context) = test_context();
         let transaction = context.open().unwrap();
-        let oid = transaction
-            .odb()
-            .unwrap()
-            .write(gix_object::Kind::Blob, b"boundary");
+        let oid = transaction.odb().write(gix_object::Kind::Blob, b"boundary");
         transaction
             .update_ref("refs/josh/blob", Expected::Absent, oid, "test")
             .unwrap();
@@ -1852,10 +1848,7 @@ mod tests {
 
         let shared = {
             let transaction = context.open().unwrap();
-            transaction
-                .odb()
-                .unwrap()
-                .write(gix_object::Kind::Blob, b"shared")
+            transaction.odb().write(gix_object::Kind::Blob, b"shared")
         };
 
         let own = {
@@ -1866,14 +1859,14 @@ mod tests {
             .ephemeral()
             .open()
             .unwrap();
-            let odb = ephemeral.odb().unwrap();
+            let odb = ephemeral.odb();
             assert_eq!(&*odb.read(shared).unwrap().1, b"shared");
             odb.write(gix_object::Kind::Blob, b"ephemeral")
         };
 
         // What the ephemeral transaction wrote is gone; what it read is still buffered.
         let transaction = context.open().unwrap();
-        let odb = transaction.odb().unwrap();
+        let odb = transaction.odb();
         assert!(odb.contains(shared));
         assert!(!odb.contains(own));
         assert_eq!(packs(dir.path()), 0);

--- a/josh-core/src/cache/tree_cache.rs
+++ b/josh-core/src/cache/tree_cache.rs
@@ -1,18 +1,18 @@
 use josh_memodb::PassthroughHasher;
 use std::hash::BuildHasherDefault;
 
-/// Raw bytes of a tree object, either straight from the odb (first read, zero-copy) or from the
+/// Raw bytes of a tree object, either as the odb decompressed them (first read) or from the
 /// per-transaction tree cache (repeated reads). Derefs to the byte slice either way.
-pub enum TreeBytes<'a> {
-    Odb(git2::OdbObject<'a>),
+pub enum TreeBytes {
+    Odb(Vec<u8>),
     Cached(std::sync::Arc<[u8]>),
 }
 
-impl std::ops::Deref for TreeBytes<'_> {
+impl std::ops::Deref for TreeBytes {
     type Target = [u8];
     fn deref(&self) -> &[u8] {
         match self {
-            TreeBytes::Odb(obj) => obj.data(),
+            TreeBytes::Odb(data) => data,
             TreeBytes::Cached(bytes) => bytes,
         }
     }
@@ -56,7 +56,7 @@ impl TreeCache {
     }
 
     /// Whether `oid` is being read for the second time and should be copied into the cache
-    /// now; the first read is only recorded, so it can hand out the odb buffer zero-copy.
+    /// now; the first read is only recorded, so it can hand out the odb's buffer as it is.
     pub(crate) fn should_promote(&mut self, oid: git2::Oid) -> bool {
         !self.seen.insert(OidKey(oid))
     }

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -24,11 +24,11 @@ pub mod text;
 pub mod tree;
 
 pub fn as_tree(transaction: &cache::Transaction, filter: Filter) -> anyhow::Result<git2::Oid> {
-    josh_filter::persist::as_tree(&transaction.odb()?, filter)
+    josh_filter::persist::as_tree(transaction.odb(), filter)
 }
 
 pub fn from_tree(transaction: &cache::Transaction, tree_oid: git2::Oid) -> anyhow::Result<Filter> {
-    josh_filter::persist::from_tree(&transaction.odb()?, tree_oid)
+    josh_filter::persist::from_tree(transaction.odb(), tree_oid)
 }
 
 static WORKSPACES: LazyLock<std::sync::Mutex<std::collections::HashMap<git2::Oid, Filter>>> =
@@ -548,7 +548,7 @@ fn get_rev_filter(
         } else {
             return Err(anyhow!("unresolved lazy ref"));
         };
-        if match_op != &RevMatch::Default && !transaction.odb()?.contains(*filter_tip) {
+        if match_op != &RevMatch::Default && !transaction.odb().contains(*filter_tip) {
             return Err(anyhow!("`:rev(...)` with nonexistent OID: {}", filter_tip));
         }
         let matches = match match_op {
@@ -612,11 +612,11 @@ pub fn apply_to_commit2(
             return Ok(Some(current_oid));
         }
         Op::Squash(None) => {
-            let odb = transaction.odb()?;
-            let commit = objects::CommitData::read(&odb, commit_id)?;
+            let odb = transaction.odb();
+            let commit = objects::CommitData::read(odb, commit_id)?;
             odb.read_header(commit.tree_id()?)?;
             return Some(history::rewrite_commit(
-                &odb,
+                odb,
                 &commit,
                 &[],
                 Rewrite::from_commit_data(&commit)?,
@@ -643,8 +643,8 @@ pub fn apply_to_commit2(
         }
     };
 
-    let odb = transaction.odb()?;
-    let commit = objects::CommitData::read(&odb, commit_id)?;
+    let odb = transaction.odb();
+    let commit = objects::CommitData::read(odb, commit_id)?;
     // Validate the commit's tree before any filter work (a header probe: no decompression,
     // no parse). Without this gate, an apply over a partially unreadable input can buffer
     // fresh objects into the store before a later read aborts the walk, and the partial
@@ -667,7 +667,7 @@ pub fn apply_to_commit2(
                 // Transplant the squash result's metadata verbatim onto the rewrite of the
                 // original commit (which must stay the base: memoization keys on its id).
                 // Timestamps are the base's own anyway -- no filter alters them.
-                let rc = objects::CommitData::read(&odb, oid)?;
+                let rc = objects::CommitData::read(odb, oid)?;
                 let rcr = rc.parsed()?;
                 Rewrite::from_tree_with_metadata(
                     rc.tree_id()?,
@@ -749,10 +749,10 @@ pub fn apply_to_commit2(
             let tree = commit.tree_id()?;
             // The link probe below folds every failure into "no link", so an unreadable
             // or unparseable commit tree must error here.
-            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
             if let Some(link_file) = read_josh_link(
                 transaction,
-                &odb,
+                odb,
                 &tree_reader,
                 &std::path::PathBuf::new(),
                 ".link.josh",
@@ -792,7 +792,7 @@ pub fn apply_to_commit2(
                 some_or!(filtered_parent_ids, { return Ok(None) });
 
             let mut link_parents = vec![];
-            for (link_path, link_file) in find_link_files(&odb, commit.tree_id()?)?.into_iter() {
+            for (link_path, link_file) in find_link_files(odb, commit.tree_id()?)?.into_iter() {
                 if let Some(commit_str) = link_file.get_meta("commit") {
                     if let Ok(commit_oid) = git2::Oid::from_str(&commit_str) {
                         if let Some(cmt) =
@@ -828,19 +828,19 @@ pub fn apply_to_commit2(
             let tree = commit.tree_id()?;
             // An unreadable commit tree is a hard error -- the retain probes and link
             // reads below fold their failures -- and they all share this one parse.
-            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
-            let mut roots = get_link_roots(transaction, &odb, tree)?;
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
+            let mut roots = get_link_roots(transaction, odb, tree)?;
 
             // A root commit (no first parent) keeps every root; when a first
             // parent is present its tree must be readable (the retain closure below cannot
             // error).
             if let Some(parent) = commit.first_parent_id() {
-                let parent_tree = git::read_tree_id(&odb, parent)?;
-                let parent_reader = tree::read_tree(transaction, &odb, parent_tree)?;
+                let parent_tree = git::read_tree_id(odb, parent)?;
+                let parent_reader = tree::read_tree(transaction, odb, parent_tree)?;
                 roots.retain(|root| {
                     match (
-                        tree::get_path_entry_at(transaction, &odb, &tree_reader, root),
-                        tree::get_path_entry_at(transaction, &odb, &parent_reader, root),
+                        tree::get_path_entry_at(transaction, odb, &tree_reader, root),
+                        tree::get_path_entry_at(transaction, odb, &parent_reader, root),
                     ) {
                         (Ok(Some(a)), Ok(Some(b))) if a.oid == b.oid => false,
                         _ => true,
@@ -848,7 +848,7 @@ pub fn apply_to_commit2(
                 });
             }
 
-            let all_links = links_from_roots(transaction, &odb, &tree_reader, roots)?;
+            let all_links = links_from_roots(transaction, odb, &tree_reader, roots)?;
 
             // Only embedded-mode links get extra parent commits spliced in
             let embedded_links: Vec<_> = all_links
@@ -921,9 +921,9 @@ pub fn apply_to_commit2(
             // The get_* helpers return a bare Filter and would fold an unreadable tree to
             // Op::Empty, so bad input must error here; every probe below shares the read.
             let tree = commit.tree_id()?;
-            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
             if let Some((redirect, _)) =
-                resolve_workspace_redirect(transaction, &odb, &tree_reader, ws_path)
+                resolve_workspace_redirect(transaction, odb, &tree_reader, ws_path)
             {
                 if let Some(r) = apply_to_commit2(redirect, commit_id, transaction)? {
                     transaction.insert(filter, commit.id(), r, true)?;
@@ -933,14 +933,14 @@ pub fn apply_to_commit2(
                 }
             }
 
-            let commit_filter = get_workspace(transaction, &odb, tree, &tree_reader, ws_path);
+            let commit_filter = get_workspace(transaction, odb, tree, &tree_reader, ws_path);
 
             let parent_filters = commit
                 .parent_ids()
                 .map(|parent| {
-                    let tree_id = git::read_tree_id(&odb, parent)?;
-                    let reader = tree::read_tree(transaction, &odb, tree_id)?;
-                    let pcw = get_workspace(transaction, &odb, tree_id, &reader, ws_path);
+                    let tree_id = git::read_tree_id(odb, parent)?;
+                    let reader = tree::read_tree(transaction, odb, tree_id)?;
+                    let pcw = get_workspace(transaction, odb, tree_id, &reader, ws_path);
                     Ok((parent, pcw))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
@@ -949,15 +949,15 @@ pub fn apply_to_commit2(
         }
         Op::Stored(s_path) => {
             let tree = commit.tree_id()?;
-            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
-            let commit_filter = get_stored(transaction, &odb, tree, &tree_reader, s_path);
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
+            let commit_filter = get_stored(transaction, odb, tree, &tree_reader, s_path);
 
             let parent_filters = commit
                 .parent_ids()
                 .map(|parent| {
-                    let tree_id = git::read_tree_id(&odb, parent)?;
-                    let reader = tree::read_tree(transaction, &odb, tree_id)?;
-                    let pcs = get_stored(transaction, &odb, tree_id, &reader, s_path);
+                    let tree_id = git::read_tree_id(odb, parent)?;
+                    let reader = tree::read_tree(transaction, odb, tree_id)?;
+                    let pcs = get_stored(transaction, odb, tree_id, &reader, s_path);
                     Ok((parent, pcs))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
@@ -967,17 +967,17 @@ pub fn apply_to_commit2(
         Op::Starlark(s_path, s_subfilter) => {
             check_experimental_features_enabled("Starlark filter")?;
             let tree = commit.tree_id()?;
-            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
             let commit_filter =
-                get_starlark(transaction, &odb, tree, &tree_reader, s_path, *s_subfilter);
+                get_starlark(transaction, odb, tree, &tree_reader, s_path, *s_subfilter);
 
             let parent_filters = commit
                 .parent_ids()
                 .map(|parent| {
-                    let tree_id = git::read_tree_id(&odb, parent)?;
-                    let reader = tree::read_tree(transaction, &odb, tree_id)?;
+                    let tree_id = git::read_tree_id(odb, parent)?;
+                    let reader = tree::read_tree(transaction, odb, tree_id)?;
                     let pcs =
-                        get_starlark(transaction, &odb, tree_id, &reader, s_path, *s_subfilter);
+                        get_starlark(transaction, odb, tree_id, &reader, s_path, *s_subfilter);
                     Ok((parent, pcs))
                 })
                 .collect::<anyhow::Result<Vec<_>>>()?;
@@ -1035,19 +1035,19 @@ pub fn apply_to_commit2(
             check_experimental_features_enabled("unapply filter")?;
             if let LazyRef::Resolved(target) = target {
                 /* dbg!(target); */
-                let target = objects::CommitData::read(&odb, *target)?;
+                let target = objects::CommitData::read(odb, *target)?;
                 // Only a root commit (no first parent) skips link detection; a
                 // first parent that is present must be readable.
                 if let Some(parent_id) = target.first_parent_id() {
-                    let parent = objects::CommitData::read(&odb, parent_id)?;
+                    let parent = objects::CommitData::read(odb, parent_id)?;
                     let ptree = apply(transaction, *uf, Rewrite::from_commit_data(&parent)?)?;
                     // The link probe folds every failure into "no link", so an unreadable
                     // filtered tree must error here.
                     let ptree_id = ptree.tree_id();
-                    let ptree_reader = tree::read_tree(transaction, &odb, ptree_id)?;
+                    let ptree_reader = tree::read_tree(transaction, odb, ptree_id)?;
                     if let Some(link) = read_josh_link(
                         transaction,
-                        &odb,
+                        odb,
                         &ptree_reader,
                         &std::path::PathBuf::new(),
                         ".link.josh",
@@ -1083,9 +1083,8 @@ pub fn apply_to_commit2(
             let tree = commit.tree_id()?;
             // The link probe below folds every failure into "no link", so an unreadable
             // or unparseable commit tree must error here.
-            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
-            if let Some(link) = read_josh_link(transaction, &odb, &tree_reader, path, ".link.josh")
-            {
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
+            if let Some(link) = read_josh_link(transaction, odb, &tree_reader, path, ".link.josh") {
                 let subdir = filter::invert(link.peel())?;
                 let unapply = to_filter(Op::Unapply(LazyRef::Resolved(commit.id()), subdir));
                 if let Some(commit_str) = link.get_meta("commit") {
@@ -1226,8 +1225,8 @@ pub fn apply(
 ) -> anyhow::Result<Rewrite> {
     // One facade handle for the whole (possibly deeply recursive) application -- building it
     // per recursion level would cost an FFI round-trip each.
-    let odb = transaction.odb()?;
-    apply_impl(transaction, &odb, filter, x)
+    let odb = transaction.odb();
+    apply_impl(transaction, odb, filter, x)
 }
 
 fn apply_impl(
@@ -1891,20 +1890,20 @@ fn unapply_per_rev_filter(
 
     match op {
         Op::Workspace(path) => {
-            let odb = transaction.odb()?;
+            let odb = transaction.odb();
             let tree = pre_process_tree(transaction, tree)?;
-            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
-            let parent_reader = tree::read_tree(transaction, &odb, parent_tree)?;
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
+            let parent_reader = tree::read_tree(transaction, odb, parent_tree)?;
             let workspace = get_filter(
                 transaction,
-                &odb,
+                odb,
                 tree,
                 &tree_reader,
                 Path::new("workspace.josh"),
             );
             let original_workspace = get_filter(
                 transaction,
-                &odb,
+                odb,
                 parent_tree,
                 &parent_reader,
                 &path.join("workspace.josh"),
@@ -1927,13 +1926,13 @@ fn unapply_per_rev_filter(
             )?))
         }
         Op::Stored(path) => {
-            let odb = transaction.odb()?;
+            let odb = transaction.odb();
             let stored_path = path.with_added_extension("josh");
-            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
-            let parent_reader = tree::read_tree(transaction, &odb, parent_tree)?;
-            let stored = get_filter(transaction, &odb, tree, &tree_reader, &stored_path);
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
+            let parent_reader = tree::read_tree(transaction, odb, parent_tree)?;
+            let stored = get_filter(transaction, odb, tree, &tree_reader, &stored_path);
             let original_stored =
-                get_filter(transaction, &odb, parent_tree, &parent_reader, &stored_path);
+                get_filter(transaction, odb, parent_tree, &parent_reader, &stored_path);
 
             let sj_file = Filter::new().file(stored_path.clone());
             let filter = compose(&[sj_file, stored]);
@@ -1947,13 +1946,13 @@ fn unapply_per_rev_filter(
             )?))
         }
         Op::Starlark(path, subfilter) => {
-            let odb = transaction.odb()?;
-            let tree_reader = tree::read_tree(transaction, &odb, tree)?;
-            let parent_reader = tree::read_tree(transaction, &odb, parent_tree)?;
-            let filter = get_starlark(transaction, &odb, tree, &tree_reader, path, *subfilter);
+            let odb = transaction.odb();
+            let tree_reader = tree::read_tree(transaction, odb, tree)?;
+            let parent_reader = tree::read_tree(transaction, odb, parent_tree)?;
+            let filter = get_starlark(transaction, odb, tree, &tree_reader, path, *subfilter);
             let original_filter = get_starlark(
                 transaction,
-                &odb,
+                odb,
                 parent_tree,
                 &parent_reader,
                 path,
@@ -1975,9 +1974,9 @@ fn pre_process_tree(
     transaction: &cache::Transaction,
     tree: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let path = Path::new("workspace.josh");
-    let ws_file = tree::get_blob(transaction, &odb, tree, path);
+    let ws_file = tree::get_blob(transaction, odb, tree, path);
     let parsed = filter::parse(&ws_file)?;
 
     if invert(parsed).is_err() {
@@ -1993,7 +1992,7 @@ fn pre_process_tree(
     let blob = &format!("{}{}\n", &blob, pretty(parsed, 0));
 
     let tree = tree::insert_oid(
-        &odb,
+        odb,
         tree,
         path,
         odb.write(gix_object::Kind::Blob, blob.as_bytes()),
@@ -2012,15 +2011,12 @@ pub fn compute_warnings(
     let mut warnings = Vec::new();
     let mut filter = filter;
 
-    let odb = match transaction.odb() {
-        Ok(odb) => odb,
-        Err(_) => return warnings,
-    };
+    let odb = transaction.odb();
 
     if let Op::Workspace(path) = to_op(filter) {
         let workspace_filter = &tree::get_blob(
             transaction,
-            &odb,
+            odb,
             tree,
             &path.join(Path::new("workspace.josh")),
         );
@@ -2034,7 +2030,7 @@ pub fn compute_warnings(
 
     if let Op::Stored(path) = to_op(filter) {
         let stored_path = path.with_added_extension("josh");
-        let stored_filter = &tree::get_blob(transaction, &odb, tree, &stored_path);
+        let stored_filter = &tree::get_blob(transaction, odb, tree, &stored_path);
         if let Ok(res) = parse(stored_filter) {
             filter = res;
         } else {
@@ -2094,7 +2090,7 @@ pub fn is_ancestor_of(
             let mut todo = vec![tip];
             let mut ancestors = std::collections::HashSet::from_iter(todo.iter().copied());
             while let Some(commit) = todo.pop() {
-                for parent in crate::git::read_parent_ids(&transaction.odb()?, commit)? {
+                for parent in crate::git::read_parent_ids(transaction.odb(), commit)? {
                     if ancestors.insert(parent) {
                         // Newly inserted! Also handle its parents.
                         todo.push(parent);
@@ -2357,7 +2353,7 @@ fn per_rev_filter(
                 .iter()
                 .filter(|x| **x != git2::Oid::ZERO_SHA1 && **x != target_id)
             {
-                if !objects::is_descendant_of(&transaction.odb()?, target_id, *id)? {
+                if !objects::is_descendant_of(transaction.odb(), target_id, *id)? {
                     return Err(anyhow!(
                         "cannot squash {}: its filtered parents {} and {} do not descend \
                          from one another. `:SQUASH` can only preserve a single lineage",
@@ -2408,7 +2404,7 @@ pub fn downstack(
     change_oid: git2::Oid,
     base_oid: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    if !objects::is_descendant_of(&transaction.odb()?, change_oid, base_oid)? {
+    if !objects::is_descendant_of(transaction.odb(), change_oid, base_oid)? {
         return Err(anyhow!(
             "change {} is not a descendant of base {}",
             change_oid,
@@ -2422,8 +2418,8 @@ pub fn downstack(
     // RangeWalk needed. A base that passes the descendant check but is NOT on
     // the spine would make "the stack from base" ill-defined; error instead
     // of answering.
-    let odb = transaction.odb()?;
-    let mut walk = objects::RevWalk::new(&odb);
+    let odb = transaction.odb();
+    let mut walk = objects::RevWalk::new(odb);
     walk.simplify_first_parent();
     walk.push(change_oid)?;
     let mut seen_base = false;
@@ -2449,7 +2445,7 @@ pub fn downstack(
 
     let mut commits: Vec<objects::CommitData> = oids
         .into_iter()
-        .map(|oid| objects::CommitData::read(&odb, oid))
+        .map(|oid| objects::CommitData::read(odb, oid))
         .collect::<anyhow::Result<Vec<_>>>()?;
 
     // The last commit is `change`; split it off from the intermediates
@@ -2457,10 +2453,10 @@ pub fn downstack(
 
     // Seed the affected dependency set with the change's own deps, then walk
     // intermediates backwards, keeping any commit whose deps intersect.
-    let mut affected = downstack_commit_deps(transaction, &odb, &change_commit)?;
+    let mut affected = downstack_commit_deps(transaction, odb, &change_commit)?;
     let mut needed: Vec<bool> = vec![false; commits.len()];
     for (i, intermediate) in commits.iter().enumerate().rev() {
-        let deps = downstack_commit_deps(transaction, &odb, intermediate)?;
+        let deps = downstack_commit_deps(transaction, odb, intermediate)?;
         if !deps.is_disjoint(&affected) {
             needed[i] = true;
             affected.extend(deps);
@@ -2470,7 +2466,7 @@ pub fn downstack(
     // Rebase needed intermediates forward onto current_base. The rebuilt base's tree is the
     // merge result just written, so no commit read-back is needed between steps.
     let mut current_base_id = base_oid;
-    let mut current_base_tree = git::read_tree_id(&odb, base_oid)?;
+    let mut current_base_tree = git::read_tree_id(odb, base_oid)?;
     for (intermediate, is_needed) in commits.iter().zip(needed.iter()) {
         if !is_needed {
             continue;
@@ -2483,12 +2479,12 @@ pub fn downstack(
         })?;
         let new_tree_oid = cached_merge_trees(
             transaction,
-            git::read_tree_id(&odb, inter_parent)?,
+            git::read_tree_id(odb, inter_parent)?,
             current_base_tree,
             intermediate.tree_id()?,
         )?;
         let new_oid = history::rewrite_commit(
-            &odb,
+            odb,
             intermediate,
             &[current_base_id],
             Rewrite::from_tree(new_tree_oid),
@@ -2504,7 +2500,7 @@ pub fn downstack(
         .ok_or_else(|| anyhow!("downstack: change {} has no parent", change_commit.id()))?;
     let new_tree_oid = cached_merge_trees(
         transaction,
-        git::read_tree_id(&odb, change_parent)?,
+        git::read_tree_id(odb, change_parent)?,
         current_base_tree,
         change_commit.tree_id()?,
     )?;
@@ -2517,7 +2513,7 @@ pub fn downstack(
     new_parents.extend(change_commit.parent_ids().skip(1));
 
     let new_oid = history::rewrite_commit(
-        &odb,
+        odb,
         &change_commit,
         &new_parents,
         Rewrite::from_tree(new_tree_oid),
@@ -2555,7 +2551,7 @@ fn cached_merge_trees(
     if let Some(hit) = transaction.get_merge_trees(key) {
         return Ok(hit);
     }
-    let oid = objects::merge_trees(&transaction.odb()?, a, b, c)?;
+    let oid = objects::merge_trees(transaction.odb(), a, b, c)?;
     transaction.insert_merge_trees(key, oid);
     Ok(oid)
 }

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -7,8 +7,8 @@ pub fn pathstree(
     input: git2::Oid,
     transaction: &cache::Transaction,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
-    pathstree_inner(root, input, transaction, &odb)
+    let odb = transaction.odb();
+    pathstree_inner(root, input, transaction, odb)
 }
 
 /// Oid-level body of [`pathstree`]; the odb is hoisted like in [`remove_pred_inner`].
@@ -76,8 +76,8 @@ pub fn regex_replace(
     replacement: &str,
     transaction: &cache::Transaction,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
-    regex_replace_inner(input, regex, replacement, transaction, &odb)
+    let odb = transaction.odb();
+    regex_replace_inner(input, regex, replacement, transaction, odb)
 }
 
 /// Oid-level body of [`regex_replace`]; the odb is hoisted like in [`remove_pred_inner`].
@@ -129,7 +129,7 @@ fn regex_replace_inner(
 
 /// The raw bytes of the blob `oid`, or `None` when the object is missing or not a blob --
 /// `find_blob`'s tolerance, in facade currency.
-pub fn blob_bytes<'a>(odb: &'a josh_memodb::Odb, oid: git2::Oid) -> Option<josh_memodb::Bytes<'a>> {
+pub fn blob_bytes(odb: &josh_memodb::Odb, oid: git2::Oid) -> Option<josh_memodb::Bytes> {
     match odb.read(oid) {
         Ok((gix_object::Kind::Blob, bytes)) => Some(bytes),
         _ => None,
@@ -264,11 +264,11 @@ fn lookup_entry<'a>(
 /// whole filter arm. Lookups walk the entries lazily and allocate nothing, which suits the
 /// sites that probe a handful of paths in one tree (a path descent, the workspace files of a
 /// commit); [`ParsedTree`] is the counterpart for iterating every entry.
-pub struct TreeReader<'a> {
-    bytes: cache::TreeBytes<'a>,
+pub struct TreeReader {
+    bytes: cache::TreeBytes,
 }
 
-impl TreeReader<'_> {
+impl TreeReader {
     /// Every entry, in stored tree order. Malformed entries are skipped.
     pub fn entries(&self) -> impl Iterator<Item = gix_object::tree::EntryRef<'_>> {
         gix_object::TreeRefIter::from_bytes(&self.bytes, gix_hash::Kind::Sha1)
@@ -285,11 +285,11 @@ impl TreeReader<'_> {
 }
 
 /// Read the tree `oid`, erroring when the object is missing or not a tree.
-pub fn read_tree<'a>(
+pub fn read_tree(
     transaction: &cache::Transaction,
-    odb: &'a josh_memodb::Odb,
+    odb: &josh_memodb::Odb,
     oid: git2::Oid,
-) -> anyhow::Result<TreeReader<'a>> {
+) -> anyhow::Result<TreeReader> {
     let bytes = transaction
         .read_tree_bytes(odb, oid)?
         .ok_or_else(|| anyhow!("{} is not a tree", oid))?;
@@ -420,8 +420,8 @@ pub fn remove_pred(
     pred: &dyn Fn(&str, bool) -> bool,
     key: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
-    remove_pred_inner(transaction, &odb, path, input, pred, key)
+    let odb = transaction.odb();
+    remove_pred_inner(transaction, odb, path, input, pred, key)
 }
 
 /// Recursive body of [`remove_pred`], with the odb handle created once at the entry point --
@@ -517,8 +517,8 @@ pub fn remove_pattern(
     key: git2::Oid,
     state: u64,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
-    remove_pattern_inner(transaction, &odb, input, cp, key, state)
+    let odb = transaction.odb();
+    remove_pattern_inner(transaction, odb, input, cp, key, state)
 }
 
 /// Recursive body of [`remove_pattern`]; see [`remove_pred_inner`] for why the odb is hoisted.
@@ -646,8 +646,8 @@ pub fn subtract(
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
-    subtract_inner(transaction, &odb, input1, input2)
+    let odb = transaction.odb();
+    subtract_inner(transaction, odb, input1, input2)
 }
 
 /// Recursive body of [`subtract`]; see [`remove_pred_inner`] for why the odb is hoisted.
@@ -730,8 +730,8 @@ pub fn intersect(
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
-    intersect_inner(transaction, &odb, input1, input2)
+    let odb = transaction.odb();
+    intersect_inner(transaction, odb, input1, input2)
 }
 
 /// Recursive body of [`intersect`]; see [`remove_pred_inner`] for why the odb is hoisted.
@@ -1018,8 +1018,8 @@ pub fn overlay(
     input1: git2::Oid,
     input2: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
-    overlay_inner(transaction, &odb, input1, input2)
+    let odb = transaction.odb();
+    overlay_inner(transaction, odb, input1, input2)
 }
 
 /// Recursive body of [`overlay`]; see [`remove_pred_inner`] for why the odb is hoisted.
@@ -1168,7 +1168,7 @@ pub fn original_path(
         to_filter(Op::Paths).chain(filter),
         Rewrite::from_tree(tree),
     )?;
-    let b = get_blob(transaction, &transaction.odb()?, paths_tree.tree_id(), path);
+    let b = get_blob(transaction, transaction.odb(), paths_tree.tree_id(), path);
     pathline(&b)
 }
 
@@ -1184,9 +1184,9 @@ pub fn repopulated_tree(
         Rewrite::from_tree(full_tree),
     )?;
 
-    let odb = transaction.odb()?;
-    let ipaths = invert_paths(transaction, &odb, "", paths_tree.tree_id())?;
-    populate(transaction, &odb, ipaths, partial_tree)
+    let odb = transaction.odb();
+    let ipaths = invert_paths(transaction, odb, "", paths_tree.tree_id())?;
+    populate(transaction, odb, ipaths, partial_tree)
 }
 
 pub fn populate(
@@ -1393,17 +1393,17 @@ mod tests {
         seen.sort();
         assert_eq!(seen, paths);
 
-        let odb = t.odb().unwrap();
+        let odb = t.odb();
         for kept in ["a/b/keep.rs", "a/keep.rs", "top.rs"] {
             assert!(
-                objects::path_entry(&odb, out, Path::new(kept))
+                objects::path_entry(odb, out, Path::new(kept))
                     .unwrap()
                     .is_some(),
                 "{kept} kept"
             );
         }
         assert!(
-            objects::path_entry(&odb, out, Path::new("a/b/drop.txt"))
+            objects::path_entry(odb, out, Path::new("a/b/drop.txt"))
                 .unwrap()
                 .is_none()
         );
@@ -1416,7 +1416,7 @@ mod tests {
     /// Read a tree the code under test produced: its result lives in the transaction's store,
     /// so it is read through the facade rather than the repository handle.
     fn out_entries(t: &cache::Transaction, oid: git2::Oid) -> Vec<gix_object::tree::Entry> {
-        objects::read_tree_entries(&t.odb().unwrap(), oid).unwrap()
+        objects::read_tree_entries(t.odb(), oid).unwrap()
     }
 
     fn out_entry(
@@ -1536,10 +1536,10 @@ mod tests {
         let out = remove_pred(&t, &mut String::new(), input, &|_, isblob| isblob, key).unwrap();
         assert_eq!(out, input, ".git in input passes through verbatim");
 
-        let odb = t.odb().unwrap();
-        let inserted = insert_oid(&odb, input, Path::new("sub/.git"), blob, 0o100644).unwrap();
+        let odb = t.odb();
+        let inserted = insert_oid(odb, input, Path::new("sub/.git"), blob, 0o100644).unwrap();
         assert_eq!(
-            get_path_entry(&t, &odb, inserted, Path::new("sub/.git"))
+            get_path_entry(&t, odb, inserted, Path::new("sub/.git"))
                 .unwrap()
                 .map(|e| objects::git2_oid(&e.oid)),
             Some(blob),
@@ -1833,7 +1833,7 @@ mod tests {
         let repo = git2::Repository::init_bare(td.path()).unwrap();
         let blob = repo.blob(b"content").unwrap();
         let t = open_transaction(&td);
-        let odb = t.odb().unwrap();
+        let odb = t.odb();
 
         let gitlink = git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap();
         let mut b = git2::build::TreeUpdateBuilder::new();
@@ -1845,20 +1845,20 @@ mod tests {
             .create_updated(&repo, &repo.find_tree(base).unwrap())
             .unwrap();
 
-        let entry = get_path_entry(&t, &odb, root, Path::new("a/b/deep.txt"))
+        let entry = get_path_entry(&t, odb, root, Path::new("a/b/deep.txt"))
             .unwrap()
             .expect("hit at depth 2");
         assert_eq!(objects::git2_oid(&entry.oid), blob);
         assert!(!entry.mode.is_tree());
 
-        let entry = get_path_entry(&t, &odb, root, Path::new("a/sub"))
+        let entry = get_path_entry(&t, odb, root, Path::new("a/sub"))
             .unwrap()
             .expect("gitlink entry resolves");
         assert!(entry.mode.is_commit());
 
         for miss in ["a/b/missing.txt", "a/missing/deep.txt", "top.txt/below"] {
             assert!(
-                get_path_entry(&t, &odb, root, Path::new(miss))
+                get_path_entry(&t, odb, root, Path::new(miss))
                     .unwrap()
                     .is_none(),
                 "{miss} must be a miss"
@@ -1869,7 +1869,7 @@ mod tests {
         // absolute paths and `..` can never name a tree entry and read as misses.
         for hit in ["a/./b/deep.txt", "a//b/deep.txt", "./top.txt", "a/b/"] {
             assert!(
-                get_path_entry(&t, &odb, root, Path::new(hit))
+                get_path_entry(&t, odb, root, Path::new(hit))
                     .unwrap()
                     .is_some(),
                 "{hit} must resolve"
@@ -1877,7 +1877,7 @@ mod tests {
         }
         for miss in ["../top.txt", "/top.txt", "."] {
             assert!(
-                get_path_entry(&t, &odb, root, Path::new(miss))
+                get_path_entry(&t, odb, root, Path::new(miss))
                     .unwrap()
                     .is_none(),
                 "{miss} must be a miss"
@@ -1886,7 +1886,7 @@ mod tests {
 
         // The empty tree reads through the virtualized disk fallback: no entries, plain miss.
         assert!(
-            get_path_entry(&t, &odb, empty_id(), Path::new("anything"))
+            get_path_entry(&t, odb, empty_id(), Path::new("anything"))
                 .unwrap()
                 .is_none()
         );

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -291,8 +291,9 @@ mod tests {
         let tree = repo.find_tree(tree_id).unwrap();
         let commit_id = repo.commit(None, &sig, &sig, "test", &tree, &[]).unwrap();
 
-        let store = josh_memodb::MemOdb::new(None, josh_memodb::objects_dir(&repo));
-        let odb = josh_memodb::Odb::new(store, repo.odb().unwrap());
+        let objects_dir = josh_memodb::objects_dir(&repo);
+        let store = josh_memodb::MemOdb::new(None, objects_dir.clone());
+        let odb = josh_memodb::Odb::at(store, &objects_dir).unwrap();
         assert_eq!(
             super::read_tree_id(&odb, commit_id).unwrap(),
             repo.find_commit(commit_id).unwrap().tree_id()

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -23,10 +23,10 @@ pub fn walk2(
         return Ok(());
     }
 
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
 
     // `walk.push` rejects a missing or non-commit input as a hard error.
-    let mut walk = objects::RevWalk::new(&odb);
+    let mut walk = objects::RevWalk::new(odb);
     if history_flag(filter.get_meta("history").as_deref(), "linear") {
         walk.simplify_first_parent();
     }
@@ -106,8 +106,8 @@ fn find_unapply_base(
     // least one other commit references them as a parent ("unlocked"); the start
     // commit has no children in this subgraph, so it's unlocked immediately.
     // Processing a commit may unlock pending ones, which are then processed too.
-    let odb = transaction.odb()?;
-    let mut walk = objects::RevWalk::new(&odb);
+    let odb = transaction.odb();
+    let mut walk = objects::RevWalk::new(odb);
     walk.push(contained_in)?;
 
     let mut result: Option<(git2::Oid, git2::Oid)> = None;
@@ -136,7 +136,7 @@ fn find_unapply_base(
                 return Ok(std::ops::ControlFlow::Break(()));
             }
 
-            for parent_id in git::read_parent_ids(&odb, pending_oid)? {
+            for parent_id in git::read_parent_ids(odb, pending_oid)? {
                 unlocked.insert(parent_id);
             }
         }
@@ -170,8 +170,8 @@ pub fn find_original(
     if filter.is_nop() {
         return Ok(filtered);
     }
-    let odb = transaction.odb()?;
-    let mut walk = objects::RevWalk::new(&odb);
+    let odb = transaction.odb();
+    let mut walk = objects::RevWalk::new(odb);
     if linear {
         walk.simplify_first_parent();
     }
@@ -179,7 +179,7 @@ pub fn find_original(
 
     for original in walk.into_topo_vec(|_| false)? {
         if filtered == filter::apply_to_commit(filter, original, transaction)? {
-            let parent_ids = git::read_parent_ids(&odb, original)?;
+            let parent_ids = git::read_parent_ids(odb, original)?;
             if parent_ids.len() == 1 {
                 let fp = filter::apply_to_commit(filter, parent_ids[0], transaction)?;
 
@@ -303,8 +303,8 @@ fn find_oldest_similar_commit(
     filter: filter::Filter,
     unfiltered: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
-    let mut walk = objects::RevWalk::new(&odb);
+    let odb = transaction.odb();
+    let mut walk = objects::RevWalk::new(odb);
     walk.push(unfiltered)?;
     tracing::info!("oldest similar?");
     let filtered = filter::apply_to_commit(filter, unfiltered, transaction)?;
@@ -329,8 +329,8 @@ fn find_new_branch_base(
     contained_in: git2::Oid,
     filtered: git2::Oid,
 ) -> anyhow::Result<git2::Oid> {
-    let odb = transaction.odb()?;
-    let mut walk = objects::RevWalk::new(&odb);
+    let odb = transaction.odb();
+    let mut walk = objects::RevWalk::new(odb);
     walk.push(filtered)?;
     tracing::info!("new branch base?");
 
@@ -421,7 +421,7 @@ pub fn unapply_filter(
 
     tracing::info!("before walk");
 
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
 
     // The old filtered oid can be missing from the repo (e.g. a new branch);
     // there is no range to exclude then, so take everything reachable.
@@ -436,11 +436,11 @@ pub fn unapply_filter(
         // non-linear walks incremental. The hint walk is itself a plain
         // pruned RevWalk, so the nested walker cannot recurse further.
         let walk =
-            objects::RangeWalk::new(&odb, |oid| cache::compute_sequence_number(transaction, oid));
+            objects::RangeWalk::new(odb, |oid| cache::compute_sequence_number(transaction, oid));
         walk.into_topo_vec(new_filtered_oid, old_filtered_oid)?
     } else {
         tracing::warn!("range walk: old filtered oid not found");
-        let mut walk = objects::RevWalk::new(&odb);
+        let mut walk = objects::RevWalk::new(odb);
         walk.push(new_filtered_oid)?;
         walk.into_topo_vec(|_| false)?
     };
@@ -451,7 +451,7 @@ pub fn unapply_filter(
         let _span_guard = span.enter();
 
         tracing::info!("walk commit: {:?}", rev);
-        let module_commit = objects::CommitData::read(&odb, rev)?;
+        let module_commit = objects::CommitData::read(odb, rev)?;
 
         if filtered_to_original.contains_key(&module_commit.id()) {
             continue;
@@ -459,7 +459,7 @@ pub fn unapply_filter(
 
         let mut filtered_parent_ids: Vec<_> = module_commit.parent_ids().collect();
         let has_new_orphan = filtered_parent_ids.len() > 1
-            && objects::merge_base_octopus(&odb, &filtered_parent_ids)?.is_none();
+            && objects::merge_base_octopus(odb, &filtered_parent_ids)?.is_none();
 
         if has_new_orphan {
             match orphans_mode {
@@ -503,14 +503,14 @@ pub fn unapply_filter(
                 }
             })
             .map(|unapply_base| -> anyhow::Result<_> {
-                objects::CommitData::read(&odb, unapply_base?)
+                objects::CommitData::read(odb, unapply_base?)
             })
             .collect();
 
         // If there are no parents and "reparent" option is given, use the given OID as a parent
         let mut original_parents = original_parents?;
         if let (0, Some(reparent)) = (original_parents.len(), reparent_orphans) {
-            original_parents = vec![objects::CommitData::read(&odb, reparent)?];
+            original_parents = vec![objects::CommitData::read(odb, reparent)?];
         }
 
         tracing::info!(
@@ -600,7 +600,7 @@ pub fn unapply_filter(
                     // not, pick the tree of the one that is a descendant.
                     if (original_parents[i].id() == original_target)
                         || objects::is_descendant_of(
-                            &odb,
+                            odb,
                             original_parents[i].id(),
                             original_target,
                         )?
@@ -623,7 +623,7 @@ pub fn unapply_filter(
                     // both resulting trees will be the same and we can pick the result to proceed.
 
                     let base_tree = objects::merge_commits(
-                        &odb,
+                        odb,
                         original_parents[0].id(),
                         original_parents[1].id(),
                         Some(objects::merge::Favor::Ours),
@@ -639,7 +639,7 @@ pub fn unapply_filter(
                     )?;
 
                     let base_tree = objects::merge_commits(
-                        &odb,
+                        odb,
                         original_parents[0].id(),
                         original_parents[1].id(),
                         Some(objects::merge::Favor::Theirs),
@@ -682,7 +682,7 @@ pub fn unapply_filter(
         let original_parent_oids: Vec<git2::Oid> =
             original_parents.iter().map(|c| c.id()).collect();
         ret = rewrite_commit(
-            &odb,
+            odb,
             &module_commit,
             &original_parent_oids,
             apply,
@@ -694,7 +694,7 @@ pub fn unapply_filter(
             && Some(module_commit.tree_id()?)
                 != module_commit
                     .first_parent_id()
-                    .and_then(|p| git::read_tree_id(&odb, p).ok())
+                    .and_then(|p| git::read_tree_id(odb, p).ok())
         {
             original_parents[0].id()
         } else {
@@ -800,7 +800,7 @@ fn create_filtered_commit2(
     rewrite_data: filter::Rewrite,
     options: BTreeMap<String, String>,
 ) -> anyhow::Result<(git2::Oid, bool)> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let mut filtered_parents: Vec<(git2::Oid, git2::Oid)> = filtered_parent_ids
         .iter()
         .filter(|x| **x != git2::Oid::ZERO_SHA1)
@@ -848,7 +848,7 @@ fn create_filtered_commit2(
             // No first parent is not a trivial merge; a present first parent
             // must have a readable tree.
             let was_trivial_merge = match original_commit.first_parent_id() {
-                Some(parent) => git::read_tree_id(&odb, parent)? == original_commit.tree_id()?,
+                Some(parent) => git::read_tree_id(odb, parent)? == original_commit.tree_id()?,
                 None => false,
             };
 
@@ -860,7 +860,7 @@ fn create_filtered_commit2(
     }
 
     let selected_filtered_parent_ids: Vec<git2::Oid> = select_parent_commits(
-        &odb,
+        odb,
         original_commit,
         rewrite_data.tree_id(),
         &filtered_parents,
@@ -868,7 +868,7 @@ fn create_filtered_commit2(
 
     if selected_filtered_parent_ids.is_empty()
         && !(original_commit.parent_count() == 0
-            && is_empty_root(transaction, &odb, original_commit.tree_id()?)?)
+            && is_empty_root(transaction, odb, original_commit.tree_id()?)?)
     {
         if !filtered_parents.is_empty() {
             // Returning the parent id here means the commit is dropped from the output history
@@ -887,7 +887,7 @@ fn create_filtered_commit2(
 
     let new_tree_id = rewrite_data.tree_id();
     let new_oid = rewrite_commit(
-        &odb,
+        odb,
         original_commit,
         &selected_filtered_parent_ids,
         rewrite_data,
@@ -912,7 +912,7 @@ pub(crate) fn filtered_parent_tree_id(
             return Ok(tree_id);
         }
     }
-    git::read_tree_id(&transaction.odb()?, oid)
+    git::read_tree_id(transaction.odb(), oid)
 }
 
 /// Whether `oid` is a tree containing nothing but (recursively) empty trees. An unreadable
@@ -970,10 +970,10 @@ mod tests {
         );
         let ctx = cache::TransactionContext::new(td.path(), cachestack);
         let t = ctx.open().unwrap();
-        let odb = t.odb().unwrap();
+        let odb = t.odb();
 
         let empty = filter::tree::empty_id();
-        assert!(is_empty_root(&t, &odb, empty).unwrap());
+        assert!(is_empty_root(&t, odb, empty).unwrap());
 
         // A chain of trees bottoming out in the (virtualized) empty tree is empty. Built by
         // hand: normal tree builders drop empty subtrees.
@@ -995,7 +995,7 @@ mod tests {
             .unwrap()
             .write(git2::ObjectType::Tree, &data)
             .unwrap();
-        assert!(is_empty_root(&t, &odb, chain2).unwrap());
+        assert!(is_empty_root(&t, odb, chain2).unwrap());
 
         // A blob anywhere makes the root non-empty; so does a gitlink.
         let blob = repo.blob(b"x").unwrap();
@@ -1005,12 +1005,12 @@ mod tests {
         let with_blob = b
             .create_updated(&repo, &repo.find_tree(base).unwrap())
             .unwrap();
-        assert!(!is_empty_root(&t, &odb, with_blob).unwrap());
+        assert!(!is_empty_root(&t, odb, with_blob).unwrap());
 
         let gitlink = git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap();
         let mut b = repo.treebuilder(None).unwrap();
         b.insert("sub", gitlink, 0o160000).unwrap();
         let with_gitlink = b.write().unwrap();
-        assert!(!is_empty_root(&t, &odb, with_gitlink).unwrap());
+        assert!(!is_empty_root(&t, odb, with_gitlink).unwrap());
     }
 }

--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -123,7 +123,7 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
     let trace_s = span!(Level::TRACE, "discover_filter_candidates");
     let _e = trace_s.enter();
 
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     transaction.for_each_ref_prefixed("refs/josh/upstream/", |name, target| {
         if !name.ends_with(".git/HEAD") {
             return Ok(());
@@ -145,7 +145,7 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
             let tree = repo
                 .find_object(target, None)?
                 .peel(git2::ObjectType::Tree)?;
-            let hs = find_all_workspaces_and_subdirectories(&odb, tree.id())?;
+            let hs = find_all_workspaces_and_subdirectories(odb, tree.id())?;
             known_f.0 = target;
             for i in hs {
                 known_f.1.insert(i);

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -173,7 +173,7 @@ pub fn filter_commit(
 ) -> anyhow::Result<git2::Oid> {
     // A chained filter feeds the previous step's freshly built commit in here, so the peel
     // has to see the transaction's buffered objects.
-    let original_commit = objects::peel_to_commit(&transaction.odb()?, oid)?;
+    let original_commit = objects::peel_to_commit(transaction.odb(), oid)?;
 
     let filter_commit = if let Some(s) = transaction.get_ref(filterobj, oid) {
         s

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -91,7 +91,7 @@ fn filtered_commit(
     commit_id: git2::Oid,
 ) -> anyhow::Result<CommitData> {
     let filtered = filter::apply_to_commit(filter, commit_id, transaction)?;
-    CommitData::read(&transaction.odb()?, filtered)
+    CommitData::read(transaction.odb(), filtered)
 }
 
 pub struct DiffPath {
@@ -119,15 +119,15 @@ impl Revision {
         kind: git2::ObjectType,
     ) -> FieldResult<Option<Vec<Path>>> {
         let transaction = context.transaction.lock().unwrap();
-        let odb = transaction.odb()?;
-        let commit = CommitData::read(&odb, self.commit_id)?;
+        let odb = transaction.odb();
+        let commit = CommitData::read(odb, self.commit_id)?;
         let x = filter::apply(
             &transaction,
             self.filter,
             Rewrite::from_tree(commit.tree_id()?),
         )?;
         let tree_id = x.tree_id();
-        let paths = find_paths(&transaction, &odb, tree_id, at, depth, kind)?;
+        let paths = find_paths(&transaction, odb, tree_id, at, depth, kind)?;
         let mut ws = vec![];
         for path in paths {
             ws.push(Path {
@@ -151,7 +151,7 @@ impl Revision {
         let transaction = context.transaction.lock().unwrap();
         // Existence/type probe: a bogus id (e.g. the zero oid `parents` substitutes when
         // find_original fails) must error here, not filter to a bogus hash under a nop filter.
-        CommitData::read(&transaction.odb()?, self.commit_id)?;
+        CommitData::read(transaction.odb(), self.commit_id)?;
         let filter_commit = filter::apply_to_commit(self.filter, self.commit_id, &transaction)?;
         Ok(format!("{}", filter_commit))
     }
@@ -218,7 +218,7 @@ impl Revision {
         let transaction = context.transaction.lock().unwrap();
         let filter_commit_id = filter::apply_to_commit(self.filter, self.commit_id, &transaction)?;
 
-        let parents = josh_core::git::read_parent_ids(&transaction.odb()?, filter_commit_id)?
+        let parents = josh_core::git::read_parent_ids(transaction.odb(), filter_commit_id)?
             .into_iter()
             .map(|id| Revision {
                 filter: self.filter,
@@ -248,7 +248,7 @@ impl Revision {
         let filter_commit = filtered_commit(&transaction, self.filter, self.commit_id)?;
 
         // First parents only, followed just far enough to fill the requested window.
-        let odb = transaction.odb()?;
+        let odb = transaction.odb();
         let mut ids = vec![];
         let mut next = Some(filter_commit.id());
         for i in 0..offset + limit {
@@ -256,9 +256,7 @@ impl Revision {
             if i >= offset {
                 ids.push(id);
             }
-            next = josh_core::git::read_parent_ids(&odb, id)?
-                .into_iter()
-                .next();
+            next = josh_core::git::read_parent_ids(odb, id)?.into_iter().next();
         }
 
         let mut contained_in = self.commit_id;
@@ -270,7 +268,7 @@ impl Revision {
 
                 if orig != git2::Oid::ZERO_SHA1 {
                     ids[i] = orig;
-                    contained_in = josh_core::git::read_parent_ids(&transaction.odb()?, ids[i])?
+                    contained_in = josh_core::git::read_parent_ids(transaction.odb(), ids[i])?
                         .into_iter()
                         .next()
                         .unwrap_or(ids[i]);
@@ -317,14 +315,14 @@ impl Revision {
         let transaction = context.transaction.lock().unwrap();
         let filter_commit = filtered_commit(&transaction, self.filter, self.commit_id)?;
 
-        let odb = transaction.odb()?;
+        let odb = transaction.odb();
         let (parent_id, parent_tree_id) = match filter_commit.first_parent_id() {
-            Some(parent) => (parent, josh_core::git::read_tree_id(&odb, parent)?),
+            Some(parent) => (parent, josh_core::git::read_tree_id(odb, parent)?),
             None => (git2::Oid::ZERO_SHA1, git2::Oid::ZERO_SHA1),
         };
 
         let filter_tree_id = filter_commit.tree_id()?;
-        let d = filter::tree::diff_paths(&transaction.odb()?, parent_tree_id, filter_tree_id, "")?;
+        let d = filter::tree::diff_paths(transaction.odb(), parent_tree_id, filter_tree_id, "")?;
 
         let df = d
             .into_iter()
@@ -370,12 +368,12 @@ impl Revision {
     fn file(&self, path: String, context: &Context) -> FieldResult<Option<Path>> {
         let transaction = context.transaction.lock().unwrap();
         let path = std::path::Path::new(&path).to_owned();
-        let odb = transaction.odb()?;
-        let tree = CommitData::read(&odb, self.commit_id)?.tree_id()?;
+        let odb = transaction.odb();
+        let tree = CommitData::read(odb, self.commit_id)?.tree_id()?;
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
 
-        if let Ok(Some(entry)) = tree::get_path_entry(&transaction, &odb, x.tree_id(), &path) {
+        if let Ok(Some(entry)) = tree::get_path_entry(&transaction, odb, x.tree_id(), &path) {
             if !entry.mode.is_tree() && !entry.mode.is_commit() {
                 Ok(Some(Path {
                     path,
@@ -394,8 +392,8 @@ impl Revision {
     fn dir(&self, path: Option<String>, context: &Context) -> FieldResult<Option<Path>> {
         let path = path.unwrap_or_default();
         let transaction = context.transaction.lock().unwrap();
-        let odb = transaction.odb()?;
-        let tree = CommitData::read(&odb, self.commit_id)?.tree_id()?;
+        let odb = transaction.odb();
+        let tree = CommitData::read(odb, self.commit_id)?.tree_id()?;
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
 
@@ -410,7 +408,7 @@ impl Revision {
             }));
         }
 
-        if let Ok(Some(entry)) = tree::get_path_entry(&transaction, &odb, x.tree_id(), &path) {
+        if let Ok(Some(entry)) = tree::get_path_entry(&transaction, odb, x.tree_id(), &path) {
             if entry.mode.is_tree() {
                 Ok(Some(Path {
                     path,
@@ -428,7 +426,7 @@ impl Revision {
 
     fn warnings(&self, context: &Context) -> FieldResult<Option<Vec<Warning>>> {
         let transaction = context.transaction.lock().unwrap();
-        let commit = CommitData::read(&transaction.odb()?, self.commit_id)?;
+        let commit = CommitData::read(transaction.odb(), self.commit_id)?;
 
         let warnings = filter::compute_warnings(&transaction, self.filter, commit.tree_id()?)
             .into_iter()
@@ -440,8 +438,8 @@ impl Revision {
 
     fn search(&self, string: String, context: &Context) -> FieldResult<Option<Vec<SearchResult>>> {
         let transaction = context.transaction.lock().unwrap();
-        let odb = transaction.odb()?;
-        let tree = CommitData::read(&odb, self.commit_id)?.tree_id()?;
+        let odb = transaction.odb();
+        let tree = CommitData::read(odb, self.commit_id)?.tree_id()?;
 
         let x = filter::apply(&transaction, self.filter, Rewrite::from_tree(tree))?;
 
@@ -450,10 +448,10 @@ impl Revision {
         let candidates = if filter::experimental_features_enabled() {
             let ifilterobj = filter::parse(":SQUASH:INDEX")?;
             let index_tree = filter::apply(&transaction, ifilterobj, x.clone())?;
-            josh_search::search_candidates(&odb, index_tree.tree_id(), x.tree_id(), &string)?
+            josh_search::search_candidates(odb, index_tree.tree_id(), x.tree_id(), &string)?
         } else {
             let mut scan = vec![];
-            objects::walk_tree_preorder(&odb, x.tree_id(), &mut |parent, entry| {
+            objects::walk_tree_preorder(odb, x.tree_id(), &mut |parent, entry| {
                 if !entry.mode.is_tree()
                     && !entry.mode.is_commit()
                     && let Ok(name) = std::str::from_utf8(entry.filename)
@@ -465,7 +463,7 @@ impl Revision {
             })?;
             scan
         };
-        let results = josh_search::search_matches(&odb, x.tree_id(), &string, &candidates)?;
+        let results = josh_search::search_matches(odb, x.tree_id(), &string, &candidates)?;
 
         let mut r = vec![];
         for m in results {
@@ -573,9 +571,9 @@ impl Markers {
 
         // Resolve on the mirror, read objects on the overlay: the overlay repo sees the
         // mirror's objects through a disk alternate.
-        let odb = transaction.odb()?;
+        let odb = transaction.odb();
         let tree = if let Some(id) = transaction_mirror.resolve_ref(&refname)? {
-            CommitData::read(&odb, id)?.tree_id()?
+            CommitData::read(odb, id)?.tree_id()?
         } else {
             filter::tree::empty_id()
         };
@@ -585,14 +583,14 @@ impl Markers {
         let path = if self.filter.is_nop() {
             marker_path(&commit, &self.topic).join(&self.path)
         } else {
-            let t = CommitData::read(&odb, self.commit_id)?.tree_id()?;
+            let t = CommitData::read(odb, self.commit_id)?.tree_id()?;
             let o = filter::tree::original_path(&transaction, self.filter, t, &self.path)?;
             marker_path(&commit, &self.topic).join(o)
         };
 
-        let prev = match tree::get_path_entry(&transaction, &odb, tree, &path)? {
+        let prev = match tree::get_path_entry(&transaction, odb, tree, &path)? {
             Some(entry) => {
-                let blob = tree::blob_bytes(&odb, objects::git2_oid(&entry.oid))
+                let blob = tree::blob_bytes(odb, objects::git2_oid(&entry.oid))
                     .ok_or_else(|| anyhow!("not a blob: {}", entry.oid))?;
                 std::str::from_utf8(&blob)?.to_owned()
             }
@@ -626,25 +624,21 @@ impl Markers {
 
         let refname = transaction_mirror.refname("refs/josh/meta");
 
-        let odb = transaction.odb()?;
+        let odb = transaction.odb();
         let mtree = if let Some(id) = transaction_mirror.resolve_ref(&refname)? {
-            CommitData::read(&odb, id)?.tree_id()?
+            CommitData::read(odb, id)?.tree_id()?
         } else {
             filter::tree::empty_id()
         };
 
         let commit = self.commit_id.to_string();
-        let mtree = tree::get_path_entry(
-            &transaction,
-            &odb,
-            mtree,
-            &marker_path(&commit, &self.topic),
-        )
-        .ok()
-        .flatten()
-        .filter(|entry| entry.mode.is_tree())
-        .map(|entry| objects::git2_oid(&entry.oid))
-        .unwrap_or_else(filter::tree::empty_id);
+        let mtree =
+            tree::get_path_entry(&transaction, odb, mtree, &marker_path(&commit, &self.topic))
+                .ok()
+                .flatten()
+                .filter(|entry| entry.mode.is_tree())
+                .map(|entry| objects::git2_oid(&entry.oid))
+                .unwrap_or_else(filter::tree::empty_id);
 
         let mtree = if self.filter.is_nop() {
             mtree
@@ -652,14 +646,14 @@ impl Markers {
             filter::tree::repopulated_tree(
                 &transaction,
                 self.filter,
-                CommitData::read(&odb, self.commit_id)?.tree_id()?,
+                CommitData::read(odb, self.commit_id)?.tree_id()?,
                 mtree,
             )?
         };
-        if let Ok(Some(p)) = tree::get_path_entry(&transaction, &odb, mtree, &self.path) {
-            return Ok(linecount(&transaction, &odb, objects::git2_oid(&p.oid)) as i32);
+        if let Ok(Some(p)) = tree::get_path_entry(&transaction, odb, mtree, &self.path) {
+            return Ok(linecount(&transaction, odb, objects::git2_oid(&p.oid)) as i32);
         } else if self.path == std::path::Path::new("") {
-            return Ok(linecount(&transaction, &odb, mtree) as i32);
+            return Ok(linecount(&transaction, odb, mtree) as i32);
         }
         Ok(0)
     }
@@ -676,8 +670,8 @@ impl Path {
         let id = if self.path == std::path::Path::new("") {
             self.tree
         } else {
-            let odb = transaction.odb()?;
-            let entry = tree::get_path_entry(&transaction, &odb, self.tree, &self.path)?
+            let odb = transaction.odb();
+            let entry = tree::get_path_entry(&transaction, odb, self.tree, &self.path)?
                 .ok_or_else(|| anyhow!("no such path: {}", self.path.display()))?;
             objects::git2_oid(&entry.oid)
         };
@@ -690,8 +684,8 @@ impl Path {
         str_to_value: impl FnOnce(&str) -> Result<serde_json::Value, E>,
     ) -> FieldResult<Document> {
         self.internal_serialize(context, |transaction, id| {
-            let odb = transaction.odb()?;
-            let blob = tree::blob_bytes(&odb, id).ok_or_else(|| anyhow!("not a blob: {}", id))?;
+            let odb = transaction.odb();
+            let blob = tree::blob_bytes(odb, id).ok_or_else(|| anyhow!("not a blob: {}", id))?;
             let value =
                 str_to_value(std::str::from_utf8(&blob)?).unwrap_or_else(|_| serde_json::json!({}));
             Ok(Document { id, value })
@@ -740,8 +734,8 @@ impl Path {
     }
     fn text(&self, context: &Context) -> FieldResult<Option<String>> {
         self.internal_serialize(context, |transaction, id| {
-            let odb = transaction.odb()?;
-            let blob = tree::blob_bytes(&odb, id).ok_or_else(|| anyhow!("not a blob: {}", id))?;
+            let odb = transaction.odb();
+            let blob = tree::blob_bytes(odb, id).ok_or_else(|| anyhow!("not a blob: {}", id))?;
             Ok(Some(std::str::from_utf8(&blob)?.to_string()))
         })
     }
@@ -996,7 +990,7 @@ impl RepositoryMut {
         let transaction_mirror = context.transaction_mirror.lock().unwrap();
 
         // Just check that the commit exists
-        CommitData::read(&transaction_mirror.odb()?, git2::Oid::from_str(&at)?)?;
+        CommitData::read(transaction_mirror.odb(), git2::Oid::from_str(&at)?)?;
 
         let filter = if let Some(spec) = filter {
             filter::parse(&spec)?
@@ -1052,7 +1046,7 @@ impl Repository {
         let transaction_mirror = context.transaction_mirror.lock().unwrap();
         let commit_id = {
             let oid = if let Ok(id) = git2::Oid::from_str(&at) {
-                Some((id, transaction_mirror.odb()?.contains(id)))
+                Some((id, transaction_mirror.odb().contains(id)))
             } else {
                 None
             };

--- a/josh-link/src/lib.rs
+++ b/josh-link/src/lib.rs
@@ -19,7 +19,7 @@ impl PreparedLinkAdd {
         signature: &git2::Signature,
     ) -> anyhow::Result<git2::Oid> {
         josh_core::objects::write_commit(
-            &transaction.odb()?,
+            transaction.odb(),
             self.tree_oid,
             &[head_commit],
             signature,
@@ -73,8 +73,8 @@ pub fn collect_all_link_refs(
 
     let mut refs = HashSet::new();
 
-    let odb = transaction.odb()?;
-    let mut walk = josh_core::objects::RevWalk::new(&odb);
+    let odb = transaction.odb();
+    let mut walk = josh_core::objects::RevWalk::new(odb);
     walk.push(filtered_commit)
         .context("Failed to push commit to revwalk")?;
 
@@ -82,10 +82,10 @@ pub fn collect_all_link_refs(
         .into_topo_vec(|_| false)
         .context("Failed to walk history")?
     {
-        let tree = josh_core::git::read_tree_id(&odb, oid).context("Failed to get commit tree")?;
+        let tree = josh_core::git::read_tree_id(odb, oid).context("Failed to get commit tree")?;
 
         let link_files =
-            josh_core::link::find_link_files(&odb, tree).context("Failed to find link files")?;
+            josh_core::link::find_link_files(odb, tree).context("Failed to find link files")?;
 
         for (_, filter) in link_files {
             if let (Some(remote), Some(commit)) =
@@ -126,7 +126,7 @@ pub fn prepare_link_add(
     head_tree: git2::Oid,
     mode: josh_core::filter::LinkMode,
 ) -> anyhow::Result<PreparedLinkAdd> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
 
     // Strip leading slash if present (git tree paths are always relative)
     let path = path.strip_prefix("/").unwrap_or(path);
@@ -146,11 +146,11 @@ pub fn prepare_link_add(
         .with_meta("mode", mode.to_string());
     let link_content = josh_core::filter::as_file(link_filter, 0);
 
-    let link_blob = josh_core::objects::write_blob(&odb, link_content.as_bytes())?;
+    let link_blob = josh_core::objects::write_blob(odb, link_content.as_bytes())?;
     let link_path = path.join(".link.josh");
 
     let new_tree = tree::insert_oid(
-        &odb,
+        odb,
         head_tree,
         &link_path,
         link_blob,
@@ -170,13 +170,13 @@ pub fn update_links(
     links_to_update: Vec<(PathBuf, git2::Oid)>,
     signature: &git2::Signature,
 ) -> anyhow::Result<Option<UpdateLinksResult>> {
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let head_tree_id =
-        josh_core::git::read_tree_id(&odb, head_commit).context("Failed to get HEAD tree")?;
+        josh_core::git::read_tree_id(odb, head_commit).context("Failed to get HEAD tree")?;
 
     // Find all link files to get their current metadata
-    let link_files = josh_core::link::find_link_files(&odb, head_tree_id)
-        .context("Failed to find link files")?;
+    let link_files =
+        josh_core::link::find_link_files(odb, head_tree_id).context("Failed to find link files")?;
 
     // Update the link files with new commit OIDs
     let mut updated_link_files: Vec<(PathBuf, josh_core::filter::Filter)> = Vec::new();
@@ -197,16 +197,17 @@ pub fn update_links(
     let mut new_tree = head_tree_id;
     for (path, link_file) in &updated_link_files {
         let link_content = josh_core::filter::as_file(*link_file, 0);
-        let link_blob = josh_core::objects::write_blob(&odb, link_content.as_bytes())?;
+        let link_blob = josh_core::objects::write_blob(odb, link_content.as_bytes())?;
         let link_path = path.join(".link.josh");
 
-        new_tree = tree::insert_oid(&odb, new_tree, &link_path, link_blob, 0o0100644)
-            .with_context(|| {
+        new_tree = tree::insert_oid(odb, new_tree, &link_path, link_blob, 0o0100644).with_context(
+            || {
                 format!(
                     "Failed to insert link file into tree at path '{}'",
                     path.display()
                 )
-            })?;
+            },
+        )?;
     }
 
     if new_tree == head_tree_id {
@@ -215,7 +216,7 @@ pub fn update_links(
 
     // Create a new commit with the updated tree
     let commit_with_updates = josh_core::objects::write_commit(
-        &odb,
+        odb,
         new_tree,
         &[head_commit],
         signature,

--- a/josh-memodb/Cargo.toml
+++ b/josh-memodb/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 edition = "2024"
 
 [dependencies]
+anyhow.workspace = true
 git2.workspace = true
 gix-features.workspace = true
 gix-hash.workspace = true

--- a/josh-memodb/src/lib.rs
+++ b/josh-memodb/src/lib.rs
@@ -14,6 +14,6 @@ pub mod registry;
 
 pub use hash::PassthroughHasher;
 pub use mem_odb::MemOdb;
-pub use odb::{Alternates, Bytes, Odb};
+pub use odb::{Bytes, Odb};
 pub use pack::objects_dir;
 pub use registry::FlushGuard;

--- a/josh-memodb/src/odb.rs
+++ b/josh-memodb/src/odb.rs
@@ -1,166 +1,217 @@
 //! The transaction object-database facade: the [`MemOdb`] store consulted directly, backed by
-//! the repository's git2 object database for objects that are not buffered.
+//! the repository's gitoxide object database for objects that are not buffered.
 //!
 //! Implements the [`gix_object`] object-access traits (memory-first, disk fallback) plus
 //! inherent helpers in `git2::Oid` currency; memory hits hand out zero-copy `Arc` buffers.
-//! The `disk` side is `repo.odb()`, including any runtime alternates added to that repository
-//! handle (josh-proxy overlays add the mirror), so the facade and plain git2 calls resolve
-//! exactly the same objects. Write dedup goes through the caller's [`Alternates`] mirror
-//! instead (see [`Odb::write`]) and never touches `disk`.
+//!
+//! A store resolves `objects/info/alternates` when it opens, so an alternate registered at
+//! runtime (the proxy overlay's mirror) is a store of its own, consulted after the
+//! repository's own. Write dedup probes only those alternates (see [`Odb::write`]).
+//!
+//! The empty tree is resolved here whether or not it is stored, and before disk: josh reads it
+//! constantly as the base of a rebuild, and a lookup that misses makes gitoxide re-read the
+//! objects directory.
+//!
+//! One facade per transaction, built once, so its cache and the store's pack indices serve a
+//! whole filter run.
 
-use std::sync::{Arc, Mutex};
+use std::cell::RefCell;
+use std::path::Path;
+use std::sync::Arc;
 
+use gix_features::threading::OwnShared;
 use gix_hash::ObjectId;
-use gix_object::Kind;
+use gix_object::{Exists, Find, FindHeader, Kind};
 
 use crate::MemOdb;
 
-/// A mirror of the runtime alternates registered on a repository handle: an odb over ONLY the
-/// alternate object directories, no repository attached. The facade's write path probes it so
-/// alternate-resident objects (the proxy overlay's mirror) are never buffered — flushed packs
-/// must not contain duplicates of mirror objects, and the pack-time disk filter cannot see
-/// runtime alternates. Deliberately excludes the repository's own odb: locally-durable objects
-/// are dropped at pack time instead, and with no alternates registered the probe is a `None`
-/// check, no filesystem I/O.
-///
-/// Owned by the holder of the repository handle rather than by the store, because what an
-/// alternate makes reachable is a property of the handle: josh-templates registers the overlay
-/// as an alternate of a mirror repository and the reverse elsewhere, and a store shared by both
-/// must not mix them.
-#[derive(Default)]
-pub struct Alternates(Mutex<Option<git2::Odb<'static>>>);
+/// Decompressed objects kept per facade, so re-reading one does not decode it again. Worth
+/// ~10% of a cold filter run; a 64 MB budget measures the same, so the size is not the lever.
+const OBJECT_CACHE_BYTES: usize = 256 * 1024 * 1024;
 
-impl Alternates {
-    /// Record `path` (an objects directory) as a runtime alternate. Callers add the alternate to
-    /// their repository odb themselves (`git2::Odb::add_disk_alternate`); this mirror only feeds
-    /// the write-dedup probe.
-    pub fn add(&self, path: &str) -> Result<(), git2::Error> {
-        let mut alternates = self.0.lock().unwrap();
-        let odb = match alternates.as_mut() {
-            Some(odb) => odb,
-            None => alternates.insert(git2::Odb::new()?),
-        };
-        odb.add_disk_alternate(path)
-    }
-
-    /// Whether `oid` exists in one of the recorded alternates. `false` without filesystem I/O
-    /// when none are recorded.
-    fn contains(&self, oid: git2::Oid) -> bool {
-        self.0
-            .lock()
-            .unwrap()
-            .as_ref()
-            .is_some_and(|o| o.exists(oid))
-    }
-}
-
-/// Raw object bytes from a facade read: zero-copy shared buffer for memory hits, a libgit2
-/// odb object for disk hits. Derefs to the raw serialized object bytes either way.
-pub enum Bytes<'a> {
+/// Raw object bytes from a facade read: a zero-copy shared buffer for memory hits, the
+/// decompressed bytes for disk hits. Derefs to the raw serialized object bytes either way.
+pub enum Bytes {
     Mem(Arc<[u8]>),
-    Disk(git2::OdbObject<'a>),
+    Disk(Vec<u8>),
 }
 
-impl std::ops::Deref for Bytes<'_> {
+impl std::ops::Deref for Bytes {
     type Target = [u8];
     fn deref(&self) -> &[u8] {
         match self {
             Bytes::Mem(data) => data,
-            Bytes::Disk(obj) => obj.data(),
+            Bytes::Disk(data) => data,
         }
     }
 }
 
-/// See the module docs. A cheap per-call value: an `Arc` clone onto the transaction's store
-/// plus the repository's odb handle, obtained via `Transaction::odb()`.
-pub struct Odb<'repo> {
+/// See the module docs. Built by `Transaction::odb()` and held for the transaction.
+pub struct Odb {
     mem: Arc<MemOdb>,
-    disk: git2::Odb<'repo>,
-    alternates: Option<&'repo Alternates>,
+    /// The repository's own objects. Handles taken from one store share its loaded pack
+    /// indices, so every transaction on a repository pays for them once between them.
+    disk: gix_odb::Handle,
+    /// Object directories registered after the repository was opened; see the module docs.
+    alternates: RefCell<Vec<Alternate>>,
 }
 
-impl<'repo> Odb<'repo> {
-    /// A facade with no runtime alternates registered, for repositories that have none.
-    pub fn new(mem: Arc<MemOdb>, disk: git2::Odb<'repo>) -> Self {
+/// A runtime alternate as two handles on one store, differing only in what a miss costs.
+struct Alternate {
+    /// Reads: refreshes on a miss, so an object that landed after registration is found.
+    read: gix_odb::Handle,
+    /// The write gate (see [`Odb::write`]), which misses for every object josh produces, so it
+    /// must not pay the directory scan a refresh costs. It answers from what the store already
+    /// knows; missing an object packed since costs a duplicate in a pack, never correctness.
+    gate: gix_odb::Handle,
+}
+
+/// The empty tree, which josh expects to resolve in every repository.
+fn empty_tree() -> ObjectId {
+    ObjectId::empty_tree(gix_hash::Kind::Sha1)
+}
+
+/// A reading handle on `store`, cached for the length of a filter run.
+///
+/// No delta-base cache, deliberately: `gix_pack` caches a decoded object under its own pack
+/// offset, and a filter run reads history oldest first, so what it caches is never a later
+/// read's chain ancestor and the cache cannot hit -- it only adds bookkeeping, measured at 4-7%
+/// on the cases it should have helped. Reading deltified packs in that order is what the object
+/// path still pays for; caching the chain's base in `decode_entry` would fix it upstream, and
+/// nothing here can, since the cache trait only sees what `decode_entry` puts in it.
+fn handle(store: OwnShared<gix_odb::Store>) -> gix_odb::Handle {
+    let mut handle = gix_odb::Cache::from(store.to_handle());
+    handle.set_object_cache(|| {
+        Box::new(gix_pack::cache::object::MemoryCappedHashmap::new(
+            OBJECT_CACHE_BYTES,
+        ))
+    });
+    // Default refresh mode: a lookup that misses re-reads the objects directory, which is how a
+    // store learns about a pack josh, a spawned `git` or another process has written.
+    handle
+}
+
+impl Odb {
+    /// The facade over `mem` and the objects of the repository `store` belongs to. Take the
+    /// store from a repository handle so its pack indices are shared between transactions;
+    /// [`Odb::at`] opens one for a bare objects directory.
+    pub fn new(mem: Arc<MemOdb>, store: OwnShared<gix_odb::Store>) -> Self {
         Odb {
             mem,
-            disk,
-            alternates: None,
+            disk: handle(store),
+            alternates: Default::default(),
         }
     }
 
-    /// A facade whose write gate skips objects reachable through `alternates` (see there).
-    pub fn with_alternates(
-        mem: Arc<MemOdb>,
-        disk: git2::Odb<'repo>,
-        alternates: &'repo Alternates,
-    ) -> Self {
-        Odb {
-            mem,
-            disk,
-            alternates: Some(alternates),
-        }
+    /// [`Odb::new`] over the objects directory `objects_dir`, opening a store of its own.
+    pub fn at(mem: Arc<MemOdb>, objects_dir: &Path) -> std::io::Result<Self> {
+        Ok(Odb::new(mem, gix_odb::at(objects_dir)?.store()))
+    }
+
+    /// Register `path` (an objects directory) as another place to read objects from, and one
+    /// whose objects the write gate must not buffer.
+    pub fn add_alternate(&self, path: &Path) -> std::io::Result<()> {
+        let store = gix_odb::at(path)?.store();
+        let mut gate = gix_odb::Cache::from(store.to_handle());
+        gate.refresh_never();
+        self.alternates.borrow_mut().push(Alternate {
+            read: handle(store),
+            gate,
+        });
+        Ok(())
+    }
+
+    /// Whether a registered alternate holds `oid`; no filesystem I/O when there are none.
+    fn in_alternate(&self, id: &gix_hash::oid) -> bool {
+        self.alternates
+            .borrow()
+            .iter()
+            .any(|alt| alt.read.exists(id))
+    }
+
+    /// [`Odb::in_alternate`] through the gate handles (see [`Alternate::gate`]).
+    fn in_alternate_gate(&self, id: &gix_hash::oid) -> bool {
+        self.alternates
+            .borrow()
+            .iter()
+            .any(|alt| alt.gate.exists(id))
     }
 
     /// Read the raw bytes and kind of `oid`; memory hits are zero-copy. A missing object is an
     /// error, like a plain odb read.
-    pub fn read(&self, oid: git2::Oid) -> Result<(Kind, Bytes<'_>), git2::Error> {
-        if let Some((kind, data)) = self.mem.get(&josh_gix_ext::gix_oid(oid)) {
+    pub fn read(&self, oid: git2::Oid) -> anyhow::Result<(Kind, Bytes)> {
+        let id = josh_gix_ext::gix_oid(oid);
+        if let Some((kind, data)) = self.mem.get(&id) {
             return Ok((kind, Bytes::Mem(data)));
         }
-        let obj = self.disk.read(oid)?;
-        let kind = josh_gix_ext::gix_kind(obj.kind()).ok_or_else(|| {
-            git2::Error::new(
-                git2::ErrorCode::Invalid,
-                git2::ErrorClass::Odb,
-                "object has no concrete kind",
-            )
-        })?;
-        Ok((kind, Bytes::Disk(obj)))
+        if id == empty_tree() {
+            return Ok((Kind::Tree, Bytes::Disk(Vec::new())));
+        }
+        let mut buffer = Vec::new();
+        if let Some(kind) = self
+            .find_on_disk(&id, &mut buffer)
+            .map_err(|e| anyhow::anyhow!("failed to read {}: {}", oid, e))?
+        {
+            return Ok((kind, Bytes::Disk(buffer)));
+        }
+        Err(anyhow::anyhow!(
+            "object not found - no match for id ({})",
+            oid
+        ))
+    }
+
+    /// Read `id` into `buffer` from the repository's objects or an alternate, reporting the
+    /// kind it was stored with, or `None` when neither holds it.
+    fn find_on_disk(
+        &self,
+        id: &gix_hash::oid,
+        buffer: &mut Vec<u8>,
+    ) -> Result<Option<Kind>, gix_object::find::Error> {
+        if let Some(data) = self.disk.try_find(id, buffer)? {
+            return Ok(Some(data.kind));
+        }
+        for alternate in self.alternates.borrow().iter() {
+            if let Some(data) = alternate.read.try_find(id, buffer)? {
+                return Ok(Some(data.kind));
+            }
+        }
+        Ok(None)
     }
 
     /// Kind and size of `oid` without reading (or decompressing) its bytes.
-    pub fn read_header(&self, oid: git2::Oid) -> Result<(Kind, u64), git2::Error> {
-        if let Some(header) = self.mem.header(&josh_gix_ext::gix_oid(oid)) {
-            return Ok(header);
-        }
-        let (size, kind) = self.disk.read_header(oid)?;
-        let kind = josh_gix_ext::gix_kind(kind).ok_or_else(|| {
-            git2::Error::new(
-                git2::ErrorCode::Invalid,
-                git2::ErrorClass::Odb,
-                "object has no concrete kind",
-            )
-        })?;
-        Ok((kind, size as u64))
+    pub fn read_header(&self, oid: git2::Oid) -> anyhow::Result<(Kind, u64)> {
+        self.header(oid)?
+            .ok_or_else(|| anyhow::anyhow!("object not found - no match for id ({})", oid))
     }
 
     pub fn contains(&self, oid: git2::Oid) -> bool {
-        self.mem.contains(&josh_gix_ext::gix_oid(oid)) || self.disk.exists(oid)
+        let id = josh_gix_ext::gix_oid(oid);
+        self.mem.contains(&id) || self.disk.exists(&id) || self.in_alternate(&id)
     }
 
-    /// Kind of `oid`, or `None` if the object does not exist. Never decompresses. The disk
-    /// fallback resolves the empty tree even when it is stored nowhere, so probes on
-    /// possibly-empty trees belong here and never on [`contains`](Odb::contains).
-    pub fn try_kind(&self, oid: git2::Oid) -> Result<Option<Kind>, git2::Error> {
-        if let Some((kind, _)) = self.mem.header(&josh_gix_ext::gix_oid(oid)) {
-            return Ok(Some(kind));
-        }
-        let (_, kind) = match self.disk.read_header(oid) {
-            Ok(h) => h,
-            Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
-            Err(e) => return Err(e),
-        };
-        Ok(josh_gix_ext::gix_kind(kind))
+    /// Kind of `oid`, or `None` if the object does not exist. Never decompresses. Resolves the
+    /// empty tree even when it is stored nowhere, so probes on possibly-empty trees belong
+    /// here and never on [`contains`](Odb::contains).
+    pub fn try_kind(&self, oid: git2::Oid) -> anyhow::Result<Option<Kind>> {
+        Ok(self.header(oid)?.map(|(kind, _)| kind))
+    }
+
+    /// Kind and size of `oid`, or `None` when no store holds it.
+    fn header(&self, oid: git2::Oid) -> anyhow::Result<Option<(Kind, u64)>> {
+        let id = josh_gix_ext::gix_oid(oid);
+        Ok(self
+            .try_header(&id)
+            .map_err(|e| anyhow::anyhow!("failed to read header of {}: {}", oid, e))?
+            .map(|header| (header.kind, header.size)))
     }
 
     /// Hash and buffer an object in the memory store, returning its content id. The buffer is
     /// skipped when the object is already in memory or in a runtime alternate: proxy overlays
     /// must never buffer mirror objects, or flushed packs would gain duplicates and change
     /// names (the pack-time disk filter cannot see runtime alternates). The gate never probes
-    /// the repository's own on-disk odb: objects already durable there are buffered anyway and
-    /// dropped at pack time, and a repository without alternates writes with zero filesystem
-    /// I/O.
+    /// the repository's own on-disk objects: objects already durable there are buffered anyway
+    /// and dropped at pack time, and a repository without alternates writes with zero
+    /// filesystem I/O.
     pub fn write(&self, kind: Kind, data: &[u8]) -> git2::Oid {
         let id = gix_object::compute_hash(gix_hash::Kind::Sha1, kind, data)
             .expect("failed to compute hash");
@@ -170,18 +221,14 @@ impl<'repo> Odb<'repo> {
 
     /// [`Odb::write`] with a caller-computed content hash, trusted verbatim.
     fn write_with_id(&self, id: ObjectId, kind: Kind, data: &[u8]) {
-        if self.mem.contains(&id)
-            || self
-                .alternates
-                .is_some_and(|alts| alts.contains(josh_gix_ext::git2_oid(&id)))
-        {
+        if self.mem.contains(&id) || self.in_alternate_gate(&id) {
             return;
         }
         self.mem.write_with_id(id, kind, data);
     }
 }
 
-impl gix_object::Find for Odb<'_> {
+impl gix_object::Find for Odb {
     fn try_find<'b>(
         &self,
         id: &gix_hash::oid,
@@ -196,16 +243,17 @@ impl gix_object::Find for Odb<'_> {
                 data: buffer,
             }));
         }
-        let obj = match self.disk.read(josh_gix_ext::git2_oid(id)) {
-            Ok(obj) => obj,
-            Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
-            Err(e) => return Err(Box::new(e)),
-        };
-        let Some(kind) = josh_gix_ext::gix_kind(obj.kind()) else {
+        if id == empty_tree() {
+            buffer.clear();
+            return Ok(Some(gix_object::Data {
+                kind: Kind::Tree,
+                object_hash: id.kind(),
+                data: buffer,
+            }));
+        }
+        let Some(kind) = self.find_on_disk(id, buffer)? else {
             return Ok(None);
         };
-        buffer.clear();
-        buffer.extend_from_slice(obj.data());
         Ok(Some(gix_object::Data {
             kind,
             object_hash: id.kind(),
@@ -214,7 +262,7 @@ impl gix_object::Find for Odb<'_> {
     }
 }
 
-impl gix_object::FindHeader for Odb<'_> {
+impl gix_object::FindHeader for Odb {
     fn try_header(
         &self,
         id: &gix_hash::oid,
@@ -222,28 +270,31 @@ impl gix_object::FindHeader for Odb<'_> {
         if let Some((kind, size)) = self.mem.header(id) {
             return Ok(Some(gix_object::Header { kind, size }));
         }
-        let (size, kind) = match self.disk.read_header(josh_gix_ext::git2_oid(id)) {
-            Ok(h) => h,
-            Err(e) if e.code() == git2::ErrorCode::NotFound => return Ok(None),
-            Err(e) => return Err(Box::new(e)),
-        };
-        let Some(kind) = josh_gix_ext::gix_kind(kind) else {
-            return Ok(None);
-        };
-        Ok(Some(gix_object::Header {
-            kind,
-            size: size as u64,
-        }))
+        if id == empty_tree() {
+            return Ok(Some(gix_object::Header {
+                kind: Kind::Tree,
+                size: 0,
+            }));
+        }
+        if let Some(header) = self.disk.try_header(id)? {
+            return Ok(Some(header));
+        }
+        for alternate in self.alternates.borrow().iter() {
+            if let Some(header) = alternate.read.try_header(id)? {
+                return Ok(Some(header));
+            }
+        }
+        Ok(None)
     }
 }
 
-impl gix_object::Exists for Odb<'_> {
+impl gix_object::Exists for Odb {
     fn exists(&self, id: &gix_hash::oid) -> bool {
-        self.mem.contains(id) || self.disk.exists(josh_gix_ext::git2_oid(id))
+        self.mem.contains(id) || self.disk.exists(id) || self.in_alternate(id)
     }
 }
 
-impl gix_object::Write for Odb<'_> {
+impl gix_object::Write for Odb {
     fn write_buf(&self, object: Kind, from: &[u8]) -> Result<ObjectId, gix_object::write::Error> {
         Ok(josh_gix_ext::gix_oid(self.write(object, from)))
     }
@@ -285,10 +336,9 @@ impl gix_object::Write for Odb<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use gix_object::{Exists as _, Find as _};
 
-    fn facade<'a>(store: &Arc<MemOdb>, repo: &'a git2::Repository) -> Odb<'a> {
-        Odb::new(store.clone(), repo.odb().unwrap())
+    fn facade(store: &Arc<MemOdb>, repo: &git2::Repository) -> Odb {
+        Odb::at(store.clone(), &crate::pack::objects_dir(repo)).unwrap()
     }
 
     /// A facade write is served from memory (zero-copy), is invisible to a plain reopened
@@ -332,27 +382,53 @@ mod tests {
         // A loose blob, so it is main-disk-only.
         let on_disk = repo.blob(b"already on disk").unwrap();
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
-        let alt = crate::pack::objects_dir(&mirror);
-        repo.odb()
-            .unwrap()
-            .add_disk_alternate(alt.to_str().unwrap())
+
+        let odb = facade(&store, &repo);
+        odb.add_alternate(&crate::pack::objects_dir(&mirror))
             .unwrap();
-        let alternates = Alternates::default();
-        alternates.add(alt.to_str().unwrap()).unwrap();
 
-        let odb = Odb::with_alternates(store.clone(), repo.odb().unwrap(), &alternates);
-
-        // Alternate hit: skipped, still readable through the disk chain.
+        // Alternate hit: skipped, still readable through the alternate.
         let oid = odb.write(Kind::Blob, b"mirror blob");
         assert_eq!(oid, in_alternate);
         assert!(!store.contains(&josh_gix_ext::gix_oid(oid)));
         assert!(matches!(odb.read(oid).unwrap().1, Bytes::Disk(_)));
 
-        // Main-disk object: buffered — the gate does not probe the repository's own odb.
+        // Main-disk object: buffered — the gate does not probe the repository's own objects.
         let oid = odb.write(Kind::Blob, b"already on disk");
         assert_eq!(oid, on_disk);
         assert!(store.contains(&josh_gix_ext::gix_oid(oid)));
         assert!(matches!(odb.read(oid).unwrap().1, Bytes::Mem(_)));
+    }
+
+    /// The gate sees a packed alternate object, which is the proxy's arrangement. One packed
+    /// after registration is deliberately outside what it sees, while reads still find it.
+    #[test]
+    fn facade_write_gate_sees_packed_alternates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mirror = git2::Repository::init(tmp.path().join("mirror")).unwrap();
+        let mirror_dir = crate::pack::objects_dir(&mirror);
+        // Packed before the alternate is registered.
+        let mirror_store = MemOdb::new(None, mirror_dir.clone());
+        let packed = josh_gix_ext::git2_oid(&mirror_store.write(Kind::Blob, b"packed in mirror"));
+        mirror_store.flush().unwrap();
+
+        let repo = git2::Repository::init(tmp.path().join("overlay")).unwrap();
+        let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
+        let odb = facade(&store, &repo);
+        odb.add_alternate(&mirror_dir).unwrap();
+
+        assert_eq!(odb.write(Kind::Blob, b"packed in mirror"), packed);
+        assert!(!store.contains(&josh_gix_ext::gix_oid(packed)));
+
+        // Packed after registration: the gate does not go looking, so it buffers a duplicate.
+        let later = josh_gix_ext::git2_oid(&mirror_store.write(Kind::Blob, b"packed later"));
+        let unread = josh_gix_ext::git2_oid(&mirror_store.write(Kind::Blob, b"never written"));
+        mirror_store.flush().unwrap();
+        assert_eq!(odb.write(Kind::Blob, b"packed later"), later);
+        assert!(store.contains(&josh_gix_ext::gix_oid(later)));
+
+        // Reads do go looking, and find an object from that same pack.
+        assert_eq!(&*odb.read(unread).unwrap().1, b"never written");
     }
 
     /// The empty tree reads as an existing tree through `try_kind` even when it is absent
@@ -368,11 +444,14 @@ mod tests {
         let empty_tree = git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap();
         assert!(!store.contains(&josh_gix_ext::gix_oid(empty_tree)));
         assert_eq!(odb.try_kind(empty_tree).unwrap(), Some(Kind::Tree));
+        assert_eq!(odb.read(empty_tree).unwrap().0, Kind::Tree);
+        assert!(odb.read(empty_tree).unwrap().1.is_empty());
         assert!(!odb.contains(empty_tree));
 
         // A genuinely absent object is None; a buffered object reports its memory kind.
         let absent = git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap();
         assert_eq!(odb.try_kind(absent).unwrap(), None);
+        assert!(odb.read(absent).is_err());
         let blob = odb.write(Kind::Blob, b"probe");
         assert_eq!(odb.try_kind(blob).unwrap(), Some(Kind::Blob));
     }
@@ -396,5 +475,29 @@ mod tests {
         assert_eq!(data.kind, Kind::Blob);
         assert_eq!(data.data, b"facade blob");
         assert!(odb.exists(&josh_gix_ext::gix_oid(oid)));
+    }
+
+    /// A pack written after the facade was built is still found, which is how a flush, a
+    /// spawned `git` and other processes stay visible to a store that outlives them.
+    #[test]
+    fn objects_packed_after_the_facade_was_built_are_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
+        let odb = facade(&store, &repo);
+
+        // Miss first, so the store has settled on the packs it found at open.
+        let oid = gix_object::compute_hash(gix_hash::Kind::Sha1, Kind::Blob, b"packed later")
+            .map(|id| josh_gix_ext::git2_oid(&id))
+            .unwrap();
+        assert!(!odb.contains(oid));
+
+        let store2 = MemOdb::new(None, crate::pack::objects_dir(&repo));
+        let facade2 = facade(&store2, &repo);
+        assert_eq!(facade2.write(Kind::Blob, b"packed later"), oid);
+        store2.flush().unwrap();
+
+        assert!(odb.contains(oid));
+        assert_eq!(&*odb.read(oid).unwrap().1, b"packed later");
     }
 }

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -299,19 +299,19 @@ pub fn merge_meta(
     }
     let rev = transaction_mirror.refname("refs/josh/meta");
 
-    let odb = transaction.odb()?;
+    let odb = transaction.odb();
     let (mut tree, parents) = if let Some(meta_oid) = transaction_mirror.resolve_ref(&rev)? {
-        let meta_commit = josh_core::objects::CommitData::read(&odb, meta_oid)?;
+        let meta_commit = josh_core::objects::CommitData::read(odb, meta_oid)?;
         (meta_commit.tree_id()?, vec![meta_oid])
     } else {
         (josh_core::filter::tree::empty_id(), vec![])
     };
 
     for (path, add_lines) in meta_add.iter() {
-        let prev = match josh_core::filter::tree::get_path_entry(transaction, &odb, tree, path)? {
+        let prev = match josh_core::filter::tree::get_path_entry(transaction, odb, tree, path)? {
             Some(entry) => {
                 let blob = josh_core::filter::tree::blob_bytes(
-                    &odb,
+                    odb,
                     josh_core::objects::git2_oid(&entry.oid),
                 )
                 .ok_or_else(|| anyhow!("not a blob: {}", entry.oid))?;
@@ -330,14 +330,14 @@ pub fn merge_meta(
         lines.sort_unstable();
         lines.dedup();
 
-        let blob = josh_core::objects::write_blob(&odb, lines.join("\n").as_bytes())?;
+        let blob = josh_core::objects::write_blob(odb, lines.join("\n").as_bytes())?;
 
-        tree = josh_core::filter::tree::insert_oid(&odb, tree, path, blob, 0o0100644)?;
+        tree = josh_core::filter::tree::insert_oid(odb, tree, path, blob, 0o0100644)?;
     }
 
     let signature = josh_core::git::josh_commit_signature()?;
     let oid =
-        josh_core::objects::write_commit(&odb, tree, &parents, &signature, &signature, "marker")?;
+        josh_core::objects::write_commit(odb, tree, &parents, &signature, &signature, "marker")?;
 
     Ok(Some(("refs/josh/meta".to_string(), oid)))
 }

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -442,15 +442,11 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
         let oid_to_push = if push_options.merge {
             if let Some(base_commit_id) = transaction_mirror.resolve_ref(&original_target_ref)? {
                 let signature = josh_core::git::josh_commit_signature()?;
-                let odb = transaction.odb()?;
-                let merged_tree = josh_core::objects::merge_commits(
-                    &odb,
-                    base_commit_id,
-                    backward_new_oid,
-                    None,
-                )?;
+                let odb = transaction.odb();
+                let merged_tree =
+                    josh_core::objects::merge_commits(odb, base_commit_id, backward_new_oid, None)?;
                 josh_core::objects::write_commit(
-                    &odb,
+                    odb,
                     merged_tree,
                     &[base_commit_id, backward_new_oid],
                     &signature,
@@ -504,8 +500,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
             let mut warnings = josh_core::filter::compute_warnings(
                 &transaction,
                 filter,
-                josh_core::objects::CommitData::read(&transaction.odb()?, push_ref.oid)?
-                    .tree_id()?,
+                josh_core::objects::CommitData::read(transaction.odb(), push_ref.oid)?.tree_id()?,
             );
 
             if !warnings.is_empty() {

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -336,12 +336,12 @@ impl TrigramBench {
             let repo = transaction.git2_repo();
             let tip_tree = repo.find_commit(tip)?.tree()?;
             let total_bytes = tree_content_bytes(repo, &tip_tree)?;
-            let odb = transaction.odb()?;
+            let odb = transaction.odb();
 
             // Cold-build the tip index, then flush: the timed groups reopen the repository and
             // read these index trees back, so they must be on disk by then.
             let index_tree_oid = josh_search::trigram_index(
-                &odb,
+                odb,
                 &transaction.trigram_index_cache(tip),
                 &mut josh_search::Indexer::default(),
                 tip_tree.id(),
@@ -353,7 +353,7 @@ impl TrigramBench {
             // degenerated and the search numbers would be meaningless. (The bound is kept at
             // the pre-rework value of 5; the exact index should always produce exactly 1.)
             let rare_path = path_for(n_files / 2).to_string_lossy().into_owned();
-            let (candidates, matches) = search(&odb, index_tree_oid, tip_tree.id(), NEEDLE_RARE)?;
+            let (candidates, matches) = search(odb, index_tree_oid, tip_tree.id(), NEEDLE_RARE)?;
             anyhow::ensure!(
                 matches.len() == 1 && matches[0].0 == rare_path,
                 "rare needle not found in exactly its planted file {rare_path}: {matches:?}"
@@ -366,13 +366,13 @@ impl TrigramBench {
 
             // Gate: the common needle is found in every planted file, the absent one nowhere.
             let common_count = n_files.div_ceil(COMMON_EVERY);
-            let (_, matches) = search(&odb, index_tree_oid, tip_tree.id(), NEEDLE_COMMON)?;
+            let (_, matches) = search(odb, index_tree_oid, tip_tree.id(), NEEDLE_COMMON)?;
             anyhow::ensure!(
                 matches.len() == common_count,
                 "common needle found in {} files, expected {common_count}",
                 matches.len()
             );
-            let (_, matches) = search(&odb, index_tree_oid, tip_tree.id(), NEEDLE_ABSENT)?;
+            let (_, matches) = search(odb, index_tree_oid, tip_tree.id(), NEEDLE_ABSENT)?;
             anyhow::ensure!(
                 matches.is_empty(),
                 "absent needle found in {} files",
@@ -386,7 +386,7 @@ impl TrigramBench {
             let transaction = context.open()?;
             let repo = transaction.git2_repo();
             let root_tree = repo.find_commit(chain[0])?.tree()?;
-            let odb = transaction.odb()?;
+            let odb = transaction.odb();
             // One indexer state for the whole chain, matching how josh keeps one per
             // transaction. Collect the per-commit (source tree, index tree) pairs on the way:
             // the history search group iterates them.
@@ -394,7 +394,7 @@ impl TrigramBench {
             let mut chain_indexes = vec![(
                 root_tree.id(),
                 josh_search::trigram_index(
-                    &odb,
+                    odb,
                     &transaction.trigram_index_cache(chain[0]),
                     &mut indexer,
                     root_tree.id(),
@@ -403,7 +403,7 @@ impl TrigramBench {
             for &oid in &chain[1..] {
                 let tree_oid = repo.find_commit(oid)?.tree_id();
                 let index_oid = josh_search::trigram_index(
-                    &odb,
+                    odb,
                     &transaction.trigram_index_cache(oid),
                     &mut indexer,
                     tree_oid,
@@ -460,13 +460,13 @@ fn trigram_benches(c: &mut Criterion) {
                 let transaction = bench.context.open().expect("open transaction");
                 let repo = transaction.git2_repo();
                 let tip_tree = repo.find_commit(case.tip()).expect("find tip").tree_id();
-                let odb = transaction.odb().expect("odb");
+                let odb = transaction.odb();
 
                 let mut indexer = josh_search::Indexer::default();
 
                 runner.run(|| {
                     josh_search::trigram_index(
-                        &odb,
+                        odb,
                         &transaction.trigram_index_cache(case.tip()),
                         &mut indexer,
                         tip_tree,
@@ -496,12 +496,12 @@ fn trigram_benches(c: &mut Criterion) {
                     .find_commit(case.chain[0])
                     .expect("find root")
                     .tree_id();
-                let odb = transaction.odb().expect("odb");
+                let odb = transaction.odb();
                 // One indexer state across the warm root and the whole chain, matching how
                 // josh keeps one per transaction.
                 let mut indexer = josh_search::Indexer::default();
                 josh_search::trigram_index(
-                    &odb,
+                    odb,
                     &transaction.trigram_index_cache(case.chain[0]),
                     &mut indexer,
                     root_tree,
@@ -512,7 +512,7 @@ fn trigram_benches(c: &mut Criterion) {
                     for &oid in &case.chain[1..] {
                         let tree = repo.find_commit(oid).expect("find churn commit").tree_id();
                         josh_search::trigram_index(
-                            &odb,
+                            odb,
                             &transaction.trigram_index_cache(oid),
                             &mut indexer,
                             tree,
@@ -544,10 +544,10 @@ fn trigram_benches(c: &mut Criterion) {
                     let transaction = bench.context.open().expect("open transaction");
                     let repo = transaction.git2_repo();
                     let source_tree = repo.find_commit(case.tip()).expect("find tip").tree_id();
-                    let odb = transaction.odb().expect("odb");
+                    let odb = transaction.odb();
 
                     runner.run(|| {
-                        search(&odb, case.index_tree_oid, source_tree, needle).expect("search")
+                        search(odb, case.index_tree_oid, source_tree, needle).expect("search")
                     });
                 });
             });
@@ -572,13 +572,13 @@ fn trigram_benches(c: &mut Criterion) {
                 b.iter_with_setup_wrapper(|runner| {
                     josh_core::reset_caches().expect("reset caches");
                     let transaction = bench.context.open().expect("open transaction");
-                    let odb = transaction.odb().expect("odb");
+                    let odb = transaction.odb();
 
                     runner.run(|| {
                         let mut hits = 0;
                         for (tree_oid, index_oid) in &case.chain_indexes {
                             let (_, matches) =
-                                search(&odb, *index_oid, *tree_oid, needle).expect("search");
+                                search(odb, *index_oid, *tree_oid, needle).expect("search");
                             hits += matches.len();
                         }
                         hits

--- a/josh-templates/src/templates.rs
+++ b/josh-templates/src/templates.rs
@@ -49,11 +49,11 @@ impl GraphQLHelper {
             self.transaction_context(&self.repo_path).open()?
         };
 
-        let odb = transaction.odb()?;
-        let tree = josh_core::objects::CommitData::read(&odb, self.commit_id)?.tree_id()?;
-        let entry = josh_core::objects::path_entry(&odb, tree, &path)?
+        let odb = transaction.odb();
+        let tree = josh_core::objects::CommitData::read(odb, self.commit_id)?.tree_id()?;
+        let entry = josh_core::objects::path_entry(odb, tree, &path)?
             .ok_or_else(|| anyhow!("no such path: {}", path.display()))?;
-        let query = josh_core::objects::blob_text(&odb, josh_core::objects::git2_oid(&entry.oid));
+        let query = josh_core::objects::blob_text(odb, josh_core::objects::git2_oid(&entry.oid));
 
         let mut variables = juniper::Variables::new();
 
@@ -149,9 +149,9 @@ pub fn render(
         return Err(anyhow!("no command"));
     };
 
-    let odb = transaction.odb()?;
-    let tree = josh_core::objects::CommitData::read(&odb, commit_id)?.tree_id()?;
-    let entry = josh_core::objects::path_entry(&odb, tree, &std::path::PathBuf::from(path))?;
+    let odb = transaction.odb();
+    let tree = josh_core::objects::CommitData::read(odb, commit_id)?.tree_id()?;
+    let entry = josh_core::objects::path_entry(odb, tree, &std::path::PathBuf::from(path))?;
 
     let entry = if let Some(entry) = entry {
         entry
@@ -160,7 +160,7 @@ pub fn render(
     };
 
     let template = if entry.mode.is_blob() {
-        let content = josh_core::objects::blob_text(&odb, josh_core::objects::git2_oid(&entry.oid));
+        let content = josh_core::objects::blob_text(odb, josh_core::objects::git2_oid(&entry.oid));
         let file = content.as_str();
         if cmd == "get" {
             return Ok(Some((file.to_string(), params)));


### PR DESCRIPTION
Read objects that memory does not hold through gitoxide

The memory store has been authoritative since the facade landed, but a
read that missed it still went through the repository handle. It now
goes to the repository's gitoxide store, taken from the thread-safe
handle the transaction already carries so its pack indices are loaded
once per context.

The facade is built once per transaction and held, so `Transaction::odb`
hands out a reference and is infallible; that is what makes its object
cache worth having, and why the change reaches every call site. Runtime
alternates move onto it: a store resolves `objects/info/alternates` when
it opens, so one registered later is a store of its own, consulted after
the repository's own.

A store re-reads its objects directory whenever a lookup misses, so the
two places josh misses systematically avoid it. The empty tree is
answered before disk, since josh probes it constantly as the base of a
rebuild. And the write gate, which asks whether an alternate already
holds an object josh has just produced and is told no every time, probes
through a second, non-refreshing handle: missing an object packed since
the store last looked costs a duplicate in a pack, not correctness.

Disk reads hand back owned bytes, which drops the lifetime from `Odb`,
`Bytes`, `TreeBytes` and `TreeReader`.

Cold read-heavy walks pay for this: `deephistory_glob_recursive` +67 to
+81%, `widetree_glob` +13 to +64%, `ultrawide_pin_hook` +8 to +28%,
against `unapply_extend` -22 to -24%, `unapply_new_branch` -19% and
sparse -7 to -22%. The cause is delta chains read in history order:
`gix_pack` caches a decoded object under its own pack offset, and a walk
that reads oldest first never revisits those, so no delta-base cache can
hit and none is set. Caching the chain's base in `decode_entry` would
fix it upstream. Even so, every case remains well ahead of where it was
before the port.

Change: facade-on-gitoxide
Assisted-By: anthropic/claude-opus-5