### PR TITLE
Add josh-git-serde crate for serde over git trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,6 +3493,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "josh-git-serde"
+version = "26.7.28"
+dependencies = [
+ "anyhow",
+ "git2",
+ "gix-hash",
+ "gix-object",
+ "josh-gix-ext",
+ "percent-encoding",
+ "serde",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "josh-github-auth"
 version = "26.7.28"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "josh-cli",
     "josh-filter",
     "josh-gix-ext",
+    "josh-git-serde",
     "josh-graphql",
     "josh-link",
     "josh-proxy",
@@ -101,6 +102,7 @@ graphql_client_codegen = { version = "^0.16.0" }
 axum-cgi = { path = "axum-cgi", version = "26.7.28" }
 josh-filter = { path = "josh-filter", version = "26.7.28" }
 josh-gix-ext = { path = "josh-gix-ext", version = "26.7.28" }
+josh-git-serde = { path = "josh-git-serde", version = "26.7.28" }
 josh-changes = { path = "josh-changes", version = "26.7.28" }
 josh-core = { path = "josh-core", version = "26.7.28" }
 josh-memodb = { path = "josh-memodb", version = "26.7.28" }
@@ -200,6 +202,7 @@ glob = { path = "vendor/rust-lang/glob" }
 axum-cgi = { path = "axum-cgi" }
 josh-filter = { path = "josh-filter" }
 josh-gix-ext = { path = "josh-gix-ext" }
+josh-git-serde = { path = "josh-git-serde" }
 josh-changes = { path = "josh-changes" }
 josh-core = { path = "josh-core" }
 josh-memodb = { path = "josh-memodb" }

--- a/josh-git-serde/Cargo.toml
+++ b/josh-git-serde/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "josh-git-serde"
+version = "26.7.28"
+repository = "https://github.com/josh-project/josh"
+license-file = "../LICENSE"
+description = "serde serialization of Rust values into git tree objects"
+keywords = ["git", "serde", "tree"]
+readme = "../README.md"
+edition = "2024"
+
+[dependencies]
+anyhow.workspace = true
+git2.workspace = true
+gix-object.workspace = true
+percent-encoding = "2.3.2"
+serde.workspace = true
+thiserror.workspace = true
+
+josh-gix-ext.workspace = true
+
+[dev-dependencies]
+gix-hash.workspace = true

--- a/josh-git-serde/examples/representation.rs
+++ b/josh-git-serde/examples/representation.rs
@@ -1,0 +1,99 @@
+//! Prints what serialized values look like as git trees.
+//!
+//! Every value is converted with [`to_value`], then rendered through
+//! `GitValue`'s `Debug`: blobs print their contents (truncated past 64
+//! bytes), trees print their entries -- the exact filenames the objects
+//! get on disk, including percent-encoded map keys.
+//!
+//! Run with `cargo run -p josh-git-serde --example representation`.
+
+use josh_git_serde::to_value;
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+#[derive(Serialize)]
+struct CommitMeta {
+    author: String,
+    committed_at: u64,
+    verified: bool,
+}
+
+#[derive(Serialize)]
+enum Change {
+    Created,
+    Renamed(String),
+    Modified { old_mode: u32, new_mode: u32 },
+}
+
+#[derive(Serialize)]
+struct PullRequest {
+    id: u64,
+    title: String,
+    milestone: Option<String>,
+    meta: Option<CommitMeta>,
+    change: Change,
+    files: BTreeMap<String, String>,
+}
+
+fn section(name: &str) {
+    println!("\n== {name} ==");
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    section("scalars");
+    println!("{:?}", to_value(&42u64)?);
+    println!("{:?}", to_value("hello")?);
+    println!("{:?}", to_value(&true)?);
+
+    section("struct");
+    let meta = CommitMeta {
+        author: "josh".to_string(),
+        committed_at: 1_724_000_000,
+        verified: true,
+    };
+    println!("{:#?}", to_value(&meta)?);
+
+    section("map with filename-unsafe keys");
+    let mut files = BTreeMap::new();
+    files.insert("src/main.rs".to_string(), "...".to_string());
+    files.insert("a b.txt".to_string(), "...".to_string());
+    println!("{:#?}", to_value(&files)?);
+
+    section("enum variants");
+    println!("{:#?}", to_value(&Change::Created)?);
+    println!("{:#?}", to_value(&Change::Renamed("old.rs".into()))?);
+    println!(
+        "{:#?}",
+        to_value(&Change::Modified {
+            old_mode: 0o100644,
+            new_mode: 0o100755,
+        })?
+    );
+
+    section("nested composite");
+    let pr = PullRequest {
+        id: 7,
+        title: "Add tree serde".to_string(),
+        milestone: Some("v2".to_string()),
+        meta: Some(meta),
+        change: Change::Modified {
+            old_mode: 0o100644,
+            new_mode: 0o100755,
+        },
+        files,
+    };
+    println!("{:#?}", to_value(&pr)?);
+
+    section("nested composite, `None` field omitted");
+    let pr_without_milestone = PullRequest {
+        id: 8,
+        title: "Drop markers".to_string(),
+        milestone: None,
+        meta: None,
+        change: Change::Created,
+        files: BTreeMap::new(),
+    };
+    println!("{:#?}", to_value(&pr_without_milestone)?);
+
+    Ok(())
+}

--- a/josh-git-serde/src/de.rs
+++ b/josh-git-serde/src/de.rs
@@ -1,0 +1,530 @@
+use std::collections::BTreeMap;
+
+use serde::de::{self, DeserializeSeed, IntoDeserializer, Visitor};
+use serde::forward_to_deserialize_any;
+
+use crate::error::SerdeGitError;
+use crate::value::GitValue;
+use crate::wire;
+
+type TreeContents = BTreeMap<String, Box<GitValue>>;
+
+struct TreeDeserializer<'a> {
+    tree: &'a TreeContents,
+}
+
+impl<'a> TreeDeserializer<'a> {
+    fn from_tree(tree: &'a TreeContents) -> Self {
+        TreeDeserializer { tree }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for TreeDeserializer<'de> {
+    type Error = SerdeGitError;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeGitError(
+            "TreeDeserializer: not implemented".to_string(),
+        ))
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // `None` is the absent entry, never a tree: a tree in this position
+        // is always `Some` payload.
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if !self.tree.is_empty() {
+            return Err(SerdeGitError("expected empty tree for unit".to_string()));
+        }
+        visitor.visit_unit()
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_unit(visitor)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // Newtypes are transparent: the tree is the inner value.
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeGitError("sequences are not supported".to_string()))
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeGitError("tuples are not supported".to_string()))
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        len: usize,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_tuple(len, visitor)
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_map(TreeMapAccess::new(self.tree))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // Structs and maps share the same flat-tree shape; absent entries
+        // surface as serde's own missing-field/`None` handling.
+        visitor.visit_map(TreeMapAccess::new(self.tree))
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let mut entries = self.tree.iter();
+        let (encoded_name, payload) = entries.next().ok_or_else(|| {
+            SerdeGitError("enum tree must have exactly one entry; found none".to_string())
+        })?;
+        if entries.next().is_some() {
+            return Err(SerdeGitError(
+                "enum tree must have exactly one entry".to_string(),
+            ));
+        }
+
+        let name = wire::decode_key(encoded_name)?;
+        visitor.visit_enum(TreeEnumAccess::new(payload, name))
+    }
+
+    forward_to_deserialize_any! {
+        // Scalar reads happen on blob payloads via BlobDeserializer; a tree
+        // carries only maps/structs, options, newtypes and enums.
+        // Floating point is unsupported everywhere.
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char string byte_buf str bytes
+        identifier ignored_any
+    }
+}
+
+struct TreeEnumAccess<'de> {
+    payload: &'de GitValue,
+    name: String,
+}
+
+impl<'de> TreeEnumAccess<'de> {
+    fn new(payload: &'de GitValue, name: String) -> Self {
+        TreeEnumAccess { payload, name }
+    }
+}
+
+impl<'de> de::EnumAccess<'de> for TreeEnumAccess<'de> {
+    type Error = SerdeGitError;
+    type Variant = TreeVariantAccess<'de>;
+
+    fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let variant = TreeVariantAccess::new(self.payload);
+
+        seed.deserialize(self.name.into_deserializer())
+            .map(|v| (v, variant))
+    }
+}
+
+struct TreeVariantAccess<'de> {
+    payload: &'de GitValue,
+}
+
+impl<'de> TreeVariantAccess<'de> {
+    fn new(payload: &'de GitValue) -> Self {
+        TreeVariantAccess { payload }
+    }
+}
+
+impl<'de> de::VariantAccess<'de> for TreeVariantAccess<'de> {
+    type Error = SerdeGitError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        match self.payload {
+            GitValue::Tree(tree) if tree.is_empty() => Ok(()),
+            _ => Err(SerdeGitError(
+                "unit variant payload must be an empty tree".to_string(),
+            )),
+        }
+    }
+
+    fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>,
+    {
+        match self.payload {
+            GitValue::Blob(bytes) => seed.deserialize(BlobDeserializer::from_blob(bytes)),
+            GitValue::Tree(tree) => seed.deserialize(TreeDeserializer::from_tree(tree)),
+        }
+    }
+
+    fn tuple_variant<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeGitError(
+            "tuple variants are not supported".to_string(),
+        ))
+    }
+
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        match self.payload {
+            GitValue::Tree(tree) => visitor.visit_map(TreeMapAccess::new(tree)),
+            _ => Err(SerdeGitError(
+                "struct variant payload must be a tree".to_string(),
+            )),
+        }
+    }
+}
+
+struct TreeMapAccess<'de> {
+    iter: std::collections::btree_map::Iter<'de, String, Box<GitValue>>,
+    value: Option<&'de GitValue>,
+}
+
+impl<'de> TreeMapAccess<'de> {
+    fn new(tree: &'de TreeContents) -> Self {
+        TreeMapAccess {
+            iter: tree.iter(),
+            value: None,
+        }
+    }
+}
+
+impl<'de> de::MapAccess<'de> for TreeMapAccess<'de> {
+    type Error = SerdeGitError;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        let (encoded_key, value) = match self.iter.next() {
+            Some(entry) => entry,
+            None => return Ok(None),
+        };
+
+        let key = wire::decode_key(encoded_key)?;
+
+        self.value = Some(value.as_ref());
+        seed.deserialize(key.into_deserializer()).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        let value = match self.value {
+            Some(entry) => entry,
+            None => return Err(SerdeGitError("missing value".to_string())),
+        };
+
+        match value {
+            GitValue::Blob(bytes) => seed.deserialize(BlobDeserializer::from_blob(bytes)),
+            GitValue::Tree(tree) => seed.deserialize(TreeDeserializer::from_tree(tree)),
+        }
+    }
+}
+
+struct BlobDeserializer<'de> {
+    blob: &'de [u8],
+}
+
+impl<'de> BlobDeserializer<'de> {
+    fn from_blob(blob: &'de [u8]) -> Self {
+        BlobDeserializer { blob }
+    }
+
+    fn try_str(&self) -> Result<&'de str, SerdeGitError> {
+        std::str::from_utf8(self.blob).map_err(|_| SerdeGitError("invalid string blob".to_string()))
+    }
+}
+
+impl<'de> de::Deserializer<'de> for BlobDeserializer<'de> {
+    type Error = SerdeGitError;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeGitError(
+            "BlobDeserializer: can't `deserialize_any`; schema change?".to_string(),
+        ))
+    }
+
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.blob.len() == 1 {
+            let mut bytes = [0u8; 1];
+            bytes.copy_from_slice(&self.blob[0..1]);
+            let value = u8::from_le_bytes(bytes);
+
+            visitor.visit_u8(value)
+        } else {
+            Err(SerdeGitError("invalid u8 blob".to_string()))
+        }
+    }
+
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.blob.len() == 2 {
+            let mut bytes = [0u8; 2];
+            bytes.copy_from_slice(&self.blob[0..2]);
+            let value = u16::from_le_bytes(bytes);
+
+            visitor.visit_u16(value)
+        } else {
+            Err(SerdeGitError("invalid u16 blob".to_string()))
+        }
+    }
+
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.blob.len() == 4 {
+            let mut bytes = [0u8; 4];
+            bytes.copy_from_slice(&self.blob[0..4]);
+            let value = u32::from_le_bytes(bytes);
+
+            visitor.visit_u32(value)
+        } else {
+            Err(SerdeGitError("invalid u32 blob".to_string()))
+        }
+    }
+
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.blob.len() == 8 {
+            let mut bytes = [0u8; 8];
+            bytes.copy_from_slice(&self.blob[0..8]);
+            let value = u64::from_le_bytes(bytes);
+
+            visitor.visit_u64(value)
+        } else {
+            Err(SerdeGitError("invalid u64 blob".to_string()))
+        }
+    }
+
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.blob.len() == 1 {
+            let mut bytes = [0u8; 1];
+            bytes.copy_from_slice(&self.blob[0..1]);
+            let value = i8::from_le_bytes(bytes);
+
+            visitor.visit_i8(value)
+        } else {
+            Err(SerdeGitError("invalid i8 blob".to_string()))
+        }
+    }
+
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.blob.len() == 2 {
+            let mut bytes = [0u8; 2];
+            bytes.copy_from_slice(&self.blob[0..2]);
+            let value = i16::from_le_bytes(bytes);
+
+            visitor.visit_i16(value)
+        } else {
+            Err(SerdeGitError("invalid i16 blob".to_string()))
+        }
+    }
+
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.blob.len() == 4 {
+            let mut bytes = [0u8; 4];
+            bytes.copy_from_slice(&self.blob[0..4]);
+            let value = i32::from_le_bytes(bytes);
+
+            visitor.visit_i32(value)
+        } else {
+            Err(SerdeGitError("invalid i32 blob".to_string()))
+        }
+    }
+
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        if self.blob.len() == 8 {
+            let mut bytes = [0u8; 8];
+            bytes.copy_from_slice(&self.blob[0..8]);
+            let value = i64::from_le_bytes(bytes);
+
+            visitor.visit_i64(value)
+        } else {
+            Err(SerdeGitError("invalid i64 blob".to_string()))
+        }
+    }
+
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let value = self.try_str()?;
+        let value = value
+            .parse::<bool>()
+            .map_err(|_| SerdeGitError("invalid bool blob".to_string()))?;
+        visitor.visit_bool(value)
+    }
+
+    fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let value = self.try_str()?;
+        let value = value
+            .parse::<char>()
+            .map_err(|_| SerdeGitError("invalid char blob".to_string()))?;
+        visitor.visit_char(value)
+    }
+
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = self.try_str()?;
+        visitor.visit_borrowed_str(result)
+    }
+
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        let result = self.try_str()?;
+        visitor.visit_string(result.to_string())
+    }
+
+    fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_borrowed_bytes(self.blob)
+    }
+
+    fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_byte_buf(self.blob.to_vec())
+    }
+
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_unit()
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // `None` is the absent entry, never a blob: a blob in this position
+        // is always `Some` payload.
+        visitor.visit_some(self)
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        // Newtypes are transparent: the blob is the inner value.
+        visitor.visit_newtype_struct(self)
+    }
+
+    forward_to_deserialize_any! {
+        // Floating point is not supported
+        f32 f64
+        // Containers are handled by TreeDeserializer
+        unit_struct seq tuple tuple_struct map struct enum identifier ignored_any
+    }
+}
+
+pub fn from_value<'de, T: serde::Deserialize<'de>>(
+    value: &'de GitValue,
+) -> Result<T, SerdeGitError> {
+    // Either shape is a valid root; the target type must match what
+    // `to_value` wrote.
+    match value {
+        GitValue::Tree(tree) => T::deserialize(TreeDeserializer::from_tree(tree)),
+        GitValue::Blob(bytes) => T::deserialize(BlobDeserializer::from_blob(bytes)),
+    }
+}

