### PR TITLE
Remove obsolete Oid wrapper

### DIFF
--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -26,43 +26,6 @@ pub mod trailers;
 pub use josh_gix_ext as objects;
 pub use josh_memodb as memodb;
 
-#[derive(
-    Clone, Hash, PartialEq, Eq, Copy, PartialOrd, Ord, Debug, serde::Serialize, serde::Deserialize,
-)]
-#[serde(try_from = "String", into = "String")]
-pub struct Oid(git2::Oid);
-
-impl Default for Oid {
-    fn default() -> Self {
-        Oid(git2::Oid::ZERO_SHA1)
-    }
-}
-
-impl std::convert::TryFrom<String> for Oid {
-    type Error = anyhow::Error;
-    fn try_from(s: String) -> anyhow::Result<Oid> {
-        Ok(Oid(git2::Oid::from_str(&s)?))
-    }
-}
-
-impl From<Oid> for String {
-    fn from(val: Oid) -> Self {
-        val.0.to_string()
-    }
-}
-
-impl From<Oid> for git2::Oid {
-    fn from(val: Oid) -> Self {
-        val.0
-    }
-}
-
-impl From<git2::Oid> for Oid {
-    fn from(oid: git2::Oid) -> Self {
-        Self(oid)
-    }
-}
-
 /// Determine the josh version number with the following precedence:
 ///
 /// 1. If in a git checkout, and `git` binary is present, use the

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -16,18 +16,12 @@ pub(crate) const MAX_MEM_PACK_SIZE: usize = 128 * 1024 * 1024;
 
 use crate::http::{IntoRetryable, RetryableError};
 use crate::upstream::RemoteAuth;
-use josh_core;
 
 josh_core::regex_parsed!(
     FilteredRepoUrl,
     r"(?P<api>/~/\w+)?(?P<upstream_repo>/[^:!]*[.]git)(?P<headref>[\^@][^:!]*)?((?P<filter_spec>[:!].*)[.]git)?(?P<pathinfo>/.*)?(?P<rest>.*)",
     [api, upstream_repo, filter_spec, pathinfo, headref, rest]
 );
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-pub struct Ref {
-    pub target: josh_core::Oid,
-}
 
 fn make_ssh_command() -> String {
     let ssh_options = [


### PR DESCRIPTION
Remove obsolete Oid wrapper

The migration left josh_core::Oid reachable only through an unused proxy Ref type. Remove both instead of mechanically porting the wrapper and its git2 conversion surface to gitoxide.

Change: gix-oid-wrapper-removal

Assisted-By: openai-codex/gpt-5.6-sol