### PR TITLE
Use git-tree-pretty throughout scrut tests

### DIFF
--- a/tests/cli/clone.t
+++ b/tests/cli/clone.t
@@ -66,22 +66,22 @@
   
   15 directories, 10 files
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- file2
-  
-  1 directory, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents2
 
   $ git checkout feature
   branch 'feature' set up to track 'origin/feature'.
   Switched to a new branch 'feature'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- file2
-  
-  1 directory, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents2
 
 

--- a/tests/cli/fetch.t
+++ b/tests/cli/fetch.t
@@ -29,12 +29,12 @@
 
   $ cd libs
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- file2
-  
-  1 directory, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents2
 
   $ echo newfile > newfile
   $ git add newfile
@@ -51,13 +51,14 @@
   updated master (d8388f5..61e377b)
   Fetched from remote: origin
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- file2
-  `-- newfile
-  
-  1 directory, 3 files
+  ├── file1
+  │   ┆  contents1
+  ├── file2
+  │   ┆  contents2
+  └── newfile
+      ┆  newfile
 
   $ git log --oneline
   6a6f932 add newfile
@@ -89,10 +90,11 @@
   
   HEAD is now at 61e377b add remote_newfile
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- file2
-  `-- remote_newfile
-  
-  1 directory, 3 files
+  ├── file1
+  │   ┆  contents1
+  ├── file2
+  │   ┆  contents2
+  └── remote_newfile
+      ┆  remote_newfile

--- a/tests/cli/pull-multiple-remotes.t
+++ b/tests/cli/pull-multiple-remotes.t
@@ -48,12 +48,12 @@
 
   $ cd libs
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- file2
-  
-  1 directory, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents2
 
   $ josh remote add remote2 ${TESTTMP}/remote2/libs :/sub2
   Added remote 'remote2' with filter ':/sub2'
@@ -64,19 +64,19 @@
   the current branch tracks 'refs/remotes/origin/master', which does not belong to remote 'remote2'
   [1]
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- file2
-  
-  1 directory, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents2
 
   $ josh changes pull
   Already up to date.
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- file2
-  
-  1 directory, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents2

--- a/tests/cli/pull.t
+++ b/tests/cli/pull.t
@@ -36,12 +36,12 @@
 
   $ cd libs
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- file2
-  
-  1 directory, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents2
 
   $ cd ${TESTTMP}/remote/libs
 
@@ -55,22 +55,23 @@
   updated master (d8388f5..0974639)
   Fast-forwarded master
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- file2
-  `-- newfile
-  
-  1 directory, 3 files
+  ├── file1
+  │   ┆  contents1
+  ├── file2
+  │   ┆  contents2
+  └── newfile
+      ┆  new_content
 
   $ git checkout feature
   branch 'feature' set up to track 'origin/feature'.
   Switched to a new branch 'feature'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- file2
-  
-  1 directory, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents2
 

--- a/tests/cli/pull_stacked_out_of_order.t
+++ b/tests/cli/pull_stacked_out_of_order.t
@@ -73,14 +73,16 @@ Pull: B is skipped, C and A are restacked on top of the landed B
   * change C
   * landed change B
   * add file1
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- file2
-  |-- file3
-  `-- file4
-  
-  1 directory, 4 files
+  ├── file1
+  │   ┆  file1 content
+  ├── file2
+  │   ┆  contents2
+  ├── file3
+  │   ┆  contents3
+  └── file4
+      ┆  contents4
 
 Pull again: no-op
 

--- a/tests/cli/pull_stacked_restacks.t
+++ b/tests/cli/pull_stacked_restacks.t
@@ -69,14 +69,16 @@ Pull: applied changes are skipped, the remaining change is restacked
   * landed change 3
   * landed change 2
   * add file1
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- file2
-  |-- file3
-  `-- file4
-  
-  1 directory, 4 files
+  ├── file1
+  │   ┆  file1 content
+  ├── file2
+  │   ┆  contents2
+  ├── file3
+  │   ┆  contents3
+  └── file4
+      ┆  contents4
 
 Pull again: no-op
 
@@ -105,13 +107,17 @@ against the upstream stack, so it is simply kept and cherry-picked on top.
   * landed change 3
   * landed change 2
   * add file1
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- file2
-  |-- file3
-  |-- file4
-  |-- file5
-  `-- file9
-  
-  1 directory, 6 files
+  ├── file1
+  │   ┆  file1 content
+  ├── file2
+  │   ┆  contents2
+  ├── file3
+  │   ┆  contents3
+  ├── file4
+  │   ┆  contents4
+  ├── file5
+  │   ┆  contents5
+  └── file9
+      ┆  other

--- a/tests/cli/push.t
+++ b/tests/cli/push.t
@@ -31,12 +31,12 @@ Clone with josh filter
   
   Cloned repository to: ${TESTTMP}/filtered/
   $ cd filtered
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- file2
-  
-  1 directory, 2 files
+  ├── file1
+  │   ┆  file1 content
+  └── file2
+      ┆  file2 content
 
   $ git log --oneline
   33cbd5f add file2

--- a/tests/cli/push_stacked.t
+++ b/tests/cli/push_stacked.t
@@ -29,11 +29,10 @@ Clone with josh filter
   
   Cloned repository to: ${TESTTMP}/filtered/
   $ cd filtered
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- file1
-  
-  1 directory, 1 file
+  └── file1
+      ┆  file1 content
 
 Make changes with Change-Id for stacked changes
 

--- a/tests/cli/push_stacked_split.t
+++ b/tests/cli/push_stacked_split.t
@@ -29,11 +29,10 @@ Clone with josh filter
   
   Cloned repository to: ${TESTTMP}/filtered/
   $ cd filtered
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- file1
-  
-  1 directory, 1 file
+  └── file1
+      ┆  file1 content
 
 Make multiple changes with Change-Ids for split testing
 

--- a/tests/experimental/indexer.t
+++ b/tests/experimental/indexer.t
@@ -114,232 +114,221 @@
     }
   }
 
-  $ git diff ${EMPTY_TREE}..refs/heads/index
-  diff --git a/20/20/20/sub1 b/20/20/20/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/20/6f/sub1 b/20/20/6f/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/20/74/sub1 b/20/20/74/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/64/6f/sub1 b/20/64/6f/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/68/61/sub2 b/20/68/61/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/6c/69/sub1 b/20/6c/69/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/6d/6f/sub1 b/20/6d/6f/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/6d/6f/sub2 b/20/6d/6f/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/6f/6e/sub1 b/20/6f/6e/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/73/65/sub2 b/20/73/65/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/74/65/sub1 b/20/74/65/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/74/68/sub1 b/20/74/68/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/74/6f/sub2 b/20/74/6f/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/77/68/sub2 b/20/77/68/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/20/77/69/sub1 b/20/77/69/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/61/6e/20/sub1 b/61/6e/20/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/61/6e/6f/sub1 b/61/6e/6f/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/61/70/70/sub2 b/61/70/70/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/61/74/20/sub2 b/61/74/20/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/63/75/6d/sub1 b/63/75/6d/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/64/6f/63/sub1 b/64/6f/63/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/65/20/20/sub1 b/65/20/20/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/65/20/6c/sub1 b/65/20/6c/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/65/20/6d/sub2 b/65/20/6d/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/65/20/74/sub2 b/65/20/74/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/65/20/77/sub2 b/65/20/77/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/65/65/20/sub2 b/65/65/20/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/65/6e/73/sub2 b/65/6e/73/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/65/6e/74/sub1 b/65/6e/74/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/65/72/20/sub1 b/65/72/20/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/65/73/74/sub1 b/65/73/74/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/66/69/72/sub1 b/66/69/72/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/68/20/6d/sub1 b/68/20/6d/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/68/61/6e/sub1 b/68/61/6e/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/68/61/70/sub2 b/68/61/70/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/68/61/74/sub2 b/68/61/74/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/68/65/72/sub1 b/68/65/72/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/69/6e/65/sub1 b/69/6e/65/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/69/72/73/sub1 b/69/72/73/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/69/74/68/sub1 b/69/74/68/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6c/69/6e/sub1 b/6c/69/6e/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6d/65/6e/sub1 b/6d/65/6e/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6d/6f/72/sub1 b/6d/6f/72/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6d/6f/72/sub2 b/6d/6f/72/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6e/20/20/sub1 b/6e/20/20/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6e/65/20/sub1 b/6e/65/20/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6e/65/20/sub2 b/6e/65/20/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6e/6f/74/sub1 b/6e/6f/74/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6e/74/20/sub1 b/6e/74/20/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6f/20/73/sub2 b/6f/20/73/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6f/63/75/sub1 b/6f/63/75/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6f/6e/65/sub1 b/6f/6e/65/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6f/6e/65/sub2 b/6f/6e/65/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6f/72/65/sub1 b/6f/72/65/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6f/72/65/sub2 b/6f/72/65/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/6f/74/68/sub1 b/6f/74/68/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/70/65/6e/sub2 b/70/65/6e/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/70/70/65/sub2 b/70/70/65/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/72/20/64/sub1 b/72/20/64/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/72/65/20/sub1 b/72/65/20/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/72/65/20/sub2 b/72/65/20/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/72/73/74/sub1 b/72/73/74/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/73/65/65/sub2 b/73/65/65/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/73/74/20/sub1 b/73/74/20/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/74/20/64/sub1 b/74/20/64/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/74/20/68/sub2 b/74/20/68/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/74/20/74/sub1 b/74/20/74/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/74/20/77/sub1 b/74/20/77/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/74/65/73/sub1 b/74/65/73/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/74/68/20/sub1 b/74/68/20/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/74/68/61/sub1 b/74/68/61/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/74/68/65/sub1 b/74/68/65/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/74/6f/20/sub2 b/74/6f/20/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/75/6d/65/sub1 b/75/6d/65/sub1
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/77/68/61/sub2 b/77/68/61/sub2
-  new file mode 100644
-  index 0000000..e69de29
-  diff --git a/77/69/74/sub1 b/77/69/74/sub1
-  new file mode 100644
-  index 0000000..e69de29
+  $ git-tree-pretty refs/heads/index
+  .
+  ├── 20/
+  │   ├── 20/
+  │   │   ├── 20/
+  │   │   │   └── sub1
+  │   │   ├── 6f/
+  │   │   │   └── sub1
+  │   │   └── 74/
+  │   │       └── sub1
+  │   ├── 64/
+  │   │   └── 6f/
+  │   │       └── sub1
+  │   ├── 68/
+  │   │   └── 61/
+  │   │       └── sub2
+  │   ├── 6c/
+  │   │   └── 69/
+  │   │       └── sub1
+  │   ├── 6d/
+  │   │   └── 6f/
+  │   │       ├── sub1
+  │   │       └── sub2
+  │   ├── 6f/
+  │   │   └── 6e/
+  │   │       └── sub1
+  │   ├── 73/
+  │   │   └── 65/
+  │   │       └── sub2
+  │   ├── 74/
+  │   │   ├── 65/
+  │   │   │   └── sub1
+  │   │   ├── 68/
+  │   │   │   └── sub1
+  │   │   └── 6f/
+  │   │       └── sub2
+  │   └── 77/
+  │       ├── 68/
+  │       │   └── sub2
+  │       └── 69/
+  │           └── sub1
+  ├── 61/
+  │   ├── 6e/
+  │   │   ├── 20/
+  │   │   │   └── sub1
+  │   │   └── 6f/
+  │   │       └── sub1
+  │   ├── 70/
+  │   │   └── 70/
+  │   │       └── sub2
+  │   └── 74/
+  │       └── 20/
+  │           └── sub2
+  ├── 63/
+  │   └── 75/
+  │       └── 6d/
+  │           └── sub1
+  ├── 64/
+  │   └── 6f/
+  │       └── 63/
+  │           └── sub1
+  ├── 65/
+  │   ├── 20/
+  │   │   ├── 20/
+  │   │   │   └── sub1
+  │   │   ├── 6c/
+  │   │   │   └── sub1
+  │   │   ├── 6d/
+  │   │   │   └── sub2
+  │   │   ├── 74/
+  │   │   │   └── sub2
+  │   │   └── 77/
+  │   │       └── sub2
+  │   ├── 65/
+  │   │   └── 20/
+  │   │       └── sub2
+  │   ├── 6e/
+  │   │   ├── 73/
+  │   │   │   └── sub2
+  │   │   └── 74/
+  │   │       └── sub1
+  │   ├── 72/
+  │   │   └── 20/
+  │   │       └── sub1
+  │   └── 73/
+  │       └── 74/
+  │           └── sub1
+  ├── 66/
+  │   └── 69/
+  │       └── 72/
+  │           └── sub1
+  ├── 68/
+  │   ├── 20/
+  │   │   └── 6d/
+  │   │       └── sub1
+  │   ├── 61/
+  │   │   ├── 6e/
+  │   │   │   └── sub1
+  │   │   ├── 70/
+  │   │   │   └── sub2
+  │   │   └── 74/
+  │   │       └── sub2
+  │   └── 65/
+  │       └── 72/
+  │           └── sub1
+  ├── 69/
+  │   ├── 6e/
+  │   │   └── 65/
+  │   │       └── sub1
+  │   ├── 72/
+  │   │   └── 73/
+  │   │       └── sub1
+  │   └── 74/
+  │       └── 68/
+  │           └── sub1
+  ├── 6c/
+  │   └── 69/
+  │       └── 6e/
+  │           └── sub1
+  ├── 6d/
+  │   ├── 65/
+  │   │   └── 6e/
+  │   │       └── sub1
+  │   └── 6f/
+  │       └── 72/
+  │           ├── sub1
+  │           └── sub2
+  ├── 6e/
+  │   ├── 20/
+  │   │   └── 20/
+  │   │       └── sub1
+  │   ├── 65/
+  │   │   └── 20/
+  │   │       ├── sub1
+  │   │       └── sub2
+  │   ├── 6f/
+  │   │   └── 74/
+  │   │       └── sub1
+  │   └── 74/
+  │       └── 20/
+  │           └── sub1
+  ├── 6f/
+  │   ├── 20/
+  │   │   └── 73/
+  │   │       └── sub2
+  │   ├── 63/
+  │   │   └── 75/
+  │   │       └── sub1
+  │   ├── 6e/
+  │   │   └── 65/
+  │   │       ├── sub1
+  │   │       └── sub2
+  │   ├── 72/
+  │   │   └── 65/
+  │   │       ├── sub1
+  │   │       └── sub2
+  │   └── 74/
+  │       └── 68/
+  │           └── sub1
+  ├── 70/
+  │   ├── 65/
+  │   │   └── 6e/
+  │   │       └── sub2
+  │   └── 70/
+  │       └── 65/
+  │           └── sub2
+  ├── 72/
+  │   ├── 20/
+  │   │   └── 64/
+  │   │       └── sub1
+  │   ├── 65/
+  │   │   └── 20/
+  │   │       ├── sub1
+  │   │       └── sub2
+  │   └── 73/
+  │       └── 74/
+  │           └── sub1
+  ├── 73/
+  │   ├── 65/
+  │   │   └── 65/
+  │   │       └── sub2
+  │   └── 74/
+  │       └── 20/
+  │           └── sub1
+  ├── 74/
+  │   ├── 20/
+  │   │   ├── 64/
+  │   │   │   └── sub1
+  │   │   ├── 68/
+  │   │   │   └── sub2
+  │   │   ├── 74/
+  │   │   │   └── sub1
+  │   │   └── 77/
+  │   │       └── sub1
+  │   ├── 65/
+  │   │   └── 73/
+  │   │       └── sub1
+  │   ├── 68/
+  │   │   ├── 20/
+  │   │   │   └── sub1
+  │   │   ├── 61/
+  │   │   │   └── sub1
+  │   │   └── 65/
+  │   │       └── sub1
+  │   └── 6f/
+  │       └── 20/
+  │           └── sub2
+  ├── 75/
+  │   └── 6d/
+  │       └── 65/
+  │           └── sub1
+  └── 77/
+      ├── 68/
+      │   └── 61/
+      │       └── sub2
+      └── 69/
+          └── 74/
+              └── sub1

--- a/tests/experimental/link-add-push.t
+++ b/tests/experimental/link-add-push.t
@@ -89,10 +89,18 @@
   * update some docs:49451f0ceb13b6e4130217b4db23e114b529e15b
   * Initial commit:0d24cd27434a19674c17b21e47f176f7151a0260
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- some_prefix
-      `-- readme.txt
-  
-  2 directories, 1 file
+  └── some_prefix/
+      ├── .link.josh
+      │   ┆  :~(
+      │   ┆      commit="49451f0ceb13b6e4130217b4db23e114b529e15b"
+      │   ┆      mode="snapshot"
+      │   ┆      remote="../docs_repo.git"
+      │   ┆      target="HEAD"
+      │   ┆  )[
+      │   ┆      docs = :/some_prefix
+      │   ┆  ]
+      └── readme.txt
+          ┆  updated documentation
 

--- a/tests/experimental/link-submodules.t
+++ b/tests/experimental/link-submodules.t
@@ -244,22 +244,20 @@ Test Adapt with submodule changes - add commits to submodule and update
   $ git add libs
   $ git commit -m "update libs submodule" 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- libs
-  |   |-- bar
-  |   |   |-- file3.txt
-  |   |   `-- file4.txt
-  |   `-- foo
-  |       |-- file1.txt
-  |       |-- file2.txt
-  |       `-- file3.txt
-  |-- main.txt
-  `-- modules
-      `-- another
-          `-- another.txt
-  
-  6 directories, 7 files
+  ├── .gitmodules
+  │   ┆  [submodule "libs"]
+  │   ┆  	path = libs
+  │   ┆  	url = ../submodule-repo
+  │   ┆  [submodule "modules/another"]
+  │   ┆  	path = modules/another
+  │   ┆  	url = ../another-submodule
+  ├── libs (submodule)
+  ├── main.txt
+  │   ┆  main content
+  └── modules/
+      └── another (submodule)
 
 
   $ josh-filter -s :adapt=submodules:link=embedded master --update refs/josh/filter/master

--- a/tests/experimental/starlark_basic.t
+++ b/tests/experimental/starlark_basic.t
@@ -33,15 +33,15 @@
   * add sub2
   * add sub1
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ git ls-tree -r HEAD
+  $ git ls-tree -r refs/josh/master
   100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile1 (esc)
   100644 blob f34a2bbfa250847f10a4102e093b48be1d2873a1\tst/config.star (esc)
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  |-- file1
-  `-- st
-      `-- config.star
-  
-  2 directories, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── st/
+      └── config.star
+          ┆  # Simple starlark filter: keep only sub1
+          ┆  filter = filter.subdir("sub1")
 

--- a/tests/experimental/starlark_subfilter.t
+++ b/tests/experimental/starlark_subfilter.t
@@ -34,16 +34,17 @@
   * add sub2
   * add sub1
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ git ls-tree -r HEAD
+  $ git ls-tree -r refs/josh/master
   100644 blob 17a02eede77454427c80e6fdf862f924f9c13ae9\tst/config.star (esc)
   100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tsub1/file1 (esc)
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  |-- st
-  |   `-- config.star
-  `-- sub1
-      `-- file1
-  
-  3 directories, 2 files
+  ├── st/
+  │   └── config.star
+  │       ┆  # With subfilter ::sub1/, the tree passed to the script has sub1 at root (just file1).
+  │       ┆  # Include that file in the result.
+  │       ┆  filter = filter.file("file1")
+  └── sub1/
+      └── file1
+          ┆  contents1
 

