### PR TITLE
Dereference gitlink object references

### DIFF
--- a/docs/src/contributing/josh-run.md
+++ b/docs/src/contributing/josh-run.md
@@ -166,6 +166,10 @@ A workspace is defined by a `.josh` file, typically under `ws/`. The file uses j
 | `inputs = :[...]` | Dependency workspaces; each named entry is run first and its output is mounted inside the container |
 | `env = :[...]` | Environment variables injected into the container |
 
+The reference-bearing entries created with `:#` (`image`, named `inputs`, image `bases`, and
+`sidecars`) are stored as gitlinks. `josh compose` reads their object IDs directly from the tree
+entries; the referenced objects remain ordinary josh workspace or image trees.
+
 ### Example: `ws/fetch.josh`
 
 ```

--- a/docs/src/reference/experimental.md
+++ b/docs/src/reference/experimental.md
@@ -7,42 +7,44 @@ may change in future releases.
 ## Filters
 
 ### Object reference **`:&path`**
-Reads the git object at `path` (a file or directory) and replaces its content with a text blob
-containing the object's SHA-1 hash. This turns a real file or tree into a lightweight pointer.
+Reads the git object at `path` (a file or directory) and replaces it with a gitlink carrying
+the object's ID. Although gitlinks normally identify submodule commits, this filter may store a
+blob or tree ID in one so the reference does not require a separate pointer blob.
 
 If `path` does not exist in the input tree, the filter is a no-op.
 
-Example: `:&sub1` on a commit where `sub1` is a directory produces a file `sub1` whose content
-is the 40-character SHA of that directory tree.
+Example: `:&sub1` on a commit where `sub1` is a directory produces a gitlink `sub1` whose object
+ID is the ID of that directory tree.
 
 ### Object dereference **`:#path`**
-Reads the SHA-1 hash stored as text in the file at `path` and replaces that file with the git
-object the hash points to (a file or a directory tree). This follows the pointer written by
-`:&path`.
+Reads the object ID stored directly in the gitlink at `path` and replaces the gitlink with the
+object it identifies. Blob and tree IDs restore the corresponding file or directory written by
+`:&path`. A commit ID is treated as a submodule reference: the commit's tree is restored at
+`path`, and pointer updates merge the referenced commit history into the filtered history.
 
-If `path` does not exist the filter is a no-op. If the content is not a valid SHA or the object
-is not present in the repository, an error is returned.
+If `path` does not exist the filter is a no-op. If the entry is not a gitlink or the referenced
+object is not present in the repository, an error is returned.
 
-Example: given a file `sub1` whose content is the SHA of a directory tree, `:#sub1` replaces
-that file with the actual directory tree at `sub1`.
+Example: given a gitlink `sub1` carrying the ID of a directory tree or commit, `:#sub1` replaces
+that gitlink with the actual directory tree at `sub1`.
 
 ### Object dereference into subdirectory **`:#/path`**
-Dereferences the pointer stored at `path` and then extracts the resulting object directly at the
+Dereferences the gitlink stored at `path` and then extracts the resulting object directly at the
 repository root, discarding the `path` prefix. This is the typical way to restore content that
 was previously stored with `:&path`.
 
 Expands to `:#path:/path`. The canonical printed form is the expanded syntax.
 
-Example: `:#/sub1` on a tree where `sub1` holds a SHA of a directory returns that directory's
+Example: `:#/sub1` on a tree where `sub1` is a gitlink to a directory returns that directory's
 contents at the root, as if `sub1` never existed.
 
 ### Tree ID capture **`:#path[filter]`**
-Applies `filter` to the current tree and writes the SHA-1 hash of the resulting tree as a text
-file at `path`. The filter itself does not appear in the output — only the hash it produces.
+Applies `filter` to the current tree and writes a gitlink carrying the resulting tree's object ID
+at `path`. The filter itself does not appear in the output — only the reference it produces.
 
-This lets you record a stable, content-addressed reference to a subtree alongside other files.
+This lets you record a stable, content-addressed reference to a subtree alongside other entries.
 
