### PR TITLE
Sample the local cache by sequence number instead of oid hash

### DIFF
--- a/josh-core/src/cache/backend.rs
+++ b/josh-core/src/cache/backend.rs
@@ -61,3 +61,89 @@ pub struct HistoryGraphHint {
     /// True when the parent measured by `jump_delta` is the second parent.
     pub jump_is_second: bool,
 }
+
+/// One in every `SAMPLE_INTERVAL` commits is a sample point, by sequence number.
+const SAMPLE_INTERVAL: u64 = 100;
+
+impl HistoryGraphHint {
+    /// Whether this commit is a point at which a backward walk can be pruned.
+    ///
+    /// Caches are meant to be sparse: not every mapping is persisted. Both the
+    /// distributed backend (to stay small and fast to download) and the local
+    /// cache (which only persists mappings for commits that produce new output,
+    /// plus these samples) rely on the same invariant, so that a filter which
+    /// drops most commits -- and therefore stores almost nothing on its own --
+    /// still gets its walks pruned within a bounded number of steps.
+    ///
+    /// Sample points are 1% of all commits (sampled by sequence number) plus
+    /// every commit the sampling alone cannot bound: orphans (a walk path ends
+    /// there with no parent whose entry could terminate it), octopus merges (the
+    /// hint only covers the first two parents), and two-parent merges whose
+    /// backward jump skips over a sample point. A single-parent step always
+    /// decreases the sequence number by exactly 1, so any walk path reaches a
+    /// sample point within at most [`SAMPLE_INTERVAL`] steps: either it takes
+    /// that many consecutive unit steps and crosses a multiple of the interval,
+    /// or it hits one of the jump/end commits first.
+    ///
+    /// Everything needed comes from the hint, so this check never reads the
+    /// commit from the ODB.
+    pub fn is_sample_point(self) -> bool {
+        if self.sequence_number % SAMPLE_INTERVAL == 0 {
+            return true;
+        }
+        match self.parent_count {
+            1 => false,
+            2 => crosses_sample_boundary(self.sequence_number, self.jump_delta),
+            _ => true,
+        }
+    }
+}
+
+// True when a backward step of `delta` from `seq` skips over a multiple of
+// SAMPLE_INTERVAL, i.e. the sampled commit that would otherwise bound the walk on
+// this path is jumped over. `delta` saturates at 127, meaning "at least 127": any
+// jump of SAMPLE_INTERVAL or more crosses a boundary, so the saturated value still
+// decodes correctly.
+fn crosses_sample_boundary(seq: u64, delta: u8) -> bool {
+    seq.saturating_sub(delta as u64) / SAMPLE_INTERVAL < seq / SAMPLE_INTERVAL
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hint(sequence_number: u64, parent_count: u8, jump_delta: u8) -> HistoryGraphHint {
+        HistoryGraphHint {
+            sequence_number,
+            parent_count,
+            jump_delta,
+            jump_is_second: false,
+        }
+    }
+
+    // Regular single-parent commits are sampled by sequence number alone.
+    #[test]
+    fn samples_by_sequence_number() {
+        assert!(hint(0, 1, 1).is_sample_point());
+        assert!(hint(SAMPLE_INTERVAL, 1, 1).is_sample_point());
+        assert!(!hint(SAMPLE_INTERVAL + 1, 1, 1).is_sample_point());
+    }
+
+    // Orphans end a walk path and octopus merges reach past the two parents the hint
+    // covers, so neither can be bounded by sampling and both are always stored.
+    #[test]
+    fn samples_unbounded_topologies() {
+        assert!(hint(SAMPLE_INTERVAL + 1, 0, 1).is_sample_point());
+        assert!(hint(SAMPLE_INTERVAL + 1, 3, 1).is_sample_point());
+    }
+
+    // A two-parent merge is stored exactly when its backward jump would skip over the
+    // sample point that would otherwise bound the walk on that path.
+    #[test]
+    fn samples_merges_that_jump_a_boundary() {
+        assert!(!hint(SAMPLE_INTERVAL + 5, 2, 4).is_sample_point());
+        assert!(hint(SAMPLE_INTERVAL + 5, 2, 6).is_sample_point());
+        // The delta saturates at 127; any jump that long crosses a boundary regardless.
+        assert!(hint(SAMPLE_INTERVAL + 5, 2, 127).is_sample_point());
+    }
+}

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -183,43 +183,15 @@ impl DistributedCacheBackend {
     }
 }
 
-// The cache is meant to be sparse. That is, not all entries are actually persisted.
+// This cache is meant to be sparse. That is, not all entries are actually persisted.
 // This makes it smaller and faster to download.
 // It is expected that on any node (server, proxy, local repo) a full "dense" local cache
 // is used in addition to the sparse cache.
 // The sparse cache is mostly only used for initial "cold starts" or longer "catch up".
 // For incremental filtering it's fine re-filter commits and rely on the local "dense" cache.