--- a/josh-git-serde/src/error.rs
+++ b/josh-git-serde/src/error.rs
@@ -1,0 +1,17 @@
+use std::fmt;
+
+#[derive(Debug, thiserror::Error)]
+#[error("git serde error: {0}")]
+pub struct SerdeGitError(pub String);
+
+impl serde::ser::Error for SerdeGitError {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        SerdeGitError(msg.to_string())
+    }
+}
+
+impl serde::de::Error for SerdeGitError {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        SerdeGitError(msg.to_string())
+    }
+}

--- a/josh-git-serde/src/lib.rs
+++ b/josh-git-serde/src/lib.rs
@@ -1,0 +1,42 @@
+//! serde serialization of Rust values into git tree objects.
+//!
+//! A `Serialize` value becomes a git tree: struct fields and map keys become
+//! child entries at the top level of their tree, scalars become blobs, and an
+//! enum becomes a tree with a single entry keyed by the variant name. No type
+//! information is carried in-band: the tree's shape is data only, and the
+//! decoding schema alone decides what it means. A `None` in entry position
+//! (struct field, map value) is omitted entirely; `None` at the root has no
+//! representation and is an error, as are sequences, tuples, and tuple
+//! variants. The conversion is split:
+//!
+//! - pure in-memory: [`GitValue`] model + serde ser/de (`to_value`/`from_value`)
+//! - object store: `GitValue` <-> tree OIDs over `gix_object::Find`/`Write`
+//!   (`to_tree_oid`/`from_tree_oid`)
+//!
+//! ```
+//! use josh_git_serde::{from_value, to_value};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Serialize, Deserialize, PartialEq, Debug)]
+//! struct Config {
+//!     name: String,
+//!     retries: u32,
+//! }
+//!
+//! let config = Config { name: "josh".into(), retries: 3 };
+//! let value = to_value(&config).unwrap();
+//! assert_eq!(from_value::<Config>(&value).unwrap(), config);
+//! ```
+
+mod de;
+mod error;
+mod ser;
+mod store;
+mod value;
+pub(crate) mod wire;
+
+pub use de::from_value;
+pub use error::SerdeGitError;
+pub use ser::to_value;
+pub use store::{from_tree_oid, to_tree_oid};
+pub use value::GitValue;

