### PR TITLE
Remove git2 from josh-memodb

### DIFF
--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -60,7 +60,7 @@ impl DistributedCacheBackend {
 
     fn open(repo_path: impl AsRef<std::path::Path>, writable: bool) -> anyhow::Result<Self> {
         let repo = git2::Repository::open(repo_path.as_ref())?;
-        let objects_dir = josh_memodb::objects_dir(&repo);
+        let objects_dir = repo.commondir().join("objects");
         let mem_odb = josh_memodb::MemOdb::new(None, objects_dir.clone());
         let odb = josh_memodb::Odb::at(mem_odb.clone(), &objects_dir)?;
         Ok(Self {

--- a/josh-core/src/cache/history_graph.rs
+++ b/josh-core/src/cache/history_graph.rs
@@ -129,7 +129,7 @@ fn ensure_hint_cached(
     }
 
     let odb = transaction.odb();
-    if !odb.contains(input) {
+    if !odb.contains(crate::objects::gix_oid(input)) {
         return Err(anyhow!("ensure_hint_cached: input does not exist"));
     }
 
@@ -283,11 +283,13 @@ fn write_roots_blob(odb: &josh_memodb::Odb, roots: &[git2::Oid]) -> anyhow::Resu
     for r in roots {
         bytes.extend_from_slice(r.as_bytes());
     }
-    Ok(odb.write(gix_object::Kind::Blob, &bytes))
+    Ok(crate::objects::git2_oid(
+        &odb.write(gix_object::Kind::Blob, &bytes),
+    ))
 }
 
 fn read_roots_blob(odb: &josh_memodb::Odb, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
-    let (kind, content) = odb.read(oid)?;
+    let (kind, content) = odb.read(crate::objects::gix_oid(oid))?;
     if kind != gix_object::Kind::Blob {
         return Err(anyhow!("reachable_roots object {} is not a blob", oid));
     }

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -346,7 +346,7 @@ impl Transaction {
 
         // An ephemeral transaction must not contribute to a store that outlives it, so it
         // buffers privately and reads through to the shared one.
-        let objects_dir = josh_memodb::objects_dir(&repo);
+        let objects_dir = gix_repo.objects.path().to_owned();
         let shared = josh_memodb::registry::shared(mem_odb_limit, &objects_dir);
         let mem_odb = if ephemeral {
             josh_memodb::MemOdb::chained(mem_odb_limit, objects_dir, shared)
@@ -451,7 +451,7 @@ impl Transaction {
         if let Some(bytes) = self.t2.borrow().tree_cache.get(oid) {
             return Ok(Some(TreeBytes::Cached(bytes)));
         }
-        let (kind, bytes) = odb.read(oid)?;
+        let (kind, bytes) = odb.read(crate::objects::gix_oid(oid))?;
         if kind != gix_object::Kind::Tree {
             return Ok(None);
         }
@@ -1224,7 +1224,7 @@ impl Transaction {
         let oid = t2.cache.read_propagate(filter, tree, hint, true).ok()??;
         // Per-subtree index trees are anchored by no ref, so gc may have pruned a
         // cached one; treat a dangling hit as a miss and reindex.
-        if self.odb().contains(oid) {
+        if self.odb().contains(crate::objects::gix_oid(oid)) {
             Some(oid)
         } else {
             None
@@ -1259,7 +1259,7 @@ impl Transaction {
     pub fn get_ref(&self, filter: crate::filter::Filter, from: git2::Oid) -> Option<git2::Oid> {
         if let Some(m) = REF_CACHE.read().unwrap().get(&filter.id())
             && let Some(oid) = m.get(&from)
-            && self.odb().contains(*oid)
+            && self.odb().contains(crate::objects::gix_oid(*oid))
         {
             return Some(*oid);
         }
@@ -1398,7 +1398,7 @@ impl Transaction {
                 return Ok(Some(oid));
             }
 
-            if self.odb().contains(oid) {
+            if self.odb().contains(crate::objects::gix_oid(oid)) {
                 // Only report an object as cached if it exists in the object database.
                 // This forces a rebuild in case the object was garbage collected.
                 return Ok(Some(oid));
@@ -2193,9 +2193,11 @@ mod tests {
 
         let oid = {
             let transaction = context.open().unwrap();
-            let oid = transaction
-                .odb()
-                .write(gix_object::Kind::Blob, b"published");
+            let oid = crate::objects::git2_oid(
+                &transaction
+                    .odb()
+                    .write(gix_object::Kind::Blob, b"published"),
+            );
             transaction
                 .update_ref("refs/josh/blob", Expected::Absent, oid, "test")
                 .unwrap();
@@ -2224,7 +2226,8 @@ mod tests {
     fn flush_mem_odb_publishes_pending_refs_after_objects() {
         let (dir, context) = test_context();
         let transaction = context.open().unwrap();
-        let oid = transaction.odb().write(gix_object::Kind::Blob, b"boundary");
+        let oid =
+            crate::objects::git2_oid(&transaction.odb().write(gix_object::Kind::Blob, b"boundary"));
         transaction
             .update_ref("refs/josh/blob", Expected::Absent, oid, "test")
             .unwrap();

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -548,7 +548,9 @@ fn get_rev_filter(
         } else {
             return Err(anyhow!("unresolved lazy ref"));
         };
-        if match_op != &RevMatch::Default && !transaction.odb().contains(*filter_tip) {
+        if match_op != &RevMatch::Default
+            && !transaction.odb().contains(objects::gix_oid(*filter_tip))
+        {
             return Err(anyhow!("`:rev(...)` with nonexistent OID: {}", filter_tip));
         }
         let matches = match match_op {
@@ -614,7 +616,7 @@ pub fn apply_to_commit2(
         Op::Squash(None) => {
             let odb = transaction.odb();
             let commit = objects::CommitData::read(odb, commit_id)?;
-            odb.read_header(commit.tree_id()?)?;
+            odb.read_header(objects::gix_oid(commit.tree_id()?))?;
             return Some(history::rewrite_commit(
                 odb,
                 &commit,
@@ -649,7 +651,7 @@ pub fn apply_to_commit2(
     // no parse). Without this gate, an apply over a partially unreadable input can buffer
     // fresh objects into the store before a later read aborts the walk, and the partial
     // write would change the next flush's pack.
-    odb.read_header(commit.tree_id()?)?;
+    odb.read_header(objects::gix_oid(commit.tree_id()?))?;
 
     let rewrite_data = match &op {
         Op::Squash(Some(ids)) => {
@@ -1344,7 +1346,9 @@ fn apply_impl(
                             odb,
                             result_tree,
                             &submodule_path.join(".link.josh"),
-                            odb.write(gix_object::Kind::Blob, link_content.as_bytes()),
+                            objects::git2_oid(
+                                &odb.write(gix_object::Kind::Blob, link_content.as_bytes()),
+                            ),
                             0o0100644,
                         )?;
                     }
@@ -1388,7 +1392,7 @@ fn apply_impl(
                     odb,
                     result_tree,
                     &link_path.join(".link.josh"),
-                    odb.write(gix_object::Kind::Blob, link_content.as_bytes()),
+                    objects::git2_oid(&odb.write(gix_object::Kind::Blob, link_content.as_bytes())),
                     0o0100644,
                 )?;
             }
@@ -1434,7 +1438,7 @@ fn apply_impl(
                     odb,
                     result_tree,
                     &root.join(".link.josh"),
-                    odb.write(gix_object::Kind::Blob, link_content.as_bytes()),
+                    objects::git2_oid(&odb.write(gix_object::Kind::Blob, link_content.as_bytes())),
                     0o0100644,
                 )?;
             }
@@ -1478,13 +1482,13 @@ fn apply_impl(
         Op::Insert(dest_path, content) => {
             let (oid, mode, is_tree) = match content {
                 InsertContent::Inline(s) => (
-                    odb.write(gix_object::Kind::Blob, s.as_bytes()),
+                    objects::git2_oid(&odb.write(gix_object::Kind::Blob, s.as_bytes())),
                     git2::FileMode::Blob.into(),
                     false,
                 ),
                 // The kind comes from the header alone; a missing oid folds into the
                 // "neither" arm below.
-                InsertContent::Oid(oid) => match odb.try_kind(*oid) {
+                InsertContent::Oid(oid) => match odb.try_kind(objects::gix_oid(*oid)) {
                     Ok(Some(gix_object::Kind::Blob)) => (*oid, git2::FileMode::Blob.into(), false),
                     Ok(Some(gix_object::Kind::Tree)) => (*oid, git2::FileMode::Tree.into(), true),
                     _ => {
@@ -1622,7 +1626,8 @@ fn apply_impl(
         Op::ObjectRef(path) => {
             if let Ok(Some(entry)) = tree::get_path_entry(transaction, odb, x.tree_id(), path) {
                 let oid_str = objects::git2_oid(&entry.oid).to_string();
-                let blob_oid = odb.write(gix_object::Kind::Blob, oid_str.as_bytes());
+                let blob_oid =
+                    objects::git2_oid(&odb.write(gix_object::Kind::Blob, oid_str.as_bytes()));
                 Ok(x.with_tree(tree::insert_oid(
                     odb,
                     tree::empty_id(),
@@ -1654,7 +1659,7 @@ fn apply_impl(
             if let Ok(oid) = git2::Oid::from_str(&oid_str) {
                 // Kind by header, never by `contains`: `read_header`'s disk fallback
                 // virtualizes the empty tree, `exists` does not.
-                let (oid, mode) = match odb.try_kind(oid) {
+                let (oid, mode) = match odb.try_kind(objects::gix_oid(oid)) {
                     Ok(Some(gix_object::Kind::Tree)) => (oid, git2::FileMode::Tree.into()),
                     Ok(Some(gix_object::Kind::Blob)) => (oid, git2::FileMode::Blob.into()),
                     _ => {
@@ -1664,7 +1669,7 @@ fn apply_impl(
                 Ok(x.with_tree(tree::insert_oid(odb, tree::empty_id(), path, oid, mode)?))
             } else {
                 // Content is not a valid OID: insert empty blob at path.
-                let empty_blob = odb.write(gix_object::Kind::Blob, b"");
+                let empty_blob = objects::git2_oid(&odb.write(gix_object::Kind::Blob, b""));
                 Ok(x.with_tree(tree::insert_oid(
                     odb,
                     tree::empty_id(),
@@ -1995,7 +2000,7 @@ fn pre_process_tree(
         odb,
         tree,
         path,
-        odb.write(gix_object::Kind::Blob, blob.as_bytes()),
+        objects::git2_oid(&odb.write(gix_object::Kind::Blob, blob.as_bytes())),
         git2::FileMode::Blob.into(), // Should this handle filemode?
     )?;
 

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -61,7 +61,7 @@ fn pathstree_inner(
             rebuild.keep(gix_object::tree::Entry {
                 mode: gix_object::tree::EntryKind::Blob.into(),
                 filename: entry.filename.to_owned(),
-                oid: objects::gix_oid(odb.write(gix_object::Kind::Blob, file_contents.as_bytes())),
+                oid: odb.write(gix_object::Kind::Blob, file_contents.as_bytes()),
             });
         }
     }
@@ -120,7 +120,7 @@ fn regex_replace_inner(
             rebuild.keep(gix_object::tree::Entry {
                 mode: entry.mode,
                 filename: entry.filename.to_owned(),
-                oid: objects::gix_oid(odb.write(gix_object::Kind::Blob, replaced.as_bytes())),
+                oid: odb.write(gix_object::Kind::Blob, replaced.as_bytes()),
             });
         }
     }
@@ -130,7 +130,7 @@ fn regex_replace_inner(
 /// The raw bytes of the blob `oid`, or `None` when the object is missing or not a blob --
 /// `find_blob`'s tolerance, in facade currency.
 pub fn blob_bytes(odb: &josh_memodb::Odb, oid: git2::Oid) -> Option<josh_memodb::Bytes> {
-    match odb.read(oid) {
+    match odb.read(objects::gix_oid(oid)) {
         Ok((gix_object::Kind::Blob, bytes)) => Some(bytes),
         _ => None,
     }
@@ -1135,7 +1135,7 @@ pub fn invert_paths(
                 odb,
                 result,
                 Path::new(&opath),
-                odb.write(gix_object::Kind::Blob, mpath.as_bytes()),
+                objects::git2_oid(&odb.write(gix_object::Kind::Blob, mpath.as_bytes())),
                 0o0100644,
             )
             .unwrap();
@@ -1200,8 +1200,14 @@ pub fn populate(
     }
 
     use gix_object::Kind;
-    let paths_kind = odb.read_header(paths).map(|(kind, _)| kind).ok();
-    let content_kind = odb.read_header(content).map(|(kind, _)| kind).ok();
+    let paths_kind = odb
+        .read_header(objects::gix_oid(paths))
+        .map(|(kind, _)| kind)
+        .ok();
+    let content_kind = odb
+        .read_header(objects::gix_oid(content))
+        .map(|(kind, _)| kind)
+        .ok();
 
     let mut result_tree = empty_id();
     if let (Some(Kind::Blob), Some(Kind::Blob)) = (paths_kind, content_kind) {

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -248,7 +248,7 @@ impl GitCommand {
 /// lock-guarded global that also decodes author/committer/message) whenever a caller only
 /// needs the parent ids; memory-store hits are zero-copy.
 pub fn read_parent_ids(odb: &josh_memodb::Odb, oid: git2::Oid) -> anyhow::Result<Vec<git2::Oid>> {
-    let (kind, bytes) = odb.read(oid)?;
+    let (kind, bytes) = odb.read(crate::objects::gix_oid(oid))?;
     // A hard error, not an assert: this is reachable from inside git2 callback frames,
     // where unwinding across the FFI boundary would abort.
     if kind != gix_object::Kind::Commit {
@@ -267,7 +267,7 @@ pub fn read_parent_ids(odb: &josh_memodb::Odb, oid: git2::Oid) -> anyhow::Result
 /// Sibling of [`read_parent_ids`]: read a commit's tree OID without touching libgit2's
 /// commit parse cache.
 pub fn read_tree_id(odb: &josh_memodb::Odb, oid: git2::Oid) -> anyhow::Result<git2::Oid> {
-    let (kind, bytes) = odb.read(oid)?;
+    let (kind, bytes) = odb.read(crate::objects::gix_oid(oid))?;
     // Same hard-error rationale as read_parent_ids.
     if kind != gix_object::Kind::Commit {
         return Err(anyhow::anyhow!(
@@ -291,7 +291,7 @@ mod tests {
         let tree = repo.find_tree(tree_id).unwrap();
         let commit_id = repo.commit(None, &sig, &sig, "test", &tree, &[]).unwrap();
 
-        let objects_dir = josh_memodb::objects_dir(&repo);
+        let objects_dir = repo.commondir().join("objects");
         let store = josh_memodb::MemOdb::new(None, objects_dir.clone());
         let odb = josh_memodb::Odb::at(store, &objects_dir).unwrap();
         assert_eq!(

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -292,7 +292,7 @@ pub fn rewrite_commit(
     let mut b = vec![];
     gix_object::WriteTo::write_to(&commit, &mut b)?;
 
-    Ok(odb.write(gix_object::Kind::Commit, &b))
+    Ok(objects::git2_oid(&odb.write(gix_object::Kind::Commit, &b)))
 }
 
 // Given an OID of an unfiltered commit and a filter,
@@ -426,7 +426,7 @@ pub fn unapply_filter(
     // The old filtered oid can be missing from the repo (e.g. a new branch);
     // there is no range to exclude then, so take everything reachable.
     let old_filtered_exists = matches!(
-        odb.read_header(old_filtered_oid),
+        odb.read_header(objects::gix_oid(old_filtered_oid)),
         Ok((gix_object::Kind::Commit, _))
     );
     let revs = if old_filtered_exists {

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -1046,7 +1046,7 @@ impl Repository {
         let transaction_mirror = context.transaction_mirror.lock().unwrap();
         let commit_id = {
             let oid = if let Ok(id) = git2::Oid::from_str(&at) {
-                Some((id, transaction_mirror.odb().contains(id)))
+                Some((id, transaction_mirror.odb().contains(objects::gix_oid(id))))
             } else {
                 None
             };

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -4424,14 +4424,12 @@ name = "josh-memodb"
 version = "26.7.28"
 dependencies = [
  "anyhow",
- "git2",
  "gix-features",
  "gix-hash",
  "gix-object",
  "gix-odb",
  "gix-pack",
  "gix-zlib",
- "josh-gix-ext",
  "log",
  "parking_lot 0.12.5",
  "tempfile",

--- a/josh-memodb/Cargo.toml
+++ b/josh-memodb/Cargo.toml
@@ -11,14 +11,16 @@ edition = "2024"
 
 [dependencies]
 anyhow.workspace = true
-git2.workspace = true
 gix-features.workspace = true
 gix-hash.workspace = true
 gix-object.workspace = true
 gix-odb.workspace = true
 gix-pack.workspace = true
 gix-zlib.workspace = true
-josh-gix-ext.workspace = true
 log.workspace = true
 parking_lot.workspace = true
 tempfile.workspace = true
+
+[dev-dependencies]
+git2.workspace = true
+josh-gix-ext.workspace = true

--- a/josh-memodb/src/flusher.rs
+++ b/josh-memodb/src/flusher.rs
@@ -80,22 +80,18 @@ pub(crate) fn enqueue_chunk(store: Arc<MemOdb>) {
 
 /// Pack `store` to disk and block until it is done, so the objects are durable before the caller
 /// proceeds. Any queued chunks for the same store complete first (FIFO on the single worker).
-pub(crate) fn drain(store: Arc<MemOdb>) -> Result<(), git2::Error> {
+pub(crate) fn drain(store: Arc<MemOdb>) -> anyhow::Result<()> {
     let (ack_tx, ack_rx) = sync_channel::<Result<(), String>>(1);
     if FLUSHER
         .sender
         .send(Job::Drain { store, ack: ack_tx })
         .is_err()
     {
-        return Err(git2::Error::from_str(
-            "mem-odb flusher channel disconnected",
-        ));
+        return Err(anyhow::anyhow!("mem-odb flusher channel disconnected"));
     }
     match ack_rx.recv() {
         Ok(Ok(())) => Ok(()),
-        Ok(Err(msg)) => Err(git2::Error::from_str(&msg)),
-        Err(_) => Err(git2::Error::from_str(
-            "mem-odb flusher ack channel disconnected",
-        )),
+        Ok(Err(msg)) => Err(anyhow::anyhow!(msg)),
+        Err(_) => Err(anyhow::anyhow!("mem-odb flusher ack channel disconnected")),
     }
 }

--- a/josh-memodb/src/lib.rs
+++ b/josh-memodb/src/lib.rs
@@ -15,5 +15,4 @@ pub mod registry;
 pub use hash::PassthroughHasher;
 pub use mem_odb::MemOdb;
 pub use odb::{Bytes, Odb};
-pub use pack::objects_dir;
 pub use registry::FlushGuard;

--- a/josh-memodb/src/mem_odb.rs
+++ b/josh-memodb/src/mem_odb.rs
@@ -189,7 +189,7 @@ impl MemOdb {
     /// ref ends. Everything *readable* through the store has to become durable, so a chained
     /// store drains what it reads through too. Runs on the background flusher behind any queued
     /// overflow chunks; a store holding nothing skips the round trip.
-    pub fn flush(self: &Arc<Self>) -> Result<(), git2::Error> {
+    pub fn flush(self: &Arc<Self>) -> anyhow::Result<()> {
         if let Some(behind) = &self.read_through {
             behind.flush()?;
         }
@@ -234,7 +234,7 @@ impl MemOdb {
     /// no repository handle involved. The snapshot shares the object buffers (`Arc`), and the
     /// objects stay in the map while the pack is written, so concurrent reads keep resolving until
     /// eviction — which happens only once the pack is on disk.
-    pub(crate) fn pack_to_disk(self: &Arc<Self>) -> Result<(), git2::Error> {
+    pub(crate) fn pack_to_disk(self: &Arc<Self>) -> anyhow::Result<()> {
         // One packer per store at a time: the flusher's own jobs are already serialised, but the
         // process-exit flush packs inline and would otherwise snapshot and evict concurrently.
         let _packing = self.pack_lock.lock();

--- a/josh-memodb/src/odb.rs
+++ b/josh-memodb/src/odb.rs
@@ -1,8 +1,8 @@
 //! The transaction object-database facade: the [`MemOdb`] store consulted directly, backed by
 //! the repository's gitoxide object database for objects that are not buffered.
 //!
-//! Implements the [`gix_object`] object-access traits (memory-first, disk fallback) plus
-//! inherent helpers in `git2::Oid` currency; memory hits hand out zero-copy `Arc` buffers.
+//! Implements the [`gix_object`] object-access traits and `ObjectId`-typed inherent helpers
+//! (memory-first, disk fallback); memory hits hand out zero-copy `Arc` buffers.
 //!
 //! A store resolves `objects/info/alternates` when it opens, so an alternate registered at
 //! runtime (the proxy overlay's mirror) is a store of its own, consulted after the
@@ -137,10 +137,9 @@ impl Odb {
             .any(|alt| alt.gate.exists(id))
     }
 
-    /// Read the raw bytes and kind of `oid`; memory hits are zero-copy. A missing object is an
+    /// Read the raw bytes and kind of `id`; memory hits are zero-copy. A missing object is an
     /// error, like a plain odb read.
-    pub fn read(&self, oid: git2::Oid) -> anyhow::Result<(Kind, Bytes)> {
-        let id = josh_gix_ext::gix_oid(oid);
+    pub fn read(&self, id: ObjectId) -> anyhow::Result<(Kind, Bytes)> {
         if let Some((kind, data)) = self.mem.get(&id) {
             return Ok((kind, Bytes::Mem(data)));
         }
@@ -150,13 +149,13 @@ impl Odb {
         let mut buffer = Vec::new();
         if let Some(kind) = self
             .find_on_disk(&id, &mut buffer)
-            .map_err(|e| anyhow::anyhow!("failed to read {}: {}", oid, e))?
+            .map_err(|e| anyhow::anyhow!("failed to read {}: {}", id, e))?
         {
             return Ok((kind, Bytes::Disk(buffer)));
         }
         Err(anyhow::anyhow!(
             "object not found - no match for id ({})",
-            oid
+            id
         ))
     }
 
@@ -178,30 +177,28 @@ impl Odb {
         Ok(None)
     }
 
-    /// Kind and size of `oid` without reading (or decompressing) its bytes.
-    pub fn read_header(&self, oid: git2::Oid) -> anyhow::Result<(Kind, u64)> {
-        self.header(oid)?
-            .ok_or_else(|| anyhow::anyhow!("object not found - no match for id ({})", oid))
+    /// Kind and size of `id` without reading (or decompressing) its bytes.
+    pub fn read_header(&self, id: ObjectId) -> anyhow::Result<(Kind, u64)> {
+        self.header(id)?
+            .ok_or_else(|| anyhow::anyhow!("object not found - no match for id ({})", id))
     }
 
-    pub fn contains(&self, oid: git2::Oid) -> bool {
-        let id = josh_gix_ext::gix_oid(oid);
+    pub fn contains(&self, id: ObjectId) -> bool {
         self.mem.contains(&id) || self.disk.exists(&id) || self.in_alternate(&id)
     }
 
-    /// Kind of `oid`, or `None` if the object does not exist. Never decompresses. Resolves the
+    /// Kind of `id`, or `None` if the object does not exist. Never decompresses. Resolves the
     /// empty tree even when it is stored nowhere, so probes on possibly-empty trees belong
     /// here and never on [`contains`](Odb::contains).
-    pub fn try_kind(&self, oid: git2::Oid) -> anyhow::Result<Option<Kind>> {
-        Ok(self.header(oid)?.map(|(kind, _)| kind))
+    pub fn try_kind(&self, id: ObjectId) -> anyhow::Result<Option<Kind>> {
+        Ok(self.header(id)?.map(|(kind, _)| kind))
     }
 
-    /// Kind and size of `oid`, or `None` when no store holds it.
-    fn header(&self, oid: git2::Oid) -> anyhow::Result<Option<(Kind, u64)>> {
-        let id = josh_gix_ext::gix_oid(oid);
+    /// Kind and size of `id`, or `None` when no store holds it.
+    fn header(&self, id: ObjectId) -> anyhow::Result<Option<(Kind, u64)>> {
         Ok(self
             .try_header(&id)
-            .map_err(|e| anyhow::anyhow!("failed to read header of {}: {}", oid, e))?
+            .map_err(|e| anyhow::anyhow!("failed to read header of {}: {}", id, e))?
             .map(|header| (header.kind, header.size)))
     }
 
@@ -212,11 +209,11 @@ impl Odb {
     /// the repository's own on-disk objects: objects already durable there are buffered anyway
     /// and dropped at pack time, and a repository without alternates writes with zero
     /// filesystem I/O.
-    pub fn write(&self, kind: Kind, data: &[u8]) -> git2::Oid {
+    pub fn write(&self, kind: Kind, data: &[u8]) -> ObjectId {
         let id = gix_object::compute_hash(gix_hash::Kind::Sha1, kind, data)
             .expect("failed to compute hash");
         self.write_with_id(id, kind, data);
-        josh_gix_ext::git2_oid(&id)
+        id
     }
 
     /// [`Odb::write`] with a caller-computed content hash, trusted verbatim.
@@ -296,7 +293,7 @@ impl gix_object::Exists for Odb {
 
 impl gix_object::Write for Odb {
     fn write_buf(&self, object: Kind, from: &[u8]) -> Result<ObjectId, gix_object::write::Error> {
-        Ok(josh_gix_ext::gix_oid(self.write(object, from)))
+        Ok(self.write(object, from))
     }
 
     fn write_buf_with_known_id(
@@ -360,11 +357,17 @@ mod tests {
 
         // Not yet on disk.
         let fresh = git2::Repository::open(dir.path()).unwrap();
-        assert!(fresh.find_blob(oid).is_err());
+        assert!(fresh.find_blob(josh_gix_ext::git2_oid(&oid)).is_err());
 
         store.flush().unwrap();
         let fresh = git2::Repository::open(dir.path()).unwrap();
-        assert_eq!(fresh.find_blob(oid).unwrap().content(), b"facade blob");
+        assert_eq!(
+            fresh
+                .find_blob(josh_gix_ext::git2_oid(&oid))
+                .unwrap()
+                .content(),
+            b"facade blob"
+        );
     }
 
     /// The write gate: an object already in a registered runtime alternate is not buffered
@@ -389,14 +392,14 @@ mod tests {
 
         // Alternate hit: skipped, still readable through the alternate.
         let oid = odb.write(Kind::Blob, b"mirror blob");
-        assert_eq!(oid, in_alternate);
-        assert!(!store.contains(&josh_gix_ext::gix_oid(oid)));
+        assert_eq!(oid, josh_gix_ext::gix_oid(in_alternate));
+        assert!(!store.contains(&oid));
         assert!(matches!(odb.read(oid).unwrap().1, Bytes::Disk(_)));
 
         // Main-disk object: buffered — the gate does not probe the repository's own objects.
         let oid = odb.write(Kind::Blob, b"already on disk");
-        assert_eq!(oid, on_disk);
-        assert!(store.contains(&josh_gix_ext::gix_oid(oid)));
+        assert_eq!(oid, josh_gix_ext::gix_oid(on_disk));
+        assert!(store.contains(&oid));
         assert!(matches!(odb.read(oid).unwrap().1, Bytes::Mem(_)));
     }
 
@@ -409,7 +412,7 @@ mod tests {
         let mirror_dir = crate::pack::objects_dir(&mirror);
         // Packed before the alternate is registered.
         let mirror_store = MemOdb::new(None, mirror_dir.clone());
-        let packed = josh_gix_ext::git2_oid(&mirror_store.write(Kind::Blob, b"packed in mirror"));
+        let packed = mirror_store.write(Kind::Blob, b"packed in mirror");
         mirror_store.flush().unwrap();
 
         let repo = git2::Repository::init(tmp.path().join("overlay")).unwrap();
@@ -418,14 +421,14 @@ mod tests {
         odb.add_alternate(&mirror_dir).unwrap();
 
         assert_eq!(odb.write(Kind::Blob, b"packed in mirror"), packed);
-        assert!(!store.contains(&josh_gix_ext::gix_oid(packed)));
+        assert!(!store.contains(&packed));
 
         // Packed after registration: the gate does not go looking, so it buffers a duplicate.
-        let later = josh_gix_ext::git2_oid(&mirror_store.write(Kind::Blob, b"packed later"));
-        let unread = josh_gix_ext::git2_oid(&mirror_store.write(Kind::Blob, b"never written"));
+        let later = mirror_store.write(Kind::Blob, b"packed later");
+        let unread = mirror_store.write(Kind::Blob, b"never written");
         mirror_store.flush().unwrap();
         assert_eq!(odb.write(Kind::Blob, b"packed later"), later);
-        assert!(store.contains(&josh_gix_ext::gix_oid(later)));
+        assert!(store.contains(&later));
 
         // Reads do go looking, and find an object from that same pack.
         assert_eq!(&*odb.read(unread).unwrap().1, b"never written");
@@ -441,15 +444,19 @@ mod tests {
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
         let odb = facade(&store, &repo);
 
-        let empty_tree = git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap();
-        assert!(!store.contains(&josh_gix_ext::gix_oid(empty_tree)));
+        let empty_tree = josh_gix_ext::gix_oid(
+            git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap(),
+        );
+        assert!(!store.contains(&empty_tree));
         assert_eq!(odb.try_kind(empty_tree).unwrap(), Some(Kind::Tree));
         assert_eq!(odb.read(empty_tree).unwrap().0, Kind::Tree);
         assert!(odb.read(empty_tree).unwrap().1.is_empty());
         assert!(!odb.contains(empty_tree));
 
         // A genuinely absent object is None; a buffered object reports its memory kind.
-        let absent = git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap();
+        let absent = josh_gix_ext::gix_oid(
+            git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap(),
+        );
         assert_eq!(odb.try_kind(absent).unwrap(), None);
         assert!(odb.read(absent).is_err());
         let blob = odb.write(Kind::Blob, b"probe");
@@ -468,13 +475,10 @@ mod tests {
         let oid = odb.write(Kind::Blob, b"facade blob");
 
         let mut buf = Vec::new();
-        let data = odb
-            .try_find(&josh_gix_ext::gix_oid(oid), &mut buf)
-            .unwrap()
-            .unwrap();
+        let data = odb.try_find(&oid, &mut buf).unwrap().unwrap();
         assert_eq!(data.kind, Kind::Blob);
         assert_eq!(data.data, b"facade blob");
-        assert!(odb.exists(&josh_gix_ext::gix_oid(oid)));
+        assert!(odb.exists(&oid));
     }
 
     /// A pack written after the facade was built is still found, which is how a flush, a
@@ -487,9 +491,8 @@ mod tests {
         let odb = facade(&store, &repo);
 
         // Miss first, so the store has settled on the packs it found at open.
-        let oid = gix_object::compute_hash(gix_hash::Kind::Sha1, Kind::Blob, b"packed later")
-            .map(|id| josh_gix_ext::git2_oid(&id))
-            .unwrap();
+        let oid =
+            gix_object::compute_hash(gix_hash::Kind::Sha1, Kind::Blob, b"packed later").unwrap();
         assert!(!odb.contains(oid));
 
         let store2 = MemOdb::new(None, crate::pack::objects_dir(&repo));

--- a/josh-memodb/src/pack.rs
+++ b/josh-memodb/src/pack.rs
@@ -7,7 +7,7 @@
 //! layout stays deterministic.
 
 use std::io::{Seek, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::AtomicBool;
 
 use gix_object::Exists;
@@ -15,18 +15,9 @@ use gix_pack::data::output;
 
 use crate::mem_odb::Snapshot;
 
-/// The directory where `repo`'s objects live (`<commondir>/objects`), captured at
-/// [`MemOdb::new`](crate::mem_odb::MemOdb::new) time while a repository handle exists.
-///
-/// Resolved from the repository's *common* directory rather than its gitdir: a linked worktree has
-/// no `objects/` of its own, so its objects live under the common dir. For a non-worktree repo the
-/// two are the same.
-pub fn objects_dir(repo: &git2::Repository) -> PathBuf {
+#[cfg(test)]
+pub(crate) fn objects_dir(repo: &git2::Repository) -> std::path::PathBuf {
     repo.commondir().join("objects")
-}
-
-fn pack_error(e: impl std::fmt::Display) -> git2::Error {
-    git2::Error::from_str(&format!("mem-odb pack write failed: {e}"))
 }
 
 /// Compress and write the objects of `snapshot` that are not already present in `objects_dir`
@@ -38,12 +29,13 @@ fn pack_error(e: impl std::fmt::Display) -> git2::Error {
 /// trailer checksum (the same rule libgit2 and modern git use), so identical snapshots produce
 /// identical packs. Files are written via tempfile-and-rename, index last, so a concurrent
 /// reader scanning for `.idx` files never sees a torn pair.
-pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> Result<(), git2::Error> {
+pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow::Result<()> {
     // A fresh store handle per flush observes every pack written by previous flushes. Misses are
     // the expected case below, and the default refresh mode re-lists the pack directory on every
     // miss — disable it; the first lookup still loads all indices present now, and loose-object
     // probes stat the filesystem directly either way.
-    let mut odb = gix_odb::at(objects_dir.to_owned()).map_err(pack_error)?;
+    let mut odb = gix_odb::at(objects_dir.to_owned())
+        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
     odb.refresh = gix_odb::store::RefreshMode::Never;
 
     let to_pack: Vec<_> = snapshot
@@ -55,17 +47,21 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> Result<
         return Ok(());
     }
     let num_entries = u32::try_from(to_pack.len())
-        .map_err(|_| pack_error("more objects in one flush than a pack header can count"))?;
+        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
 
     let pack_dir = objects_dir.join("pack");
-    std::fs::create_dir_all(&pack_dir).map_err(pack_error)?;
+    std::fs::create_dir_all(&pack_dir)
+        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
 
     // Serialize the pack byte stream (header, compressed entries, checksum trailer) through an
     // anonymous spool file in the pack directory: objects are compressed one at a time as the
     // serializer pulls them, so no more than one compressed object is ever held in memory —
     // a snapshot's size is only *typically* bounded by the store's chunk limit (unbounded stores
     // exist, and the limit is an overflow trigger, not a cap).
-    let mut spool = std::io::BufWriter::new(tempfile::tempfile_in(&pack_dir).map_err(pack_error)?);
+    let mut spool = std::io::BufWriter::new(
+        tempfile::tempfile_in(&pack_dir)
+            .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?,
+    );
     let mut iter = output::bytes::FromEntriesIter::new(
         to_pack.iter().map(|(oid, kind, data)| {
             output::Entry::from_data(
@@ -82,12 +78,18 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> Result<
         gix_hash::Kind::Sha1,
     );
     for written in &mut iter {
-        written.map_err(pack_error)?;
+        written.map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
     }
     drop(iter);
-    spool.flush().map_err(pack_error)?;
-    let mut spool = spool.into_inner().map_err(pack_error)?;
-    spool.rewind().map_err(pack_error)?;
+    spool
+        .flush()
+        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
+    let mut spool = spool
+        .into_inner()
+        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
+    spool
+        .rewind()
+        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
 
     let outcome = gix_pack::Bundle::write_to_directory(
         &mut std::io::BufReader::new(spool),
@@ -105,7 +107,7 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> Result<
             compression: gix_zlib::Compression::DEFAULT,
         },
     )
-    .map_err(pack_error)?;
+    .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
     // gix marks the freshly-landed pack with a `.keep` file for the caller to remove once its
     // referencing refs exist. josh's flushes carry no such handshake (libgit2's packbuilder wrote
     // no `.keep` either), and a leftover one would exempt the pack from `git repack -d` forever.
@@ -116,7 +118,7 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> Result<
     if let Some(data_path) = &outcome.data_path {
         if let Err(e) = std::fs::remove_file(data_path.with_extension("keep")) {
             if e.kind() != std::io::ErrorKind::NotFound {
-                return Err(pack_error(e));
+                return Err(anyhow::anyhow!("mem-odb pack write failed: {e}"));
             }
         }
     }


### PR DESCRIPTION
Remove git2 from josh-memodb

Make the object facade's inherent API use gitoxide ObjectId throughout, and keep git2 conversions at the still-legacy caller seams. Packing and flushing now return pure Rust errors, while the object directory comes from the gitoxide store. git2 and josh-gix-ext remain dev-only test dependencies.

Change: gix-pure-memodb

Assisted-By: openai-codex/gpt-5.6-sol