--- a/tests/filter/ambiguous_merge.t
+++ b/tests/filter/ambiguous_merge.t
@@ -102,19 +102,24 @@
   On branch master
   nothing to commit, working tree clean
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   |-- file1
-  |   |-- file2
-  |   |-- file3
-  |   |-- file4
-  |   `-- fileY
-  `-- sub2
-      |-- file2
-      `-- fileX
-  
-  3 directories, 7 files
+  ├── sub1/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   ├── file2
+  │   │   ┆  contents1
+  │   ├── file3
+  │   │   ┆  contents3
+  │   ├── file4
+  │   │   ┆  contents4
+  │   └── fileY
+  │       ┆  contents6
+  └── sub2/
+      ├── file2
+      │   ┆  contents1
+      └── fileX
+          ┆  contents2
 
   $ git log --graph --oneline --decorate master
   *   8cbae19 (HEAD -> master) Merge branch 'hidden_branch1' into hidden_master

--- a/tests/filter/cmdline.t
+++ b/tests/filter/cmdline.t
@@ -99,16 +99,17 @@
   $ git reset --hard
   HEAD is now at fbd00b3 sync
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file3
-  `-- c
-      |-- file1
-      `-- file2
-  
-  4 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file3
+  │           ┆  contents1
+  └── c/
+      ├── file1
+      │   ┆  contents1
+      └── file2
+          ┆  contents2
   $ git log --graph --pretty=%s
   * sync
   * initial

--- a/tests/filter/compose_shadow_dir_same_name.t
+++ b/tests/filter/compose_shadow_dir_same_name.t
@@ -20,72 +20,39 @@
   $ git add sub
   $ git commit -m "add file3" 1> /dev/null
 
-  $ git diff ${EMPTY_TREE}..HEAD
-  diff --git a/sub/xx/file3 b/sub/xx/file3
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/sub/xx/file3
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/sub/xx/file4 b/sub/xx/file4
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/sub/xx/file4
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/sub1/file1 b/sub1/file1
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/sub1/file1
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/xx/file2 b/xx/file2
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/xx/file2
-  @@ -0,0 +1 @@
-  +contents1
+  $ git-tree-pretty HEAD
+  .
+  ├── sub/
+  │   └── xx/
+  │       ├── file3
+  │       │   ┆  contents1
+  │       └── file4
+  │           ┆  contents1
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  └── xx/
+      └── file2
+          ┆  contents1
 
 
   $ josh-filter ":[:/sub1,:/xx]"
   11f4a718fc1c49fdda1b3ebce22efec68683edaf
-  $ git diff ${EMPTY_TREE}..FILTERED_HEAD
-  diff --git a/file1 b/file1
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/file1
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/file2 b/file2
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/file2
-  @@ -0,0 +1 @@
-  +contents1
+  $ git-tree-pretty FILTERED_HEAD
+  .
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents1
 
   $ josh-filter ":[:/xx,:/sub1]"
   11f4a718fc1c49fdda1b3ebce22efec68683edaf
-  $ git diff ${EMPTY_TREE}..FILTERED_HEAD
-  diff --git a/file1 b/file1
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/file1
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/file2 b/file2
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/file2
-  @@ -0,0 +1 @@
-  +contents1
+  $ git-tree-pretty FILTERED_HEAD
+  .
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents1
 
   $ josh-filter -s ":[:/sub/xx::file3,:/sub1,:/xx,:/sub/xx]"
   f9da6dcfc582a60447a9870b596eb9f28a7e03ec
@@ -105,32 +72,13 @@
   ]
   [3] reachable_roots
   [3] sequence_number
-  $ git diff ${EMPTY_TREE}..FILTERED_HEAD
-  diff --git a/file1 b/file1
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/file1
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/file2 b/file2
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/file2
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/file3 b/file3
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/file3
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/file4 b/file4
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/file4
-  @@ -0,0 +1 @@
-  +contents1
+  $ git-tree-pretty FILTERED_HEAD
+  .
+  ├── file1
+  │   ┆  contents1
+  ├── file2
+  │   ┆  contents1
+  ├── file3
+  │   ┆  contents1
+  └── file4
+      ┆  contents1

--- a/tests/filter/empty_orphan.t
+++ b/tests/filter/empty_orphan.t
@@ -61,16 +61,19 @@ Empty root commits from unrelated parts of the tree should not be included
   Switched to branch 'master'
   $ git merge -q other --no-ff --allow-unrelated
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- some_file
-  |-- some_other_file
-  `-- sub1
-      |-- file1
-      |-- file2
-      `-- file3
-  
-  2 directories, 5 files
+  ├── some_file
+  │   ┆  contents2
+  ├── some_other_file
+  │   ┆  contents2
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      ├── file2
+      │   ┆  contents2
+      └── file3
+          ┆  contents2
 
   $ git log master --graph --pretty=%s
   *   Merge branch 'other'

--- a/tests/filter/exclude_compose.t
+++ b/tests/filter/exclude_compose.t
@@ -25,14 +25,14 @@
   [3] reachable_roots
   [3] sequence_number
   $ git checkout -q hidden 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- file1
-  `-- sub3
-      `-- file1
-  
-  3 directories, 2 files
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  └── sub3/
+      └── file1
+          ┆  contents1
   $ git log --graph --pretty=%s
   * add file3
   * add file1
@@ -51,13 +51,11 @@
   [3] reachable_roots
   [3] sequence_number
 
-  $ git checkout -q refs/josh/filtered
-  $ tree
+  $ git-tree-pretty refs/josh/filtered
   .
-  `-- sub3
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub3/
+      └── file1
+          ┆  contents1
 
   $ josh-filter -s :exclude[sub1=:/sub3] master --update refs/josh/filtered
   990f678a016ea2e798f1341ac1049993a0fab726
@@ -70,12 +68,11 @@
   [3] reachable_roots
   [3] sequence_number
 
-  $ git checkout -q refs/josh/filtered
-  $ tree
+  $ git-tree-pretty refs/josh/filtered
   .
-  |-- sub2
-  |   `-- file2
-  `-- sub3
-      `-- file1
-  
-  3 directories, 2 files
+  ├── sub2/
+  │   └── file2
+  │       ┆  contents1
+  └── sub3/
+      └── file1
+          ┆  contents1

--- a/tests/filter/file_destination.t
+++ b/tests/filter/file_destination.t
@@ -21,14 +21,10 @@ Test File filter with destination path
   [3] reachable_roots
   [3] sequence_number
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  `-- renamed.txt
-  
-  1 directory, 1 file
-  $ cat renamed.txt
-  source content
+  └── renamed.txt
+      ┆  source content
 
 Test File filter with destination path in subdirectory
   $ cd ${TESTTMP}
@@ -53,16 +49,12 @@ Test File filter with destination path in subdirectory
   [5] reachable_roots
   [5] sequence_number
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  `-- dest
-      `-- subdir
-          `-- renamed.txt
-  
-  3 directories, 1 file
-  $ cat dest/subdir/renamed.txt
-  source content
+  └── dest/
+      └── subdir/
+          └── renamed.txt
+              ┆  source content
 
 Test File filter spec formatting with destination path
   $ josh-filter -p ::dest/renamed.txt=src/file.txt
@@ -91,16 +83,12 @@ Test File filter backward compatibility (no destination path - keeps same path)
   [5] reachable_roots
   [5] sequence_number
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  `-- src
-      `-- subdir
-          `-- file.txt
-  
-  3 directories, 1 file
-  $ cat src/subdir/file.txt
-  content
+  └── src/
+      └── subdir/
+          └── file.txt
+              ┆  content
 
 Test File filter with destination path --reverse
   $ cd ${TESTTMP}
@@ -136,21 +124,18 @@ Test File filter with destination path --reverse
   [3] reachable_roots
   [3] sequence_number
 
-  $ git checkout master 2> /dev/null
-  $ cat src/subdir/original.txt
-  source content
-  $ cat src/subdir/other.txt
-  other file
-  $ tree
+  $ git-tree-pretty master
   .
-  |-- another.txt
-  `-- src
-      |-- root.txt
-      `-- subdir
-          |-- original.txt
-          `-- other.txt
-  
-  3 directories, 4 files
+  ├── another.txt
+  │   ┆  another
+  └── src/
+      ├── root.txt
+      │   ┆  root file
+      └── subdir/
+          ├── original.txt
+          │   ┆  source content
+          └── other.txt
+              ┆  other file
 
 Test File filter backward compatibility --reverse
   $ cd ${TESTTMP}
@@ -190,19 +175,16 @@ Test File filter backward compatibility --reverse
   [5] reachable_roots
   [5] sequence_number
 
-  $ git checkout master 2> /dev/null
-  $ cat src/subdir/file.txt
-  content
-  $ cat src/subdir/other.txt
-  other file
-  $ tree
+  $ git-tree-pretty master
   .
-  |-- another.txt
-  `-- src
-      |-- root.txt
-      `-- subdir
-          |-- file.txt
-          `-- other.txt
-  
-  3 directories, 4 files
+  ├── another.txt
+  │   ┆  another
+  └── src/
+      ├── root.txt
+      │   ┆  root file
+      └── subdir/
+          ├── file.txt
+          │   ┆  content
+          └── other.txt
+              ┆  other file
 

--- a/tests/filter/filter_id.t
+++ b/tests/filter/filter_id.t
@@ -9,35 +9,17 @@
       :/a
       :/b
   ]
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- compose
-      |-- 0
-      |   `-- subdir
-      |       `-- 0
-      `-- 1
-          `-- subdir
-              `-- 0
-  
-  6 directories, 2 files
-  $ git diff ${EMPTY_TREE}..${FILTER_HASH}
-  diff --git a/compose/0/subdir/0 b/compose/0/subdir/0
-  new file mode 100644
-  index 0000000..2e65efe
-  --- /dev/null
-  +++ b/compose/0/subdir/0
-  @@ -0,0 +1 @@
-  +a
-  \ No newline at end of file
-  diff --git a/compose/1/subdir/0 b/compose/1/subdir/0
-  new file mode 100644
-  index 0000000..63d8dbd
-  --- /dev/null
-  +++ b/compose/1/subdir/0
-  @@ -0,0 +1 @@
-  +b
-  \ No newline at end of file
+  └── compose/
+      ├── 0/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  a
+      └── 1/
+          └── subdir/
+              └── 0
+                  ╵  b
   $ josh-filter -p :/"a"
   :/a
   $ josh-filter --reverse -p :/a
@@ -62,96 +44,43 @@
       x = :/b/d
       y = :/c/d
   ]
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- chain
-      |-- 0
-      |   `-- subdir
-      |       `-- 0
-      `-- 1
-          `-- compose
-              |-- 0
-              |   `-- chain
-              |       |-- 0
-              |       |   `-- subdir
-              |       |       `-- 0
-              |       |-- 1
-              |       |   `-- subdir
-              |       |       `-- 0
-              |       `-- 2
-              |           `-- prefix
-              |               `-- 0
-              `-- 1
-                  `-- chain
-                      |-- 0
-                      |   `-- subdir
-                      |       `-- 0
-                      |-- 1
-                      |   `-- subdir
-                      |       `-- 0
-                      `-- 2
-                          `-- prefix
-                              `-- 0
-  
-  22 directories, 7 files
-  $ git diff ${EMPTY_TREE}..${FILTER_HASH}
-  diff --git a/chain/0/subdir/0 b/chain/0/subdir/0
-  new file mode 100644
-  index 0000000..2e65efe
-  --- /dev/null
-  +++ b/chain/0/subdir/0
-  @@ -0,0 +1 @@
-  +a
-  \ No newline at end of file
-  diff --git a/chain/1/compose/0/chain/0/subdir/0 b/chain/1/compose/0/chain/0/subdir/0
-  new file mode 100644
-  index 0000000..63d8dbd
-  --- /dev/null
-  +++ b/chain/1/compose/0/chain/0/subdir/0
-  @@ -0,0 +1 @@
-  +b
-  \ No newline at end of file
-  diff --git a/chain/1/compose/0/chain/1/subdir/0 b/chain/1/compose/0/chain/1/subdir/0
-  new file mode 100644
-  index 0000000..c59d9b6
-  --- /dev/null
-  +++ b/chain/1/compose/0/chain/1/subdir/0
-  @@ -0,0 +1 @@
-  +d
-  \ No newline at end of file
-  diff --git a/chain/1/compose/0/chain/2/prefix/0 b/chain/1/compose/0/chain/2/prefix/0
-  new file mode 100644
-  index 0000000..c1b0730
-  --- /dev/null
-  +++ b/chain/1/compose/0/chain/2/prefix/0
-  @@ -0,0 +1 @@
-  +x
-  \ No newline at end of file
-  diff --git a/chain/1/compose/1/chain/0/subdir/0 b/chain/1/compose/1/chain/0/subdir/0
-  new file mode 100644
-  index 0000000..3410062
-  --- /dev/null
-  +++ b/chain/1/compose/1/chain/0/subdir/0
-  @@ -0,0 +1 @@
-  +c
-  \ No newline at end of file
-  diff --git a/chain/1/compose/1/chain/1/subdir/0 b/chain/1/compose/1/chain/1/subdir/0
-  new file mode 100644
-  index 0000000..c59d9b6
-  --- /dev/null
-  +++ b/chain/1/compose/1/chain/1/subdir/0
-  @@ -0,0 +1 @@
-  +d
-  \ No newline at end of file
-  diff --git a/chain/1/compose/1/chain/2/prefix/0 b/chain/1/compose/1/chain/2/prefix/0
-  new file mode 100644
-  index 0000000..e25f181
-  --- /dev/null
-  +++ b/chain/1/compose/1/chain/2/prefix/0
-  @@ -0,0 +1 @@
-  +y
-  \ No newline at end of file
+  └── chain/
+      ├── 0/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  a
+      └── 1/
+          └── compose/
+              ├── 0/
+              │   └── chain/
+              │       ├── 0/
+              │       │   └── subdir/
+              │       │       └── 0
+              │       │           ╵  b
+              │       ├── 1/
+              │       │   └── subdir/
+              │       │       └── 0
+              │       │           ╵  d
+              │       └── 2/
+              │           └── prefix/
+              │               └── 0
+              │                   ╵  x
+              └── 1/
+                  └── chain/
+                      ├── 0/
+                      │   └── subdir/
+                      │       └── 0
+                      │           ╵  c
+                      ├── 1/
+                      │   └── subdir/
+                      │       └── 0
+                      │           ╵  d
+                      └── 2/
+                          └── prefix/
+                              └── 0
+                                  ╵  y
   $ josh-filter --reverse -p :[x=:/a:/b:/d,y=:/a:/c:/d]
   a = :[
       b/d = :/x
@@ -419,14 +348,13 @@ Test ::file.txt (single argument, no trailing slash, no =, no *)
   $ FILTER_HASH=$(josh-filter -i ::file.txt)
   $ josh-filter -p ${FILTER_HASH}
   ::file.txt
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- file
-      |-- 0
-      `-- 1
-  
-  2 directories, 2 files
+  └── file/
+      ├── 0
+      │   ╵  file.txt
+      └── 1
+          ╵  file.txt
   $ git diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904..${FILTER_HASH}
   diff --git a/file/0 b/file/0
   new file mode 100644
@@ -449,14 +377,13 @@ Test ::dest.txt=src.txt (with =, destination=source)
   $ FILTER_HASH=$(josh-filter -i ::dest.txt=src.txt)
   $ josh-filter -p ${FILTER_HASH}
   ::dest.txt=src.txt
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- file
-      |-- 0
-      `-- 1
-  
-  2 directories, 2 files
+  └── file/
+      ├── 0
+      │   ╵  dest.txt
+      └── 1
+          ╵  src.txt
   $ git diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904..${FILTER_HASH}
   diff --git a/file/0 b/file/0
   new file mode 100644
@@ -479,13 +406,11 @@ Test ::*.txt (with *, pattern)
   $ FILTER_HASH=$(josh-filter -i ::*.txt)
   $ josh-filter -p ${FILTER_HASH}
   ::*.txt
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- pattern
-      `-- 0
-  
-  2 directories, 1 file
+  └── pattern/
+      └── 0
+          ╵  *.txt
   $ git diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904..${FILTER_HASH}
   diff --git a/pattern/0 b/pattern/0
   new file mode 100644
@@ -500,18 +425,17 @@ Test ::dir/ (with trailing slash, directory)
   $ FILTER_HASH=$(josh-filter -i ::dir/)
   $ josh-filter -p ${FILTER_HASH}
   ::dir/
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- chain
-      |-- 0
-      |   `-- subdir
-      |       `-- 0
-      `-- 1
-          `-- prefix
-              `-- 0
-  
-  6 directories, 2 files
+  └── chain/
+      ├── 0/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  dir
+      └── 1/
+          └── prefix/
+              └── 0
+                  ╵  dir
   $ git diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904..${FILTER_HASH}
   diff --git a/chain/0/subdir/0 b/chain/0/subdir/0
   new file mode 100644
@@ -534,30 +458,33 @@ Test ::a/b/c/ (nested directory path with trailing slash)
   $ FILTER_HASH=$(josh-filter -i ::a/b/c/)
   $ josh-filter -p ${FILTER_HASH}
   ::a/b/c/
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- chain
-      |-- 0
-      |   `-- subdir
-      |       `-- 0
-      |-- 1
-      |   `-- subdir
-      |       `-- 0
-      |-- 2
-      |   `-- subdir
-      |       `-- 0
-      |-- 3
-      |   `-- prefix
-      |       `-- 0
-      |-- 4
-      |   `-- prefix
-      |       `-- 0
-      `-- 5
-          `-- prefix
-              `-- 0
-  
-  14 directories, 6 files
+  └── chain/
+      ├── 0/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  a
+      ├── 1/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  b
+      ├── 2/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  c
+      ├── 3/
+      │   └── prefix/
+      │       └── 0
+      │           ╵  c
+      ├── 4/
+      │   └── prefix/
+      │       └── 0
+      │           ╵  b
+      └── 5/
+          └── prefix/
+              └── 0
+                  ╵  a
   $ git diff 4b825dc642cb6eb9a060e54bf8d69288fbee4904..${FILTER_HASH}
   diff --git a/chain/0/subdir/0 b/chain/0/subdir/0
   new file mode 100644
@@ -633,23 +560,17 @@ Test :FOLD
   $ FILTER_HASH=$(josh-filter -i ':FOLD')
   $ josh-filter -p ${FILTER_HASH}
   :FOLD
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- fold
-  
-  1 directory, 1 file
+  └── fold
 
 Test :PATHS
   $ FILTER_HASH=$(josh-filter -i ':PATHS')
   $ josh-filter -p ${FILTER_HASH}
   :PATHS
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- paths
-  
-  1 directory, 1 file
+  └── paths
 
 Test :INDEX (the filter is experimental; parsing it needs the opt-in)
   $ josh-filter -i ':INDEX' 2>&1 | head -1
@@ -657,23 +578,17 @@ Test :INDEX (the filter is experimental; parsing it needs the opt-in)
   $ FILTER_HASH=$(JOSH_EXPERIMENTAL_FEATURES=1 josh-filter -i ':INDEX')
   $ josh-filter -p ${FILTER_HASH}
   :INDEX
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- index
-  
-  1 directory, 1 file
+  └── index
 
 Test :INVERT
   $ FILTER_HASH=$(josh-filter -i ':INVERT')
   $ josh-filter -p ${FILTER_HASH}
   :INVERT
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- invert
-  
-  1 directory, 1 file
+  └── invert
 
 Test :linear
   $ FILTER_HASH=$(josh-filter -i ':linear')
@@ -683,15 +598,13 @@ Test :linear
   )[
       :/
   ]
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- meta
-      |-- 0
-      |   `-- nop
-      `-- history
-  
-  3 directories, 2 files
+  └── meta/
+      ├── 0/
+      │   └── nop
+      └── history
+          ╵  linear
 
   $ FILTER_HASH=$(josh-filter -i ':linear[::x/]')
   $ josh-filter -p ${FILTER_HASH}
@@ -700,34 +613,32 @@ Test :linear
   )[
       ::x/
   ]
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- meta
-      |-- 0
-      |   `-- compose
-      |       `-- 0
-      |           `-- chain
-      |               |-- 0
-      |               |   `-- subdir
-      |               |       `-- 0
-      |               `-- 1
-      |                   `-- prefix
-      |                       `-- 0
-      `-- history
-  
-  10 directories, 3 files
+  └── meta/
+      ├── 0/
+      │   └── compose/
+      │       └── 0/
+      │           └── chain/
+      │               ├── 0/
+      │               │   └── subdir/
+      │               │       └── 0
+      │               │           ╵  x
+      │               └── 1/
+      │                   └── prefix/
+      │                       └── 0
+      │                           ╵  x
+      └── history
+          ╵  linear
 
 Test :prune=trivial-merge
   $ FILTER_HASH=$(josh-filter -i ':prune=trivial-merge')
   $ josh-filter -p ${FILTER_HASH}
   :prune=trivial-merge
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- prune
-  
-  1 directory, 1 file
+  └── prune
+      ╵  trivial-merge
 
 Test :unsign
   $ FILTER_HASH=$(josh-filter -i ':unsign')
@@ -737,128 +648,111 @@ Test :unsign
   )[
       :/
   ]
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- meta
-      |-- 0
-      |   `-- nop
-      `-- gpgsig
-  
-  3 directories, 2 files
+  └── meta/
+      ├── 0/
+      │   └── nop
+      └── gpgsig
+          ╵  remove
 
 Test :workspace=path/to/workspace
   $ FILTER_HASH=$(josh-filter -i ':workspace=path/to/workspace')
   $ josh-filter -p ${FILTER_HASH}
   :workspace=path/to/workspace
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- workspace
-      `-- 0
-  
-  2 directories, 1 file
+  └── workspace/
+      └── 0
+          ╵  path/to/workspace
 
 Test :+path/to/stored
   $ FILTER_HASH=$(josh-filter -i ':+path/to/stored')
   $ josh-filter -p ${FILTER_HASH}
   :+path/to/stored
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- stored
-      `-- 0
-  
-  2 directories, 1 file
+  └── stored/
+      └── 0
+          ╵  path/to/stored
 
 Test :hook=hookname
   $ FILTER_HASH=$(josh-filter -i ':hook=hookname')
   $ josh-filter -p ${FILTER_HASH}
   :hook="hookname"
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- hook
-      `-- 0
-  
-  2 directories, 1 file
+  └── hook/
+      └── 0
+          ╵  hookname
 
 Test :author=Name;email@example.com
   $ FILTER_HASH=$(josh-filter -i ':author="Name";"email@example.com"')
   $ josh-filter -p ${FILTER_HASH}
   :author="Name";"email@example.com"
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- author
-      |-- 0
-      `-- 1
-  
-  2 directories, 2 files
+  └── author/
+      ├── 0
+      │   ╵  Name
+      └── 1
+          ╵  email@example.com
 
 Test :committer=Name;email@example.com
   $ FILTER_HASH=$(josh-filter -i ':committer="Name";"email@example.com"')
   $ josh-filter -p ${FILTER_HASH}
   :committer="Name";"email@example.com"
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- committer
-      |-- 0
-      `-- 1
-  
-  2 directories, 2 files
+  └── committer/
+      ├── 0
+      │   ╵  Name
+      └── 1
+          ╵  email@example.com
 
 Test :"commit message"
   $ FILTER_HASH=$(josh-filter -i ':"commit message"')
   $ josh-filter -p ${FILTER_HASH}
   :"commit message"
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- message
-      |-- 0
-      `-- 1
-  
-  2 directories, 2 files
+  └── message/
+      ├── 0
+      │   ╵  commit message
+      └── 1
+          ╵  (?s)^.*$
 
 Test :"commit message";".*"
   $ FILTER_HASH=$(josh-filter -i ':"commit message";".*"')
   $ josh-filter -p ${FILTER_HASH}
   :"commit message";".*"
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- message
-      |-- 0
-      `-- 1
-  
-  2 directories, 2 files
+  └── message/
+      ├── 0
+      │   ╵  commit message
+      └── 1
+          ╵  .*
 
 Test :pin[:/a]
   $ FILTER_HASH=$(josh-filter -i ':pin[:/a]')
   $ josh-filter -p ${FILTER_HASH}
   :pin[:/a]
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- pin
-      `-- 0
-          `-- subdir
-              `-- 0
-  
-  4 directories, 1 file
+  └── pin/
+      └── 0/
+          └── subdir/
+              └── 0
+                  ╵  a
 
 Test :SQUASH
   $ FILTER_HASH=$(josh-filter -i ':SQUASH')
   $ josh-filter -p ${FILTER_HASH}
   :SQUASH
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- squash
-  
-  1 directory, 1 file
+  └── squash
 
 Test :replace("pattern":"replacement")
   $ FILTER_HASH=$(josh-filter -i ':replace("pattern":"replacement")')