--- a/josh-git-serde/src/ser.rs
+++ b/josh-git-serde/src/ser.rs
@@ -1,0 +1,513 @@
+use crate::error::SerdeGitError;
+use crate::value::GitValue;
+use crate::wire::encode_key;
+use serde::ser::{
+    Impossible, Serialize, SerializeMap, SerializeStruct, SerializeStructVariant, Serializer,
+};
+use std::collections::BTreeMap;
+
+/// `None` has no representation of its own; `Absent` lets the parent drop
+/// the entry (struct field, map value) or reject it where omission is
+/// impossible (root, enum payload, nested `None`).
+enum Node {
+    Value(GitValue),
+    Absent,
+}
+
+struct GitValueSerializer;
+
+impl GitValueSerializer {
+    fn new() -> Self {
+        GitValueSerializer
+    }
+}
+
+impl Serializer for GitValueSerializer {
+    type Ok = Node;
+    type Error = SerdeGitError;
+
+    type SerializeSeq = Impossible<Node, SerdeGitError>;
+    type SerializeTuple = Impossible<Node, SerdeGitError>;
+    type SerializeTupleStruct = Impossible<Node, SerdeGitError>;
+    type SerializeTupleVariant = Impossible<Node, SerdeGitError>;
+    type SerializeMap = GitValueMapSerializer;
+    type SerializeStruct = GitValueStructSerializer;
+    type SerializeStructVariant = GitValueStructVariantSerializer;
+
+    fn serialize_i8(self, v: i8) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Blob(v.to_le_bytes().to_vec())))
+    }
+
+    fn serialize_i16(self, v: i16) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Blob(v.to_le_bytes().to_vec())))
+    }
+
+    fn serialize_i32(self, v: i32) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Blob(v.to_le_bytes().to_vec())))
+    }
+
+    fn serialize_i64(self, v: i64) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Blob(v.to_le_bytes().to_vec())))
+    }
+
+    fn serialize_u8(self, v: u8) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Blob(v.to_le_bytes().to_vec())))
+    }
+
+    fn serialize_u16(self, v: u16) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Blob(v.to_le_bytes().to_vec())))
+    }
+
+    fn serialize_u32(self, v: u32) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Blob(v.to_le_bytes().to_vec())))
+    }
+
+    fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Blob(v.to_le_bytes().to_vec())))
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_f32` not supported"))
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_f64` not supported"))
+    }
+
+    fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::blob_from_str(v.to_string())))
+    }
+
+    fn serialize_char(self, v: char) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::blob_from_str(v.to_string())))
+    }
+
+    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::blob_from_str(v)))
+    }
+
+    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Blob(v.to_vec())))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Absent)
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        match value.serialize(GitValueSerializer::new())? {
+            Node::Absent => Err(serde::ser::Error::custom(
+                "`serialize_some` cannot serialize nested `None`",
+            )),
+            node => Ok(node),
+        }
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Tree(BTreeMap::new())))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Tree(BTreeMap::new())))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Tree(BTreeMap::from([(
+            encode_key(variant),
+            Box::new(GitValue::Tree(BTreeMap::new())),
+        )]))))
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(GitValueSerializer::new())
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        match value.serialize(GitValueSerializer::new())? {
+            Node::Absent => Err(serde::ser::Error::custom(
+                "`serialize_newtype_variant` cannot serialize `None` payload",
+            )),
+            Node::Value(inner) => Ok(Node::Value(GitValue::Tree(BTreeMap::from([(
+                encode_key(variant),
+                Box::new(inner),
+            )])))),
+        }
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_seq` not supported"))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_tuple` not supported"))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(serde::ser::Error::custom(
+            "`serialize_tuple_struct` not supported",
+        ))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(serde::ser::Error::custom(
+            "`serialize_tuple_variant` not supported",
+        ))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(GitValueMapSerializer::default())
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(GitValueStructSerializer::default())
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Ok(GitValueStructVariantSerializer::new(variant))
+    }
+}
+
+#[derive(Default)]
+struct GitValueMapSerializer {
+    next_key: Option<String>,
+    result: BTreeMap<String, Box<GitValue>>,
+}
+
+impl SerializeMap for GitValueMapSerializer {
+    type Ok = Node;
+    type Error = SerdeGitError;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let key = key.serialize(StringSerializer)?;
+        self.next_key = Some(key);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        let key = self
+            .next_key
+            .take()
+            .expect("serialize_value without serialize_key");
+
+        // `None` values omit the entry entirely; the key is still consumed.
+        if let Node::Value(entry) = value.serialize(GitValueSerializer::new())? {
+            self.result.insert(encode_key(&key), Box::new(entry));
+        }
+
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Tree(self.result)))
+    }
+}
+
+struct GitValueStructVariantSerializer {
+    variant: &'static str,
+    fields: BTreeMap<String, Box<GitValue>>,
+}
+
+impl GitValueStructVariantSerializer {
+    fn new(variant: &'static str) -> Self {
+        GitValueStructVariantSerializer {
+            variant,
+            fields: Default::default(),
+        }
+    }
+}
+
+impl SerializeStructVariant for GitValueStructVariantSerializer {
+    type Ok = Node;
+    type Error = SerdeGitError;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        // Field names share the map-key namespace; the deserializer decodes
+        // both through `decode_key`.
+        if let Node::Value(entry) = value.serialize(GitValueSerializer::new())? {
+            self.fields.insert(encode_key(key), Box::new(entry));
+        }
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        // Always wrapped, even with zero fields: an all-`None` struct variant
+        // intentionally degenerates to the unit-variant shape.
+        Ok(Node::Value(GitValue::Tree(BTreeMap::from([(
+            encode_key(self.variant),
+            Box::new(GitValue::Tree(self.fields)),
+        )]))))
+    }
+}
+
+#[derive(Default)]
+struct GitValueStructSerializer {
+    entries: BTreeMap<String, Box<GitValue>>,
+}
+
+impl SerializeStruct for GitValueStructSerializer {
+    type Ok = Node;
+    type Error = SerdeGitError;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        // Field names share the map-key namespace; the deserializer decodes
+        // both through `decode_key`.
+        if let Node::Value(entry) = value.serialize(GitValueSerializer::new())? {
+            self.entries.insert(encode_key(key), Box::new(entry));
+        }
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(Node::Value(GitValue::Tree(self.entries)))
+    }
+}
+
+pub(crate) struct StringSerializer;
+
+impl Serializer for StringSerializer {
+    type Ok = String;
+    type Error = SerdeGitError;
+
+    type SerializeSeq = Impossible<String, SerdeGitError>;
+    type SerializeTuple = Impossible<String, SerdeGitError>;
+    type SerializeTupleStruct = Impossible<String, SerdeGitError>;
+    type SerializeTupleVariant = Impossible<String, SerdeGitError>;
+    type SerializeMap = Impossible<String, SerdeGitError>;
+    type SerializeStruct = Impossible<String, SerdeGitError>;
+    type SerializeStructVariant = Impossible<String, SerdeGitError>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_bool` not supported"))
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_i8` not supported"))
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_i16` not supported"))
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_i32` not supported"))
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_i64` not supported"))
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_u8` not supported"))
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_u16` not supported"))
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_u32` not supported"))
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_u64` not supported"))
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_f32` not supported"))
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_f64` not supported"))
+    }
+
+    fn serialize_char(self, value: char) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        Ok(value.to_owned())
+    }
+
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_bytes` not supported"))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_none` not supported"))
+    }
+
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_unit` not supported"))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom(
+            "`serialize_unit_struct` not supported",
+        ))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(serde::ser::Error::custom(
+            "`serialize_unit_variant` not supported",
+        ))
+    }
+
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        value.serialize(self)
+    }
+
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize + ?Sized,
+    {
+        Err(serde::ser::Error::custom(
+            "`serialize_newtype_variant` not supported",
+        ))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_seq` not supported"))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_tuple` not supported"))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(serde::ser::Error::custom(
+            "`serialize_tuple_struct` not supported",
+        ))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(serde::ser::Error::custom(
+            "`serialize_tuple_variant` not supported",
+        ))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(serde::ser::Error::custom("`serialize_map` not supported"))
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(serde::ser::Error::custom(
+            "`serialize_struct` not supported",
+        ))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(serde::ser::Error::custom(
+            "`serialize_struct_variant` not supported",
+        ))
+    }
+}
+
+pub fn to_value<T: Serialize + ?Sized>(value: &T) -> Result<GitValue, SerdeGitError> {
+    match value.serialize(GitValueSerializer::new())? {
+        Node::Value(value) => Ok(value),
+        Node::Absent => Err(serde::ser::Error::custom(
+            "`None` at the top level has no representation",
+        )),
+    }
+}