-// We store entries for 1% of all commits (sampled by sequence number), and
-// additionally every commit the sampling alone cannot bound: orphans (a walk
-// path ends there with no parent whose entry could terminate it), octopus
-// merges (the hint only covers the first two parents), and two-parent merges
-// whose backward jump skips over a sample point. A single-parent step always
-// decreases the sequence number by exactly 1, so any walk path reaches a
-// stored entry within at most 100 steps: either it takes 100 consecutive
-// unit steps and crosses a multiple of 100, or it hits one of the stored
-// jump/end commits first.
-// Everything needed comes from the cached history-graph hint, so this check
-// never reads the commit from the ODB.
-fn is_eligible(hint: HistoryGraphHint) -> bool {
-    if hint.sequence_number % 100 == 0 {
-        return true;
-    }
-    match hint.parent_count {
-        1 => false,
-        2 => crosses_sample_boundary(hint.sequence_number, hint.jump_delta),
-        _ => true,
-    }
-}
-
-// True when a backward step of `delta` from `seq` skips over a multiple of 100,
-// i.e. the sampled commit that would otherwise bound the walk on this path is
-// jumped over. `delta` saturates at 127, meaning "at least 127": any jump of
-// 100 or more crosses a boundary, so the saturated value still decodes
-// correctly.
-fn crosses_sample_boundary(seq: u64, delta: u8) -> bool {
-    seq.saturating_sub(delta as u64) / 100 < seq / 100
-}
-
+// Only the sample points are persisted; see `HistoryGraphHint::is_sample_point` for the
+// invariant that bounds how far a walk runs before it hits one.
+//
 // To additionally limit the size of the trees the cache is also sharded by sequence
 // number in groups of 10000. Note that this does not limit the number of entries per bucket
 // as branches mean many commits share the same sequence number.