@@ -866,31 +760,29 @@ Test :replace("pattern":"replacement")
   :replace(
       "pattern":"replacement"
   )
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- regex_replace
-      `-- 0
-          |-- p
-          `-- r
-  
-  3 directories, 2 files
+  └── regex_replace/
+      └── 0/
+          ├── p
+          │   ╵  pattern
+          └── r
+              ╵  replacement
 
 Test :rev(_:/a)
   $ FILTER_HASH=$(josh-filter -i ':rev(_:/a)')
   $ josh-filter -p ${FILTER_HASH}
   :rev(_:/a)
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- rev
-      `-- 0
-          |-- f
-          |   `-- subdir
-          |       `-- 0
-          `-- o
-  
-  5 directories, 2 files
+  └── rev/
+      └── 0/
+          ├── f/
+          │   └── subdir/
+          │       └── 0
+          │           ╵  a
+          └── o
+              ╵  _
 
 
   $ FILTER_HASH=$(josh-filter -i ':~(key1="value1",key2="value2",a="b")[:/sub1]')
@@ -902,15 +794,16 @@ Test :rev(_:/a)
   )[
       :/sub1
   ]
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- meta
-      |-- 0
-      |   `-- subdir
-      |       `-- 0
-      |-- a
-      |-- key1
-      `-- key2
-  
-  4 directories, 4 files
+  └── meta/
+      ├── 0/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  sub1
+      ├── a
+      │   ╵  b
+      ├── key1
+      │   ╵  value1
+      └── key2
+          ╵  value2

--- a/tests/filter/hide_view.t
+++ b/tests/filter/hide_view.t
@@ -23,15 +23,16 @@
   * add file2
   * add file1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   |-- file1
-  |   `-- file2
-  `-- sub2
-      `-- file3
-  
-  3 directories, 3 files
+  ├── sub1/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file2
+  │       ┆  contents2
+  └── sub2/
+      └── file3
+          ┆  contents1
 
   $ josh-filter -s c=:exclude[::sub1/] master --update refs/josh/filter/master
   ba6cff78351dfd8135eb25c543f17fcb80b79e2e
@@ -42,13 +43,12 @@
   $ git checkout josh/filter/master 2> /dev/null
   $ git log --graph --pretty=%s
   * add file3
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- c
-      `-- sub2
-          `-- file3
-  
-  3 directories, 1 file
+  └── c/
+      └── sub2/
+          └── file3
+              ┆  contents1
 
   $ josh-filter -s c=:exclude[::sub1/file2] master --update refs/josh/filter/master
   d407c3a1d5fc72fb0e001795b08d76c4b246f8d0
@@ -61,15 +61,15 @@
   $ git log --graph --pretty=%s
   * add file3
   * add file1
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- c
-      |-- sub1
-      |   `-- file1
-      `-- sub2
-          `-- file3
-  
-  4 directories, 2 files
+  └── c/
+      ├── sub1/
+      │   └── file1
+      │       ┆  contents1
+      └── sub2/
+          └── file3
+              ┆  contents1
 
   $ josh-filter -s c=:exclude[::sub2/file3] master --update refs/josh/filter/master
   04cda64def8cdb4ef3c4507362e5d66c58bd935e
@@ -83,11 +83,11 @@
   $ git log --graph --pretty=%s
   * add file2
   * add file1
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- c
-      `-- sub1
-          |-- file1
-          `-- file2
-  
-  3 directories, 2 files
+  └── c/
+      └── sub1/
+          ├── file1
+          │   ┆  contents1
+          └── file2
+              ┆  contents2

--- a/tests/filter/insert.t
+++ b/tests/filter/insert.t
@@ -49,22 +49,12 @@ Apply: blob at a multi-component path lands at the nested destination
 
 Apply: compose with blob inserts blob alongside other files
   $ josh-filter -s ':[:/sub1,:$added.txt="hello world"]' master --update refs/josh/filter/master2 1> /dev/null
-  $ git diff ${EMPTY_TREE}..josh/filter/master2
-  diff --git a/added.txt b/added.txt
-  new file mode 100644
-  index 0000000..95d09f2
-  --- /dev/null
-  +++ b/added.txt
-  @@ -0,0 +1 @@
-  +hello world
-  \ No newline at end of file
-  diff --git a/file1 b/file1
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/file1
-  @@ -0,0 +1 @@
-  +contents1
+  $ git-tree-pretty josh/filter/master2
+  .
+  ├── added.txt
+  │   ╵  hello world
+  └── file1
+      ┆  contents1
 
 Apply: composing many inserts across sibling directories keeps every insert
 (regression: an insert group must invert to :empty, not a union of excludes,

--- a/tests/filter/pin_compose.t
+++ b/tests/filter/pin_compose.t
@@ -37,22 +37,28 @@ will take priority over the next tree in the composition filter
 
 Here's the repo layout at this point:
 
-  $ tree .
+  $ git add .
+  $ git-tree-pretty +
   .
-  |-- code
-  |   |-- app.js
-  |   `-- lib.js
-  |-- josh
-  |   `-- overlay
-  `-- workspaces
-      `-- overlay
-          `-- workspace.josh
-  
-  6 directories, 3 files
+  ├── code/
+  │   ├── app.js
+  │   │   ┆  async fn main() {
+  │   │   ┆    await fetch("http://127.0.0.1");
+  │   │   ┆  }
+  │   └── lib.js
+  │       ┆  fn log() {
+  │       ┆    console.log("logged!");
+  │       ┆  }
+  └── workspaces/
+      └── overlay/
+          └── workspace.josh
+              ┆  :[
+              ┆    :/code
+              ┆    :/josh/overlay
+              ┆  ]
 
 Commit this:
 
-  $ git add .
   $ git commit -q -m "first commit"
 
 Now, filter the ws and check the result

--- a/tests/filter/replace.t
+++ b/tests/filter/replace.t
@@ -16,21 +16,13 @@
    create mode 100644 hw.txt
    create mode 100644 subdir/hw.txt
 