--- a/josh-git-serde/src/store.rs
+++ b/josh-git-serde/src/store.rs
@@ -1,0 +1,114 @@
+//! Object-store side of the serde conversion: materialize a [`GitValue`] as git
+//! objects over [`gix_object::Write`], and read a tree back over [`gix_object::Find`].
+
+use std::collections::BTreeMap;
+
+use crate::value::GitValue;
+
+/// Write `value` to `out` as git objects, returning the root object's id: a
+/// tree oid for [`GitValue::Tree`], a blob oid for [`GitValue::Blob`].
+///
+/// Every object is written unconditionally; batching and flushing are left to
+/// `out`. Tree entries are emitted in canonical git order -- filename bytes,
+/// with '/' appended to directory names for the comparison, exactly
+/// [`gix_object::tree::Entry`]'s `Ord`.
+///
+/// Tree entry names must be single path components: non-empty, no '/' or
+/// NUL, not "." or "..". Keys produced by the serializer always satisfy
+/// this; the check exists because [`GitValue`] is public.
+pub fn to_tree_oid(out: &impl gix_object::Write, value: &GitValue) -> anyhow::Result<git2::Oid> {
+    match value {
+        GitValue::Blob(data) => josh_gix_ext::write_blob(out, data),
+        GitValue::Tree(entries) => {
+            let mut tree_entries = Vec::with_capacity(entries.len());
+            for (name, child) in entries {
+                validate_entry_name(name)?;
+                let oid = to_tree_oid(out, child)?;
+                tree_entries.push(gix_object::tree::Entry {
+                    mode: match **child {
+                        GitValue::Tree(_) => gix_object::tree::EntryKind::Tree.into(),
+                        GitValue::Blob(_) => gix_object::tree::EntryKind::Blob.into(),
+                    },
+                    filename: name.as_str().into(),
+                    oid: josh_gix_ext::gix_oid(oid),
+                });
+            }
+            tree_entries.sort();
+            josh_gix_ext::write_tree_now(out, tree_entries)
+        }
+    }
+}
+
+/// Read `root` and everything it references from `source` into a
+/// [`GitValue`]. `root` may be a tree or a blob; commits, tags, symlinks,
+/// executable blobs and submodule entries are rejected -- this crate models
+/// plain data, and anything else would be silently mutated on a later write.
+///
+/// Entry names are taken over as-is; decoding percent-escapes is left to the
+/// deserializer. Shared subtrees are materialized repeatedly; the
+/// input is expected to be repo-shaped serde data, not arbitrary DAGs.
+/// Nesting deeper than [`MAX_TREE_DEPTH`] is rejected rather than risking a
+/// stack overflow on adversarial objects, as are duplicate entry names
+/// (possible only in hand-crafted trees).
+pub fn from_tree_oid(source: &impl gix_object::Find, root: git2::Oid) -> anyhow::Result<GitValue> {
+    read_tree_oid(source, root, 0)
+}
+
+const MAX_TREE_DEPTH: usize = 1024;
+
+fn validate_entry_name(name: &str) -> anyhow::Result<()> {
+    if name.is_empty() || name == "." || name == ".." || name.contains('/') || name.contains('\0') {
+        return Err(anyhow::anyhow!("to_tree_oid: invalid entry name {name:?}"));
+    }
+    Ok(())
+}
+
+fn read_tree_oid(
+    source: &impl gix_object::Find,
+    root: git2::Oid,
+    depth: usize,
+) -> anyhow::Result<GitValue> {
+    if depth > MAX_TREE_DEPTH {
+        return Err(anyhow::anyhow!(
+            "from_tree_oid: tree nesting exceeds {MAX_TREE_DEPTH} levels"
+        ));
+    }
+
+    let mut buf = Vec::new();
+    let data = source
+        .try_find(&josh_gix_ext::gix_oid(root), &mut buf)
+        .map_err(|e| anyhow::anyhow!("from_tree_oid: {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("from_tree_oid: object {root} not found"))?;
+    let object_hash = data.object_hash;
+    match data.kind {
+        gix_object::Kind::Blob => Ok(GitValue::Blob(buf)),
+        gix_object::Kind::Tree => {
+            let tree = gix_object::TreeRef::from_bytes(&buf, object_hash)?;
+            let mut entries = BTreeMap::new();
+            for entry in &tree.entries {
+                let name = String::from_utf8(entry.filename.to_vec()).map_err(|_| {
+                    anyhow::anyhow!("from_tree_oid: non-utf8 entry name {:?}", entry.filename)
+                })?;
+                // `is_blob` also matches executable blobs; accept exactly
+                // the regular-file mode this crate writes back.
+                if !entry.mode.is_tree() && entry.mode.kind() != gix_object::tree::EntryKind::Blob {
+                    return Err(anyhow::anyhow!(
+                        "from_tree_oid: entry {:?} has unsupported mode {:?}",
+                        entry.filename,
+                        entry.mode
+                    ));
+                }
+                let child = read_tree_oid(source, josh_gix_ext::git2_oid(entry.oid), depth + 1)?;
+                if entries.insert(name.clone(), Box::new(child)).is_some() {
+                    return Err(anyhow::anyhow!(
+                        "from_tree_oid: duplicate entry name {name:?}"
+                    ));
+                }
+            }
+            Ok(GitValue::Tree(entries))
+        }
+        kind => Err(anyhow::anyhow!(
+            "from_tree_oid: object {root} is a {kind:?}, not a tree or a blob"
+        )),
+    }
+}

--- a/josh-git-serde/src/value.rs
+++ b/josh-git-serde/src/value.rs
@@ -1,0 +1,40 @@
+use std::collections::BTreeMap;
+use std::fmt;
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum GitValue {
+    Blob(Vec<u8>),
+    Tree(BTreeMap<String, Box<GitValue>>),
+}
+
+impl fmt::Debug for GitValue {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GitValue::Blob(data) => {
+                const MAX: usize = 64;
+                // Truncated so a {:?} on a huge blob cannot flood a log or
+                // an assert_eq! failure message.
+                match std::str::from_utf8(data) {
+                    Ok(s) if data.len() <= MAX => {
+                        formatter.write_fmt(format_args!("Blob {{ {s:?} }}"))
+                    }
+                    _ => formatter.write_fmt(format_args!("Blob {{ <{} bytes> }}", data.len())),
+                }
+            }
+            GitValue::Tree(entries) => {
+                write!(formatter, "Tree ")?;
+                formatter.debug_map().entries(entries.iter()).finish()
+            }
+        }
+    }
+}
+
+impl GitValue {
+    pub fn empty_blob() -> Self {
+        GitValue::Blob(Vec::new())
+    }
+
+    pub fn blob_from_str(s: impl AsRef<[u8]>) -> Self {
+        GitValue::Blob(s.as_ref().to_vec())
+    }
+}