@@ -254,7 +226,7 @@ impl CacheBackend for DistributedCacheBackend {
         // Tree-keyed records were written by whichever indexing commit was eligible,
         // so gating reads on the reader's eligibility would hide them from the
         // (usually non-sampled) commits that reuse them.
-        if !tree_keyed && !is_eligible(hint) {
+        if !tree_keyed && !hint.is_sample_point() {
             return Ok(None);
         }
         let repo = self.repo.lock().unwrap();
@@ -325,7 +297,7 @@ impl CacheBackend for DistributedCacheBackend {
         if filter == filter::sequence_number() || filter == filter::reachable_roots() {
             return Ok(());
         }
-        if !is_eligible(hint) {
+        if !hint.is_sample_point() {
             return Ok(());
         }
 

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -746,10 +746,12 @@ impl Transaction {
             .or_default()
             .insert(from, to);
 
-        // In addition to commits that are explicitly requested to be stored, also store
-        // random extra commits (probability 1/256) to avoid long searches for filters that reduce
-        // the history length by a very large factor.
-        if store || from.as_bytes()[0] == 0 {
+        // In addition to commits that are explicitly requested to be stored, also store the
+        // sample points, so that every backward walk reaches a stored entry within a bounded
+        // number of steps -- including across merge jumps and at orphans. This is what keeps
+        // filters that reduce the history length by a very large factor (which store almost
+        // nothing of their own) from re-walking all of history on every request.
+        if store || hint.is_sample_point() {
             t2.cache.write_all(filter, from, to, hint, false)?;
         }
         Ok(())

--- a/tests/filter/rev_squash.t
+++ b/tests/filter/rev_squash.t
@@ -52,7 +52,7 @@ post-cutoff commit attached directly to it; the elided region leaves no trace
   $ josh-filter -s "$FILTER" refs/heads/master --update refs/heads/filtered
   ddbbceeab0f8a545c505cccb24ae71b76cdc4f67
   [2] :/subtree
-  [2] :~(
+  [3] :~(
       history="keep-trivial-merges,no-splice"
   )[
       :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=75a11dcdd41d68e57d9d9f07862bd284a99da6f0:SQUASH)
@@ -86,7 +86,7 @@ resolution must reverse like a fall-through commit
   $ josh-filter -s "$FILTER" refs/heads/master --update refs/heads/filtered --reverse --check-roundtrip
   502c4f2c20e968f20dc97f4bb54b6a1598f690fd
   [4] :/subtree
-  [4] :~(
+  [5] :~(
       history="keep-trivial-merges,no-splice"
   )[
       :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=75a11dcdd41d68e57d9d9f07862bd284a99da6f0:SQUASH)
@@ -130,13 +130,13 @@ would disconnect one of them: the filter fails loudly instead
   $ export R2=$(git rev-parse HEAD)
 
   $ josh-filter -s ":~(history=\"keep-trivial-merges,no-splice\")[:rev(<=$SUBTREE_TIP:prefix=subtree,<=$SUB2_TIP:prefix=subtree2,<=$R2:SQUASH)]" refs/heads/master --update refs/heads/broken
-  [2] :~(
+  [3] :~(
       history="keep-trivial-merges,no-splice"
   )[
       :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=64eeef227e94b848388854ea5e8b86a043c7ac12:prefix=subtree2,<=2019cb20591f675b8600a09209e884ccaaf8d1cd:SQUASH)
   ]
   [4] :/subtree
-  [4] :~(
+  [5] :~(
       history="keep-trivial-merges,no-splice"
   )[
       :rev(<=104346ac7daf00a08bef19a999e4c7601aae519a:prefix=subtree,<=75a11dcdd41d68e57d9d9f07862bd284a99da6f0:SQUASH)

--- a/tests/filter/squash.t
+++ b/tests/filter/squash.t
@@ -31,6 +31,9 @@
   $ josh-filter -s --squash-pattern "refs/tags/*" --update refs/heads/filtered
   Warning: reference refs/heads/filtered wasn't updated
   0000000000000000000000000000000000000000
+  [1] :squash(
+  
+  )
   [5] reachable_roots
   [5] sequence_number
 
@@ -47,6 +50,9 @@ This one tag is an annotated tag, to make sure those are handled as well
   [1] :"refs/tags/tag_a"
   [1] :author="New Author";"new@e.mail"
   [1] :squash(
+  
+  )
+  [2] :squash(
       1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
   )
   [7] reachable_roots
@@ -72,6 +78,9 @@ This one tag is an annotated tag, to make sure those are handled as well
   [1] :"refs/tags/tag_a"
   [1] :"refs/tags/tag_b"
   [1] :squash(
+  
+  )
+  [2] :squash(
       1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
   )
   [3] :squash(
@@ -109,6 +118,9 @@ This one tag is an annotated tag, to make sure those are handled as well
   [1] :"refs/tags/tag_a"
   [1] :"refs/tags/tag_b"
   [1] :squash(
+  
+  )
+  [2] :squash(
       1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
   )
   [3] :squash(
@@ -168,6 +180,9 @@ This one tag is an annotated tag, to make sure those are handled as well
   [1] :"refs/tags/tag_b"
   [1] :"refs/tags/tag_c"
   [1] :squash(
+  
+  )
+  [2] :squash(
       1d69b7d2651f744be3416f2ad526aeccefb99310:"refs/tags/tag_a"
   )
   [3] :squash(

--- a/tests/filter/squash_empty_initial.t
+++ b/tests/filter/squash_empty_initial.t
@@ -38,6 +38,9 @@
   $ josh-filter -s --squash-pattern "refs/tags/*" --update refs/heads/filtered
   Warning: reference refs/heads/filtered wasn't updated
   0000000000000000000000000000000000000000
+  [1] :squash(
+  
+  )
   [5] reachable_roots
   [5] sequence_number
   $ git log --graph --decorate --pretty=oneline refs/heads/filtered
@@ -52,6 +55,9 @@
   [1] :"refs/tags/tag_a"
   [1] :author="New Author";"new@e.mail"
   [1] :squash(
+  
+  )
+  [2] :squash(
       882f2656a5075936eb37bfefde740e0b453e4479:"refs/tags/tag_a"
   )
   [7] reachable_roots


### PR DESCRIPTION
Sample the local cache by sequence number instead of oid hash

Transaction::insert persisted an unrequested mapping when the input commit's
first oid byte was zero. Oid-hash sampling scatters the stored entries randomly
over the graph: it bounds neither how deep a backward walk runs before it hits
one, nor merge jumps, nor orphans. That only shows for filters which drop
almost every commit, because those store nothing of their own -- history.rs
persists a mapping when the commit produces new output, and under a filter like
:rev(<=<recent>:SQUASH) essentially the whole history is dropped, leaving the
samples as walk2's only prune points. Such a filter re-walked all of history on
every request.

The distributed backend already solved this with sequence-number sampling, and
insert computes the same hint one line above the decision. Both caches now
share it: is_eligible and crosses_sample_boundary move to cache::backend as
HistoryGraphHint::is_sample_point, next to the hint they read, so the local
cache does not depend on the distributed one. Unit tests cover the three
classes the predicate distinguishes. Sampling density goes from ~0.39% to ~1%
plus merges and orphans, so a filter that keeps most commits stores modestly
more.

Change: cache-sequence-sampling
Assisted-By: anthropic/claude-opus-5