-Example: `:#version.txt[:/sub1]` writes the SHA of the `sub1` directory tree into `version.txt`.
+Example: `:#version[:/sub1]` writes the ID of the `sub1` directory tree into the gitlink `version`.
 
 ### Starlark filter **`:!path/to/script[context filter]`**
 Evaluates a [Starlark](https://github.com/bazelbuild/starlark) script stored in the repository

--- a/josh-compose/src/container.rs
+++ b/josh-compose/src/container.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 use std::path::Path;
-use std::str::FromStr;
 
 use josh_core::cache;
 use josh_core::memodb;
@@ -114,21 +113,14 @@ pub fn run_container(
     eprintln!("[{}] Running ({})", workspace_meta.label, ws_tree);
 
     // Run all dependencies, collecting failures so sibling jobs still get a chance to run.
-    let input_entries = meta::read_blob_entries(transaction, odb, ws_tree, "inputs");
+    let input_entries = meta::read_gitlink_entries(transaction, odb, ws_tree, "inputs")?;
     let mut dep_volumes: Vec<(String, String, bool)> = vec![];
     let mut dep_errors: Vec<String> = vec![];
-    for (dep_name, dep_sha) in &input_entries {
-        let dep_tree = match gix_hash::ObjectId::from_str(dep_sha.trim()) {
-            Ok(oid) => oid,
-            Err(_) => {
-                dep_errors.push(format!("dependency {dep_name}: invalid SHA {dep_sha:?}"));
-                continue;
-            }
-        };
+    for (dep_name, dep_tree) in &input_entries {
         if let Err(e) = run_container(
             transaction,
             odb,
-            dep_tree,
+            *dep_tree,
             attempted,
             extract_to_workdir,
             runtime,
@@ -136,11 +128,11 @@ pub fn run_container(
             dep_errors.push(format!("dependency {dep_name} failed: {e}"));
             continue;
         }
-        let dep_meta = meta::read_meta(transaction, odb, dep_tree)?;
+        let dep_meta = meta::read_meta(transaction, odb, *dep_tree)?;
         if dep_meta.output == OutputMode::None {
             continue;
         }
-        let dep_out_vol = naming::output(dep_tree);
+        let dep_out_vol = naming::output(*dep_tree);
         if !runtime.artifact_exists(&dep_out_vol)? {
             dep_errors.push(format!("dependency {dep_name} has no output volume"));
             continue;

--- a/josh-compose/src/image.rs
+++ b/josh-compose/src/image.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use std::str::FromStr;
 
 use josh_compose_backend::{EnvRecipe, EnvironmentBackend};
 use josh_core::cache;
@@ -30,12 +29,10 @@ pub fn ensure_image(
 
     // Build each base environment and pass its key as a build arg so the
     // Containerfile can reference it (e.g. ARG my_base; FROM $my_base).
-    let base_entries = meta::read_blob_entries(transaction, odb, build_tree, "bases");
-    for (base_name, base_sha) in &base_entries {
-        let base_oid = gix_hash::ObjectId::from_str(base_sha.trim())
-            .with_context(|| format!("invalid base SHA for {base_name}: {base_sha}"))?;
+    for (base_name, base_oid) in meta::read_gitlink_entries(transaction, odb, build_tree, "bases")?
+    {
         let base_env = ensure_image(transaction, odb, base_oid, runtime)?;
-        build_args.push((base_name.clone(), base_env));
+        build_args.push((base_name, base_env));
     }
 
     for (k, v) in meta::read_blob_entries(transaction, odb, build_tree, "args") {

--- a/josh-compose/src/meta.rs
+++ b/josh-compose/src/meta.rs
@@ -1,12 +1,7 @@
-//! Workspace metadata parsed from git trees.
-//!
-//! Each workspace in the build graph stores its configuration as blobs in a git tree
-//! (`label`, `output`, `cmd`, `image`/build-tree OID, sidecar specs, etc.). This
-//! module reads those blobs and constructs typed [`WorkspaceMeta`] values for the
-//! scheduler.
+//! Decodes compose workspace trees into scheduler metadata.
+//! Scalar settings are blobs; object references are gitlinks.
 
 use std::path::Path;
-use std::str::FromStr;
 
 use crate::OutputMode;
 use josh_compose_backend::NetworkPolicy;
@@ -105,11 +100,48 @@ pub fn read_blob_entries(
         .collect()
 }
 
-/// Parse a workspace's configuration from its git tree.
-///
-/// Reads blobs named `label`, `output`, `cmd`, `cache`, `network`, and `image`, plus
-/// the optional `worktree` subtree. Returns `None` for `image` and `worktree` when
-/// the workspace is orchestrator-only (no image to build and no files to mount).
+pub fn read_gitlink(
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
+    tree_oid: gix_hash::ObjectId,
+    path: &str,
+) -> anyhow::Result<Option<gix_hash::ObjectId>> {
+    let Some(entry) = tree::get_path_entry(transaction, odb, tree_oid, Path::new(path))? else {
+        return Ok(None);
+    };
+    if !entry.mode.is_commit() {
+        anyhow::bail!("expected gitlink at {path}");
+    }
+    Ok(Some(entry.oid))
+}
+
+pub fn read_gitlink_entries(
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
+    tree_oid: gix_hash::ObjectId,
+    prefix: &str,
+) -> anyhow::Result<Vec<(String, gix_hash::ObjectId)>> {
+    let Ok(Some(entry)) = tree::get_path_entry(transaction, odb, tree_oid, Path::new(prefix))
+    else {
+        return Ok(vec![]);
+    };
+    let Ok(subtree) = tree::read_tree(transaction, odb, entry.oid) else {
+        return Ok(vec![]);
+    };
+    Ok(subtree
+        .entries()
+        .filter(|entry| entry.mode.is_commit())
+        .map(|entry| {
+            (
+                String::from_utf8_lossy(entry.filename).into_owned(),
+                entry.oid.to_owned(),
+            )
+        })
+        .collect())
+}
+
+/// Decode a workspace tree.
+/// Missing image and worktree entries represent orchestrator-only nodes.
 pub fn read_meta(
     transaction: &cache::Transaction,
     odb: &memodb::Odb,
@@ -136,13 +168,7 @@ pub fn read_meta(
         _ => NetworkPolicy::None,
     };
 
-    let image = read_blob(transaction, odb, ws_tree, "image")
-        .filter(|s| !s.is_empty())
-        .map(|sha| {
-            gix_hash::ObjectId::from_str(&sha)
-                .map_err(|_| anyhow::anyhow!("invalid image SHA in workspace tree: {sha}"))
-        })
-        .transpose()?;
+    let image = read_gitlink(transaction, odb, ws_tree, "image")?;
 
     let tree = tree::read_tree(transaction, odb, ws_tree)?;
     let worktree = tree.entry(b"worktree").map(|e| e.oid.to_owned());
@@ -167,14 +193,9 @@ pub fn read_sidecars(
     ws_tree: gix_hash::ObjectId,
 ) -> anyhow::Result<Vec<SidecarSpec>> {
     let mut out = vec![];
-    for (name, content) in read_blob_entries(transaction, odb, ws_tree, "sidecars") {
-        let sidecar_tree = gix_hash::ObjectId::from_str(content.trim())
-            .map_err(|_| anyhow::anyhow!("sidecar {name}: invalid tree SHA {content:?}"))?;
-        let image_sha = read_blob(transaction, odb, sidecar_tree, "image")
-            .filter(|s| !s.is_empty())
+    for (name, sidecar_tree) in read_gitlink_entries(transaction, odb, ws_tree, "sidecars")? {
+        let image = read_gitlink(transaction, odb, sidecar_tree, "image")?
             .ok_or_else(|| anyhow::anyhow!("sidecar {name}: missing image"))?;
-        let image = gix_hash::ObjectId::from_str(&image_sha)
-            .map_err(|_| anyhow::anyhow!("sidecar {name}: invalid image SHA {image_sha:?}"))?;
         let port_str = read_blob(transaction, odb, sidecar_tree, "port")
             .filter(|s| !s.is_empty())
             .ok_or_else(|| anyhow::anyhow!("sidecar {name}: missing port"))?;
@@ -191,4 +212,54 @@ pub fn read_sidecars(
         });
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_references_are_gitlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        gix::init_bare(dir.path()).unwrap();
+        let context = cache::TransactionContext::new(
+            dir.path(),
+            std::sync::Arc::new(cache::CacheStack::new()),
+        );
+        let transaction = context.open().unwrap();
+        let odb = transaction.odb();
+        let leaf = gix_hash::ObjectId::from_bytes_or_panic(&[1; 20]);
+        let target =
+            tree::insert_oid(odb, tree::empty_id(), Path::new("leaf"), leaf, 0o100644).unwrap();
+
+        let inputs = tree::insert_oid(
+            odb,
+            tree::empty_id(),
+            Path::new("dependency"),
+            target,
+            0o160000,
+        )
+        .unwrap();
+        let workspace =
+            tree::insert_oid(odb, tree::empty_id(), Path::new("image"), target, 0o160000).unwrap();
+        let workspace =
+            tree::insert_oid(odb, workspace, Path::new("inputs"), inputs, 0o040000).unwrap();
+        let workspace =
+            tree::insert_oid(odb, workspace, Path::new("invalid"), target, 0o100644).unwrap();
+
+        assert_eq!(
+            read_meta(&transaction, odb, workspace).unwrap().image,
+            Some(target)
+        );
+        assert_eq!(
+            read_gitlink_entries(&transaction, odb, workspace, "inputs").unwrap(),
+            vec![("dependency".to_string(), target)]
+        );
+        assert_eq!(
+            read_gitlink(&transaction, odb, workspace, "invalid")
+                .unwrap_err()
+                .to_string(),
+            "expected gitlink at invalid"
+        );
+    }
 }

--- a/josh-compose/src/plan.rs
+++ b/josh-compose/src/plan.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::str::FromStr;
 
 use josh_core::cache;
 use josh_core::memodb;
@@ -97,9 +96,7 @@ fn walk_workspace(
         return Ok(());
     }
 
-    for (dep_name, dep_sha) in meta::read_blob_entries(transaction, odb, ws_tree, "inputs") {
-        let dep_tree = gix_hash::ObjectId::from_str(dep_sha.trim())
-            .map_err(|_| anyhow::anyhow!("dependency {dep_name}: invalid tree SHA {dep_sha:?}"))?;
+    for (_, dep_tree) in meta::read_gitlink_entries(transaction, odb, ws_tree, "inputs")? {
         walk_workspace(
             transaction,
             odb,
@@ -141,9 +138,7 @@ fn walk_workspace_jobs(
         return Ok(());
     }
 
-    for (dep_name, dep_sha) in meta::read_blob_entries(transaction, odb, ws_tree, "inputs") {
-        let dep_tree = gix_hash::ObjectId::from_str(dep_sha.trim())
-            .map_err(|_| anyhow::anyhow!("dependency {dep_name}: invalid tree SHA {dep_sha:?}"))?;
+    for (_, dep_tree) in meta::read_gitlink_entries(transaction, odb, ws_tree, "inputs")? {
         walk_workspace_jobs(
             transaction,
             odb,
@@ -194,9 +189,7 @@ fn collect_image_with_bases(
         return Ok(());
     }
 
-    for (base_name, base_sha) in meta::read_blob_entries(transaction, odb, image_oid, "bases") {
-        let base_oid = gix_hash::ObjectId::from_str(base_sha.trim())
-            .map_err(|_| anyhow::anyhow!("invalid base SHA for {base_name}: {base_sha:?}"))?;
+    for (_, base_oid) in meta::read_gitlink_entries(transaction, odb, image_oid, "bases")? {
         collect_image_with_bases(transaction, odb, base_oid, out, image_seen)?;
     }
 

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -933,6 +933,79 @@ pub fn apply_to_commit2(
                 .transpose();
             }
         }
+        Op::ObjectDeref(path) => {
+            let referenced_commit = tree::get_path_entry(transaction, odb, commit.tree_id()?, path)
+                .ok()
+                .flatten()
+                .filter(|entry| entry.mode.is_commit())
+                .and_then(|entry| {
+                    matches!(odb.try_kind(entry.oid), Ok(Some(gix_object::Kind::Commit)))
+                        .then_some(entry.oid)
+                });
+
+            if let Some(new_oid) = referenced_commit {
+                let normal_parents = commit
+                    .parent_ids()
+                    .map(|parent| transaction.get(filter, parent))
+                    .collect::<anyhow::Result<Option<Vec<gix_hash::ObjectId>>>>()?;
+                let normal_parents = some_or!(normal_parents, { return Ok(None) });
+
+                let old_oid = if let Some(parent) = commit.first_parent_id() {
+                    let parent_tree = git::read_tree_id(odb, parent)?;
+                    tree::get_path_entry(transaction, odb, parent_tree, path)
+                        .ok()
+                        .flatten()
+                        .filter(|entry| entry.mode.is_commit())
+                        .and_then(|entry| {
+                            matches!(odb.try_kind(entry.oid), Ok(Some(gix_object::Kind::Commit)))
+                                .then_some(entry.oid)
+                        })
+                        .unwrap_or_else(|| gix_hash::ObjectId::null(gix_hash::Kind::Sha1))
+                } else {
+                    gix_hash::ObjectId::null(gix_hash::Kind::Sha1)
+                };
+
+                let original_target = normal_parents
+                    .first()
+                    .copied()
+                    .unwrap_or_else(|| gix_hash::ObjectId::null(gix_hash::Kind::Sha1));
+                let mut filtered_parents = normal_parents;
+                let path_filter = to_filter(Op::Subdir(path.clone()));
+                if original_target != gix_hash::ObjectId::null(gix_hash::Kind::Sha1)
+                    && transaction.get(path_filter, original_target)?.is_none()
+                {
+                    return Ok(None);
+                }
+
+                if old_oid != new_oid {
+                    let referenced_history = history::unapply_filter(
+                        transaction,
+                        path_filter,
+                        original_target,
+                        old_oid,
+                        new_oid,
+                        history::OrphansMode::Keep,
+                        None,
+                    )?;
+                    if referenced_history != gix_hash::ObjectId::null(gix_hash::Kind::Sha1) {
+                        filtered_parents.push(referenced_history);
+                    }
+                }
+
+                let filtered_tree =
+                    apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?;
+                return Some(history::create_filtered_commit(
+                    &commit,
+                    filtered_parents,
+                    filtered_tree,
+                    transaction,
+                    filter,
+                ))
+                .transpose();
+            }
+
+            apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?
+        }
         Op::Workspace(ws_path) => {
             // The get_* helpers return a bare Filter and would fold an unreadable tree to
             // Op::Empty, so bad input must error here; every probe below shares the read.
@@ -1631,25 +1704,23 @@ fn apply_impl(
             apply_impl(transaction, odb, f, x)
         }
         Op::TreeId(path, subfilter) => {
-            let applied = apply_impl(transaction, odb, *subfilter, x.clone())?;
-            let oid_str = applied.tree_id().to_string();
-            apply_impl(
-                transaction,
+            let tree_oid = apply_impl(transaction, odb, *subfilter, x.clone())?.tree_id();
+            Ok(x.with_tree(tree::insert_oid(
                 odb,
-                to_filter(Op::Insert(path.clone(), InsertContent::Inline(oid_str))),
-                x,
-            )
+                tree::empty_id(),
+                path,
+                tree_oid,
+                0o160000,
+            )?))
         }
         Op::ObjectRef(path) => {
             if let Ok(Some(entry)) = tree::get_path_entry(transaction, odb, x.tree_id(), path) {
-                let oid_str = entry.oid.to_string();
-                let blob_oid = odb.write(gix_object::Kind::Blob, oid_str.as_bytes());
                 Ok(x.with_tree(tree::insert_oid(
                     odb,
                     tree::empty_id(),
                     path,
-                    blob_oid,
-                    0o100644,
+                    entry.oid,
+                    0o160000,
                 )?))
             } else {
                 Ok(x)
@@ -1661,39 +1732,23 @@ fn apply_impl(
                 Ok(Some(e)) => e,
                 _ => return Ok(x),
             };
-            // Path exists: read OID string from blob content.
-            let oid_str = if let Some(blob) = tree::blob_bytes(odb, entry.oid) {
-                std::str::from_utf8(&blob)?
-                    .lines()
-                    .next()
-                    .unwrap_or("")
-                    .trim()
-                    .to_string()
-            } else {
-                String::new()
-            };
-            if let Ok(oid) = gix_hash::ObjectId::from_str(&oid_str) {
-                // Kind by header, never by `contains`: `read_header`'s disk fallback
-                // virtualizes the empty tree, `exists` does not.
-                let (oid, mode) = match odb.try_kind(oid) {
-                    Ok(Some(gix_object::Kind::Tree)) => (oid, 0o040000),
-                    Ok(Some(gix_object::Kind::Blob)) => (oid, 0o100644),
-                    _ => {
-                        return Err(anyhow::anyhow!(":#: object not found in repo: {}", oid));
-                    }
-                };
-                Ok(x.with_tree(tree::insert_oid(odb, tree::empty_id(), path, oid, mode)?))
-            } else {
-                // Content is not a valid OID: insert empty blob at path.
-                let empty_blob = odb.write(gix_object::Kind::Blob, b"");
-                Ok(x.with_tree(tree::insert_oid(
-                    odb,
-                    tree::empty_id(),
-                    path,
-                    empty_blob,
-                    0o100644,
-                )?))
+            if !entry.mode.is_commit() {
+                return Err(anyhow::anyhow!(
+                    ":#: expected gitlink at path: {}",
+                    path.display()
+                ));
             }
+            let oid = entry.oid;
+            // Header lookup can resolve the virtual empty tree; existence checks cannot.
+            let (oid, mode) = match odb.try_kind(oid) {
+                Ok(Some(gix_object::Kind::Commit)) => (git::read_tree_id(odb, oid)?, 0o040000),
+                Ok(Some(gix_object::Kind::Tree)) => (oid, 0o040000),
+                Ok(Some(gix_object::Kind::Blob)) => (oid, 0o100644),
+                _ => {
+                    return Err(anyhow::anyhow!(":#: object not found in repo: {}", oid));
+                }
+            };
+            Ok(x.with_tree(tree::insert_oid(odb, tree::empty_id(), path, oid, mode)?))
         }
 
         Op::Compose(filters) => {

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -164,8 +164,8 @@ impl Filter {
         Ok(self.chain(to_filter(Op::Starlark(path.into(), subfilter))))
     }
 
-    /// Chain a filter that inserts a blob containing the tree OID of the subfilter applied to the input tree.
-    /// Syntax: `:#path[filter]` (e.g. `:#version.txt[:/lib]` inserts a blob at `version.txt` with the OID of `:/lib` applied).
+    /// Chain a filter that stores the subfilter's tree ID as a gitlink at `path`.
+    /// Syntax: `:#path[filter]`, for example `:#version[:/lib]`.
     pub fn treeid(
         self,
         path: impl Into<std::path::PathBuf>,

--- a/tests/experimental/object_deref_submodule.t
+++ b/tests/experimental/object_deref_submodule.t
@@ -1,0 +1,124 @@
+  $ export TESTTMP=${PWD}
+  $ export JOSH_EXPERIMENTAL_FEATURES=1
+  $ git config --global protocol.file.allow always
+
+  $ cd ${TESTTMP}
+  $ git init -q submodule-repo 1> /dev/null
+  $ cd submodule-repo
+
+  $ mkdir -p foo
+  $ echo "foo content" > foo/file1.txt
+  $ git add foo
+  $ git commit -m "add foo with files" 1> /dev/null
+
+  $ mkdir -p bar
+  $ echo "bar content" > bar/file2.txt
+  $ git add bar
+  $ git commit -m "add bar with file" 1> /dev/null
+
+  $ cd ${TESTTMP}
+  $ git init -q main-repo 1> /dev/null
+  $ cd main-repo
+
+  $ echo "main content" > main.txt
+  $ git add main.txt
+  $ git commit -m "add main.txt" 1> /dev/null
+
+  $ git submodule add ../submodule-repo libs 2> /dev/null
+  $ git commit -m "add libs submodule" 1> /dev/null
+  $ git fetch ../submodule-repo
+  From ../submodule-repo
+   * branch            HEAD       -> FETCH_HEAD
+
+Dereferencing a gitlink that points at a commit restores the commit's tree and
+merges its history at the pointer update.
+
+  $ josh-filter ':#libs' master --update refs/josh/filter/master 1> /dev/null
+
+  $ git log --graph --pretty=%s refs/josh/filter/master
+  *   add libs submodule
+  |\  
+  | * add bar with file
+  | * add foo with files
+  * add main.txt
+
+The dereference filter selects only the referenced path. The gitlink becomes a
+plain tree, while unrelated files and .gitmodules are absent.
+
+  $ git-tree-pretty refs/josh/filter/master
+  .
+  └── libs/
+      ├── bar/
+      │   └── file2.txt
+      │       ┆  bar content
+      └── foo/
+          └── file1.txt
+              ┆  foo content
+
+Composing the dereference with the original tree minus the referenced path
+keeps the main repository content and replaces only the gitlink.
+
+  $ josh-filter ':[:exclude[:#libs],:#libs]' master --update refs/josh/filter/combined 1> /dev/null
+
+  $ git-tree-pretty refs/josh/filter/combined
+  .
+  ├── .gitmodules
+  │   ┆  [submodule "libs"]
+  │   ┆  	path = libs
+  │   ┆  	url = ../submodule-repo
+  ├── libs/
+  │   ├── bar/
+  │   │   └── file2.txt
+  │   │       ┆  bar content
+  │   └── foo/
+  │       └── file1.txt
+  │           ┆  foo content
+  └── main.txt
+      ┆  main content
+
+Moving the gitlink merges only the newly referenced submodule commits.
+
+  $ cd ${TESTTMP}/submodule-repo
+  $ echo "new content" > foo/file3.txt
+  $ git add foo/file3.txt
+  $ git commit -m "add file3.txt" 1> /dev/null
+
+  $ echo "another new content" > bar/file4.txt
+  $ git add bar/file4.txt
+  $ git commit -m "add file4.txt" 1> /dev/null
+
+  $ cd ${TESTTMP}/main-repo
+  $ git submodule update --remote libs 1> /dev/null 2> /dev/null
+  $ git add libs
+  $ git commit -m "update libs submodule" 1> /dev/null
+  $ git fetch ../submodule-repo
+  From ../submodule-repo
+   * branch            HEAD       -> FETCH_HEAD
+
+  $ josh-filter ':#libs' master --update refs/josh/filter/master 1> /dev/null
+
+  $ git log --graph --pretty=%s refs/josh/filter/master
+  *   update libs submodule
+  |\  
+  | * add file4.txt
+  | * add file3.txt
+  |/  
+  *   add libs submodule
+  |\  
+  | * add bar with file
+  | * add foo with files
+  * add main.txt
+
+  $ git-tree-pretty refs/josh/filter/master
+  .
+  └── libs/
+      ├── bar/
+      │   ├── file2.txt
+      │   │   ┆  bar content
+      │   └── file4.txt
+      │       ┆  another new content
+      └── foo/
+          ├── file1.txt
+          │   ┆  foo content
+          └── file3.txt
+              ┆  new content

--- a/tests/experimental/treeblob.t
+++ b/tests/experimental/treeblob.t
@@ -34,18 +34,20 @@ Roundtrip: :& spec is preserved
   $ josh-filter -p ':&version.txt'
   :&version.txt
 
-Apply via stored filter: blob at path contains tree OID of subfilter result
+TreeId via stored filter: gitlink carries the tree OID of the subfilter result
   $ cat > filter.josh <<'EOF'
-  > :#version.txt[:/sub1]
+  > :#version[:/sub1]
   > EOF
   $ git add filter.josh
   $ git commit -m "add filter" 1> /dev/null
   $ josh-filter -s :+filter master --update refs/josh/master 1> /dev/null
-  $ [ "$(git show refs/josh/master:version.txt)" = "$(git rev-parse master:sub1)" ] && echo "match"
+  $ git ls-tree refs/josh/master version | cut -d' ' -f1-2
+  160000 commit
+  $ [ "$(git rev-parse refs/josh/master:version)" = "$(git rev-parse master:sub1)" ] && echo "match"
   match
 
-Reverse: a treeid inverts to :empty (it fabricates a blob and consumes no input)
-  $ josh-filter --reverse -p ':#version.txt[:/sub1]'
+Reverse: a treeid inverts to :empty (it fabricates a gitlink and consumes no input)
+  $ josh-filter --reverse -p ':#version[:/sub1]'
   :empty
 
 Apply: composing treeid groups across sibling directories keeps every entry
@@ -71,37 +73,37 @@ Deref: path not found is treated as nop (reference is updated, path absent from 
   $ git show refs/josh/noptest:version.txt 2>/dev/null || echo "not present"
   not present
 
-Deref: blob containing a valid tree SHA resolves and inserts at path
-  $ git rev-parse master:sub1 > ptr.txt
-  $ git add ptr.txt
+Deref: gitlink carrying a valid tree SHA resolves and inserts at path
+  $ git update-index --add --cacheinfo 160000,$(git rev-parse master:sub1),ptr
   $ git commit -m "add ptr" 1> /dev/null
-  $ josh-filter -s ':#ptr.txt' master --update refs/josh/deref 1> /dev/null
-  $ git show refs/josh/deref:ptr.txt/file1
+  $ josh-filter -s ':#ptr' master --update refs/josh/deref 1> /dev/null
+  $ git show refs/josh/deref:ptr/file1
   contents1
 
-Deref: blob with invalid content inserts empty blob at path
-  $ printf 'not-a-sha\n' > bad_ptr.txt
+Deref: a non-gitlink entry is an error (reference is not updated)
+  $ printf 'not-a-reference\n' > bad_ptr.txt
   $ git add bad_ptr.txt
   $ git commit -m "add bad_ptr" 1> /dev/null
-  $ josh-filter ':#bad_ptr.txt' master --update refs/josh/badtest 1> /dev/null
-  $ git rev-parse --verify refs/josh/badtest > /dev/null && echo "updated"
-  updated
-  $ git show refs/josh/badtest:bad_ptr.txt | wc -c | tr -d ' '
-  0
+  $ josh-filter ':#bad_ptr.txt' master --update refs/josh/badtest 2>&1; echo "exit:$?"
+  *:#: expected gitlink at path: bad_ptr.txt (glob)
+  exit:1
+  $ git rev-parse --verify refs/josh/badtest 2>/dev/null || echo "not updated"
+  not updated
 
-Deref: blob with valid SHA but object not in repo is an error (reference not updated)
-  $ printf '0000000000000000000000000000000000000001\n' > ghost_ptr.txt
-  $ git add ghost_ptr.txt
+Deref: gitlink with object not in repo is an error (reference is not updated)
+  $ git update-index --add --cacheinfo 160000,0000000000000000000000000000000000000001,ghost_ptr
   $ git commit -m "add ghost_ptr" 1> /dev/null
-  $ josh-filter ':#ghost_ptr.txt' master --update refs/josh/ghosttest 2>&1; echo "exit:$?"
+  $ josh-filter ':#ghost_ptr' master --update refs/josh/ghosttest 2>&1; echo "exit:$?"
   *:#: object not found in repo: 0000000000000000000000000000000000000001 (glob)
   exit:1
   $ git rev-parse --verify refs/josh/ghosttest 2>/dev/null || echo "not updated"
   not updated
 
-ObjectRef: stores tree OID of sub1 as blob content at sub1
+ObjectRef: stores the tree OID of sub1 in a gitlink at sub1
   $ josh-filter -s ':&sub1' master --update refs/josh/treeref 1> /dev/null
-  $ [ "$(git show refs/josh/treeref:sub1)" = "$(git rev-parse master:sub1)" ] && echo "match"
+  $ git ls-tree refs/josh/treeref sub1 | cut -d' ' -f1-2
+  160000 commit
+  $ [ "$(git rev-parse refs/josh/treeref:sub1)" = "$(git rev-parse master:sub1)" ] && echo "match"
   match
 
 ObjectRef + ObjectDeref round-trip: tree entry restored
@@ -114,12 +116,14 @@ ObjectRef + :#/path sugar round-trip: tree entry restored via canonical expansio
   $ git show refs/josh/roundtrip_sugar:file1
   contents1
 
-ObjectRef: stores blob OID as blob content at path
+ObjectRef: stores the blob OID in a gitlink at path
   $ josh-filter -s ':&sub1/file1' master --update refs/josh/blobref 1> /dev/null
-  $ [ "$(git show refs/josh/blobref:sub1/file1)" = "$(git rev-parse master:sub1/file1)" ] && echo "match"
+  $ git ls-tree refs/josh/blobref sub1/file1 | cut -d' ' -f1-2
+  160000 commit
+  $ [ "$(git rev-parse refs/josh/blobref:sub1/file1)" = "$(git rev-parse master:sub1/file1)" ] && echo "match"
   match
 
-ObjectDeref: blob OID reference wraps blob at path (round-trip)
+ObjectDeref: blob OID gitlink restores the blob at path (round-trip)
   $ josh-filter ':#sub1/file1' refs/josh/blobref --update refs/josh/blobroundtrip 1> /dev/null
   $ git show refs/josh/blobroundtrip:sub1/file1
   contents1


### PR DESCRIPTION
Dereference gitlink object references

Store TreeId and object-reference outputs as gitlinks, consume them directly
in josh-compose, and dereference commit targets as submodule trees with their
history.

Change: gitlink-object-references
Assisted-By: openai-codex/gpt-5.6-sol