--- a/josh-git-serde/src/wire.rs
+++ b/josh-git-serde/src/wire.rs
@@ -1,0 +1,58 @@
+use percent_encoding::{AsciiSet, CONTROLS, percent_decode_str, utf8_percent_encode};
+
+use crate::error::SerdeGitError;
+
+pub(crate) const FILENAME_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'!')
+    .add(b'"')
+    .add(b'#')
+    .add(b'$')
+    .add(b'%')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b',')
+    .add(b'.')
+    .add(b'/')
+    .add(b':')
+    .add(b';')
+    .add(b'<')
+    .add(b'=')
+    .add(b'>')
+    .add(b'?')
+    .add(b'@')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}')
+    .add(b'~');
+
+pub(crate) fn encode_key(key: &str) -> String {
+    utf8_percent_encode(key, FILENAME_SET).to_string()
+}
+
+/// Inverse of [`encode_key`], and strictly so: the decoded key must re-encode
+/// to exactly its input. Plain percent-decoding accepts any `%XX`, so distinct
+/// filenames could collapse into one key. Re-encoding instead of hand-checking
+/// escapes keeps the encoder's set as the single source of truth.
+pub(crate) fn decode_key(encoded_key: &str) -> Result<String, SerdeGitError> {
+    let err = || SerdeGitError("invalid key encoding".to_string());
+    let decoded = percent_decode_str(encoded_key)
+        .decode_utf8()
+        .map_err(|_| err())?
+        .into_owned();
+
+    if utf8_percent_encode(&decoded, FILENAME_SET).to_string() != encoded_key {
+        return Err(err());
+    }
+
+    Ok(decoded)
+}

