### PR TITLE
Move persisted object IDs to gitoxide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,7 +3479,6 @@ name = "josh-filter"
 version = "26.7.28"
 dependencies = [
  "anyhow",
- "git2",
  "gix-hash",
  "gix-object",
  "glob",
@@ -3499,7 +3498,6 @@ name = "josh-git-serde"
 version = "26.7.28"
 dependencies = [
  "anyhow",
- "git2",
  "gix-hash",
  "gix-object",
  "josh-gix-ext",

--- a/josh-changes/src/change.rs
+++ b/josh-changes/src/change.rs
@@ -124,7 +124,8 @@ pub(crate) fn split_changes(
     changes
         .into_values()
         .map(|c| {
-            let filter = josh_core::filter::Filter::new().downstack(c.base);
+            let filter =
+                josh_core::filter::Filter::new().downstack(josh_core::objects::gix_oid(c.base));
             let new_oid = josh_core::filter::apply_to_commit(filter, c.commit, transaction)?;
             let mut result = c;
             result.commit = new_oid;

--- a/josh-changes/src/comments.rs
+++ b/josh-changes/src/comments.rs
@@ -246,7 +246,7 @@ fn read_comment(
     entry_oid: git2::Oid,
     file: Option<String>,
 ) -> anyhow::Result<Comment> {
-    let value = from_tree_oid(odb, entry_oid)?;
+    let value = from_tree_oid(odb, objects::gix_oid(entry_oid))?;
     let meta: CommentMeta = from_value(&value)?;
     Ok(Comment {
         id: id.to_string(),

--- a/josh-changes/src/store.rs
+++ b/josh-changes/src/store.rs
@@ -124,7 +124,7 @@ pub fn value_oid<T: serde::Serialize>(
         GitValue::Tree(_) => 0o0040000,
         GitValue::Blob(_) => git2::FileMode::Blob.into(),
     };
-    Ok((root, mode))
+    Ok((objects::git2_oid(&root), mode))
 }
 
 /// Place the already-written object `root` at `path` inside `scope`'s ref and
@@ -197,7 +197,7 @@ pub fn read_filtered<T: serde::de::DeserializeOwned>(
         filter,
         josh_core::filter::Rewrite::from_tree(root),
     )?;
-    let value = josh_git_serde::from_tree_oid(odb, filtered.tree_id())?;
+    let value = josh_git_serde::from_tree_oid(odb, objects::gix_oid(filtered.tree_id()))?;
     Ok(Some(josh_git_serde::from_value(&value)?))
 }
 
@@ -235,12 +235,18 @@ pub fn store_diff_data(
     let path = std::path::Path::new("diffs").join(encode_change_id_path(&change_id));
 
     if let Ok(Some(existing)) = tree::get_path_entry(transaction, odb, base_tree, &path) {
-        if objects::git2_oid(&existing.oid) == tree_oid {
+        if existing.oid == tree_oid {
             return Ok(());
         }
     }
 
-    let tree = tree::insert_oid(odb, base_tree, &path, tree_oid, 0o0040000)?;
+    let tree = tree::insert_oid(
+        odb,
+        base_tree,
+        &path,
+        objects::git2_oid(&tree_oid),
+        0o0040000,
+    )?;
 
     let sig = transaction.signature()?;
 

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -222,7 +222,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
     let input_ref = args.get_one::<String>("input").unwrap();
 
     let mut refs = vec![];
-    let mut ids: Vec<(git2::Oid, josh_core::filter::Filter)> = vec![];
+    let mut ids = vec![];
 
     let (input_ref, oid) = resolve_input_ref(&transaction, input_ref)?;
     refs.push((input_ref.clone(), oid));
@@ -243,7 +243,10 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
                 return Ok(());
             }
             let target = repo.find_object(oid, None)?.peel_to_commit()?.id();
-            ids.push((target, josh_core::filter::Filter::new().message(name)));
+            ids.push((
+                josh_core::objects::gix_oid(target),
+                josh_core::filter::Filter::new().message(name),
+            ));
             refs.push((name.to_string(), target));
             Ok(())
         })?;
@@ -260,7 +263,10 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             if let [sha, name] = split.as_slice() {
                 let target = git2::Oid::from_str(sha)?;
                 let target = repo.find_object(target, None)?.peel_to_commit()?.id();
-                ids.push((target, josh_core::filter::Filter::new().message(name)));
+                ids.push((
+                    josh_core::objects::gix_oid(target),
+                    josh_core::filter::Filter::new().message(name),
+                ));
                 refs.push((name.to_string(), target));
             } else if !split.is_empty() {
                 eprintln!("Warning: malformed line: {:?}", line);

--- a/josh-core/benches/deephistory_subdir.rs
+++ b/josh-core/benches/deephistory_subdir.rs
@@ -310,7 +310,7 @@ fn deephistory_rev(c: &mut Criterion) {
         let case = bench.cases.first().expect("at least one case");
         let rev_filter = Filter::new().rev(vec![(
             RevMatch::AncestorInclusive,
-            case.head,
+            gix_oid(case.head),
             Filter::new().subdir(SUBDIR),
         )]);
         let transaction = bench.context.open().expect("open transaction");
@@ -338,7 +338,7 @@ fn deephistory_rev(c: &mut Criterion) {
     for case in &bench.cases {
         let rev_filter = Filter::new().rev(vec![(
             RevMatch::AncestorInclusive,
-            case.head,
+            gix_oid(case.head),
             Filter::new().subdir(SUBDIR),
         )]);
         group.throughput(Throughput::Elements(case.n_commits as u64));

--- a/josh-core/benches/ultrawide_pin_hook.rs
+++ b/josh-core/benches/ultrawide_pin_hook.rs
@@ -290,7 +290,7 @@ fn pin_filter_tree(
             gix_oid(placeholder),
         )?;
     }
-    let tree = git2_oid(builder.write()?.detach());
+    let tree = builder.write()?.detach();
     let param = josh_filter::Filter::new().insert_oid(".", tree)?;
     Ok(josh_filter::Filter::new().pin(param))
 }

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -34,7 +34,7 @@ pub struct DistributedCacheBackend {
     // Filter -> persisted tree id (`as_tree`), used to name cache refs. `as_tree` resolves
     // insert OIDs, so ref names always reference persisted, reachable filter trees even when
     // the filter passed in still contains unresolved ones.
-    tree_ids: std::sync::Mutex<HashMap<Filter, git2::Oid>>,
+    tree_ids: std::sync::Mutex<HashMap<Filter, gix_hash::ObjectId>>,
 }
 
 impl Drop for DistributedCacheBackend {
@@ -74,7 +74,11 @@ impl DistributedCacheBackend {
         })
     }
 
-    fn tree_id(&self, odb: &josh_memodb::Odb, filter: Filter) -> anyhow::Result<git2::Oid> {
+    fn tree_id(
+        &self,
+        odb: &josh_memodb::Odb,
+        filter: Filter,
+    ) -> anyhow::Result<gix_hash::ObjectId> {
         if let Some(oid) = self.tree_ids.lock().unwrap().get(&filter) {
             return Ok(*oid);
         }
@@ -197,7 +201,7 @@ impl DistributedCacheBackend {
 // To additionally limit the size of the trees the cache is also sharded by sequence
 // number in groups of 10000. Note that this does not limit the number of entries per bucket
 // as branches mean many commits share the same sequence number.
-fn ref_path(filter_tree_id: git2::Oid, shard: u64) -> String {
+fn ref_path(filter_tree_id: gix_hash::ObjectId, shard: u64) -> String {
     format!(
         "refs/josh/cache/{}/{}/{}",
         CACHE_VERSION, shard, filter_tree_id,

--- a/josh-core/src/cache/sled.rs
+++ b/josh-core/src/cache/sled.rs
@@ -17,7 +17,7 @@ struct State {
     /// Cache directory, set by [`SledCacheBackend::new`]. `None` until the first backend is built.
     path: Option<std::path::PathBuf>,
     db: Option<sled::Db>,
-    trees: std::collections::HashMap<git2::Oid, sled::Tree>,
+    trees: std::collections::HashMap<gix_hash::ObjectId, sled::Tree>,
     active: usize,
 }
 

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -87,7 +87,7 @@ fn previous_value(expected: Expected) -> gix::refs::transaction::PreviousValue {
     }
 }
 
-static REF_CACHE: LazyLock<RwLock<HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>>> =
+static REF_CACHE: LazyLock<RwLock<HashMap<gix_hash::ObjectId, HashMap<git2::Oid, git2::Oid>>>> =
     LazyLock::new(Default::default);
 
 static POPULATE_MAP: LazyLock<RwLock<HashMap<(git2::Oid, git2::Oid), git2::Oid>>> =
@@ -239,12 +239,12 @@ impl TransactionContext {
 
 #[allow(unused)]
 struct Transaction2 {
-    commit_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
-    apply_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
+    commit_map: HashMap<gix_hash::ObjectId, HashMap<git2::Oid, git2::Oid>>,
+    apply_map: HashMap<gix_hash::ObjectId, HashMap<git2::Oid, git2::Oid>>,
     subtract_map: HashMap<(git2::Oid, git2::Oid), git2::Oid>,
     intersect_map: HashMap<(git2::Oid, git2::Oid), git2::Oid>,
     overlay_map: HashMap<(git2::Oid, git2::Oid), git2::Oid>,
-    unapply_map: HashMap<git2::Oid, HashMap<git2::Oid, git2::Oid>>,
+    unapply_map: HashMap<gix_hash::ObjectId, HashMap<git2::Oid, git2::Oid>>,
     legalize_map: HashMap<(crate::filter::Filter, git2::Oid), crate::filter::Filter>,
     downstack_deps_map: HashMap<git2::Oid, std::collections::HashSet<crate::filter::DownstackDep>>,
     merge_trees_map: HashMap<(git2::Oid, git2::Oid, git2::Oid), git2::Oid>,

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -24,11 +24,14 @@ pub mod text;
 pub mod tree;
 
 pub fn as_tree(transaction: &cache::Transaction, filter: Filter) -> anyhow::Result<git2::Oid> {
-    josh_filter::persist::as_tree(transaction.odb(), filter)
+    Ok(objects::git2_oid(&josh_filter::persist::as_tree(
+        transaction.odb(),
+        filter,
+    )?))
 }
 
 pub fn from_tree(transaction: &cache::Transaction, tree_oid: git2::Oid) -> anyhow::Result<Filter> {
-    josh_filter::persist::from_tree(transaction.odb(), tree_oid)
+    josh_filter::persist::from_tree(transaction.odb(), objects::gix_oid(tree_oid))
 }
 
 static WORKSPACES: LazyLock<std::sync::Mutex<std::collections::HashMap<git2::Oid, Filter>>> =
@@ -230,7 +233,7 @@ fn resolve_refs2(refs: &std::collections::HashMap<String, git2::Oid>, op: &Op) -
                     let f = resolve_refs(refs, *f);
                     let resolved_r = if let LazyRef::Lazy(s) = r {
                         if let Some(res) = refs.get(s) {
-                            LazyRef::Resolved(*res)
+                            LazyRef::Resolved(objects::gix_oid(*res))
                         } else {
                             r.clone()
                         }
@@ -248,7 +251,7 @@ fn resolve_refs2(refs: &std::collections::HashMap<String, git2::Oid>, op: &Op) -
                 .map(|(r, m)| {
                     if let LazyRef::Lazy(s) = r {
                         if let Some(res) = refs.get(s) {
-                            (LazyRef::Resolved(*res), *m)
+                            (LazyRef::Resolved(objects::gix_oid(*res)), *m)
                         } else {
                             (r.clone(), *m)
                         }
@@ -261,7 +264,7 @@ fn resolve_refs2(refs: &std::collections::HashMap<String, git2::Oid>, op: &Op) -
         }
         Op::Downstack(LazyRef::Lazy(s)) => {
             if let Some(res) = refs.get(s) {
-                Op::Downstack(LazyRef::Resolved(*res))
+                Op::Downstack(LazyRef::Resolved(objects::gix_oid(*res)))
             } else {
                 op.clone()
             }
@@ -544,12 +547,12 @@ fn get_rev_filter(
     // First match wins - iterate in order
     for (match_op, filter_tip_ref, startfilter) in filters.iter() {
         let filter_tip = if let LazyRef::Resolved(filter_tip) = filter_tip_ref {
-            filter_tip
+            objects::git2_oid(filter_tip.as_ref())
         } else {
             return Err(anyhow!("unresolved lazy ref"));
         };
         if match_op != &RevMatch::Default
-            && !transaction.odb().contains(objects::gix_oid(*filter_tip))
+            && !transaction.odb().contains(objects::gix_oid(filter_tip))
         {
             return Err(anyhow!("`:rev(...)` with nonexistent OID: {}", filter_tip));
         }
@@ -557,17 +560,17 @@ fn get_rev_filter(
             RevMatch::AncestorStrict => {
                 // `<` - matches if commit is ancestor of tip AND commit != tip (strict)
 
-                is_ancestor_of(transaction, commit_id, *filter_tip)? && commit_id != *filter_tip
+                is_ancestor_of(transaction, commit_id, filter_tip)? && commit_id != filter_tip
             }
             RevMatch::AncestorInclusive => {
                 // `<=` - matches if commit is ancestor of tip OR commit == tip (inclusive)
 
-                is_ancestor_of(transaction, commit_id, *filter_tip)?
+                is_ancestor_of(transaction, commit_id, filter_tip)?
             }
             RevMatch::Equal => {
                 // `==` - matches if commit == tip
 
-                commit_id == *filter_tip
+                commit_id == filter_tip
             }
             RevMatch::Default => {
                 // `_` - always matches (makes filters after it unreachable)
@@ -630,7 +633,7 @@ pub fn apply_to_commit2(
             if let Some(oid) = transaction.get(filter, commit_id)? {
                 return Ok(Some(oid));
             }
-            let new_oid = downstack(transaction, commit_id, *base)?;
+            let new_oid = downstack(transaction, commit_id, objects::git2_oid(base.as_ref()))?;
             transaction.insert(filter, commit_id, new_oid, false)?;
             return Ok(Some(new_oid));
         }
@@ -655,7 +658,7 @@ pub fn apply_to_commit2(
 
     let rewrite_data = match &op {
         Op::Squash(Some(ids)) => {
-            if let Some(sq) = ids.get(&LazyRef::Resolved(commit.id())) {
+            if let Some(sq) = ids.get(&LazyRef::Resolved(objects::gix_oid(commit.id()))) {
                 let oid = if let Some(oid) = apply_to_commit2(
                     filter::Filter::new().squash(None).chain(*sq),
                     commit_id,
@@ -1037,7 +1040,7 @@ pub fn apply_to_commit2(
             check_experimental_features_enabled("unapply filter")?;
             if let LazyRef::Resolved(target) = target {
                 /* dbg!(target); */
-                let target = objects::CommitData::read(odb, *target)?;
+                let target = objects::CommitData::read(odb, objects::git2_oid(target.as_ref()))?;
                 // Only a root commit (no first parent) skips link detection; a
                 // first parent that is present must be readable.
                 if let Some(parent_id) = target.first_parent_id() {
@@ -1057,8 +1060,10 @@ pub fn apply_to_commit2(
                         if let Some(commit_str) = link.get_meta("commit") {
                             if let Ok(link_commit) = git2::Oid::from_str(&commit_str) {
                                 if commit.id() == link_commit {
-                                    let unapply =
-                                        to_filter(Op::Unapply(LazyRef::Resolved(parent.id()), *uf));
+                                    let unapply = to_filter(Op::Unapply(
+                                        LazyRef::Resolved(objects::gix_oid(parent.id())),
+                                        *uf,
+                                    ));
                                     let r = some_or!(transaction.get(unapply, link_commit)?, {
                                         return Ok(None);
                                     });
@@ -1088,7 +1093,10 @@ pub fn apply_to_commit2(
             let tree_reader = tree::read_tree(transaction, odb, tree)?;
             if let Some(link) = read_josh_link(transaction, odb, &tree_reader, path, ".link.josh") {
                 let subdir = filter::invert(link.peel())?;
-                let unapply = to_filter(Op::Unapply(LazyRef::Resolved(commit.id()), subdir));
+                let unapply = to_filter(Op::Unapply(
+                    LazyRef::Resolved(objects::gix_oid(commit.id())),
+                    subdir,
+                ));
                 if let Some(commit_str) = link.get_meta("commit") {
                     if let Ok(commit_oid) = git2::Oid::from_str(&commit_str) {
                         let r = some_or!(transaction.get(unapply, commit_oid)?, {
@@ -1456,7 +1464,7 @@ fn apply_impl(
 
         Op::Pattern(cp) => {
             let input = x.tree_id();
-            let key = peel_filter(filter).id();
+            let key = objects::git2_oid(peel_filter(filter).id().as_ref());
             let t = if cp.fallback {
                 // More components than the NFA state mask can hold: match full paths.
                 tree::remove_pred(
@@ -1488,9 +1496,17 @@ fn apply_impl(
                 ),
                 // The kind comes from the header alone; a missing oid folds into the
                 // "neither" arm below.
-                InsertContent::Oid(oid) => match odb.try_kind(objects::gix_oid(*oid)) {
-                    Ok(Some(gix_object::Kind::Blob)) => (*oid, git2::FileMode::Blob.into(), false),
-                    Ok(Some(gix_object::Kind::Tree)) => (*oid, git2::FileMode::Tree.into(), true),
+                InsertContent::Oid(oid) => match odb.try_kind(*oid) {
+                    Ok(Some(gix_object::Kind::Blob)) => (
+                        objects::git2_oid(oid.as_ref()),
+                        git2::FileMode::Blob.into(),
+                        false,
+                    ),
+                    Ok(Some(gix_object::Kind::Tree)) => (
+                        objects::git2_oid(oid.as_ref()),
+                        git2::FileMode::Tree.into(),
+                        true,
+                    ),
                     _ => {
                         return Err(anyhow::anyhow!(
                             "insert: {} is neither a blob nor a tree",
@@ -1705,7 +1721,7 @@ fn apply_impl(
         Op::Unapply(target, uf) => {
             check_experimental_features_enabled("unapply filter")?;
             if let LazyRef::Resolved(target) = target {
-                let target = objects::CommitData::read(odb, *target)?;
+                let target = objects::CommitData::read(odb, objects::git2_oid(target.as_ref()))?;
                 // The message must parse as an oid, so non-UTF-8 is an error.
                 let target_msg = target.message()?;
                 let target = git2::Oid::from_str(std::str::from_utf8(target_msg)?)?;

--- a/josh-filter/Cargo.toml
+++ b/josh-filter/Cargo.toml
@@ -18,7 +18,6 @@ indoc = "2.0.7"
 itertools = "0.15.0"
 
 anyhow.workspace = true
-git2.workspace = true
 josh-memodb.workspace = true
 josh-gix-ext.workspace = true
 gix-object.workspace = true

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -56,7 +56,7 @@ impl Default for Filter {
 impl Filter {
     /// The content-addressed OID of this filter, computed lazily on first call and cached on the
     /// node. This is the only place a filter's tree is built (via `build_op`).
-    pub fn id(&self) -> git2::Oid {
+    pub fn id(&self) -> gix_hash::ObjectId {
         *self.0.oid.get_or_init(|| persist::build_node_oid(self.0))
     }
 }
@@ -90,7 +90,7 @@ impl Filter {
     /// relationship to `tip` satisfies `match` (e.g. `AncestorInclusive` is `<=tip`); the first
     /// matching arm wins and a commit matching none passes through unchanged. Tips are resolved
     /// oids (`RevMatch::Default` ignores its tip); construct `Op::Rev` directly for lazy refs.
-    pub fn rev(self, arms: Vec<(RevMatch, git2::Oid, Filter)>) -> Filter {
+    pub fn rev(self, arms: Vec<(RevMatch, gix_hash::ObjectId, Filter)>) -> Filter {
         self.chain(to_filter(Op::Rev(
             arms.into_iter()
                 .map(|(m, tip, then)| (m, LazyRef::Resolved(tip), then))
@@ -196,7 +196,7 @@ impl Filter {
     pub fn insert_oid(
         self,
         path: impl Into<std::path::PathBuf>,
-        oid: git2::Oid,
+        oid: gix_hash::ObjectId,
     ) -> anyhow::Result<Filter> {
         Ok(self.chain(to_filter(Op::Insert(path.into(), InsertContent::Oid(oid)))))
     }
@@ -242,7 +242,7 @@ impl Filter {
     }
 
     /// Chain a squash filter
-    pub fn squash(self, ids: Option<&[(git2::Oid, Filter)]>) -> Filter {
+    pub fn squash(self, ids: Option<&[(gix_hash::ObjectId, Filter)]>) -> Filter {
         self.chain(if let Some(ids) = ids {
             to_filter(Op::Squash(Some(
                 ids.iter()
@@ -256,7 +256,7 @@ impl Filter {
 
     /// Chain a downstack filter that rebuilds the stack from `base` to the input commit,
     /// dropping intermediate commits whose paths are disjoint from the tip's changes.
-    pub fn downstack(self, base: git2::Oid) -> Filter {
+    pub fn downstack(self, base: gix_hash::ObjectId) -> Filter {
         self.chain(to_filter(Op::Downstack(LazyRef::Resolved(base))))
     }
 
@@ -373,7 +373,8 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
 /// The sequence_number filter used for tracking commit sequence numbers. A memoized sentinel
 /// node whose OID is the zero OID, so identity comparison and cache-keying stay correct.
 pub fn sequence_number() -> Filter {
-    static F: LazyLock<Filter> = LazyLock::new(|| persist::sentinel(git2::Oid::ZERO_SHA1));
+    static F: LazyLock<Filter> =
+        LazyLock::new(|| persist::sentinel(gix_hash::ObjectId::null(gix_hash::Kind::Sha1)));
     *F
 }
 
@@ -386,7 +387,7 @@ pub fn reachable_roots() -> Filter {
     static F: LazyLock<Filter> = LazyLock::new(|| {
         let mut bytes = [0u8; 20];
         bytes[19] = 1;
-        persist::sentinel(git2::Oid::from_bytes(&bytes).expect("valid sentinel oid"))
+        persist::sentinel(gix_hash::ObjectId::from_bytes_or_panic(&bytes))
     });
     *F
 }

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -183,7 +183,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
             let content_pair = inner.next().unwrap();
             let content = match content_pair.as_rule() {
                 Rule::string => InsertContent::Inline(unquote(content_pair.as_str())),
-                Rule::object_oid => InsertContent::Oid(git2::Oid::from_str(content_pair.as_str())?),
+                Rule::object_oid => InsertContent::Oid(content_pair.as_str().parse()?),
                 _ => unreachable!(),
             };
             Ok(to_filter(Op::Insert(path, content)))
@@ -278,7 +278,9 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
                                 let filter = parse(filter_pair.as_str())?;
                                 entries.push((
                                     RevMatch::Default,
-                                    LazyRef::Resolved(git2::Oid::ZERO_SHA1),
+                                    LazyRef::Resolved(gix_hash::ObjectId::null(
+                                        gix_hash::Kind::Sha1,
+                                    )),
                                     filter,
                                 ));
                             }

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -57,7 +57,7 @@ impl LinkMode {
 
 #[derive(Hash, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub enum LazyRef {
-    Resolved(git2::Oid),
+    Resolved(gix_hash::ObjectId),
     Lazy(String),
 }
 
@@ -67,7 +67,7 @@ pub enum InsertContent {
     /// An object referenced by OID. The kind (blob or tree) is resolved against a repository
     /// when the filter is applied or persisted; `persist::as_tree` references the object as a
     /// tree entry with the matching mode so it is reachable from the filter tree.
-    Oid(git2::Oid),
+    Oid(gix_hash::ObjectId),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -98,7 +98,7 @@ impl LazyRef {
             return Ok(LazyRef::Lazy(s));
         }
 
-        if let Ok(oid) = git2::Oid::from_str(&s) {
+        if let Ok(oid) = s.parse() {
             Ok(LazyRef::Resolved(oid))
         } else {
             Err(anyhow!("invalid ref: {:?}", s))

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -12,7 +12,7 @@ use crate::op::{InsertContent, LazyRef, Op, Regex, RevMatch};
 /// most once, on demand, via `Filter::id`/`build_node_oid` — never during `to_filter`.
 pub(crate) struct Node {
     pub(crate) op: Op,
-    pub(crate) oid: OnceLock<git2::Oid>,
+    pub(crate) oid: OnceLock<gix_hash::ObjectId>,
 }
 
 /// Canonicalizes each `Op` to a single interned node by structural equality, so equal `Op`s
@@ -121,7 +121,7 @@ impl<'a> InMemoryBuilder<'a> {
         self.persist_ids
             .get(&filter)
             .copied()
-            .unwrap_or_else(|| gix_hash::ObjectId::from_bytes_or_panic(filter.id().as_bytes()))
+            .unwrap_or_else(|| filter.id())
     }
 
     fn write_blob(&mut self, data: &[u8]) -> gix_hash::ObjectId {
@@ -403,7 +403,7 @@ impl<'a> InMemoryBuilder<'a> {
                     InsertContent::Oid(oid) => {
                         if let Some(src) = self.src {
                             let kind = src
-                                .try_header(&josh_gix_ext::gix_oid(*oid))
+                                .try_header(oid.as_ref())
                                 .map_err(|e| anyhow!("insert: object {}: {}", oid, e))?
                                 .map(|header| header.kind);
                             let mode = match kind {
@@ -426,7 +426,7 @@ impl<'a> InMemoryBuilder<'a> {
                                 gix_object::tree::Entry {
                                     mode: mode.into(),
                                     filename: BString::from("o"),
-                                    oid: gix_hash::ObjectId::from_bytes_or_panic(oid.as_bytes()),
+                                    oid: *oid,
                                 },
                             ];
                             self.write_tree(gix_object::Tree { entries })
@@ -594,17 +594,16 @@ pub fn to_filter(op: Op) -> Filter {
 /// Materialize a node's content OID, building its tree (and, recursively via `build_op`'s child
 /// `Filter::id` calls, its children's). Called only from `Filter::id`, never on the optimizer
 /// hot path.
-pub(crate) fn build_node_oid(node: &'static Node) -> git2::Oid {
+pub(crate) fn build_node_oid(node: &'static Node) -> gix_hash::ObjectId {
     let mut builder = InMemoryBuilder::new(None);
-    let tree_id = builder.build_op(&node.op).expect("failed to build op");
-    git2::Oid::from_bytes(tree_id.as_bytes()).unwrap()
+    builder.build_op(&node.op).expect("failed to build op")
 }
 
 /// Construct a sentinel filter: a unique leaked node whose OID is pre-seeded to `oid` (so it
 /// never goes through `build_op`) and whose op is `Nop`. Sentinels bypass interning, so each
 /// is a distinct node — pointer-identity equality keeps them distinct from the real `Nop`
 /// filter and from each other, while `to_op_ref` still yields `Nop`.
-pub(crate) fn sentinel(oid: git2::Oid) -> Filter {
+pub(crate) fn sentinel(oid: gix_hash::ObjectId) -> Filter {
     let node: &'static Node = Box::leak(Box::new(Node {
         op: Op::Nop,
         oid: OnceLock::new(),
@@ -637,10 +636,10 @@ impl<'a> InMemoryBuilder<'a> {
         let oid = if dirty {
             self.build_op(op)?
         } else {
-            if !out.exists(&josh_gix_ext::gix_oid(filter.id())) {
+            if !out.exists(filter.id().as_ref()) {
                 self.build_op(op)?;
             }
-            gix_hash::ObjectId::from_bytes_or_panic(filter.id().as_bytes())
+            filter.id()
         };
         self.persist_ids.insert(filter, oid);
         Ok(oid)
@@ -650,12 +649,11 @@ impl<'a> InMemoryBuilder<'a> {
 pub fn as_tree(
     out: &(impl gix_object::FindHeader + gix_object::Exists + gix_object::Write),
     filter: Filter,
-) -> anyhow::Result<git2::Oid> {
+) -> anyhow::Result<gix_hash::ObjectId> {
     let filter = crate::opt::optimize(filter);
 
     let mut builder = InMemoryBuilder::new(Some(out));
     let root_oid = builder.build_persist(out, filter)?;
-    let root_oid = git2::Oid::from_bytes(root_oid.as_bytes())?;
 
     builder.staging.flush(out)?;
 
@@ -755,8 +753,11 @@ impl Blob {
     }
 }
 
-pub fn from_tree(src: &impl gix_object::Find, tree_oid: git2::Oid) -> anyhow::Result<Filter> {
-    Ok(to_filter(from_tree2(src, josh_gix_ext::gix_oid(tree_oid))?))
+pub fn from_tree(
+    src: &impl gix_object::Find,
+    tree_oid: gix_hash::ObjectId,
+) -> anyhow::Result<Filter> {
+    Ok(to_filter(from_tree2(src, tree_oid)?))
 }
 
 fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyhow::Result<Op> {
@@ -918,7 +919,7 @@ fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyh
             if let Some(obj_entry) = inner.get_name("o") {
                 return Ok(Op::Insert(
                     std::path::PathBuf::from(path),
-                    InsertContent::Oid(josh_gix_ext::git2_oid(&obj_entry.id())),
+                    InsertContent::Oid(obj_entry.id()),
                 ));
             }
             let kind_blob = Blob::read(
@@ -1182,7 +1183,10 @@ fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyh
                 // Parse match operator from key
                 let (match_op, lazy_ref) = if key == "_" {
                     // Default filter - no SHA needed
-                    (RevMatch::Default, LazyRef::Resolved(git2::Oid::ZERO_SHA1))
+                    (
+                        RevMatch::Default,
+                        LazyRef::Resolved(gix_hash::ObjectId::null(gix_hash::Kind::Sha1)),
+                    )
                 } else if let Some(ref_str) = key.strip_prefix("<=") {
                     (RevMatch::AncestorInclusive, LazyRef::parse(ref_str)?)
                 } else if let Some(ref_str) = key.strip_prefix('<') {

--- a/josh-git-serde/Cargo.toml
+++ b/josh-git-serde/Cargo.toml
@@ -10,13 +10,11 @@ edition = "2024"
 
 [dependencies]
 anyhow.workspace = true
-git2.workspace = true
 gix-object.workspace = true
+gix-hash.workspace = true
 percent-encoding = "2.3.2"
 serde.workspace = true
 thiserror.workspace = true
 
-josh-gix-ext.workspace = true
-
 [dev-dependencies]
-gix-hash.workspace = true
+josh-gix-ext.workspace = true

--- a/josh-git-serde/src/store.rs
+++ b/josh-git-serde/src/store.rs
@@ -16,9 +16,14 @@ use crate::value::GitValue;
 /// Tree entry names must be single path components: non-empty, no '/' or
 /// NUL, not "." or "..". Keys produced by the serializer always satisfy
 /// this; the check exists because [`GitValue`] is public.
-pub fn to_tree_oid(out: &impl gix_object::Write, value: &GitValue) -> anyhow::Result<git2::Oid> {
+pub fn to_tree_oid(
+    out: &impl gix_object::Write,
+    value: &GitValue,
+) -> anyhow::Result<gix_hash::ObjectId> {
     match value {
-        GitValue::Blob(data) => josh_gix_ext::write_blob(out, data),
+        GitValue::Blob(data) => out
+            .write_buf(gix_object::Kind::Blob, data)
+            .map_err(|e| anyhow::anyhow!("to_tree_oid: {e}")),
         GitValue::Tree(entries) => {
             let mut tree_entries = Vec::with_capacity(entries.len());
             for (name, child) in entries {
@@ -30,11 +35,14 @@ pub fn to_tree_oid(out: &impl gix_object::Write, value: &GitValue) -> anyhow::Re
                         GitValue::Blob(_) => gix_object::tree::EntryKind::Blob.into(),
                     },
                     filename: name.as_str().into(),
-                    oid: josh_gix_ext::gix_oid(oid),
+                    oid,
                 });
             }
             tree_entries.sort();
-            josh_gix_ext::write_tree_now(out, tree_entries)
+            out.write(&gix_object::Tree {
+                entries: tree_entries,
+            })
+            .map_err(|e| anyhow::anyhow!("to_tree_oid: {e}"))
         }
     }
 }
@@ -50,7 +58,10 @@ pub fn to_tree_oid(out: &impl gix_object::Write, value: &GitValue) -> anyhow::Re
 /// Nesting deeper than [`MAX_TREE_DEPTH`] is rejected rather than risking a
 /// stack overflow on adversarial objects, as are duplicate entry names
 /// (possible only in hand-crafted trees).
-pub fn from_tree_oid(source: &impl gix_object::Find, root: git2::Oid) -> anyhow::Result<GitValue> {
+pub fn from_tree_oid(
+    source: &impl gix_object::Find,
+    root: gix_hash::ObjectId,
+) -> anyhow::Result<GitValue> {
     read_tree_oid(source, root, 0)
 }
 
@@ -65,7 +76,7 @@ fn validate_entry_name(name: &str) -> anyhow::Result<()> {
 
 fn read_tree_oid(
     source: &impl gix_object::Find,
-    root: git2::Oid,
+    root: gix_hash::ObjectId,
     depth: usize,
 ) -> anyhow::Result<GitValue> {
     if depth > MAX_TREE_DEPTH {
@@ -76,7 +87,7 @@ fn read_tree_oid(
 
     let mut buf = Vec::new();
     let data = source
-        .try_find(&josh_gix_ext::gix_oid(root), &mut buf)
+        .try_find(&root, &mut buf)
         .map_err(|e| anyhow::anyhow!("from_tree_oid: {e}"))?
         .ok_or_else(|| anyhow::anyhow!("from_tree_oid: object {root} not found"))?;
     let object_hash = data.object_hash;
@@ -98,7 +109,7 @@ fn read_tree_oid(
                         entry.mode
                     ));
                 }
-                let child = read_tree_oid(source, josh_gix_ext::git2_oid(entry.oid), depth + 1)?;
+                let child = read_tree_oid(source, entry.oid.to_owned(), depth + 1)?;
                 if entries.insert(name.clone(), Box::new(child)).is_some() {
                     return Err(anyhow::anyhow!(
                         "from_tree_oid: duplicate entry name {name:?}"

--- a/josh-git-serde/tests/store.rs
+++ b/josh-git-serde/tests/store.rs
@@ -100,7 +100,11 @@ fn blob_root_roundtrips() {
     let stage = Stage::new();
     let value = GitValue::blob_from_str("lone blob");
     let root = to_tree_oid(&stage, &value).unwrap();
-    assert_eq!(root, josh_gix_ext::hash_blob(b"lone blob"));
+    assert_eq!(
+        root,
+        gix_object::compute_hash(gix_hash::Kind::Sha1, gix_object::Kind::Blob, b"lone blob")
+            .unwrap()
+    );
     let back = from_tree_oid(&*stage.0.borrow(), root).unwrap();
     assert_eq!(value, back);
 }
@@ -127,10 +131,7 @@ fn written_tree_is_in_canonical_order() {
     let staging = stage.0.borrow();
     let mut buf = Vec::new();
     let (kind, object_hash) = {
-        let data = staging
-            .try_find(&josh_gix_ext::gix_oid(root), &mut buf)
-            .unwrap()
-            .unwrap();
+        let data = staging.try_find(&root, &mut buf).unwrap().unwrap();
         (data.kind, data.object_hash)
     };
     assert_eq!(kind, gix_object::Kind::Tree);
@@ -161,7 +162,7 @@ fn written_tree_is_in_canonical_order() {
         let name: &[u8] = entry.filename.as_ref();
         if name == b"foo" {
             assert_eq!(entry.mode.kind(), gix_object::tree::EntryKind::Tree);
-            let sub = from_tree_oid(&*staging, josh_gix_ext::git2_oid(entry.oid)).unwrap();
+            let sub = from_tree_oid(&*staging, entry.oid.to_owned()).unwrap();
             assert_eq!(
                 sub,
                 GitValue::Tree(BTreeMap::from([(
@@ -184,7 +185,7 @@ fn commit_object_is_rejected() {
     let mut staging = StagingOdb::new();
     // Contents are irrelevant: the kind alone must trigger the error.
     let commit = staging.write_raw(gix_object::Kind::Commit, b"tree".to_vec());
-    let err = from_tree_oid(&staging, josh_gix_ext::git2_oid(&commit)).unwrap_err();
+    let err = from_tree_oid(&staging, commit).unwrap_err();
     assert!(
         err.to_string().contains("not a tree or a blob"),
         "unexpected error: {err}"
@@ -194,7 +195,7 @@ fn commit_object_is_rejected() {
 #[test]
 fn missing_object_is_an_error() {
     let staging = StagingOdb::new();
-    let missing = git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap();
+    let missing = gix_hash::ObjectId::from_bytes_or_panic(&[1; 20]);
     let err = from_tree_oid(&staging, missing).unwrap_err();
     assert!(
         err.to_string().contains("not found"),
@@ -222,7 +223,7 @@ fn executable_blob_entry_is_rejected() {
         gix_object::Kind::Tree,
         raw_tree(&[("100755", "exec", &blob)]),
     );
-    let err = from_tree_oid(&staging, josh_gix_ext::git2_oid(&tree)).unwrap_err();
+    let err = from_tree_oid(&staging, tree).unwrap_err();
     assert!(
         err.to_string().contains("unsupported mode"),
         "unexpected error: {err}"
@@ -238,7 +239,7 @@ fn duplicate_entry_names_are_rejected() {
         gix_object::Kind::Tree,
         raw_tree(&[("100644", "dup", &a), ("100644", "dup", &b)]),
     );
-    let err = from_tree_oid(&staging, josh_gix_ext::git2_oid(&tree)).unwrap_err();
+    let err = from_tree_oid(&staging, tree).unwrap_err();
     assert!(
         err.to_string().contains("duplicate entry name"),
         "unexpected error: {err}"

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -138,7 +138,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1768,7 +1768,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2001,7 +2001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4265,7 +4265,6 @@ name = "josh-filter"
 version = "26.7.28"
 dependencies = [
  "anyhow",
- "git2",
  "gix-hash",
  "gix-object",
  "glob",
@@ -4285,9 +4284,8 @@ name = "josh-git-serde"
 version = "26.7.28"
 dependencies = [
  "anyhow",
- "git2",
+ "gix-hash",
  "gix-object",
- "josh-gix-ext",
  "percent-encoding",
  "serde",
  "thiserror 2.0.20",
@@ -6044,7 +6042,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6530,7 +6528,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6587,7 +6585,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7130,7 +7128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7534,10 +7532,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8393,7 +8391,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/josh-memodb/src/pack.rs
+++ b/josh-memodb/src/pack.rs
@@ -6,6 +6,7 @@
 //! on disk are filtered out first, so a pack contains only genuinely-new objects and the on-disk
 //! layout stays deterministic.
 
+use anyhow::Context;
 use std::io::{Seek, Write};
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
@@ -34,8 +35,7 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow:
     // the expected case below, and the default refresh mode re-lists the pack directory on every
     // miss — disable it; the first lookup still loads all indices present now, and loose-object
     // probes stat the filesystem directly either way.
-    let mut odb = gix_odb::at(objects_dir.to_owned())
-        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
+    let mut odb = gix_odb::at(objects_dir.to_owned()).context("mem-odb pack write failed")?;
     odb.refresh = gix_odb::store::RefreshMode::Never;
 
     let to_pack: Vec<_> = snapshot
@@ -46,12 +46,10 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow:
     if to_pack.is_empty() {
         return Ok(());
     }
-    let num_entries = u32::try_from(to_pack.len())
-        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
+    let num_entries = u32::try_from(to_pack.len()).context("mem-odb pack write failed")?;
 
     let pack_dir = objects_dir.join("pack");
-    std::fs::create_dir_all(&pack_dir)
-        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
+    std::fs::create_dir_all(&pack_dir).context("mem-odb pack write failed")?;
 
     // Serialize the pack byte stream (header, compressed entries, checksum trailer) through an
     // anonymous spool file in the pack directory: objects are compressed one at a time as the
@@ -59,8 +57,7 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow:
     // a snapshot's size is only *typically* bounded by the store's chunk limit (unbounded stores
     // exist, and the limit is an overflow trigger, not a cap).
     let mut spool = std::io::BufWriter::new(
-        tempfile::tempfile_in(&pack_dir)
-            .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?,
+        tempfile::tempfile_in(&pack_dir).context("mem-odb pack write failed")?,
     );
     let mut iter = output::bytes::FromEntriesIter::new(
         to_pack.iter().map(|(oid, kind, data)| {
@@ -78,18 +75,12 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow:
         gix_hash::Kind::Sha1,
     );
     for written in &mut iter {
-        written.map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
+        written.context("mem-odb pack write failed")?;
     }
     drop(iter);
-    spool
-        .flush()
-        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
-    let mut spool = spool
-        .into_inner()
-        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
-    spool
-        .rewind()
-        .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
+    spool.flush().context("mem-odb pack write failed")?;
+    let mut spool = spool.into_inner().context("mem-odb pack write failed")?;
+    spool.rewind().context("mem-odb pack write failed")?;
 
     let outcome = gix_pack::Bundle::write_to_directory(
         &mut std::io::BufReader::new(spool),
@@ -107,7 +98,7 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow:
             compression: gix_zlib::Compression::DEFAULT,
         },
     )
-    .map_err(|e| anyhow::anyhow!("mem-odb pack write failed: {e}"))?;
+    .context("mem-odb pack write failed")?;
     // gix marks the freshly-landed pack with a `.keep` file for the caller to remove once its
     // referencing refs exist. josh's flushes carry no such handshake (libgit2's packbuilder wrote
     // no `.keep` either), and a leftover one would exempt the pack from `git repack -d` forever.
@@ -118,7 +109,7 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow:
     if let Some(data_path) = &outcome.data_path {
         if let Err(e) = std::fs::remove_file(data_path.with_extension("keep")) {
             if e.kind() != std::io::ErrorKind::NotFound {
-                return Err(anyhow::anyhow!("mem-odb pack write failed: {e}"));
+                return Err(e).context("mem-odb pack write failed");
             }
         }
     }


### PR DESCRIPTION
Move persisted object IDs to gitoxide

Use gix_hash::ObjectId throughout josh-filter and josh-git-serde public and persisted representations. Keep explicit conversions at callers that still use libgit2 OIDs, and key filter-identity caches directly by ObjectId.

Remove the resulting direct git2 dependencies and preserve serialized filter trees and legacy consumer behavior. Use anyhow context for mem-ODB pack errors that cross the updated dependency boundary.

Change: gix-filter-oid-currency

Assisted-By: openai-codex/gpt-5.6-sol