-  $ git diff ${EMPTY_TREE}..refs/heads/master
-  diff --git a/hw.txt b/hw.txt
-  new file mode 100644
-  index 0000000..3b18e51
-  --- /dev/null
-  +++ b/hw.txt
-  @@ -0,0 +1 @@
-  +hello world
-  diff --git a/subdir/hw.txt b/subdir/hw.txt
-  new file mode 100644
-  index 0000000..1b95c6e
-  --- /dev/null
-  +++ b/subdir/hw.txt
-  @@ -0,0 +1 @@
-  +hello moon
+  $ git-tree-pretty refs/heads/master
+  .
+  ├── hw.txt
+  │   ┆  hello world
+  └── subdir/
+      └── hw.txt
+          ┆  hello moon
 
   $ josh-filter -p ':replace("hello":"bye","^(?P<l>.*(?m))$":"$l!")'
   :replace(
@@ -40,55 +32,31 @@
   $ josh-filter --update refs/heads/filtered ':replace("hello":"bye","(?m)^(?P<l>.+)$":"$l!")'
   f44b7f09eac089146c824d1f149b3b155e7cda50
 
-  $ git diff ${EMPTY_TREE}..refs/heads/filtered
-  diff --git a/hw.txt b/hw.txt
-  new file mode 100644
-  index 0000000..9836695
-  --- /dev/null
-  +++ b/hw.txt
-  @@ -0,0 +1 @@
-  +bye world!
-  diff --git a/subdir/hw.txt b/subdir/hw.txt
-  new file mode 100644
-  index 0000000..cb72486
-  --- /dev/null
-  +++ b/subdir/hw.txt
-  @@ -0,0 +1 @@
-  +bye moon!
+  $ git-tree-pretty refs/heads/filtered
+  .
+  ├── hw.txt
+  │   ┆  bye world!
+  └── subdir/
+      └── hw.txt
+          ┆  bye moon!
 
   $ josh-filter --update refs/heads/filtered --reverse ':replace("hello":"bye","(?m)^(?P<l>.+)$":"$l!")'
   79f224d32bbdf7dcec1b488336f6c0baa4712138
 
-  $ git diff ${EMPTY_TREE}..refs/heads/master
-  diff --git a/hw.txt b/hw.txt
-  new file mode 100644
-  index 0000000..3b18e51
-  --- /dev/null
-  +++ b/hw.txt
-  @@ -0,0 +1 @@
-  +hello world
-  diff --git a/subdir/hw.txt b/subdir/hw.txt
-  new file mode 100644
-  index 0000000..1b95c6e
-  --- /dev/null
-  +++ b/subdir/hw.txt
-  @@ -0,0 +1 @@
-  +hello moon
+  $ git-tree-pretty refs/heads/master
+  .
+  ├── hw.txt
+  │   ┆  hello world
+  └── subdir/
+      └── hw.txt
+          ┆  hello moon
 
   $ josh-filter --update refs/heads/filtered ':[xdir=:/subdir,:replace("hello":"bye","(?m)^(?P<l>.+)$":"$l!")]'
   80d073c7484b37d564025d7e760e4511ca6d0785
-  $ git diff ${EMPTY_TREE}..refs/heads/filtered
-  diff --git a/hw.txt b/hw.txt
-  new file mode 100644
-  index 0000000..9836695
-  --- /dev/null
-  +++ b/hw.txt
-  @@ -0,0 +1 @@
-  +bye world!
-  diff --git a/xdir/hw.txt b/xdir/hw.txt
-  new file mode 100644
-  index 0000000..1b95c6e
-  --- /dev/null
-  +++ b/xdir/hw.txt
-  @@ -0,0 +1 @@
-  +hello moon
+  $ git-tree-pretty refs/heads/filtered
+  .
+  ├── hw.txt
+  │   ┆  bye world!
+  └── xdir/
+      └── hw.txt
+          ┆  hello moon

--- a/tests/filter/rev.t
+++ b/tests/filter/rev.t
@@ -178,18 +178,24 @@
   * e707f76bb6a1390f28b2162da5b5eb6933009070:5d8a699f74b48c9c595f4615dd3755244e11d176
   * 0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb:3d77ff51363c9825cc2a221fc0ba5a883a1a2c72
 
-  $ git diff --stat ${EMPTY_TREE}..f8e8bc9daf54340c9fce647be467d2577b623bbe
-   file1 | 1 +
-   file2 | 1 +
-   file3 | 1 +
-   3 files changed, 3 insertions(+)
-  $ git diff --stat ${EMPTY_TREE}..e707f76bb6a1390f28b2162da5b5eb6933009070
-   file1 | 1 +
-   file2 | 1 +
-   2 files changed, 2 insertions(+)
-  $ git diff --stat ${EMPTY_TREE}..0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb
-   file1 | 1 +
-   1 file changed, 1 insertion(+)
+  $ git-tree-pretty f8e8bc9daf54340c9fce647be467d2577b623bbe
+  .
+  ├── file1
+  │   ┆  contents2
+  ├── file2
+  │   ┆  contents3
+  └── file3
+      ┆  contents3
+  $ git-tree-pretty e707f76bb6a1390f28b2162da5b5eb6933009070
+  .
+  ├── file1
+  │   ┆  contents1
+  └── file2
+      ┆  contents3
+  $ git-tree-pretty 0b4cf6c9efbbda1eada39fa9c1d21d2525b027bb
+  .
+  └── file1
+      ┆  contents1
 
   $ cat > filter.josh <<EOF
   > :linear:rev(
@@ -219,15 +225,24 @@
   * f3378cf22f8de05bd2b411b640df4096e0fcf4d2:3440aebdbc752b9f2671b57f02df3a023788d849
   * 902467f53eaa9c352159cf8a81c72715bdb3a4c3:cf77b08d2fe1c0530a1bcd10c5d3434737a80cc5
 
-  $ git diff --stat ${EMPTY_TREE}..refs/heads/filtered
-   x/file1 | 1 +
-   x/file2 | 1 +
-   x/file3 | 1 +
-   3 files changed, 3 insertions(+)
-  $ git diff --stat ${EMPTY_TREE}..refs/heads/filtered~1
-   x/file1 | 1 +
-   x/file2 | 1 +
-   2 files changed, 2 insertions(+)
-  $ git diff --stat ${EMPTY_TREE}..refs/heads/filtered~2
-   x/file1 | 1 +
-   1 file changed, 1 insertion(+)
+  $ git-tree-pretty refs/heads/filtered
+  .
+  └── x/
+      ├── file1
+      │   ┆  contents2
+      ├── file2
+      │   ┆  contents3
+      └── file3
+          ┆  contents3
+  $ git-tree-pretty refs/heads/filtered~1
+  .
+  └── x/
+      ├── file1
+      │   ┆  contents1
+      └── file2
+          ┆  contents3
+  $ git-tree-pretty refs/heads/filtered~2
+  .
+  └── x/
+      └── file1
+          ┆  contents1

--- a/tests/filter/reverse_hide.t
+++ b/tests/filter/reverse_hide.t
@@ -21,12 +21,11 @@
   [2] sequence_number
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
   $ git log --graph --pretty=%s
   * add file1
 
@@ -43,19 +42,18 @@
   $ git checkout master
   Switched to branch 'master'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   |-- file1
-  |   `-- file3
-  `-- sub2
-      `-- file2
-  
-  3 directories, 3 files
+  ├── sub1/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file3
+  │       ┆  contents3
+  └── sub2/
+      └── file2
+          ┆  contents1
 
 
-  $ cat sub1/file3
-  contents3
 
   $ git log --graph --pretty=%s
   * add sub1/file3

--- a/tests/filter/reverse_hide_edit.t
+++ b/tests/filter/reverse_hide_edit.t
@@ -21,12 +21,11 @@
   [2] sequence_number
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
   $ git log --graph --pretty=%s
   * add file1
 
@@ -59,12 +58,13 @@
    contents1
   +contents3
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- file1
-  `-- sub2
-      `-- file2
-  
-  3 directories, 2 files
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  │       ┆  contents3
+  └── sub2/
+      └── file2
+          ┆  contents1
 

--- a/tests/filter/reverse_hide_edit_missing_change.t
+++ b/tests/filter/reverse_hide_edit_missing_change.t
@@ -16,16 +16,18 @@
   $ git add .
   $ git commit -m "add file2" 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- rootfile
-  |-- sub2
-  |   |-- file1
-  |   `-- file2
-  `-- subx
-      `-- filex
-  
-  3 directories, 4 files
+  ├── rootfile
+  │   ┆  contentsroot
+  ├── sub2/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file2
+  │       ┆  contents2
+  └── subx/
+      └── filex
+          ┆  contentsx
 
   $ josh-filter -s :exclude[::sub2/] master --update refs/heads/hidden
   e736ad9e31a359186cd09c3a234bc497d5de7462
@@ -34,13 +36,13 @@
   [2] sequence_number
   $ git checkout hidden 1> /dev/null
   Switched to branch 'hidden'
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- rootfile
-  `-- subx
-      `-- filex
-  
-  2 directories, 2 files
+  ├── rootfile
+  │   ┆  contentsroot
+  └── subx/
+      └── filex
+          ┆  contentsx
   $ git log --graph --pretty=%s
   * add file1
 
@@ -81,14 +83,17 @@
    contentsx
   +new_x
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- rootfile
-  |-- sub2
-  |   |-- file1
-  |   `-- file2
-  `-- subx
-      `-- filex
-  
-  3 directories, 4 files
+  ├── rootfile
+  │   ┆  new_root
+  ├── sub2/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file2
+  │       ┆  contents2
+  └── subx/
+      └── filex
+          ┆  contentsx
+          ┆  new_x
 

--- a/tests/filter/reverse_merge.t
+++ b/tests/filter/reverse_merge.t
@@ -31,12 +31,11 @@
   [2] sequence_number
   $ git checkout hidden_branch1
   Switched to branch 'hidden_branch1'
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
   $ echo contents3 > sub1/file3
   $ git add sub1/file3
   $ git commit -m "add file3" 1> /dev/null
@@ -48,13 +47,13 @@
   [3] sequence_number
   $ git checkout hidden_master
   Switched to branch 'hidden_master'
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      `-- file2
-  
-  2 directories, 2 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      └── file2
+          ┆  contents1
   $ echo contents4 > sub1/file4
   $ git add sub1/file4
   $ git commit -m "add file4" 1> /dev/null
@@ -86,17 +85,20 @@
   $ git checkout master
   Switched to branch 'master'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   |-- file1
-  |   |-- file2
-  |   |-- file3
-  |   `-- file4
-  `-- sub2
-      `-- file2
-  
-  3 directories, 5 files
+  ├── sub1/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   ├── file2
+  │   │   ┆  contents1
+  │   ├── file3
+  │   │   ┆  contents3
+  │   └── file4
+  │       ┆  contents4
+  └── sub2/
+      └── file2
+          ┆  contents1
 
 
 

--- a/tests/filter/reverse_split.t
+++ b/tests/filter/reverse_split.t
@@ -23,14 +23,14 @@
   [2] sequence_number
   $ git checkout filtered 1> /dev/null
   Switched to branch 'filtered'
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- file1.a
-  `-- rest
-      `-- file2.b
-  
-  3 directories, 2 files
+  ├── a/
+  │   └── file1.a
+  │       ┆  contents1
+  └── rest/
+      └── file2.b
+          ┆  contents1
   $ git log --graph --pretty=%s
   * add file2.b
   * add file1.a
@@ -75,12 +75,14 @@
   @@ -0,0 +1 @@
   +contents3
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1.a
-  |-- file2.b
-  |-- file3.a
-  `-- file4.b
-  
-  1 directory, 4 files
+  ├── file1.a
+  │   ┆  contents1
+  ├── file2.b
+  │   ┆  contents1
+  ├── file3.a
+  │   ┆  contents3
+  └── file4.b
+      ┆  contents3
 

--- a/tests/filter/roundtrip_custom_header.t
+++ b/tests/filter/roundtrip_custom_header.t
@@ -19,21 +19,13 @@
    1 file changed, 1 insertion(+)
    create mode 100644 subdir/hw.txt
 
-  $ git diff ${EMPTY_TREE}..refs/heads/master
-  diff --git a/hw.txt b/hw.txt
-  new file mode 100644
-  index 0000000..3b18e51
-  --- /dev/null
-  +++ b/hw.txt
-  @@ -0,0 +1 @@
-  +hello world
-  diff --git a/subdir/hw.txt b/subdir/hw.txt
-  new file mode 100644
-  index 0000000..1b95c6e
-  --- /dev/null
-  +++ b/subdir/hw.txt
-  @@ -0,0 +1 @@
-  +hello moon
+  $ git-tree-pretty refs/heads/master
+  .
+  ├── hw.txt
+  │   ┆  hello world
+  └── subdir/
+      └── hw.txt
+          ┆  hello moon
 
 Write a custom header into the commit (h/t https://github.com/Byron/gitoxide/blob/68cbea8gix/tests/fixtures/make_pre_epoch_repo.sh#L12-L27)
   $ git cat-file -p @ | tee commit.txt
@@ -69,21 +61,14 @@ Write a custom header into the commit (h/t https://github.com/Byron/gitoxide/blo
   $ josh-filter --update refs/heads/filtered ':prefix=pre'
   63982dc9240ef0b6dc10fa1643bfa8700b5e2a3f
 
-  $ git diff ${EMPTY_TREE}..refs/heads/filtered
-  diff --git a/pre/hw.txt b/pre/hw.txt
-  new file mode 100644
-  index 0000000..3b18e51
-  --- /dev/null
-  +++ b/pre/hw.txt
-  @@ -0,0 +1 @@
-  +hello world
-  diff --git a/pre/subdir/hw.txt b/pre/subdir/hw.txt
-  new file mode 100644
-  index 0000000..1b95c6e
-  --- /dev/null
-  +++ b/pre/subdir/hw.txt
-  @@ -0,0 +1 @@
-  +hello moon
+  $ git-tree-pretty refs/heads/filtered
+  .
+  └── pre/
+      ├── hw.txt
+      │   ┆  hello world
+      └── subdir/
+          └── hw.txt
+              ┆  hello moon
 
   $ git cat-file -p refs/heads/filtered
   tree 6876aad1a2259b9d4c7c24e0e3ff908d3d580404

--- a/tests/filter/scope_filter.t
+++ b/tests/filter/scope_filter.t
@@ -17,24 +17,21 @@ Test basic scope filter syntax :<X>[Y]
   $ FILTER_HASH=$(josh-filter -i ':<:/sub1>[:/file1]')
   $ josh-filter -p ${FILTER_HASH}
   sub1 = :/sub1/file1
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- chain
-      |-- 0
-      |   `-- subdir
-      |       `-- 0
-      |-- 1
-      |   `-- subdir
-      |       `-- 0
-      `-- 2
-          `-- prefix
-              `-- 0
-  
-  8 directories, 3 files
-  $ cat sub1/file1
-  cat: sub1/file1: No such file or directory
-  [1]
+  └── chain/
+      ├── 0/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  sub1
+      ├── 1/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  file1
+      └── 2/
+          └── prefix/
+              └── 0
+                  ╵  sub1
 
 Test scope filter with multiple filters in compose
   $ FILTER_HASH=$(josh-filter -i ':<:/sub1>[:/file1,:/sub2/file2]')
@@ -43,65 +40,65 @@ Test scope filter with multiple filters in compose
       :/file1
       :/sub2/file2
   ]
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- chain
-      |-- 0
-      |   `-- subdir
-      |       `-- 0
-      |-- 1
-      |   `-- compose
-      |       |-- 0
-      |       |   `-- subdir
-      |       |       `-- 0
-      |       `-- 1
-      |           `-- chain
-      |               |-- 0
-      |               |   `-- subdir
-      |               |       `-- 0
-      |               `-- 1
-      |                   `-- subdir
-      |                       `-- 0
-      `-- 2
-          `-- prefix
-              `-- 0
-  
-  16 directories, 5 files
+  └── chain/
+      ├── 0/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  sub1
+      ├── 1/
+      │   └── compose/
+      │       ├── 0/
+      │       │   └── subdir/
+      │       │       └── 0
+      │       │           ╵  file1
+      │       └── 1/
+      │           └── chain/
+      │               ├── 0/
+      │               │   └── subdir/
+      │               │       └── 0
+      │               │           ╵  sub2
+      │               └── 1/
+      │                   └── subdir/
+      │                       └── 0
+      │                           ╵  file2
+      └── 2/
+          └── prefix/
+              └── 0
+                  ╵  sub1
 
 Test scope filter with prefix filter
   $ FILTER_HASH=$(josh-filter -i ':<:prefix=sub1>[:prefix=file1]')
   $ josh-filter -p ${FILTER_HASH}
   :empty
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- empty
-  
-  1 directory, 1 file
+  └── empty
 
 Test scope filter with subdir and exclude
   $ FILTER_HASH=$(josh-filter -i ':<:/sub1>[:exclude[::file1]]')
   $ josh-filter -p ${FILTER_HASH}
   sub1 = :/sub1:exclude[::file1]
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- chain
-      |-- 0
-      |   `-- subdir
-      |       `-- 0
-      |-- 1
-      |   `-- exclude
-      |       `-- 0
-      |           `-- file
-      |               |-- 0
-      |               `-- 1
-      `-- 2
-          `-- prefix
-              `-- 0
-  
-  10 directories, 4 files
+  └── chain/
+      ├── 0/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  sub1
+      ├── 1/
+      │   └── exclude/
+      │       └── 0/
+      │           └── file/
+      │               ├── 0
+      │               │   ╵  file1
+      │               └── 1
+      │                   ╵  file1
+      └── 2/
+          └── prefix/
+              └── 0
+                  ╵  sub1
 
 Test scope filter verifies it expands to chain(X, chain(Y, invert(X)))
   $ FILTER_HASH=$(josh-filter -i ':<:/sub1>[:/file1]')
@@ -116,29 +113,31 @@ Test scope filter with nested filters
       :/file1
       :/sub2/file2
   ]
-  $ git read-tree --reset -u ${FILTER_HASH}
-  $ tree
+  $ git-tree-pretty ${FILTER_HASH}
   .
-  `-- chain
-      |-- 0
-      |   `-- subdir
-      |       `-- 0
-      |-- 1
-      |   `-- compose
-      |       |-- 0
-      |       |   `-- subdir
-      |       |       `-- 0
-      |       `-- 1
-      |           `-- chain
-      |               |-- 0
-      |               |   `-- subdir
-      |               |       `-- 0
-      |               `-- 1
-      |                   `-- subdir
-      |                       `-- 0
-      `-- 2
-          `-- prefix
-              `-- 0
-  
-  16 directories, 5 files
+  └── chain/
+      ├── 0/
+      │   └── subdir/
+      │       └── 0
+      │           ╵  sub1
+      ├── 1/
+      │   └── compose/
+      │       ├── 0/
+      │       │   └── subdir/
+      │       │       └── 0
+      │       │           ╵  file1
+      │       └── 1/
+      │           └── chain/
+      │               ├── 0/
+      │               │   └── subdir/
+      │               │       └── 0
+      │               │           ╵  sub2
+      │               └── 1/
+      │                   └── subdir/
+      │                       └── 0
+      │                           ╵  file2
+      └── 2/
+          └── prefix/
+              └── 0
+                  ╵  sub1
 

--- a/tests/filter/select.t
+++ b/tests/filter/select.t
@@ -24,15 +24,12 @@ select keeps only the paths matched by the inner filter (the complement of exclu
   [2] sequence_number
   $ git checkout selected 1> /dev/null
   Switched to branch 'selected'
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub2
-      `-- file2
-  
-  2 directories, 1 file
+  └── sub2/
+      └── file2
+          ┆  contents2
 
-  $ cat sub2/file2
-  contents2
 
 selecting into a subtree keeps only the matched file, dropping siblings and other trees:
 
@@ -42,12 +39,11 @@ selecting into a subtree keeps only the matched file, dropping siblings and othe
   179c05ebefb1e481a31334cdf6dc552e28e28151
   $ git checkout selected_file 1> /dev/null
   Switched to branch 'selected_file'
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
 
 :select[::sub2/] and :exclude[::sub1/] produce the same tree:

--- a/tests/filter/stored_combine_filter.t
+++ b/tests/filter/stored_combine_filter.t
@@ -33,21 +33,27 @@
   $ git add .
   $ git commit -m "add st" 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- st
-  |   `-- config.josh
-  |-- st2
-  |   `-- config.josh
-  |-- sub1
-  |   `-- file1
-  |-- sub2
-  |   `-- subsub
-  |       `-- file2
-  `-- sub3
-      `-- sub_file
-  
-  7 directories, 5 files
+  ├── st/
+  │   └── config.josh
+  │       ┆  x = :[::sub2/subsub/,::sub1/]
+  ├── st2/
+  │   └── config.josh
+  │       ┆  :[
+  │       ┆    a = :[::sub2/subsub/,::sub3/]
+  │       ┆    :/sub1:prefix=blub
+  │       ┆  ]:prefix=xyz
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  ├── sub2/
+  │   └── subsub/
+  │       └── file2
+  │           ┆  contents1
+  └── sub3/
+      └── sub_file
+          ┆  contents1
 
   $ josh-filter -s :+st/config
   9527d0249f419b172c6ca02390fde00f81e9c078
@@ -70,21 +76,20 @@
   * add file2
   * add file1
 
-  $ git checkout FILTERED_HEAD 2> /dev/null
-  $ tree
+  $ git-tree-pretty FILTERED_HEAD
   .
-  |-- st
-  |   `-- config.josh
-  `-- x
-      |-- sub1
-      |   `-- file1
-      `-- sub2
-          `-- subsub
-              `-- file2
-  
-  6 directories, 3 files
+  ├── st/
+  │   └── config.josh
+  │       ┆  x = :[::sub2/subsub/,::sub1/]
+  └── x/
+      ├── sub1/
+      │   └── file1
+      │       ┆  contents1
+      └── sub2/
+          └── subsub/
+              └── file2
+                  ┆  contents1
 
-  $ git checkout master 2> /dev/null
   $ josh-filter -s :+st2/config
   f9e1862628d454b0cc4e98305983335d9c615113
   [2] :+st/config
@@ -121,20 +126,24 @@
   * add file2
   * add file1
 
-  $ git checkout FILTERED_HEAD 2> /dev/null
-  $ tree
+  $ git-tree-pretty FILTERED_HEAD
   .
-  |-- st2
-  |   `-- config.josh
-  `-- xyz
-      |-- a
-      |   |-- sub2
-      |   |   `-- subsub
-      |   |       `-- file2
-      |   `-- sub3
-      |       `-- sub_file
-      `-- blub
-          `-- file1
-  
-  8 directories, 4 files
+  ├── st2/
+  │   └── config.josh
+  │       ┆  :[
+  │       ┆    a = :[::sub2/subsub/,::sub3/]
+  │       ┆    :/sub1:prefix=blub
+  │       ┆  ]:prefix=xyz
+  └── xyz/
+      ├── a/
+      │   ├── sub2/
+      │   │   └── subsub/
+      │   │       └── file2
+      │   │           ┆  contents1
+      │   └── sub3/
+      │       └── sub_file
+      │           ┆  contents1
+      └── blub/
+          └── file1
+              ┆  contents1
 

--- a/tests/filter/stored_implicit_filter.t
+++ b/tests/filter/stored_implicit_filter.t
@@ -41,16 +41,17 @@
   * add file2
   * add file1
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  |-- st
-  |   `-- config.josh
-  |-- sub1
-  |   `-- file1
-  `-- sub2
-      `-- subsub
-          `-- file2
-  
-  5 directories, 3 files
+  ├── st/
+  │   └── config.josh
+  │       ┆  ::sub2/subsub/
+  │       ┆  ::sub1/
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  └── sub2/
+      └── subsub/
+          └── file2
+              ┆  contents1
 

--- a/tests/filter/stored_redirect.t
+++ b/tests/filter/stored_redirect.t
@@ -102,89 +102,47 @@
   * add file2
   * add file1
 
-  $ git diff ${EMPTY_TREE}..refs/heads/filtered
-  diff --git a/a/file1 b/a/file1
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/a/file1
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/a/file4 b/a/file4
-  new file mode 100644
-  index 0000000..288746e
-  --- /dev/null
-  +++ b/a/file4
-  @@ -0,0 +1 @@
-  +contents4
-  diff --git a/b/file4 b/b/file4
-  new file mode 100644
-  index 0000000..1cb5d64
-  --- /dev/null
-  +++ b/b/file4
-  @@ -0,0 +1 @@
-  +contents3
-  diff --git a/st/config.josh b/st/config.josh
-  new file mode 100644
-  index 0000000..795cb6d
-  --- /dev/null
-  +++ b/st/config.josh
-  @@ -0,0 +1,3 @@
-  +::sub2/subsub/
-  +a = :/sub1
-  +b = :/sub3
-  diff --git a/sub2/subsub/file2 b/sub2/subsub/file2
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/sub2/subsub/file2
-  @@ -0,0 +1 @@
-  +contents1
-  $ git diff ${EMPTY_TREE}..refs/heads/filtered_new
-  diff --git a/a/file1 b/a/file1
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/a/file1
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/a/file4 b/a/file4
-  new file mode 100644
-  index 0000000..288746e
-  --- /dev/null
-  +++ b/a/file4
-  @@ -0,0 +1 @@
-  +contents4
-  diff --git a/b/file4 b/b/file4
-  new file mode 100644
-  index 0000000..1cb5d64
-  --- /dev/null
-  +++ b/b/file4
-  @@ -0,0 +1 @@
-  +contents3
-  diff --git a/st/config.josh b/st/config.josh
-  new file mode 100644
-  index 0000000..795cb6d
-  --- /dev/null
-  +++ b/st/config.josh
-  @@ -0,0 +1,3 @@
-  +::sub2/subsub/
-  +a = :/sub1
-  +b = :/sub3
-  diff --git a/st_new/config.josh b/st_new/config.josh
-  new file mode 100644
-  index 0000000..15782f4
-  --- /dev/null
-  +++ b/st_new/config.josh
-  @@ -0,0 +1 @@
-  +:+st/config
-  diff --git a/sub2/subsub/file2 b/sub2/subsub/file2
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/sub2/subsub/file2
-  @@ -0,0 +1 @@
-  +contents1
+  $ git-tree-pretty refs/heads/filtered
+  .
+  ├── a/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file4
+  │       ┆  contents4
+  ├── b/
+  │   └── file4
+  │       ┆  contents3
+  ├── st/
+  │   └── config.josh
+  │       ┆  ::sub2/subsub/
+  │       ┆  a = :/sub1
+  │       ┆  b = :/sub3
+  └── sub2/
+      └── subsub/
+          └── file2
+              ┆  contents1
+  $ git-tree-pretty refs/heads/filtered_new
+  .
+  ├── a/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file4
+  │       ┆  contents4
+  ├── b/
+  │   └── file4
+  │       ┆  contents3
+  ├── st/
+  │   └── config.josh
+  │       ┆  ::sub2/subsub/
+  │       ┆  a = :/sub1
+  │       ┆  b = :/sub3
+  ├── st_new/
+  │   └── config.josh
+  │       ┆  :+st/config
+  └── sub2/
+      └── subsub/
+          └── file2
+              ┆  contents1
 
 
   $ cat > st/config.josh <<EOF

--- a/tests/filter/stored_reverse.t
+++ b/tests/filter/stored_reverse.t
@@ -44,18 +44,21 @@
 
   $ git checkout filtered
   Switched to branch 'filtered'
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   |-- file1
-  |   `-- file4
-  |-- st
-  |   `-- config.josh
-  `-- sub2
-      `-- subsub
-          `-- file2
-  
-  5 directories, 4 files
+  ├── a/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file4
+  │       ┆  contents4
+  ├── st/
+  │   └── config.josh
+  │       ┆  ::sub2/subsub/
+  │       ┆  a = :/sub1
+  └── sub2/
+      └── subsub/
+          └── file2
+              ┆  contents1
 
   $ echo modified_content > a/file1
   $ echo new_file_content > new_file
@@ -78,22 +81,18 @@
   $ git checkout master
   Switched to branch 'master'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- st
-  |   `-- config.josh
-  |-- sub1
-  |   |-- file1
-  |   `-- file4
-  `-- sub2
-      `-- subsub
-          `-- file2
-  
-  5 directories, 4 files
-
-  $ cat sub1/file1
-  modified_content
-  $ cat new_file
-  cat: new_file: No such file or directory
-  [1]
-
+  ├── st/
+  │   └── config.josh
+  │       ┆  ::sub2/subsub/
+  │       ┆  a = :/sub1
+  ├── sub1/
+  │   ├── file1
+  │   │   ┆  modified_content
+  │   └── file4
+  │       ┆  contents4
+  └── sub2/
+      └── subsub/
+          └── file2
+              ┆  contents1

--- a/tests/filter/stored_reverse_exclude.t
+++ b/tests/filter/stored_reverse_exclude.t
@@ -44,17 +44,19 @@
 
   $ git checkout filtered
   Switched to branch 'filtered'
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- file4
-  |-- st
-  |   `-- config.josh
-  `-- sub2
-      `-- subsub
-          `-- file2
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── file4
+  │       ┆  contents4
+  ├── st/
+  │   └── config.josh
+  │       ┆  ::sub2/subsub/
+  │       ┆  a = :/sub1:exclude[::file1]
+  └── sub2/
+      └── subsub/
+          └── file2
+              ┆  contents1
 
   $ echo ws_content > fileX
   $ echo ws_content > file1
@@ -77,22 +79,18 @@
   $ git checkout master
   Switched to branch 'master'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- st
-  |   `-- config.josh
-  |-- sub1
-  |   |-- file1
-  |   `-- file4
-  `-- sub2
-      `-- subsub
-          `-- file2
-  
-  5 directories, 4 files
-
-  $ cat file1
-  cat: file1: No such file or directory
-  [1]
-  $ cat sub1/file1
-  contents1
-
+  ├── st/
+  │   └── config.josh
+  │       ┆  ::sub2/subsub/
+  │       ┆  a = :/sub1:exclude[::file1]
+  ├── sub1/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file4
+  │       ┆  contents4
+  └── sub2/
+      └── subsub/
+          └── file2
+              ┆  contents1

--- a/tests/filter/stored_reverse_shadow.t
+++ b/tests/filter/stored_reverse_shadow.t
@@ -28,23 +28,22 @@
   * add st
   * add file2
   * add file1
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- st
-  |   |-- c
-  |   |   `-- file1
-  |   `-- config.josh
-  |-- sub1
-  |   `-- file1
-  `-- sub2
-      `-- file2
-  
-  5 directories, 4 files
+  ├── st/
+  │   ├── c/
+  │   │   └── file1
+  │   │       ┆  st_content
+  │   └── config.josh
+  │       ┆  a/b = :/sub2
+  │       ┆  c = :/sub1
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  └── sub2/
+      └── file2
+          ┆  contents1
 
-  $ cat sub1/file1
-  contents1
-  $ cat st/c/file1
-  st_content
 
   $ josh-filter :+st/config master --update refs/heads/st
   99b3384cb31ab9d642bd2e5e4050d57f97fe2862
@@ -54,20 +53,20 @@
   * add st
   * add file2
   * add file1
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- file1
-  `-- st
-      `-- config.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── file1
+  │       ┆  contents1
+  └── st/
+      └── config.josh
+          ┆  a/b = :/sub2
+          ┆  c = :/sub1
 
-  $ cat c/file1
-  contents1
 
   $ echo modified_content > c/file1
   $ echo contents3 > st_created_file
@@ -80,24 +79,22 @@
   $ git checkout master
   Switched to branch 'master'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- st
-  |   |-- c
-  |   |   `-- file1
-  |   `-- config.josh
-  |-- sub1
-  |   `-- file1
-  `-- sub2
-      `-- file2
-  
-  5 directories, 4 files
+  ├── st/
+  │   ├── c/
+  │   │   └── file1
+  │   │       ┆  st_content
+  │   └── config.josh
+  │       ┆  a/b = :/sub2
+  │       ┆  c = :/sub1
+  ├── sub1/
+  │   └── file1
+  │       ┆  modified_content
+  └── sub2/
+      └── file2
+          ┆  contents1
 
-  $ cat sub1/file1
-  modified_content
-  $ cat st/st_created_file
-  cat: st/st_created_file: No such file or directory
-  [1]
 
   $ git log --graph --pretty=%s
   * modify and add files

--- a/tests/filter/stored_single_file.t
+++ b/tests/filter/stored_single_file.t
@@ -53,21 +53,24 @@ by ".josh" but rather kept and extended
   * add file2
   * add file1
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ git ls-tree HEAD
+  $ git ls-tree refs/josh/master
   100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile1 (esc)
   100755 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile2 (esc)
   040000 tree 708c21a7d31d142c2d1030810e573154134f32e6\tst (esc)
   040000 tree 81b2a24c53f9090c6f6a23176a2a5660e6f48317\tsub2 (esc)
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  |-- file1
-  |-- file2
-  |-- st
-  |   `-- config.filter.josh
-  `-- sub2
-      `-- subsub
-          `-- file2
-  
-  4 directories, 4 files
+  ├── file1
+  │   ┆  contents1
+  ├── file2
+  │   ┆  contents1
+  ├── st/
+  │   └── config.filter.josh
+  │       ┆  :/sub1::file1
+  │       ┆  :/sub1::file2
+  │       ┆  ::sub2/subsub/
+  └── sub2/
+      └── subsub/
+          └── file2
+              ┆  contents1
 

--- a/tests/filter/subtree_prefix.t
+++ b/tests/filter/subtree_prefix.t
@@ -45,13 +45,13 @@ Artificially create a subtree merge
   $ git mv file2 subtree/
   $ git add subtree
   $ git commit -a --amend -m "subtree merge" 1>/dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- subtree
-      `-- file2
-  
-  2 directories, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── subtree/
+      └── file2
+          ┆  contents2
   $ git log --graph --pretty=%s
   *   subtree merge
   |\  

--- a/tests/filter/subtree_prefix_legacy.t
+++ b/tests/filter/subtree_prefix_legacy.t
@@ -34,13 +34,13 @@ Artificially create a subtree merge
   $ git mv file2 subtree/
   $ git add subtree
   $ git commit -a --amend -m "subtree merge" 1>/dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- subtree
-      `-- file2
-  
-  2 directories, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── subtree/
+      └── file2
+          ┆  contents2
   $ git log --graph --pretty=%s
   *   subtree merge
   |\  

--- a/tests/filter/workspace_combine_filter.t
+++ b/tests/filter/workspace_combine_filter.t
@@ -33,21 +33,27 @@
   $ git add .
   $ git commit -m "add ws" 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- file1
-  |-- sub2
-  |   `-- subsub
-  |       `-- file2
-  |-- sub3
-  |   `-- sub_file
-  |-- ws
-  |   `-- workspace.josh
-  `-- ws2
-      `-- workspace.josh
-  
-  7 directories, 5 files
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  ├── sub2/
+  │   └── subsub/
+  │       └── file2
+  │           ┆  contents1
+  ├── sub3/
+  │   └── sub_file
+  │       ┆  contents1
+  ├── ws/
+  │   └── workspace.josh
+  │       ┆  x = :[::sub2/subsub/,::sub1/]
+  └── ws2/
+      └── workspace.josh
+          ┆  :[
+          ┆    a = :[::sub2/subsub/,::sub3/]
+          ┆    :/sub1:prefix=blub
+          ┆  ]:prefix=xyz
 
   $ josh-filter -s :workspace=ws
   0fe13f59da8ba3f49ca610f2354254747502fa40
@@ -65,20 +71,19 @@
   * add file2
   * add file1
 
-  $ git checkout FILTERED_HEAD 2> /dev/null
-  $ tree
+  $ git-tree-pretty FILTERED_HEAD
   .
-  |-- workspace.josh
-  `-- x
-      |-- sub1
-      |   `-- file1
-      `-- sub2
-          `-- subsub
-              `-- file2
-  
-  5 directories, 3 files
+  ├── workspace.josh
+  │   ┆  x = :[::sub2/subsub/,::sub1/]
+  └── x/
+      ├── sub1/
+      │   └── file1
+      │       ┆  contents1
+      └── sub2/
+          └── subsub/
+              └── file2
+                  ┆  contents1
 
-  $ git checkout master 2> /dev/null
   $ josh-filter -s :workspace=ws2
   8a0812406d4c375a5f173abc839b00ad3b7fc30d
   [2] :[
@@ -105,18 +110,22 @@
   * add file2
   * add file1
 
-  $ git checkout FILTERED_HEAD 2> /dev/null
-  $ tree
+  $ git-tree-pretty FILTERED_HEAD
   .
-  |-- workspace.josh
-  `-- xyz
-      |-- a
-      |   |-- sub2
-      |   |   `-- subsub
-      |   |       `-- file2
-      |   `-- sub3
-      |       `-- sub_file
-      `-- blub
-          `-- file1
-  
-  7 directories, 4 files
+  ├── workspace.josh
+  │   ┆  :[
+  │   ┆    a = :[::sub2/subsub/,::sub3/]
+  │   ┆    :/sub1:prefix=blub
+  │   ┆  ]:prefix=xyz
+  └── xyz/
+      ├── a/
+      │   ├── sub2/
+      │   │   └── subsub/
+      │   │       └── file2
+      │   │           ┆  contents1
+      │   └── sub3/
+      │       └── sub_file
+      │           ┆  contents1
+      └── blub/
+          └── file1
+              ┆  contents1

--- a/tests/filter/workspace_exclude.t
+++ b/tests/filter/workspace_exclude.t
@@ -40,16 +40,18 @@
 
   $ git checkout filtered
   Switched to branch 'filtered'
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- file4
-  |-- sub2
-  |   `-- subsub
-  |       `-- file2
-  `-- workspace.josh
-  
-  4 directories, 3 files
+  ├── a/
+  │   └── file4
+  │       ┆  contents4
+  ├── sub2/
+  │   └── subsub/
+  │       └── file2
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  ::sub2/subsub/
+      ┆  a = :/sub1:exclude[::file1]
 
   $ echo ws_content > fileX
   $ echo ws_content > file1
@@ -77,22 +79,22 @@
   $ git checkout master
   Switched to branch 'master'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   |-- file1
-  |   `-- file4
-  |-- sub2
-  |   `-- subsub
-  |       `-- file2
-  `-- ws
-      |-- file1
-      |-- fileX
-      `-- workspace.josh
-  
-  5 directories, 6 files
-
-  $ cat ws/file1
-  ws_content
-  $ cat sub1/file1
-  contents1
+  ├── sub1/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file4
+  │       ┆  contents4
+  ├── sub2/
+  │   └── subsub/
+  │       └── file2
+  │           ┆  contents1
+  └── ws/
+      ├── file1
+      │   ┆  ws_content
+      ├── fileX
+      │   ┆  ws_content
+      └── workspace.josh
+          ┆  a = :/sub1:exclude[::file1]
+          ┆  ::sub2/subsub/

--- a/tests/filter/workspace_implicit_filter.t
+++ b/tests/filter/workspace_implicit_filter.t
@@ -37,14 +37,15 @@
   * add file2
   * add file1
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  |-- sub1
-  |   `-- file1
-  |-- sub2
-  |   `-- subsub
-  |       `-- file2
-  `-- workspace.josh
-  
-  4 directories, 3 files
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  ├── sub2/
+  │   └── subsub/
+  │       └── file2
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  ::sub2/subsub/
+      ┆  ::sub1/

--- a/tests/filter/workspace_modify_chain.t
+++ b/tests/filter/workspace_modify_chain.t
@@ -38,12 +38,11 @@
 
   $ git checkout filtered
   Switched to branch 'filtered'
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- subsub
-      `-- file2
-  
-  2 directories, 1 file
+  └── subsub/
+      └── file2
+          ┆  contents1
 
   $ echo ws_content > subsub/fileX
   $ echo ws_content > subsub/file1
@@ -71,23 +70,21 @@
   $ git checkout master
   Switched to branch 'master'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   |-- file1
-  |   `-- file4
-  |-- sub2
-  |   `-- subsub
-  |       |-- file1
-  |       |-- file2
-  |       `-- fileX
-  `-- ws
-      `-- workspace.josh
-  
-  5 directories, 6 files
-
-  $ cat ws/file1
-  *: No such file or directory (glob)
-  [1]
-  $ cat sub1/file1
-  contents1
+  ├── sub1/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file4
+  │       ┆  contents4
+  ├── sub2/
+  │   └── subsub/
+  │       ├── file1
+  │       │   ┆  ws_content
+  │       ├── file2
+  │       │   ┆  contents1
+  │       └── fileX
+  │           ┆  ws_content
+  └── ws/
+      └── workspace.josh
+          ┆  ::sub2/subsub/

--- a/tests/filter/workspace_multiple_globs.t
+++ b/tests/filter/workspace_multiple_globs.t
@@ -42,22 +42,24 @@
   * add file2
   * add file1
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ git ls-tree HEAD
+  $ git ls-tree refs/josh/master
   040000 tree 911c4952e2ea6662b24ba38f173bd25a0ea30f25\ta (esc)
   040000 tree c82fc150c43f13cc56c0e9caeba01b58ec612022\tb (esc)
   100644 blob ad7c87a358d35432edbe44a052b7b7731ca3103f\tworkspace.josh (esc)
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  |-- a
-  |   |-- sub1
-  |   |   `-- file2
-  |   `-- sub2
-  |       `-- subsub
-  |           `-- file2
-  |-- b
-  |   `-- sub1
-  |       `-- file1
-  `-- workspace.josh
-  
-  7 directories, 4 files
+  ├── a/
+  │   ├── sub1/
+  │   │   └── file2
+  │   │       ┆  contents1
+  │   └── sub2/
+  │       └── subsub/
+  │           └── file2
+  │               ┆  contents1
+  ├── b/
+  │   └── sub1/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a = ::**/file2
+      ┆  b = ::**/file1

--- a/tests/filter/workspace_redirect.t
+++ b/tests/filter/workspace_redirect.t
@@ -85,96 +85,46 @@
   * add file2
   * add file1
 
-  $ git diff ${EMPTY_TREE}..refs/heads/filtered
-  diff --git a/a/file1 b/a/file1
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/a/file1
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/a/file4 b/a/file4
-  new file mode 100644
-  index 0000000..288746e
-  --- /dev/null
-  +++ b/a/file4
-  @@ -0,0 +1 @@
-  +contents4
-  diff --git a/b/file4 b/b/file4
-  new file mode 100644
-  index 0000000..1cb5d64
-  --- /dev/null
-  +++ b/b/file4
-  @@ -0,0 +1 @@
-  +contents3
-  diff --git a/extra_file b/extra_file
-  new file mode 100644
-  index 0000000..323fae0
-  --- /dev/null
-  +++ b/extra_file
-  @@ -0,0 +1 @@
-  +foobar
-  diff --git a/sub2/subsub/file2 b/sub2/subsub/file2
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/sub2/subsub/file2
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/workspace.josh b/workspace.josh
-  new file mode 100644
-  index 0000000..795cb6d
-  --- /dev/null
-  +++ b/workspace.josh
-  @@ -0,0 +1,3 @@
-  +::sub2/subsub/
-  +a = :/sub1
-  +b = :/sub3
-  $ git diff ${EMPTY_TREE}..refs/heads/filtered_new
-  diff --git a/a/file1 b/a/file1
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/a/file1
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/a/file4 b/a/file4
-  new file mode 100644
-  index 0000000..288746e
-  --- /dev/null
-  +++ b/a/file4
-  @@ -0,0 +1 @@
-  +contents4
-  diff --git a/b/file4 b/b/file4
-  new file mode 100644
-  index 0000000..1cb5d64
-  --- /dev/null
-  +++ b/b/file4
-  @@ -0,0 +1 @@
-  +contents3
-  diff --git a/extra_file b/extra_file
-  new file mode 100644
-  index 0000000..323fae0
-  --- /dev/null
-  +++ b/extra_file
-  @@ -0,0 +1 @@
-  +foobar
-  diff --git a/sub2/subsub/file2 b/sub2/subsub/file2
-  new file mode 100644
-  index 0000000..a024003
-  --- /dev/null
-  +++ b/sub2/subsub/file2
-  @@ -0,0 +1 @@
-  +contents1
-  diff --git a/workspace.josh b/workspace.josh
-  new file mode 100644
-  index 0000000..795cb6d
-  --- /dev/null
-  +++ b/workspace.josh
-  @@ -0,0 +1,3 @@
-  +::sub2/subsub/
-  +a = :/sub1
-  +b = :/sub3
+  $ git-tree-pretty refs/heads/filtered
+  .
+  ├── a/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file4
+  │       ┆  contents4
+  ├── b/
+  │   └── file4
+  │       ┆  contents3
+  ├── extra_file
+  │   ┆  foobar
+  ├── sub2/
+  │   └── subsub/
+  │       └── file2
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  ::sub2/subsub/
+      ┆  a = :/sub1
+      ┆  b = :/sub3
+  $ git-tree-pretty refs/heads/filtered_new
+  .
+  ├── a/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file4
+  │       ┆  contents4
+  ├── b/
+  │   └── file4
+  │       ┆  contents3
+  ├── extra_file
+  │   ┆  foobar
+  ├── sub2/
+  │   └── subsub/
+  │       └── file2
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  ::sub2/subsub/
+      ┆  a = :/sub1
+      ┆  b = :/sub3
 
 
   $ cat > ws/workspace.josh <<EOF

--- a/tests/filter/workspace_shadow_file.t
+++ b/tests/filter/workspace_shadow_file.t
@@ -34,23 +34,22 @@
   * add ws
   * add file2
   * add file1
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- file1
-  |-- sub2
-  |   `-- file2
-  `-- ws
-      |-- c
-      |   `-- file1
-      `-- workspace.josh
-  
-  5 directories, 4 files
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  ├── sub2/
+  │   └── file2
+  │       ┆  contents1
+  └── ws/
+      ├── c/
+      │   └── file1
+      │       ┆  ws_content
+      └── workspace.josh
+          ┆  a/b = :/sub2
+          ┆  c = :/sub1
 
-  $ cat sub1/file1
-  contents1
-  $ cat ws/c/file1
-  ws_content
 
   $ josh-filter :workspace=ws master --update refs/heads/ws
   4da312ea25eac6a97c651e185ff76f9bc488b963
@@ -60,19 +59,19 @@
   * add ws
   * add file2
   * add file1
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- file1
-  `-- workspace.josh
-  
-  4 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── file1
+  │       ┆  ws_content
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
-  $ cat c/file1
-  ws_content
 
   $ echo contents3 > ws_created_file
   $ git add ws_created_file
@@ -86,22 +85,24 @@
   $ git checkout master
   Switched to branch 'master'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- file1
-  |-- sub2
-  |   `-- file2
-  `-- ws
-      |-- c
-      |   `-- file1
-      |-- workspace.josh
-      `-- ws_created_file
-  
-  5 directories, 5 files
+  ├── sub1/
+  │   └── file1
+  │       ┆  ws_content
+  ├── sub2/
+  │   └── file2
+  │       ┆  contents1
+  └── ws/
+      ├── c/
+      │   └── file1
+      │       ┆  ws_content
+      ├── workspace.josh
+      │   ┆  c = :/sub1
+      │   ┆  a/b = :/sub2
+      └── ws_created_file
+          ┆  contents3
 
-  $ cat sub1/file1
-  ws_content
 
   $ git log --graph --pretty=%s
   * add ws_created_file

--- a/tests/filter/workspace_single_file.t
+++ b/tests/filter/workspace_single_file.t
@@ -55,22 +55,25 @@
   * add file2
   * add file1
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ git ls-tree HEAD
+  $ git ls-tree refs/josh/master
   100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile1 (esc)
   100755 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile2 (esc)
   040000 tree 81b2a24c53f9090c6f6a23176a2a5660e6f48317\tsub2 (esc)
   100644 blob 63f07c908400fab3a663e52e480970d8458bc86a\tworkspace.josh (esc)
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  |-- file1
-  |-- file2
-  |-- sub2
-  |   `-- subsub
-  |       `-- file2
-  `-- workspace.josh
-  
-  3 directories, 4 files
+  ├── file1
+  │   ┆  contents1
+  ├── file2
+  │   ┆  contents1
+  ├── sub2/
+  │   └── subsub/
+  │       └── file2
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  :/sub1::file1
+      ┆  :/sub1::file2
+      ┆  ::sub2/subsub/
 
   $ josh-filter -s :workspace=ws2 master --update refs/josh/master
   be20e659999253f02308f34dbfc697f0cd5ae514
@@ -98,19 +101,22 @@
   * add file2
   * add file1
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ git ls-tree HEAD
+  $ git ls-tree refs/josh/master
   100644 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile1 (esc)
   100755 blob a024003ee1acc6bf70318a46e7b6df651b9dc246\tfile2 (esc)
   040000 tree 81b2a24c53f9090c6f6a23176a2a5660e6f48317\tsub2 (esc)
   100644 blob f7863ebb4c21391857fe5d27bc381553a2056223\tworkspace.josh (esc)
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  |-- file1
-  |-- file2
-  |-- sub2
-  |   `-- subsub
-  |       `-- file2
-  `-- workspace.josh
-  
-  3 directories, 4 files
+  ├── file1
+  │   ┆  contents1
+  ├── file2
+  │   ┆  contents1
+  ├── sub2/
+  │   └── subsub/
+  │       └── file2
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  :/sub1::file1
+      ┆  :/sub1::file2
+      ┆  ::sub2/subsub

--- a/tests/filter/workspace_trailing_slash.t
+++ b/tests/filter/workspace_trailing_slash.t
@@ -61,26 +61,22 @@
   * add file2
   * add file1
 
-  $ git checkout -q refs/josh/master 1> /dev/null
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  |-- workspace.josh
-  `-- ws
-      `-- c
-  
-  3 directories, 1 file
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c/ = :/sub1
 
-  $ git checkout -q HEAD~1
-  $ tree
+  $ git-tree-pretty refs/josh/master~1
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- file1
-  |-- workspace.josh
-  `-- ws
-      `-- c
-  
-  6 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── file1
+  │       ┆  contents1
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 

--- a/tests/filter/workspace_unique.t
+++ b/tests/filter/workspace_unique.t
@@ -47,15 +47,19 @@ so the workspace.josh will still appear in the root of the workspace
   * add file2
   * add file1
 
-  $ git checkout refs/josh/master 2> /dev/null
-  $ tree
+  $ git-tree-pretty refs/josh/master
   .
-  |-- a
-  |   `-- file4
-  |-- file1
-  |-- sub2
-  |   `-- subsub
-  |       `-- file2
-  `-- workspace.josh
-  
-  4 directories, 4 files
+  ├── a/
+  │   └── file4
+  │       ┆  contents4
+  ├── file1
+  │   ┆  contents1
+  ├── sub2/
+  │   └── subsub/
+  │       └── file2
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  :/sub1::file1
+      ┆  ::sub2/subsub/
+      ┆  a = :/sub1
+      ┆  b = ::ws/workspace.josh

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -38,13 +38,12 @@
 
   $ git clone -q http://localhost:8002/real_repo.git full
   $ cd ${TESTTMP}/full
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- sub3
-      `-- file3
-  
-  2 directories, 2 files
+  ├── file1
+  └── sub3/
+      └── file3
+          ┆  contents3
 
   $ git log --graph --pretty=%s
   * add file3
@@ -81,12 +80,11 @@
   $ git log --graph --pretty=%s
   * Add in full
   * add file3
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file2x
-  `-- file3
-  
-  1 directory, 2 files
+  ├── file2x
+  └── file3
+      ┆  contents3
 
   $ echo content4 > file_new 1> /dev/null
   $ git add .
@@ -107,15 +105,14 @@
   * Add in full
   * add file3
   * initial
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- sub3
-      |-- file2x
-      |-- file3
-      `-- file_new
-  
-  2 directories, 4 files
+  ├── file1
+  └── sub3/
+      ├── file2x
+      ├── file3
+      │   ┆  contents3
+      └── file_new
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [

--- a/tests/proxy/authentication.t
+++ b/tests/proxy/authentication.t
@@ -22,12 +22,11 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
   $ git push
   To http://localhost:8001/real_repo.git
@@ -70,15 +69,12 @@
   $ git clone -q http://testuser:${TESTPASS}@localhost:8002/real_repo.git full_repo
 
   $ cd full_repo
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
-  $ cat sub1/file1
-  contents1
 
   $ echo contents1 > file2
   $ git add .
@@ -100,13 +96,13 @@
   $ git clone -q http://x\':bla@localhost:8002/real_repo.git full_repo
   fatal: Authentication failed for 'http://localhost:8002/real_repo.git/'
   [128]
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file2
-  `-- sub1
-      `-- file1
-  
-  2 directories, 2 files
+  ├── file2
+  │   ┆  contents1
+  └── sub1/
+      └── file1
+          ┆  contents1
 
   $ cd ${TESTTMP}/real_repo
   $ curl -s http://localhost:8001/_noauth

--- a/tests/proxy/clone_absent_head.t
+++ b/tests/proxy/clone_absent_head.t
@@ -28,12 +28,11 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
   $ git push
   To http://localhost:8001/real_repo.git
@@ -62,15 +61,12 @@
 
   $ cd full_repo
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
-  $ cat sub1/file1
-  contents1
 
   $ cd ${TESTTMP}/remote/real_repo.git
 

--- a/tests/proxy/clone_all.t
+++ b/tests/proxy/clone_all.t
@@ -21,12 +21,11 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
   $ git push
   To http://localhost:8001/real_repo.git
@@ -38,15 +37,12 @@
 
   $ cd full_repo
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
-  $ cat sub1/file1
-  contents1
 
 
   $ bash ${TESTDIR}/destroy_test_env.sh

--- a/tests/proxy/clone_invalid_filter.t
+++ b/tests/proxy/clone_invalid_filter.t
@@ -31,15 +31,15 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub2/file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- subsub
-  |       `-- file1
-  `-- sub2
-      `-- file2
-  
-  4 directories, 2 files
+  ├── sub1/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── sub2/
+      └── file2
+          ┆  contents1
 
   $ git log --graph --pretty=%s
   * add file2

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -29,14 +29,14 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub2/file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- file1
-  `-- sub2
-      `-- file2
-  
-  3 directories, 2 files
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  └── sub2/
+      └── file2
+          ┆  contents1
 
   $ git log --graph --pretty=%s
   * add file2
@@ -52,15 +52,15 @@
 
   $ cd pre
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- pre
-      |-- sub1
-      |   `-- file1
-      `-- sub2
-          `-- file2
-  
-  4 directories, 2 files
+  └── pre/
+      ├── sub1/
+      │   └── file1
+      │       ┆  contents1
+      └── sub2/
+          └── file2
+              ┆  contents1
 
   $ git log --graph --pretty=%s
   * add file2

--- a/tests/proxy/clone_sha.t
+++ b/tests/proxy/clone_sha.t
@@ -21,12 +21,11 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
   $ git push -q
 
@@ -78,15 +77,12 @@ Check (2) and (3) but with a branch ref
 
   $ cd full_repo
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
-  $ cat sub1/file1
-  contents1
 
 
   $ bash ${TESTDIR}/destroy_test_env.sh

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -31,15 +31,15 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub2/file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- subsub
-  |       `-- file1
-  `-- sub2
-      `-- file2
-  
-  4 directories, 2 files
+  ├── sub1/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── sub2/
+      └── file2
+          ┆  contents1
 
   $ git log --graph --pretty=%s
   * add file2
@@ -52,12 +52,11 @@
   $ cd ${TESTTMP}
   $ git clone -q http://localhost:8002/real_repo.git:/sub1.git
   $ cd sub1
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- subsub
-      `-- file1
-  
-  2 directories, 1 file
+  └── subsub/
+      └── file1
+          ┆  contents1
 
   $ git log --graph --pretty=%s master
   * add file1
@@ -67,11 +66,10 @@
   $ cd subsub
   $ git branch
   * master
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- file1
-  
-  1 directory, 1 file
+  └── file1
+      ┆  contents1
 
   $ git log --graph --pretty=%s master
   * add file1

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -29,14 +29,14 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub2/file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- file1
-  `-- sub2
-      `-- file2
-  
-  3 directories, 2 files
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  └── sub2/
+      └── file2
+          ┆  contents1
 
   $ git log --graph --pretty=%s
   * add file2
@@ -65,11 +65,10 @@
   $ cat .git/refs/remotes/origin/HEAD
   ref: refs/remotes/origin/master
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- file1
-  
-  1 directory, 1 file
+  └── file1
+      ┆  contents1
 
   $ git log --graph --pretty=%s
   * add file1

--- a/tests/proxy/clone_subtree_no_master.t
+++ b/tests/proxy/clone_subtree_no_master.t
@@ -29,14 +29,14 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub2/file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- file1
-  `-- sub2
-      `-- file2
-  
-  3 directories, 2 files
+  ├── sub1/
+  │   └── file1
+  │       ┆  contents1
+  └── sub2/
+      └── file2
+          ┆  contents1
 
   $ git log --graph --pretty=%s
   * add file2
@@ -61,10 +61,9 @@
   *: No such file or directory (glob)
   [1]
 
-  $ tree
+  $ git read-tree --empty
+  $ git-tree-pretty +
   .
-  
-  0 directories, 0 files
 
   $ git log --graph --pretty=%s
   fatal: your current branch 'master' does not have any commits yet

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -43,15 +43,16 @@
   $ git describe --tags
   a_tag_object-1-gbbc3f80
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   |-- file1
-  |   `-- file12
-  `-- sub2
-      `-- file2
-  
-  3 directories, 3 files
+  ├── sub1/
+  │   ├── file1
+  │   │   ┆  contents1
+  │   └── file12
+  │       ┆  contents1
+  └── sub2/
+      └── file2
+          ┆  contents1
 
   $ git log --graph --pretty=%s
   * add file2
@@ -74,12 +75,12 @@
 
   $ cd sub1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- file12
-  
-  1 directory, 2 files
+  ├── file1
+  │   ┆  contents1
+  └── file12
+      ┆  contents1
 
   $ git log --graph --pretty=%s
   * add file12
@@ -97,11 +98,10 @@
 
   $ git checkout FETCH_HEAD 2> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- file1
-  
-  1 directory, 1 file
+  └── file1
+      ┆  contents1
 
   $ git log --graph --pretty=%s
   * add file1

--- a/tests/proxy/empty_commit.t
+++ b/tests/proxy/empty_commit.t
@@ -40,13 +40,13 @@ should still be included.
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      `-- file2
-  
-  2 directories, 2 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      └── file2
+          ┆  contents2
 
   $ git log --graph --pretty=%s
   * add file2
@@ -63,13 +63,13 @@ should still be included.
 
   $ cd full_repo
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      `-- file2
-  
-  2 directories, 2 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      └── file2
+          ┆  contents2
 
   $ git log --graph --pretty=%s
   * add file2

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -46,12 +46,10 @@ Flushed credential cache
   Switched to branch 'repo1_in_subdir'
   $ git log --graph --pretty=%s
   * initial1
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- repo1
-      `-- file1
-  
-  2 directories, 1 file
+  └── repo1/
+      └── file1
 
 $ curl -s http://localhost:8002/flush
 Flushed credential cache
@@ -65,14 +63,12 @@ Flushed credential cache
   |\  
   | * initial2
   * initial1
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- repo1
-  |   `-- file1
-  `-- repo2
-      `-- file2
-  
-  3 directories, 2 files
+  ├── repo1/
+  │   └── file1
+  └── repo2/
+      └── file2
 
   $ git checkout master
   Switched to branch 'master'
@@ -93,15 +89,13 @@ Flushed credential cache
   $ git add repo1
   $ git commit -m "add new_file1" 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- repo1
-  |   |-- file1
-  |   `-- new_file1
-  `-- repo2
-      `-- file2
-  
-  3 directories, 3 files
+  ├── repo1/
+  │   ├── file1
+  │   └── new_file1
+  └── repo2/
+      └── file2
 
   $ git push 2> /dev/null
 
@@ -113,12 +107,10 @@ Flushed credential cache
   * add new_file1
   * initial1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- new_file1
-  
-  1 directory, 2 files
+  ├── file1
+  └── new_file1
 
   $ cd ${TESTTMP}/repo1
   $ echo new_content2 > new_file2 1> /dev/null
@@ -139,16 +131,14 @@ Flushed credential cache
   * initial1
 
   $ git merge -m "Import 2" repo1_in_subdir --allow-unrelated-histories 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- repo1
-  |   |-- file1
-  |   |-- new_file1
-  |   `-- new_file2
-  `-- repo2
-      `-- file2
-  
-  3 directories, 4 files
+  ├── repo1/
+  │   ├── file1
+  │   ├── new_file1
+  │   └── new_file2
+  └── repo2/
+      └── file2
 
   $ git log --graph --pretty=%s
   *   Import 2
@@ -176,13 +166,11 @@ Flushed credential cache
    new_file2 | 0
    1 file changed, 0 insertions(+), 0 deletions(-)
    create mode 100644 new_file2
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- new_file1
-  `-- new_file2
-  
-  1 directory, 3 files
+  ├── file1
+  ├── new_file1
+  └── new_file2
   $ git log --graph --pretty=%s
   *   Import 2
   |\  
@@ -236,13 +224,11 @@ Flushed credential cache
   $ git pull --rebase 2> /dev/null
   Updating 6fe45a9..8047211
   Fast-forward
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- new_file1
-  `-- new_file2
-  
-  1 directory, 3 files
+  ├── file1
+  ├── new_file1
+  └── new_file2
   $ git log --graph --pretty=%s
   *   Import 3
   |\  
@@ -280,16 +266,14 @@ Flushed credential cache
   | | * initial2
   | * initial1
   * initial
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- repo1
-  |   |-- file1
-  |   |-- new_file1
-  |   `-- new_file2
-  `-- repo2
-      `-- file2
-  
-  3 directories, 4 files
+  ├── repo1/
+  │   ├── file1
+  │   ├── new_file1
+  │   └── new_file2
+  └── repo2/
+      └── file2
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -45,14 +45,12 @@
   |/  
   * initial
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      |-- newfile1
-      `-- newfile_master
-  
-  2 directories, 3 files
+  └── sub1/
+      ├── file1
+      ├── newfile1
+      └── newfile_master
 
 
   $ bash ${TESTDIR}/destroy_test_env.sh

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -40,15 +40,15 @@
   @@ -0,0 +1 @@
   +contents
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- d
-  `-- sub1
-      `-- file1
-  
-  4 directories, 2 files
+  ├── a/
+  │   └── b/
+  │       └── d
+  │           ┆  abdcontent
+  └── sub1/
+      └── file1
+          ┆  contents
 
   $ git push
   To http://localhost:8001/real_repo.git
@@ -60,18 +60,16 @@
 
   $ cd full_repo
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- d
-  `-- sub1
-      `-- file1
-  
-  4 directories, 2 files
+  ├── a/
+  │   └── b/
+  │       └── d
+  │           ┆  abdcontent
+  └── sub1/
+      └── file1
+          ┆  contents
 
-  $ cat sub1/file1
-  contents
 
   $ cat > ../query <<EOF
   > {"query":"mutation {
@@ -99,15 +97,19 @@
   $ git log --graph --pretty=%s FETCH_HEAD
   * marker
 
-  $ git diff ${EMPTY_TREE}..FETCH_HEAD
-  diff --git a/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/c b/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/c
-  new file mode 100644
-  index 0000000..11474f8
-  --- /dev/null
-  +++ b/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/c
-  @@ -0,0 +1 @@
-  +43a0f340d27ea912af7a1cfbaa491cd117564a4e:{"location":"1234","message":"m1"}
-  \ No newline at end of file
+  $ git-tree-pretty FETCH_HEAD
+  .
+  └── tool/
+      └── warn/
+          └── ~/
+              └── 1e/
+                  └── 64d/
+                      └── c713/
+                          └── 1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/
+                              └── a/
+                                  └── b/
+                                      └── c
+                                          ╵  43a0f340d27ea912af7a1cfbaa491cd117564a4e:{"location":"1234","message":"m1"}
 
   $ cat > ../query <<EOF
   > {"query":"mutation {
@@ -136,16 +138,20 @@
   * marker
   * marker
 
-  $ git diff ${EMPTY_TREE}..FETCH_HEAD
-  diff --git a/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/c b/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/c
-  new file mode 100644
-  index 0000000..f81b303
-  --- /dev/null
-  +++ b/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/c
-  @@ -0,0 +1,2 @@
-  +43a0f340d27ea912af7a1cfbaa491cd117564a4e:{"location":"1234","message":"m1"}
-  +c6058f73704cfe1879d4ef110910fc8b50ff04c7:{"location":"1235","message":"foobar"}
-  \ No newline at end of file
+  $ git-tree-pretty FETCH_HEAD
+  .
+  └── tool/
+      └── warn/
+          └── ~/
+              └── 1e/
+                  └── 64d/
+                      └── c713/
+                          └── 1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/
+                              └── a/
+                                  └── b/
+                                      └── c
+                                          ┆  43a0f340d27ea912af7a1cfbaa491cd117564a4e:{"location":"1234","message":"m1"}
+                                          ╵  c6058f73704cfe1879d4ef110910fc8b50ff04c7:{"location":"1235","message":"foobar"}
 
 
 
@@ -181,25 +187,23 @@
   * marker
   * marker
 
-  $ git diff ${EMPTY_TREE}..FETCH_HEAD
-  diff --git a/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/c b/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/c
-  new file mode 100644
-  index 0000000..f81b303
-  --- /dev/null
-  +++ b/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/c
-  @@ -0,0 +1,2 @@
-  +43a0f340d27ea912af7a1cfbaa491cd117564a4e:{"location":"1234","message":"m1"}
-  +c6058f73704cfe1879d4ef110910fc8b50ff04c7:{"location":"1235","message":"foobar"}
-  \ No newline at end of file
-  diff --git a/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/d b/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/d
-  new file mode 100644
-  index 0000000..249fd13
-  --- /dev/null
-  +++ b/tool/warn/~/1e/64d/c713/1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/a/b/d
-  @@ -0,0 +1,2 @@
-  +53296c9e4dbc2b6ad15e15b2fc66870cd0548515:{"location":"1236","message":"foobar"}
-  +c6058f73704cfe1879d4ef110910fc8b50ff04c7:{"location":"1235","message":"foobar"}
-  \ No newline at end of file
+  $ git-tree-pretty FETCH_HEAD
+  .
+  └── tool/
+      └── warn/
+          └── ~/
+              └── 1e/
+                  └── 64d/
+                      └── c713/
+                          └── 1e64dc7136eae9c6b88e4ab831322f3c72a5c0e4/
+                              └── a/
+                                  └── b/
+                                      ├── c
+                                      │   ┆  43a0f340d27ea912af7a1cfbaa491cd117564a4e:{"location":"1234","message":"m1"}
+                                      │   ╵  c6058f73704cfe1879d4ef110910fc8b50ff04c7:{"location":"1235","message":"foobar"}
+                                      └── d
+                                          ┆  53296c9e4dbc2b6ad15e15b2fc66870cd0548515:{"location":"1236","message":"foobar"}
+                                          ╵  c6058f73704cfe1879d4ef110910fc8b50ff04c7:{"location":"1235","message":"foobar"}
 
   $ cat > ../query <<EOF
   > {"query":"{ rev(at:\"refs/heads/master\") {

--- a/tests/proxy/no_proxy.t
+++ b/tests/proxy/no_proxy.t
@@ -21,12 +21,11 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
   $ git push
   To http://localhost:8001/real_repo.git

--- a/tests/proxy/no_proxy_lfs.t
+++ b/tests/proxy/no_proxy_lfs.t
@@ -30,12 +30,15 @@
    1 file changed, 3 insertions(+)
    create mode 100644 sub1/file1.large
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1.large
-  
-  2 directories, 1 file
+  ├── .gitattributes
+  │   ┆  *.large filter=lfs diff=lfs merge=lfs -text
+  └── sub1/
+      └── file1.large
+          ┆  version https://git-lfs.github.com/spec/v1
+          ┆  oid sha256:8f88da056e2ed130ee23b3b61245d2e0948fe335236dcb23a100a087f92130f2
+          ┆  size 10
 
   $ git config lfs.http://localhost:8001/real_repo.git/info/lfs.locksverify false
 

--- a/tests/proxy/push_new_orphan_branch.t
+++ b/tests/proxy/push_new_orphan_branch.t
@@ -102,17 +102,16 @@ Flushed credential cache
   * add file2
   * add file1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      |-- file2
-      `-- orphan_file
-  
-  2 directories, 3 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      ├── file2
+      │   ┆  contents2
+      └── orphan_file
+          ┆  unrelated
 
-  $ cat sub1/file2
-  contents2
 
 Make sure all temporary namespace got removed
   $ tree ${TESTTMP}/remote/scratch/real_repo.git/refs/ | grep request_

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -41,13 +41,13 @@
    1 file changed, 1 insertion(+)
    create mode 100644 file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file2
-  `-- sub1
-      `-- file1
-  
-  2 directories, 2 files
+  ├── file2
+  │   ┆  contents2
+  └── sub1/
+      └── file1
+          ┆  contents1
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -50,30 +50,26 @@
   $ git checkout rfm
   Switched to branch 'rfm'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      `-- file2
-  
-  2 directories, 2 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      └── file2
+          ┆  contents2
 
-  $ cat sub1/file2
-  contents2
 
   $ git checkout rdm
   Switched to branch 'rdm'
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      `-- file2
-  
-  2 directories, 2 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      └── file2
+          ┆  contents2
 
-  $ cat sub1/file2
-  contents2
 
 
 Make sure all temporary namespace got removed

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -55,13 +55,13 @@ Flushed credential cache
   * add file3
   * add file1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      `-- file3
-  
-  2 directories, 2 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      └── file3
+          ┆  contents3
 
   $ git rebase master -q
   $ git log --graph --pretty=%s
@@ -69,14 +69,15 @@ Flushed credential cache
   * add file2
   * add file1
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      |-- file2
-      `-- file3
-  
-  2 directories, 3 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      ├── file2
+      │   ┆  contents2
+      └── file3
+          ┆  contents3
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -113,13 +113,13 @@
   $ git log --decorate --graph --pretty="%s %d"
   * add file1  (HEAD -> master, origin/master, origin/HEAD, origin/@base/master/josh@example.com/foo7, origin/@base/master/josh@example.com/1234)
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file7
-  `-- sub1
-      `-- file1
-  
-  2 directories, 2 files
+  ├── file7
+  │   ┆  before
+  └── sub1/
+      └── file1
+          ┆  contents1
 
 To avoid stacked changes to cause excessive amounts of refs, refs get filtered to only
 get listed if they differ from HEAD

--- a/tests/proxy/push_stacked_gerrit.t
+++ b/tests/proxy/push_stacked_gerrit.t
@@ -93,13 +93,13 @@
   $ git log --decorate --graph --pretty="%s %d"
   * add file1  (HEAD -> master, origin/master, origin/HEAD)
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file7
-  `-- sub1
-      `-- file1
-  
-  2 directories, 2 files
+  ├── file7
+  │   ┆  before
+  └── sub1/
+      └── file1
+          ┆  contents1
 
 Make sure all temporary namespace got removed
   $ tree ${TESTTMP}/remote/scratch/real_repo.git/refs/ | grep request_

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -132,12 +132,11 @@
   $ git log --decorate --graph --pretty="%s %d"
   * add file1  (HEAD -> master, origin/master, origin/HEAD, origin/@base/other_branch/josh@example.com/foo7, origin/@base/other_branch/josh@example.com/1234, origin/@base/master/josh@example.com/foo7, origin/@base/master/josh@example.com/1234)
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      `-- file1
-  
-  2 directories, 1 file
+  └── sub1/
+      └── file1
+          ┆  contents1
 
 Make sure all temporary namespace got removed
   $ tree ${TESTTMP}/remote/scratch/real_repo.git/refs/ | grep request_

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -33,13 +33,13 @@
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      `-- file2
-  
-  2 directories, 2 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      └── file2
+          ┆  contents2
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -68,16 +68,14 @@ Flushed credential cache
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      `-- file2
-  
-  2 directories, 2 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      └── file2
+          ┆  contents2
 
-  $ cat sub1/file2
-  contents2
 
 Make sure all temporary namespace got removed
   $ tree ${TESTTMP}/remote/scratch/real_repo.git/refs/ | grep request_

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -75,16 +75,14 @@ Put a double slash in the URL to see that it also works
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      `-- file2
-  
-  2 directories, 2 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1
+      └── file2
+          ┆  contents2
 
-  $ cat sub1/file2
-  contents2
 
   $ cd ${TESTTMP}/real_repo2
   $ git pull --rebase
@@ -96,16 +94,14 @@ Put a double slash in the URL to see that it also works
    1 file changed, 1 insertion(+)
    create mode 100644 sub1/file2
 
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- sub1
-      |-- file1
-      `-- file2
-  
-  2 directories, 2 files
+  └── sub1/
+      ├── file1
+      │   ┆  contents1_repo2
+      └── file2
+          ┆  contents2_repo2
 
-  $ cat sub1/file2
-  contents2_repo2
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real/repo2.git" = [

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -87,26 +87,25 @@
 
   $ git clone -q http://localhost:8002/real_repo.git:workspace=ws.git ws
   $ cd ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  # comment
+      ┆  #
+      ┆
+      ┆  # comment 2
+      ┆
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
-  $ cat workspace.josh
-  # comment
-  #
-  
-  # comment 2
-  
-  a/b = :/sub2
-  c = :/sub1
 
   $ git log --graph --pretty=%s
   * add file2
@@ -115,14 +114,20 @@
 
   $ git checkout -q HEAD~1 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  3 directories, 2 files
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  # comment
+      ┆  #
+      ┆
+      ┆  # comment 2
+      ┆
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
   $ git checkout master 1> /dev/null
   Previous HEAD position was e27e2ee add file1
@@ -154,33 +159,35 @@
 
   $ git clean -ffdx 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       |-- file1
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      `-- workspace.josh
-  
-  6 directories, 9 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       ├── file1
+  │       │   ┆  contents1
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      └── workspace.josh
+          ┆  # comment
+          ┆  #
+          ┆
+          ┆  # comment 2
+          ┆
+          ┆  c = :/sub1
+          ┆  a/b = :/sub2
 
-  $ cat ws/workspace.josh
-  # comment
-  #
-  
-  # comment 2
-  
-  c = :/sub1
-  a/b = :/sub2
 
   $ git log --graph --pretty=%s
   * add in filter
@@ -197,22 +204,30 @@
 
   $ git checkout -q HEAD~1 1> /dev/null
   $ git clean -ffdx 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- file1
-  |-- sub2
-  |   `-- file2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      `-- workspace.josh
-  
-  6 directories, 7 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── sub2/
+  │   └── file2
+  │       ┆  contents1
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      └── workspace.josh
+          ┆  # comment
+          ┆  #
+          ┆
+          ┆  # comment 2
+          ┆
+          ┆  a/b = :/sub2
+          ┆  c = :/sub1
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -92,17 +92,19 @@ Flushed credential cache
    + 1b46698...003a297 master     -> origin/master  (forced update)
   Already up to date.
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  c = :/sub1
+      ┆  a/b = :/sub2
 
   $ git log --graph --pretty=%s
   * add workspace
@@ -178,19 +180,23 @@ Flushed credential cache
    2 files changed, 3 insertions(+), 1 deletion(-)
    create mode 100644 d/file3
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  |-- d
-  |   `-- file3
-  `-- workspace.josh
-  
-  6 directories, 4 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── d/
+  │   └── file3
+  │       ┆  contents3
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
+      ┆  d = :/sub3
 
   $ git log --graph --pretty=%s
   *   mod workspace
@@ -200,36 +206,31 @@ Flushed credential cache
   * add file2
   * add file1
 
-  $ git checkout -q HEAD~1 1> /dev/null
-  $ tree
+  $ git-tree-pretty HEAD~1
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  c = :/sub1
+      ┆  a/b = :/sub2
 
-  $ git checkout HEAD~1 1> /dev/null
-  Previous HEAD position was 003a297 add workspace
-  HEAD is now at 2a03ad0 add file2
-  $ tree
+  $ git-tree-pretty HEAD~2
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  `-- c
-      `-- subsub
-          `-- file1
-  
-  5 directories, 2 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  └── c/
+      └── subsub/
+          └── file1
+              ┆  contents1
 
-  $ git checkout master 1> /dev/null
-  Previous HEAD position was 2a03ad0 add file2
-  Switched to branch 'master'
 
   $ echo newfile_1_contents > c/subsub/newfile_1
   $ git rm c/subsub/file1
@@ -293,28 +294,31 @@ Flushed credential cache
   Already up to date.
 
 Note that d/ is still in the tree but now it is not overlayed
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       |-- file2
-  |       `-- newfile_2
-  |-- c
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- d
-  |   `-- file3
-  |-- w
-  |   `-- file3
-  |-- workspace.josh
-  `-- ws_file
-  
-  7 directories, 7 files
+  ├── a/
+  │   └── b/
+  │       ├── file2
+  │       │   ┆  contents1
+  │       └── newfile_2
+  │           ┆  newfile_2_contents
+  ├── c/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── d/
+  │   └── file3
+  │       ┆  contents3
+  ├── w/
+  │   └── file3
+  │       ┆  contents3
+  ├── workspace.josh
+  │   ┆  c = :/sub1
+  │   ┆  a/b = :/sub2
+  │   ┆  w = :/sub3
+  └── ws_file
+      ┆  ws_file_contents
 
-  $ cat workspace.josh
-  c = :/sub1
-  a/b = :/sub2
-  w = :/sub3
 
   $ git log --graph --pretty=%s
   * try to modify ws
@@ -352,26 +356,33 @@ Flushed credential cache
   $ git clean -ffdx 1> /dev/null
 
 Note that ws/d/ is now present in the ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      |-- d
-      |   `-- file3
-      |-- workspace.josh
-      `-- ws_file
-  
-  7 directories, 10 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      ├── d/
+      │   └── file3
+      │       ┆  contents3
+      ├── workspace.josh
+      │   ┆  c = :/sub1
+      │   ┆  a/b = :/sub2
+      │   ┆  w = :/sub3
+      └── ws_file
+          ┆  ws_file_contents
   $ git log --graph --pretty=%s
   * try to modify ws
   * add in filter
@@ -390,45 +401,55 @@ Note that ws/d/ is now present in the ws
 
   $ git checkout -q HEAD~1 1> /dev/null
   $ git clean -ffdx 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      |-- workspace.josh
-      `-- ws_file
-  
-  6 directories, 9 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      ├── workspace.josh
+      │   ┆  c = :/sub1
+      │   ┆  a/b = :/sub2
+      │   ┆  d = :/sub3
+      └── ws_file
+          ┆  ws_file_contents
 
   $ git checkout HEAD~1 1> /dev/null
   Previous HEAD position was a1a7760 add in filter
   HEAD is now at f021d4b mod workspace
   $ git clean -ffdx 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- file1
-  |-- sub2
-  |   `-- file2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      `-- workspace.josh
-  
-  6 directories, 7 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── sub2/
+  │   └── file2
+  │       ┆  contents1
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      └── workspace.josh
+          ┆  a/b = :/sub2
+          ┆  c = :/sub1
+          ┆  d = :/sub3
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -91,17 +91,19 @@
 
   $ git clone -q http://localhost:8002/real_repo.git:workspace=ws.git ws
   $ cd ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
   $ git log --graph --pretty=%s
   * add file2

--- a/tests/proxy/workspace_errors.t
+++ b/tests/proxy/workspace_errors.t
@@ -34,11 +34,10 @@
 
   $ git clone -q http://localhost:8002/real_repo.git:workspace=ws.git ws
   $ cd ws
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- file1
-  
-  1 directory, 1 file
+  └── file1
+      ┆  content
 
 Error: comment in the middle
   $ cat > workspace.josh <<EOF

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -82,21 +82,20 @@
 
   $ git clone -q http://localhost:8002/real_repo.git:workspace=ws.git ws
   $ cd ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
-  $ cat workspace.josh
-  a/b = :/sub2
-  c = :/sub1
 
   $ git log --graph --pretty=%s
   * add file2
@@ -105,14 +104,15 @@
 
   $ git checkout -q HEAD~1 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  3 directories, 2 files
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
   $ git checkout master 1> /dev/null
   Previous HEAD position was 833812f add file1
@@ -144,28 +144,30 @@
 
   $ git clean -ffdx 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       |-- file1
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      `-- workspace.josh
-  
-  6 directories, 9 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       ├── file1
+  │       │   ┆  contents1
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      └── workspace.josh
+          ┆  c = :/sub1
+          ┆  a/b = :/sub2
 
-  $ cat ws/workspace.josh
-  c = :/sub1
-  a/b = :/sub2
 
   $ git log --graph --pretty=%s
   * add in filter

--- a/tests/proxy/workspace_in_workspace_prefix.t
+++ b/tests/proxy/workspace_in_workspace_prefix.t
@@ -82,21 +82,20 @@
 
   $ git clone -q http://localhost:8002/real_repo.git:workspace=ws.git ws
   $ cd ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
-  $ cat workspace.josh
-  a/b = :/sub2
-  c = :/sub1
 
   $ git log --graph --pretty=%s
   * add file2
@@ -105,14 +104,15 @@
 
   $ git checkout -q HEAD~1 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  3 directories, 2 files
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
   $ git checkout master 1> /dev/null
   Previous HEAD position was 833812f add file1
@@ -144,28 +144,30 @@
 
   $ git clean -ffdx 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       |-- file1
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      `-- workspace.josh
-  
-  6 directories, 9 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       ├── file1
+  │       │   ┆  contents1
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      └── workspace.josh
+          ┆  c = :/sub1
+          ┆  a/b = :/sub2
 
-  $ cat ws/workspace.josh
-  c = :/sub1
-  a/b = :/sub2
 
   $ git log --graph --pretty=%s
   * add in filter

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -73,21 +73,20 @@ Flushed credential cache
   | * add subsub1
   * add workspace
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   |-- subsub1
-  |   |   `-- file1
-  |   `-- subsub2
-  |       `-- file1
-  `-- workspace.josh
-  
-  4 directories, 3 files
-  $ cat workspace.josh
-  a = :/sub1:[
-      ::subsub1/
-      ::subsub2/
-  ]
+  ├── a/
+  │   ├── subsub1/
+  │   │   └── file1
+  │   │       ┆  contents1
+  │   └── subsub2/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a = :/sub1:[
+      ┆      ::subsub1/
+      ┆      ::subsub2/
+      ┆  ]
 
   $ cd ${TESTTMP}/real_repo
   $ git pull --rebase
@@ -155,16 +154,17 @@ Flushed credential cache
   $ git pull --rebase
   Current branch master is up to date.
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   |-- subsub1
-  |   |   `-- file1
-  |   `-- subsub2
-  |       `-- file1
-  `-- workspace.josh
-  
-  4 directories, 3 files
+  ├── a/
+  │   ├── subsub1/
+  │   │   └── file1
+  │   │       ┆  contents1
+  │   └── subsub2/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a/ = :/sub1
 
   $ git log --graph --pretty=%s
   * mod workspace

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -92,17 +92,19 @@ Flushed credential cache
    + 1b46698...d91fa49 master     -> origin/master  (forced update)
   Already up to date.
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  c = :/sub1
+      ┆  a/b = :/sub2
 
   $ git log --graph --pretty="%s - %an <%ae>"
   *   Merge from :workspace=ws - JOSH <josh@josh-project.dev>
@@ -184,19 +186,23 @@ Flushed credential cache
    2 files changed, 3 insertions(+), 1 deletion(-)
    create mode 100644 d/file3
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  |-- d
-  |   `-- file3
-  `-- workspace.josh
-  
-  6 directories, 4 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── d/
+  │   └── file3
+  │       ┆  contents3
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
+      ┆  d = :/sub3
 
   $ git log --graph --pretty=%s
   *   mod workspace
@@ -208,31 +214,26 @@ Flushed credential cache
   | * add file1
   * add workspace
 
-  $ git checkout -q HEAD~1 1> /dev/null
-  $ tree
+  $ git-tree-pretty HEAD~1
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  c = :/sub1
+      ┆  a/b = :/sub2
 
-  $ git checkout HEAD~1 1> /dev/null
-  Previous HEAD position was d91fa49 Merge from :workspace=ws
-  HEAD is now at 9441c1b add workspace
-  $ tree
+  $ git-tree-pretty HEAD~2
   .
-  `-- workspace.josh
-  
-  1 directory, 1 file
+  └── workspace.josh
+      ┆  c = :/sub1
+      ┆  a/b = :/sub2
 
-  $ git checkout master 1> /dev/null
-  Previous HEAD position was 9441c1b add workspace
-  Switched to branch 'master'
 
   $ echo newfile_1_contents > c/subsub/newfile_1
   $ git rm c/subsub/file1
@@ -295,26 +296,28 @@ Flushed credential cache
    + 7da1ae7...14c0592 master     -> origin/master  (forced update)
   Already up to date.
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       |-- file2
-  |       `-- newfile_2
-  |-- c
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- w
-  |   `-- file3
-  |-- workspace.josh
-  `-- ws_file
-  
-  6 directories, 6 files
+  ├── a/
+  │   └── b/
+  │       ├── file2
+  │       │   ┆  contents1
+  │       └── newfile_2
+  │           ┆  newfile_2_contents
+  ├── c/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── w/
+  │   └── file3
+  │       ┆  contents3
+  ├── workspace.josh
+  │   ┆  c = :/sub1
+  │   ┆  a/b = :/sub2
+  │   ┆  w = :/sub3
+  └── ws_file
+      ┆  ws_file_contents
 
-  $ cat workspace.josh
-  c = :/sub1
-  a/b = :/sub2
-  w = :/sub3
 
   $ git log --graph --pretty=%s
   * try to modify ws
@@ -352,24 +355,30 @@ Flushed credential cache
   $ git clean -ffdx 1> /dev/null
 
 Note that ws/d/ is now present in the ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      |-- workspace.josh
-      `-- ws_file
-  
-  6 directories, 9 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      ├── workspace.josh
+      │   ┆  c = :/sub1
+      │   ┆  a/b = :/sub2
+      │   ┆  w = :/sub3
+      └── ws_file
+          ┆  ws_file_contents
   $ git log --graph --pretty=%s
   * try to modify ws
   * add in filter
@@ -390,45 +399,55 @@ Note that ws/d/ is now present in the ws
 
   $ git checkout -q HEAD~1 1> /dev/null
   $ git clean -ffdx 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      |-- workspace.josh
-      `-- ws_file
-  
-  6 directories, 9 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      ├── workspace.josh
+      │   ┆  c = :/sub1
+      │   ┆  a/b = :/sub2
+      │   ┆  d = :/sub3
+      └── ws_file
+          ┆  ws_file_contents
 
   $ git checkout HEAD~1 1> /dev/null
   Previous HEAD position was c88a8ce add in filter
   HEAD is now at f9be76c mod workspace
   $ git clean -ffdx 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- file1
-  |-- sub2
-  |   `-- file2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      `-- workspace.josh
-  
-  6 directories, 7 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── sub2/
+  │   └── file2
+  │       ┆  contents1
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      └── workspace.josh
+          ┆  a/b = :/sub2
+          ┆  c = :/sub1
+          ┆  d = :/sub3
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -93,18 +93,19 @@
  
   $ git clone -q http://localhost:8002/real_repo.git:workspace=ws:/pre.git ws
   $ cd ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- d
-      `-- file3
-  
-  6 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── d/
+      └── file3
+          ┆  contents3
  
   $ git log --graph --pretty=%s
   *   mod workspace
@@ -114,27 +115,26 @@
   * add file1
  
   $ git checkout -q HEAD~1 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  `-- c
-      `-- subsub
-          `-- file1
-  
-  5 directories, 2 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  └── c/
+      └── subsub/
+          └── file1
+              ┆  contents1
  
   $ git checkout HEAD~1 1> /dev/null
   Previous HEAD position was 2a03ad0 add file2
   HEAD is now at 02668d7 add file1
-  $ tree
+  $ git-tree-pretty .
   .
-  `-- c
-      `-- subsub
-          `-- file1
-  
-  3 directories, 1 file
+  └── c/
+      └── subsub/
+          └── file1
+              ┆  contents1
  
   $ git checkout master 1> /dev/null
   Previous HEAD position was 02668d7 add file1
@@ -160,25 +160,33 @@
  
   $ git clean -ffdx 1> /dev/null
  
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- newfile1
-  |-- newfile_master
-  |-- root_file1
-  |-- sub1
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      |-- pre
-      |   `-- ws_file
-      `-- workspace.josh
-  
-  7 directories, 9 files
+  ├── newfile1
+  ├── newfile_master
+  ├── root_file1
+  ├── sub1/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      ├── pre/
+      │   └── ws_file
+      │       ┆  ws_file_contents
+      └── workspace.josh
+          ┆  pre = :[
+          ┆      c = :/sub1
+          ┆      a/b = :/sub2
+          ┆      d = :/sub3
+          ┆  ]
   $ git log --graph --pretty=%s
   * add in filter
   * mod workspace
@@ -196,45 +204,50 @@
  
   $ git checkout -q HEAD~1 1> /dev/null
   $ git clean -ffdx 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- newfile1
-  |-- newfile_master
-  |-- root_file1
-  |-- sub1
-  |   `-- subsub
-  |       `-- file1
-  |-- sub2
-  |   `-- file2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      `-- workspace.josh
-  
-  6 directories, 7 files
-  $ cat sub1/subsub/file1
-  contents1
+  ├── newfile1
+  ├── newfile_master
+  ├── root_file1
+  ├── sub1/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── sub2/
+  │   └── file2
+  │       ┆  contents1
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      └── workspace.josh
+          ┆  pre/a/b = :/sub2
+          ┆  pre/c = :/sub1
+          ┆  pre/d = :/sub3
  
   $ git checkout HEAD~1 1> /dev/null
   Previous HEAD position was 2b7018e mod workspace
   HEAD is now at d038198 add file3
   $ git clean -ffdx 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- newfile1
-  |-- newfile_master
-  |-- root_file1
-  |-- sub1
-  |   `-- subsub
-  |       `-- file1
-  |-- sub2
-  |   `-- file2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      `-- workspace.josh
-  
-  6 directories, 7 files
+  ├── newfile1
+  ├── newfile_master
+  ├── root_file1
+  ├── sub1/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── sub2/
+  │   └── file2
+  │       ┆  contents1
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      └── workspace.josh
+          ┆  pre/a/b = :/sub2
+          ┆  pre/c = :/sub1
  
  
   $ bash ${TESTDIR}/destroy_test_env.sh

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -89,19 +89,23 @@
 
   $ git clone -q http://localhost:8002/real_repo.git:workspace=ws:prefix=pre:/pre.git ws
   $ cd ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  |-- d
-  |   `-- file3
-  `-- workspace.josh
-  
-  6 directories, 4 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── d/
+  │   └── file3
+  │       ┆  contents3
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
+      ┆  d = :/sub3
 
   $ git log --graph --pretty=%s
   *   mod workspace
@@ -111,32 +115,31 @@
   * add file2
   * add file1
 
-  $ git checkout -q HEAD~1 1> /dev/null
-  $ tree
+  $ git-tree-pretty HEAD~1
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
-  $ git checkout -q HEAD~1 1> /dev/null
-  $ tree
+  $ git-tree-pretty HEAD~2
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  `-- c
-      `-- subsub
-          `-- file1
-  
-  5 directories, 2 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  └── c/
+      └── subsub/
+          └── file1
+              ┆  contents1
 
-  $ git checkout -q master 1> /dev/null
 
   $ echo newfile_1_contents > c/subsub/newfile_1
   $ git rm c/subsub/file1
@@ -186,21 +189,27 @@ Flushed credential cache
   $ git pull --rebase 2> /dev/null
 
 Note that d/ is still in the tree but now it is not overlayed
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       |-- file2
-  |       `-- newfile_2
-  |-- c
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- w
-  |   `-- file3
-  |-- workspace.josh
-  `-- ws_file
-  
-  6 directories, 6 files
+  ├── a/
+  │   └── b/
+  │       ├── file2
+  │       │   ┆  contents1
+  │       └── newfile_2
+  │           ┆  newfile_2_contents
+  ├── c/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── w/
+  │   └── file3
+  │       ┆  contents3
+  ├── workspace.josh
+  │   ┆  c = :/sub1
+  │   ┆  a/b = :/sub2
+  │   ┆  w = :/sub3
+  └── ws_file
+      ┆  ws_file_contents
 
 
 
@@ -215,24 +224,30 @@ Flushed credential cache
   $ git clean -ffdx 1> /dev/null
 
 Note that ws/d/ is now present in the ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      |-- workspace.josh
-      `-- ws_file
-  
-  6 directories, 9 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      ├── workspace.josh
+      │   ┆  c = :/sub1
+      │   ┆  a/b = :/sub2
+      │   ┆  w = :/sub3
+      └── ws_file
+          ┆  ws_file_contents
   $ git log --graph --pretty=%s
   * try to modify ws
   * add in filter
@@ -254,43 +269,53 @@ Note that ws/d/ is now present in the ws
 
   $ git checkout -q HEAD~1 1> /dev/null
   $ git clean -ffdx 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      |-- workspace.josh
-      `-- ws_file
-  
-  6 directories, 9 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      ├── workspace.josh
+      │   ┆  c = :/sub1
+      │   ┆  a/b = :/sub2
+      │   ┆  d = :/sub3
+      └── ws_file
+          ┆  ws_file_contents
 
   $ git checkout -q HEAD~1 1> /dev/null
   $ git clean -ffdx 1> /dev/null
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- file1
-  |-- sub2
-  |   `-- file2
-  |-- sub3
-  |   `-- file3
-  `-- ws
-      `-- workspace.josh
-  
-  6 directories, 7 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── sub2/
+  │   └── file2
+  │       ┆  contents1
+  ├── sub3/
+  │   └── file3
+  │       ┆  contents3
+  └── ws/
+      └── workspace.josh
+          ┆  a/b = :/sub2
+          ┆  c = :/sub1
+          ┆  d = :/sub3
 
 
   $ bash ${TESTDIR}/destroy_test_env.sh

--- a/tests/proxy/workspace_mv_folder.t
+++ b/tests/proxy/workspace_mv_folder.t
@@ -92,17 +92,19 @@ Flushed credential cache
    + 1b46698...d91fa49 master     -> origin/master  (forced update)
   Already up to date.
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  c = :/sub1
+      ┆  a/b = :/sub2
 
   $ git log --graph --pretty=%s
   *   Merge from :workspace=ws
@@ -178,17 +180,19 @@ Flushed credential cache
    + 5d8563b...251b9a3 master     -> origin/master  (forced update)
   Already up to date.
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- c
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── c/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  c = :/sub1
+      ┆  a/c = :/sub2
 
   $ git log --graph --pretty=%s
   * mod workspace
@@ -210,20 +214,22 @@ Flushed credential cache
    ws/workspace.josh | 2 +-
    1 file changed, 1 insertion(+), 1 deletion(-)
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  |-- newfile1
-  |-- newfile_master
-  |-- sub1
-  |   `-- subsub
-  |       `-- file1
-  |-- sub2
-  |   `-- file2
-  `-- ws
-      `-- workspace.josh
-  
-  5 directories, 6 files
+  ├── file1
+  ├── newfile1
+  ├── newfile_master
+  ├── sub1/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── sub2/
+  │   └── file2
+  │       ┆  contents1
+  └── ws/
+      └── workspace.josh
+          ┆  c = :/sub1
+          ┆  a/c = :/sub2
   $ git log --graph --pretty=%s
   * mod workspace
   *   Merge from :workspace=ws

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -55,15 +55,16 @@ file was created
 
   $ git clone -q http://localhost:8002/real_repo.git:workspace=ws.git ws
   $ cd ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  |-- file1
-  `-- workspace.josh
-  
-  3 directories, 3 files
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  ├── file1
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
   $ git log --graph --pretty=%s
   * add file1
@@ -72,12 +73,12 @@ file was created
 
   $ git checkout -q HEAD~1 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- file1
-  `-- workspace.josh
-  
-  1 directory, 2 files
+  ├── file1
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -43,14 +43,14 @@
 
   $ git clone -q http://localhost:8002/real_repo.git:workspace=ws.git ws
   $ cd ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  `-- workspace.josh
-  
-  3 directories, 2 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a/b = :/sub2
 
   $ git log --graph --pretty=%s
   * add file2
@@ -85,37 +85,41 @@
 
   $ git clean -ffdx 1> /dev/null
 
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- sub1
-  |   `-- subsub
-  |       `-- newfile_1
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  `-- ws
-      `-- workspace.josh
-  
-  5 directories, 4 files
+  ├── sub1/
+  │   └── subsub/
+  │       └── newfile_1
+  │           ┆  newfile_1_contents
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  └── ws/
+      └── workspace.josh
+          ┆  c = :/sub1
+          ┆  a/b = :/sub2
   $ git log --graph --pretty=%s
   * publish
   * add in filter
   * add file2
   * add workspace
 
-  $ git checkout -q HEAD~1 1> /dev/null
-  $ tree
+  $ git-tree-pretty HEAD~1
   .
-  |-- sub2
-  |   |-- file2
-  |   `-- newfile_2
-  `-- ws
-      |-- c
-      |   `-- subsub
-      |       `-- newfile_1
-      `-- workspace.josh
-  
-  5 directories, 4 files
+  ├── sub2/
+  │   ├── file2
+  │   │   ┆  contents1
+  │   └── newfile_2
+  │       ┆  newfile_2_contents
+  └── ws/
+      ├── c/
+      │   └── subsub/
+      │       └── newfile_1
+      │           ┆  newfile_1_contents
+      └── workspace.josh
+          ┆  a/b = :/sub2
 
   $ bash ${TESTDIR}/destroy_test_env.sh
   "real_repo.git" = [

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -82,21 +82,20 @@
 
   $ git clone -q http://localhost:8002/real_repo.git:workspace=ws.git ws
   $ cd ws
-  $ tree
+  $ git-tree-pretty .
   .
-  |-- a
-  |   `-- b
-  |       `-- file2
-  |-- c
-  |   `-- subsub
-  |       `-- file1
-  `-- workspace.josh
-  
-  5 directories, 3 files
+  ├── a/
+  │   └── b/
+  │       └── file2
+  │           ┆  contents1
+  ├── c/
+  │   └── subsub/
+  │       └── file1
+  │           ┆  contents1
+  └── workspace.josh
+      ┆  a/b = :/sub2
+      ┆  c = :/sub1
 
-  $ cat workspace.josh
-  a/b = :/sub2
-  c = :/sub1
 
   $ git log --graph --pretty=%s
   * add file2

--- a/ws/tests-per-category.star
+++ b/ws/tests-per-category.star
@@ -29,6 +29,7 @@ def generate_test_nodes():
 
         inputs = compose([
             filter.treeid("josh", filter.stored("ws/build-rust")),
+            filter.treeid("devtools-build", filter.stored("ws/devtools-build")),
             filter.treeid("build-go", filter.stored("ws/build-go")),
         ]).prefix("inputs")
 


### PR DESCRIPTION
Use git-tree-pretty throughout scrut tests

Render Git trees and blob contents directly from revisions instead of
materializing them in working copies or diffing against the empty tree.
Make the devtool available to each scrut test category.

Change: pretty-scrut-tree-snapshots
Assisted-By: openai-codex/gpt-5.6-sol