--- a/josh-git-serde/tests/de.rs
+++ b/josh-git-serde/tests/de.rs
@@ -1,0 +1,218 @@
+use josh_git_serde::{GitValue, from_value};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+#[test]
+#[allow(dead_code)]
+fn test_simple() -> anyhow::Result<()> {
+    #[derive(Deserialize, Debug)]
+    struct MyStruct {
+        pub field1: String,
+        pub field2: String,
+    }
+
+    let value = GitValue::Tree(BTreeMap::from([
+        (
+            "field1".to_string(),
+            Box::new(GitValue::Blob(b"value1".to_vec())),
+        ),
+        (
+            "field2".to_string(),
+            Box::new(GitValue::Blob(b"value2".to_vec())),
+        ),
+    ]));
+
+    let my_struct: MyStruct = from_value(&value)?;
+
+    assert_eq!(
+        format!("{my_struct:#?}"),
+        "MyStruct {\n    field1: \"value1\",\n    field2: \"value2\",\n}"
+    );
+
+    Ok(())
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_nested() -> anyhow::Result<()> {
+    #[derive(Deserialize, Debug)]
+    struct Inner {
+        pub field1: String,
+    }
+
+    #[derive(Deserialize, Debug)]
+    struct Outer {
+        pub inner: Inner,
+    }
+
+    let inner = GitValue::Tree(BTreeMap::from([(
+        "field1".to_string(),
+        Box::new(GitValue::Blob(b"value1".to_vec())),
+    )]));
+
+    let value = GitValue::Tree(BTreeMap::from([("inner".to_string(), Box::new(inner))]));
+
+    let outer: Outer = from_value(&value)?;
+
+    assert_eq!(
+        format!("{outer:#?}"),
+        "Outer {\n    inner: Inner {\n        field1: \"value1\",\n    },\n}"
+    );
+
+    Ok(())
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_number() -> anyhow::Result<()> {
+    #[derive(Deserialize, Debug)]
+    struct MyStruct {
+        pub field1: u64,
+    }
+
+    let value = GitValue::Tree(BTreeMap::from([(
+        "field1".to_string(),
+        Box::new(GitValue::Blob(u64::MAX.to_le_bytes().to_vec())),
+    )]));
+
+    let my_struct: MyStruct = from_value(&value)?;
+
+    assert_eq!(
+        format!("{my_struct:#?}"),
+        "MyStruct {\n    field1: 18446744073709551615,\n}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_non_canonical_key_rejected() -> anyhow::Result<()> {
+    // Two encodings of one key must be rejected, not collapsed into one.
+    let value = GitValue::Tree(BTreeMap::from([
+        ("a".to_string(), Box::new(GitValue::blob_from_str("one"))),
+        ("%61".to_string(), Box::new(GitValue::blob_from_str("two"))),
+    ]));
+
+    let err = from_value::<BTreeMap<String, String>>(&value).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid key encoding"),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_enum_single_entry_rule() -> anyhow::Result<()> {
+    #[derive(Deserialize, Debug, PartialEq)]
+    enum TestEnum {
+        A(String),
+        B,
+    }
+
+    let err = from_value::<TestEnum>(&GitValue::Tree(BTreeMap::new())).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("enum tree must have exactly one entry"),
+        "unexpected error: {err}"
+    );
+
+    let two = GitValue::Tree(BTreeMap::from([
+        ("A".to_string(), Box::new(GitValue::blob_from_str("x"))),
+        ("B".to_string(), Box::new(GitValue::Tree(BTreeMap::new()))),
+    ]));
+    let err = from_value::<TestEnum>(&two).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("enum tree must have exactly one entry"),
+        "unexpected error: {err}"
+    );
+
+    let unknown = GitValue::Tree(BTreeMap::from([(
+        "C".to_string(),
+        Box::new(GitValue::Tree(BTreeMap::new())),
+    )]));
+    let err = from_value::<TestEnum>(&unknown).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown variant"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_unit_from_empty_tree() -> anyhow::Result<()> {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Unit;
+
+    let empty = GitValue::Tree(BTreeMap::new());
+    let _: () = from_value(&empty)?;
+    let unit: Unit = from_value(&empty)?;
+    assert_eq!(unit, Unit);
+
+    let non_empty = GitValue::Tree(BTreeMap::from([(
+        "x".to_string(),
+        Box::new(GitValue::blob_from_str("v")),
+    )]));
+    let err = from_value::<()>(&non_empty).unwrap_err();
+    assert!(
+        err.to_string().contains("expected empty tree for unit"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_option_field_absent_vs_present() -> anyhow::Result<()> {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct WithOption {
+        field: Option<String>,
+    }
+
+    // Absent entry decodes to None via serde's generated default.
+    let absent = GitValue::Tree(BTreeMap::new());
+    let parsed: WithOption = from_value(&absent)?;
+    assert_eq!(parsed, WithOption { field: None });
+
+    // A present empty blob is `Some("")`, distinct from absent.
+    let present = GitValue::Tree(BTreeMap::from([(
+        "field".to_string(),
+        Box::new(GitValue::empty_blob()),
+    )]));
+    let parsed: WithOption = from_value(&present)?;
+    assert_eq!(
+        parsed,
+        WithOption {
+            field: Some(String::new())
+        }
+    );
+
+    // A missing required field errors instead of defaulting.
+    #[derive(Deserialize, Debug)]
+    struct Required {
+        #[allow(dead_code)]
+        field: String,
+    }
+    let err = from_value::<Required>(&GitValue::Tree(BTreeMap::new())).unwrap_err();
+    assert!(
+        err.to_string().contains("missing field"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_seq_deserialize_unsupported() -> anyhow::Result<()> {
+    let value = GitValue::Tree(BTreeMap::from([(
+        "x".to_string(),
+        Box::new(GitValue::blob_from_str("v")),
+    )]));
+    let err = from_value::<Vec<String>>(&value).unwrap_err();
+    assert!(
+        err.to_string().contains("sequences are not supported"),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}

--- a/josh-git-serde/tests/ser.rs
+++ b/josh-git-serde/tests/ser.rs
@@ -1,0 +1,323 @@
+use josh_git_serde::{GitValue, from_value, to_value};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+fn blob(s: &str) -> Box<GitValue> {
+    Box::new(GitValue::blob_from_str(s))
+}
+
+#[test]
+fn test_simple_struct() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct TestStruct {
+        a: String,
+        b: String,
+    }
+
+    let value = TestStruct {
+        a: "content of a".to_string(),
+        b: "content of b".to_string(),
+    };
+
+    let result = to_value(&value)?;
+
+    let expected = GitValue::Tree(BTreeMap::from([
+        ("a".to_string(), blob("content of a")),
+        ("b".to_string(), blob("content of b")),
+    ]));
+    assert_eq!(result, expected);
+
+    let roundtrip: TestStruct = from_value(&result)?;
+    assert_eq!(roundtrip, value);
+
+    Ok(())
+}
+
+#[test]
+fn test_map() -> anyhow::Result<()> {
+    let mut map = BTreeMap::new();
+    map.insert("a".to_string(), "content of a".to_string());
+    map.insert("b".to_string(), "content of b".to_string());
+
+    let result = to_value(&map)?;
+
+    // Same flat shape as a struct: the schema, not the tree, says "map".
+    let expected = GitValue::Tree(BTreeMap::from([
+        ("a".to_string(), blob("content of a")),
+        ("b".to_string(), blob("content of b")),
+    ]));
+    assert_eq!(result, expected);
+
+    let roundtrip: BTreeMap<String, String> = from_value(&result)?;
+    assert_eq!(roundtrip, map);
+
+    Ok(())
+}
+
+#[test]
+fn test_struct_variant() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum TestEnum {
+        A { value: String },
+    }
+
+    let value = TestEnum::A {
+        value: "content of a".to_string(),
+    };
+
+    let result = to_value(&value)?;
+
+    let expected = GitValue::Tree(BTreeMap::from([(
+        "A".to_string(),
+        Box::new(GitValue::Tree(BTreeMap::from([(
+            "value".to_string(),
+            blob("content of a"),
+        )]))),
+    )]));
+    assert_eq!(result, expected);
+
+    let roundtrip: TestEnum = from_value(&result)?;
+    assert_eq!(roundtrip, value);
+
+    Ok(())
+}
+
+#[test]
+fn test_unit_and_unit_struct_roundtrip() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Unit;
+
+    // Both are the same empty tree; the target type carries the meaning.
+    let empty = GitValue::Tree(BTreeMap::new());
+    assert_eq!(to_value(&())?, empty);
+    assert_eq!(to_value(&Unit)?, empty);
+
+    let _: () = from_value(&empty)?;
+    let _: Unit = from_value(&empty)?;
+    Ok(())
+}
+
+#[test]
+fn test_empty_containers_roundtrip() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Empty {}
+
+    let _: Empty = from_value(&to_value(&Empty {})?)?;
+    let _: BTreeMap<String, String> = from_value(&to_value(&BTreeMap::<String, String>::new())?)?;
+    Ok(())
+}
+
+#[test]
+fn test_scalar_roots_roundtrip() -> anyhow::Result<()> {
+    assert_eq!(from_value::<String>(&to_value("hello")?)?, "hello");
+    assert_eq!(from_value::<u64>(&to_value(&42u64)?)?, 42);
+    Ok(())
+}
+
+#[test]
+fn test_borrowed_str_field() -> anyhow::Result<()> {
+    #[derive(Deserialize)]
+    struct Borrowed<'a> {
+        s: &'a str,
+    }
+
+    // Same shape the serializer writes; constructed by hand so the test
+    // isolates the borrow path of the deserializer.
+    let expected = GitValue::Tree(BTreeMap::from([("s".to_string(), blob("borrowed"))]));
+    let parsed: Borrowed = from_value(&expected)?;
+    assert_eq!(parsed.s, "borrowed");
+    Ok(())
+}
+
+#[test]
+fn test_renamed_field_with_escape_roundtrip() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct Renamed {
+        #[serde(rename = "a%b")]
+        field: String,
+    }
+
+    let original = Renamed { field: "v".into() };
+    assert_eq!(from_value::<Renamed>(&to_value(&original)?)?, original);
+    Ok(())
+}
+
+#[test]
+fn test_map_key_encoding_roundtrip() -> anyhow::Result<()> {
+    // Keys that exercise every escape class: separators, spaces, dots,
+    // literal percent signs (including percent + hex digits).
+    let original: BTreeMap<String, String> = [
+        ("a/b", "path"),
+        ("a b", "space"),
+        ("a.b", "dot"),
+        ("100%", "percent"),
+        ("%61", "looks like an escape"),
+        ("a%2Fb", "escape-like sequence"),
+        ("键", "non-ascii"),
+        ("-", "_"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v.to_string()))
+    .collect();
+
+    assert_eq!(
+        from_value::<BTreeMap<String, String>>(&to_value(&original)?)?,
+        original
+    );
+    Ok(())
+}
+
+#[test]
+fn test_none_root_and_nested_option_error() -> anyhow::Result<()> {
+    #[derive(Serialize)]
+    enum TestEnum {
+        A(Option<String>),
+    }
+
+    let err = to_value(&None::<String>).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("`None` at the top level has no representation"),
+        "unexpected error: {err}"
+    );
+
+    let err = to_value(&Some(None::<String>)).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("`serialize_some` cannot serialize nested `None`"),
+        "unexpected error: {err}"
+    );
+
+    let err = to_value(&TestEnum::A(None)).unwrap_err();
+    assert!(
+        err.to_string().contains("cannot serialize `None` payload"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_seq_tuple_unsupported() -> anyhow::Result<()> {
+    #[derive(Serialize)]
+    struct Pair(String, u32);
+
+    let err = to_value(&vec!["a".to_string()]).unwrap_err();
+    assert!(
+        err.to_string().contains("`serialize_seq` not supported"),
+        "unexpected error: {err}"
+    );
+
+    let err = to_value(&("a".to_string(), 1u32)).unwrap_err();
+    assert!(
+        err.to_string().contains("`serialize_tuple` not supported"),
+        "unexpected error: {err}"
+    );
+
+    let err = to_value(&Pair("a".to_string(), 1)).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("`serialize_tuple_struct` not supported"),
+        "unexpected error: {err}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_none_field_omission_roundtrip() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct WithOption {
+        present: String,
+        absent: Option<String>,
+    }
+
+    let value = WithOption {
+        present: "p".to_string(),
+        absent: None,
+    };
+
+    let result = to_value(&value)?;
+
+    let expected = GitValue::Tree(BTreeMap::from([("present".to_string(), blob("p"))]));
+    assert_eq!(result, expected);
+
+    let roundtrip: WithOption = from_value(&result)?;
+    assert_eq!(roundtrip, value);
+
+    // Map values follow the same omission rule.
+    let mut map = BTreeMap::new();
+    map.insert("present".to_string(), Some("p".to_string()));
+    map.insert("absent".to_string(), None);
+
+    let result = to_value(&map)?;
+    assert_eq!(result, expected);
+
+    let roundtrip: BTreeMap<String, Option<String>> = from_value(&result)?;
+    assert_eq!(
+        roundtrip,
+        BTreeMap::from([("present".to_string(), Some("p".to_string()))])
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_some_empty_string_field_roundtrip() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    struct WithOption {
+        field: Option<String>,
+    }
+
+    // `Some("")` and `None` must stay distinguishable on the wire.
+    let some_empty = WithOption {
+        field: Some(String::new()),
+    };
+    let none = WithOption { field: None };
+
+    let some_value = to_value(&some_empty)?;
+    let none_value = to_value(&none)?;
+
+    assert_eq!(
+        some_value,
+        GitValue::Tree(BTreeMap::from([("field".to_string(), blob(""))]))
+    );
+    assert_eq!(none_value, GitValue::Tree(BTreeMap::new()));
+    assert_ne!(some_value, none_value);
+
+    assert_eq!(from_value::<WithOption>(&some_value)?, some_empty);
+    assert_eq!(from_value::<WithOption>(&none_value)?, none);
+
+    Ok(())
+}
+
+#[test]
+fn test_unit_variant_and_newtype_variant_shape() -> anyhow::Result<()> {
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    enum TestEnum {
+        Unit,
+        Newtype(String),
+    }
+
+    let unit = to_value(&TestEnum::Unit)?;
+    assert_eq!(
+        unit,
+        GitValue::Tree(BTreeMap::from([(
+            "Unit".to_string(),
+            Box::new(GitValue::Tree(BTreeMap::new())),
+        )]))
+    );
+    assert_eq!(from_value::<TestEnum>(&unit)?, TestEnum::Unit);
+
+    let newtype = to_value(&TestEnum::Newtype("payload".to_string()))?;
+    assert_eq!(
+        newtype,
+        GitValue::Tree(BTreeMap::from([("Newtype".to_string(), blob("payload"))]))
+    );
+    assert_eq!(
+        from_value::<TestEnum>(&newtype)?,
+        TestEnum::Newtype("payload".to_string())
+    );
+
+    Ok(())
+}

--- a/josh-git-serde/tests/store.rs
+++ b/josh-git-serde/tests/store.rs
@@ -1,0 +1,276 @@
+use gix_object::Find;
+use josh_git_serde::{GitValue, from_tree_oid, to_tree_oid};
+use josh_gix_ext::StagingOdb;
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+
+/// Write facade over [`StagingOdb`], which implements only the read side:
+/// writes stage in memory exactly like `StagingOdb`'s own `write_*` methods.
+struct Stage(RefCell<StagingOdb>);
+
+impl Stage {
+    fn new() -> Self {
+        Stage(RefCell::new(StagingOdb::new()))
+    }
+
+    fn stage(&self, kind: gix_object::Kind, data: Vec<u8>) -> gix_hash::ObjectId {
+        self.0.borrow_mut().write_raw(kind, data)
+    }
+}
+
+impl gix_object::Write for Stage {
+    fn write_buf_with_known_id(
+        &self,
+        kind: gix_object::Kind,
+        from: &[u8],
+        _id: gix_hash::ObjectId,
+    ) -> Result<gix_hash::ObjectId, gix_object::write::Error> {
+        Ok(self.stage(kind, from.to_vec()))
+    }
+
+    fn write_stream(
+        &self,
+        kind: gix_object::Kind,
+        _size: u64,
+        from: &mut dyn std::io::Read,
+    ) -> Result<gix_hash::ObjectId, gix_object::write::Error> {
+        let mut data = Vec::new();
+        from.read_to_end(&mut data)?;
+        Ok(self.stage(kind, data))
+    }
+
+    fn write_stream_with_known_id(
+        &self,
+        kind: gix_object::Kind,
+        _size: u64,
+        from: &mut dyn std::io::Read,
+        _id: gix_hash::ObjectId,
+    ) -> Result<gix_hash::ObjectId, gix_object::write::Error> {
+        let mut data = Vec::new();
+        from.read_to_end(&mut data)?;
+        Ok(self.stage(kind, data))
+    }
+}
+
+fn nested_value() -> GitValue {
+    GitValue::Tree(BTreeMap::from([
+        ("name".into(), Box::new(GitValue::blob_from_str("josh"))),
+        ("empty".into(), Box::new(GitValue::empty_blob())),
+        (
+            "bin".into(),
+            Box::new(GitValue::Blob(vec![0xff, 0x00, 0xfe])),
+        ),
+        (
+            "sub".into(),
+            Box::new(GitValue::Tree(BTreeMap::from([
+                ("leaf".into(), Box::new(GitValue::blob_from_str("deep"))),
+                (
+                    "subsub".into(),
+                    Box::new(GitValue::Tree(BTreeMap::from([(
+                        "x".into(),
+                        Box::new(GitValue::blob_from_str("42")),
+                    )]))),
+                ),
+            ]))),
+        ),
+    ]))
+}
+
+#[test]
+fn roundtrip_nested_tree() {
+    let stage = Stage::new();
+    let value = nested_value();
+    let root = to_tree_oid(&stage, &value).unwrap();
+    let back = from_tree_oid(&*stage.0.borrow(), root).unwrap();
+    assert_eq!(value, back);
+}
+
+#[test]
+fn empty_tree_roundtrips() {
+    let stage = Stage::new();
+    let value = GitValue::Tree(BTreeMap::new());
+    let root = to_tree_oid(&stage, &value).unwrap();
+    assert_eq!(root.to_string(), "4b825dc642cb6eb9a060e54bf8d69288fbee4904");
+    let back = from_tree_oid(&*stage.0.borrow(), root).unwrap();
+    assert_eq!(value, back);
+}
+
+#[test]
+fn blob_root_roundtrips() {
+    let stage = Stage::new();
+    let value = GitValue::blob_from_str("lone blob");
+    let root = to_tree_oid(&stage, &value).unwrap();
+    assert_eq!(root, josh_gix_ext::hash_blob(b"lone blob"));
+    let back = from_tree_oid(&*stage.0.borrow(), root).unwrap();
+    assert_eq!(value, back);
+}
+
+#[test]
+fn written_tree_is_in_canonical_order() {
+    // "foo" as a tree sorts as "foo/": after "foo-bar" and "foo.txt".
+    // Plain byte order would place it before both.
+    let value = GitValue::Tree(BTreeMap::from([
+        (
+            "foo".into(),
+            Box::new(GitValue::Tree(BTreeMap::from([(
+                "inner".into(),
+                Box::new(GitValue::blob_from_str("i")),
+            )]))),
+        ),
+        ("foo.txt".into(), Box::new(GitValue::blob_from_str("t"))),
+        ("foo-bar".into(), Box::new(GitValue::blob_from_str("b"))),
+        ("bar".into(), Box::new(GitValue::blob_from_str("a"))),
+    ]));
+    let stage = Stage::new();
+    let root = to_tree_oid(&stage, &value).unwrap();
+
+    let staging = stage.0.borrow();
+    let mut buf = Vec::new();
+    let (kind, object_hash) = {
+        let data = staging
+            .try_find(&josh_gix_ext::gix_oid(root), &mut buf)
+            .unwrap()
+            .unwrap();
+        (data.kind, data.object_hash)
+    };
+    assert_eq!(kind, gix_object::Kind::Tree);
+    let tree = gix_object::TreeRef::from_bytes(&buf, object_hash).unwrap();
+
+    let order: Vec<(bool, String)> = tree
+        .entries
+        .iter()
+        .map(|e| {
+            (
+                e.mode.is_tree(),
+                String::from_utf8(e.filename.to_vec()).unwrap(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        order,
+        vec![
+            (false, "bar".to_string()),
+            (false, "foo-bar".to_string()),
+            (false, "foo.txt".to_string()),
+            (true, "foo".to_string()),
+        ]
+    );
+
+    // Entry oids must resolve to the objects just written.
+    for entry in &tree.entries {
+        let name: &[u8] = entry.filename.as_ref();
+        if name == b"foo" {
+            assert_eq!(entry.mode.kind(), gix_object::tree::EntryKind::Tree);
+            let sub = from_tree_oid(&*staging, josh_gix_ext::git2_oid(entry.oid)).unwrap();
+            assert_eq!(
+                sub,
+                GitValue::Tree(BTreeMap::from([(
+                    "inner".into(),
+                    Box::new(GitValue::blob_from_str("i")),
+                )]))
+            );
+        } else {
+            assert!(
+                matches!(name, b"bar" | b"foo-bar" | b"foo.txt"),
+                "unexpected entry {name:?}"
+            );
+            assert_eq!(entry.mode.kind(), gix_object::tree::EntryKind::Blob);
+        }
+    }
+}
+
+#[test]
+fn commit_object_is_rejected() {
+    let mut staging = StagingOdb::new();
+    // Contents are irrelevant: the kind alone must trigger the error.
+    let commit = staging.write_raw(gix_object::Kind::Commit, b"tree".to_vec());
+    let err = from_tree_oid(&staging, josh_gix_ext::git2_oid(&commit)).unwrap_err();
+    assert!(
+        err.to_string().contains("not a tree or a blob"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn missing_object_is_an_error() {
+    let staging = StagingOdb::new();
+    let missing = git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap();
+    let err = from_tree_oid(&staging, missing).unwrap_err();
+    assert!(
+        err.to_string().contains("not found"),
+        "unexpected error: {err}"
+    );
+}
+
+fn raw_tree(entries: &[(&str, &str, &gix_hash::ObjectId)]) -> Vec<u8> {
+    let mut raw = Vec::new();
+    for (mode, name, oid) in entries {
+        raw.extend_from_slice(mode.as_bytes());
+        raw.push(b' ');
+        raw.extend_from_slice(name.as_bytes());
+        raw.push(0);
+        raw.extend_from_slice(oid.as_bytes());
+    }
+    raw
+}
+
+#[test]
+fn executable_blob_entry_is_rejected() {
+    let mut staging = StagingOdb::new();
+    let blob = staging.write_raw(gix_object::Kind::Blob, b"x".to_vec());
+    let tree = staging.write_raw(
+        gix_object::Kind::Tree,
+        raw_tree(&[("100755", "exec", &blob)]),
+    );
+    let err = from_tree_oid(&staging, josh_gix_ext::git2_oid(&tree)).unwrap_err();
+    assert!(
+        err.to_string().contains("unsupported mode"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn duplicate_entry_names_are_rejected() {
+    let mut staging = StagingOdb::new();
+    let a = staging.write_raw(gix_object::Kind::Blob, b"aaa".to_vec());
+    let b = staging.write_raw(gix_object::Kind::Blob, b"bbb".to_vec());
+    let tree = staging.write_raw(
+        gix_object::Kind::Tree,
+        raw_tree(&[("100644", "dup", &a), ("100644", "dup", &b)]),
+    );
+    let err = from_tree_oid(&staging, josh_gix_ext::git2_oid(&tree)).unwrap_err();
+    assert!(
+        err.to_string().contains("duplicate entry name"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn excessive_nesting_is_rejected() {
+    let mut value = GitValue::blob_from_str("bottom");
+    for _ in 0..1200 {
+        value = GitValue::Tree(BTreeMap::from([("n".into(), Box::new(value))]));
+    }
+    let stage = Stage::new();
+    let root = to_tree_oid(&stage, &value).unwrap();
+    let err = from_tree_oid(&*stage.0.borrow(), root).unwrap_err();
+    assert!(
+        err.to_string().contains("nesting exceeds"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn invalid_entry_names_are_rejected_on_write() {
+    for bad in ["", "a/b", "..", "."] {
+        let value = GitValue::Tree(BTreeMap::from([(
+            bad.to_string(),
+            Box::new(GitValue::empty_blob()),
+        )]));
+        let err = to_tree_oid(&Stage::new(), &value).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid entry name"),
+            "unexpected error for {bad:?}: {err}"
+        );
+    }
+}


### PR DESCRIPTION
Add josh-git-serde crate for serde over git trees

Serialize Rust values into git tree objects and read them back:
struct fields and map keys become flat tree entries
(percent-encoded for filename safety), scalars become blobs,
enums become single-entry trees keyed by variant name, and None
omits the entry entirely. The format is schema-driven rather than
self-describing: trees carry no type markers, so the same shape
can be queried as different types. Sequences and tuples are not
supported. The pure layer converts between serde and an
in-memory GitValue; the store layer writes and reads objects
through gix_object::Find/Write with canonical entry ordering and
guards against deep nesting, duplicate names, and unsupported
entry modes.

Assisted-By: openrouter/stealth/ox-alpha
Change: add-josh-git-serde-crate