### PR TITLE
Port signatures and runtime file modes to gitoxide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,6 +3313,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "git2",
+ "gix-actor",
  "gix-hash",
  "josh-core",
  "josh-git-serde",
@@ -3331,6 +3332,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "git2",
+ "gix-actor",
  "gix-hash",
  "glob",
  "josh-changes",
@@ -3661,7 +3663,7 @@ name = "josh-link"
 version = "26.7.28"
 dependencies = [
  "anyhow",
- "git2",
+ "gix-actor",
  "gix-hash",
  "josh-core",
 ]

--- a/cq/josh-cq/src/cq.rs
+++ b/cq/josh-cq/src/cq.rs
@@ -90,14 +90,8 @@ pub fn handle_track(
 
     let refs_path = std::path::Path::new("remotes").join(id).join("refs.json");
 
-    let final_tree = tree::insert_oid(
-        odb,
-        tree_with_link_oid,
-        &refs_path,
-        refs_blob,
-        git2::FileMode::Blob.into(),
-    )
-    .context("Failed to insert refs.json into tree")?;
+    let final_tree = tree::insert_oid(odb, tree_with_link_oid, &refs_path, refs_blob, 0o100644)
+        .context("Failed to insert refs.json into tree")?;
 
     let final_commit = josh_core::objects::write_commit(
         odb,

--- a/josh-changes/Cargo.toml
+++ b/josh-changes/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["git", "monorepo", "workflow", "scm"]
 anyhow.workspace = true
 chrono.workspace = true
 git2.workspace = true
+gix-actor.workspace = true
 gix-hash.workspace = true
 serde.workspace = true
 

--- a/josh-changes/src/store.rs
+++ b/josh-changes/src/store.rs
@@ -32,14 +32,23 @@ pub fn scope_tree(
     }
 }
 
-pub(crate) fn parse_timestamp(s: Option<&str>) -> git2::Time {
+pub(crate) fn parse_timestamp(s: Option<&str>) -> gix_actor::date::Time {
     let Some(s) = s else {
-        return git2::Time::new(0, 0);
+        return gix_actor::date::Time {
+            seconds: 0,
+            offset: 0,
+        };
     };
     let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) else {
-        return git2::Time::new(0, 0);
+        return gix_actor::date::Time {
+            seconds: 0,
+            offset: 0,
+        };
     };
-    git2::Time::new(dt.timestamp(), dt.offset().local_minus_utc() / 60)
+    gix_actor::date::Time {
+        seconds: dt.timestamp(),
+        offset: dt.offset().local_minus_utc(),
+    }
 }
 
 /// Write `blob_oid` at `path` inside `scope`'s ref, committing the updated
@@ -70,14 +79,14 @@ pub fn write_changes_tree(
         }
     }
 
-    let tree = tree::insert_oid(odb, base_tree, path, blob_oid, git2::FileMode::Blob.into())?;
+    let tree = tree::insert_oid(odb, base_tree, path, blob_oid, 0o0100644)?;
 
     let sig = match author {
-        Some(name) => {
-            let email = format!("{}@github", name);
-            let time = parse_timestamp(timestamp);
-            git2::Signature::new(name, &email, &time)?
-        }
+        Some(name) => gix_actor::Signature {
+            name: name.into(),
+            email: format!("{}@github", name).into(),
+            time: parse_timestamp(timestamp),
+        },
         None => josh_core::git::user_signature(transaction)?,
     };
     let msg = format!("update {}\n", ref_name);
@@ -122,7 +131,7 @@ pub fn value_oid<T: serde::Serialize>(
     let root = josh_git_serde::to_tree_oid(odb, &value)?;
     let mode: i32 = match &value {
         GitValue::Tree(_) => 0o0040000,
-        GitValue::Blob(_) => git2::FileMode::Blob.into(),
+        GitValue::Blob(_) => 0o0100644,
     };
     Ok((root, mode))
 }
@@ -155,11 +164,11 @@ pub fn place_oid(
     let tree = tree::insert_oid(odb, base_tree, path, root, mode)?;
 
     let sig = match author {
-        Some(name) => {
-            let email = format!("{}@github", name);
-            let time = parse_timestamp(timestamp);
-            git2::Signature::new(name, &email, &time)?
-        }
+        Some(name) => gix_actor::Signature {
+            name: name.into(),
+            email: format!("{}@github", name).into(),
+            time: parse_timestamp(timestamp),
+        },
         None => josh_core::git::user_signature(transaction)?,
     };
     let msg = format!("update {}\n", ref_name);
@@ -244,7 +253,14 @@ pub fn store_diff_data(
 
     let sig = transaction.signature()?;
 
-    let anchor_sig = git2::Signature::new("JOSH", "josh@josh-project.dev", &git2::Time::new(0, 0))?;
+    let anchor_sig = gix_actor::Signature {
+        name: "JOSH".into(),
+        email: "josh@josh-project.dev".into(),
+        time: gix_actor::date::Time {
+            seconds: 0,
+            offset: 0,
+        },
+    };
     let anchor_oid = objects::write_commit(
         odb,
         tree::empty_id(),

--- a/josh-changes/src/votes.rs
+++ b/josh-changes/src/votes.rs
@@ -63,6 +63,13 @@ pub fn write_outbox_vote(
     )
 }
 
+fn configured_email(transaction: &Transaction) -> anyhow::Result<String> {
+    let signature = transaction.signature()?;
+    Ok(std::str::from_utf8(signature.email.as_ref())
+        .unwrap_or("unknown")
+        .to_owned())
+}
+
 fn write_vote_inner(
     transaction: &Transaction,
     change: &Change,
@@ -83,11 +90,7 @@ fn write_vote_inner(
 
     let user = match author {
         Some(name) => name.to_string(),
-        None => transaction
-            .signature()?
-            .email()
-            .unwrap_or("unknown")
-            .to_string(),
+        None => configured_email(transaction)?,
     };
 
     let path = std::path::Path::new(path_prefix)
@@ -106,11 +109,7 @@ pub fn read_vote(
 ) -> anyhow::Result<Option<VoteData>> {
     let user = match user {
         Some(name) => name.to_string(),
-        None => transaction
-            .signature()?
-            .email()
-            .unwrap_or("unknown")
-            .to_string(),
+        None => configured_email(transaction)?,
     };
 
     let Some(data) =

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -43,6 +43,7 @@ josh-link.workspace = true
 josh-templates.workspace = true
 
 [dev-dependencies]
+gix-actor.workspace = true
 tempfile.workspace = true
 
 [features]

--- a/josh-cli/src/commands/pull.rs
+++ b/josh-cli/src/commands/pull.rs
@@ -562,8 +562,14 @@ mod tests {
             std::sync::Arc::new(josh_core::cache::CacheStack::new()),
         );
         let transaction = context.open().unwrap();
-        let signature =
-            git2::Signature::new("Test", "test@example.com", &git2::Time::new(0, 0)).unwrap();
+        let signature = gix_actor::Signature {
+            name: "Test".into(),
+            email: "test@example.com".into(),
+            time: gix_actor::date::Time {
+                seconds: 0,
+                offset: 0,
+            },
+        };
         let commit = |parents: &[gix_hash::ObjectId], change: Option<&str>| {
             let message = change
                 .map(|id| format!("Subject\n\nChange: {id}\n"))

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -191,7 +191,7 @@ fn prepare_push(
         let odb = transaction.odb();
         let merged_tree =
             josh_core::objects::merge_commits(odb, original_target, unfiltered_oid, None)?;
-        let signature = josh_core::git::josh_commit_signature()?;
+        let signature = josh_core::git::josh_actor_signature()?;
         josh_core::objects::write_commit(
             odb,
             merged_tree,

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -146,7 +146,7 @@ impl DistributedCacheBackend {
                     .map_err(|e| anyhow::anyhow!("write cache tree: {e}"))
             })?;
 
-            let signature = crate::git::josh_commit_signature()?;
+            let signature = crate::git::josh_actor_signature()?;
             let commit = objects::write_commit(
                 odb,
                 updated,

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -62,17 +62,12 @@ fn full_ref_name(refname: &str) -> anyhow::Result<gix::refs::FullName> {
 
 /// Who a reflog entry names. A missing configured identity must not prevent ref updates from
 /// writing their reflogs.
-fn reflog_committer(
-    signature: Option<&git2::Signature<'_>>,
-) -> anyhow::Result<gix_actor::Signature> {
-    match signature {
-        Some(signature) => crate::objects::gix_signature(signature),
-        None => Ok(gix_actor::Signature {
-            name: "unknown".into(),
-            email: "unknown".into(),
-            time: gix_actor::date::Time::now_local_or_utc(),
-        }),
-    }
+fn reflog_committer(signature: Option<&gix_actor::Signature>) -> gix_actor::Signature {
+    signature.cloned().unwrap_or_else(|| gix_actor::Signature {
+        name: "unknown".into(),
+        email: "unknown".into(),
+        time: gix_actor::date::Time::now_local_or_utc(),
+    })
 }
 
 /// The gix guard an [`Expected`] is.
@@ -763,20 +758,12 @@ impl Transaction {
 
     /// The identity to record as author and committer, from the repository's configuration
     /// with the usual environment overrides. Errors when no identity is configured.
-    pub fn signature(&self) -> anyhow::Result<git2::Signature<'static>> {
+    pub fn signature(&self) -> anyhow::Result<gix_actor::Signature> {
         let repo = self.repo();
         let signature = repo
             .committer()
             .ok_or_else(|| anyhow!("no committer identity is configured"))??;
-        let time = gix_actor::date::parse_header(signature.time)
-            .ok_or_else(|| anyhow!("committer date is invalid"))?;
-        let name = std::str::from_utf8(signature.name.as_ref())?;
-        let email = std::str::from_utf8(signature.email.as_ref())?;
-        Ok(git2::Signature::new(
-            name,
-            email,
-            &git2::Time::new(time.seconds, time.offset / 60),
-        )?)
+        Ok(signature.to_owned()?)
     }
 
     /// Create or update the direct ref `refname` to point at `target`, guarded by
@@ -839,7 +826,7 @@ impl Transaction {
         edits: Vec<gix::refs::transaction::RefEdit>,
     ) -> anyhow::Result<Vec<gix::refs::transaction::RefEdit>> {
         use gix::lock::acquire::Fail;
-        let committer = reflog_committer(self.signature().ok().as_ref())?;
+        let committer = reflog_committer(self.signature().ok().as_ref());
         let mut time_buf = gix_actor::date::parse::TimeBuf::default();
         Ok(self
             .refs()
@@ -1989,8 +1976,8 @@ mod tests {
         );
         assert_eq!(transaction.upstream_ref("refs/heads/other").unwrap(), None);
         let signature = transaction.signature().unwrap();
-        assert_eq!(signature.name().unwrap(), "Configured User");
-        assert_eq!(signature.email().unwrap(), "configured@example.com");
+        assert_eq!(signature.name.as_slice(), b"Configured User");
+        assert_eq!(signature.email.as_slice(), b"configured@example.com");
     }
 
     #[test]
@@ -2030,7 +2017,7 @@ mod tests {
 
     #[test]
     fn reflog_committer_falls_back_to_unknown() {
-        let committer = reflog_committer(None).unwrap();
+        let committer = reflog_committer(None);
         assert_eq!(committer.name, "unknown");
         assert_eq!(committer.email, "unknown");
     }

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1500,18 +1500,14 @@ fn apply_impl(
             let (oid, mode, is_tree) = match content {
                 InsertContent::Inline(s) => (
                     odb.write(gix_object::Kind::Blob, s.as_bytes()),
-                    git2::FileMode::Blob.into(),
+                    0o100644,
                     false,
                 ),
                 // The kind comes from the header alone; a missing oid folds into the
                 // "neither" arm below.
                 InsertContent::Oid(oid) => match odb.try_kind(*oid) {
-                    Ok(Some(gix_object::Kind::Blob)) => {
-                        (oid.to_owned(), git2::FileMode::Blob.into(), false)
-                    }
-                    Ok(Some(gix_object::Kind::Tree)) => {
-                        (oid.to_owned(), git2::FileMode::Tree.into(), true)
-                    }
+                    Ok(Some(gix_object::Kind::Blob)) => (oid.to_owned(), 0o100644, false),
+                    Ok(Some(gix_object::Kind::Tree)) => (oid.to_owned(), 0o040000, true),
                     _ => {
                         return Err(anyhow::anyhow!(
                             "insert: {} is neither a blob nor a tree",
@@ -1545,10 +1541,7 @@ fn apply_impl(
             let (file, mode) =
                 match tree::get_path_entry(transaction, odb, x.tree_id(), source_path) {
                     Ok(Some(e)) => (e.oid, e.mode.value() as i32),
-                    _ => (
-                        gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
-                        git2::FileMode::Blob.into(),
-                    ),
+                    _ => (gix_hash::ObjectId::null(gix_hash::Kind::Sha1), 0o100644),
                 };
             Ok(x.with_tree(tree::insert_oid(
                 odb,
@@ -1575,7 +1568,7 @@ fn apply_impl(
                 tree::empty_id(),
                 path,
                 tree,
-                git2::FileMode::Tree.into(),
+                0o040000,
             )?))
         }
 
@@ -1656,7 +1649,7 @@ fn apply_impl(
                     tree::empty_id(),
                     path,
                     blob_oid,
-                    git2::FileMode::Blob.into(),
+                    0o100644,
                 )?))
             } else {
                 Ok(x)
@@ -1683,8 +1676,8 @@ fn apply_impl(
                 // Kind by header, never by `contains`: `read_header`'s disk fallback
                 // virtualizes the empty tree, `exists` does not.
                 let (oid, mode) = match odb.try_kind(oid) {
-                    Ok(Some(gix_object::Kind::Tree)) => (oid, git2::FileMode::Tree.into()),
-                    Ok(Some(gix_object::Kind::Blob)) => (oid, git2::FileMode::Blob.into()),
+                    Ok(Some(gix_object::Kind::Tree)) => (oid, 0o040000),
+                    Ok(Some(gix_object::Kind::Blob)) => (oid, 0o100644),
                     _ => {
                         return Err(anyhow::anyhow!(":#: object not found in repo: {}", oid));
                     }
@@ -1698,7 +1691,7 @@ fn apply_impl(
                     tree::empty_id(),
                     path,
                     empty_blob,
-                    git2::FileMode::Blob.into(),
+                    0o100644,
                 )?))
             }
         }
@@ -2024,7 +2017,7 @@ fn pre_process_tree(
         tree,
         path,
         odb.write(gix_object::Kind::Blob, blob.as_bytes()),
-        git2::FileMode::Blob.into(), // Should this handle filemode?
+        0o100644, // Should this handle filemode?
     )?;
 
     Ok(tree)

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -50,6 +50,7 @@ const JOSH_COMMIT_TIME_ENV: &str = "JOSH_COMMIT_TIME";
 const JOSH_COMMIT_NAME: &str = "JOSH";
 const JOSH_COMMIT_EMAIL: &str = "josh@josh-project.dev";
 
+/// The libgit2 spelling of Josh's fixed commit identity, for porcelain and fixture seams.
 pub fn josh_commit_signature<'a>() -> anyhow::Result<git2::Signature<'a>> {
     Ok(if let Ok(time) = std::env::var(JOSH_COMMIT_TIME_ENV) {
         git2::Signature::new(
@@ -62,58 +63,73 @@ pub fn josh_commit_signature<'a>() -> anyhow::Result<git2::Signature<'a>> {
     })
 }
 
+/// Josh's fixed commit identity for commits written through the object store.
+pub fn josh_actor_signature() -> anyhow::Result<gix_actor::Signature> {
+    let time = match std::env::var(JOSH_COMMIT_TIME_ENV) {
+        Ok(time) => gix_actor::date::Time {
+            seconds: time.parse()?,
+            offset: 0,
+        },
+        Err(_) => gix_actor::date::Time::now_local_or_utc(),
+    };
+    Ok(gix_actor::Signature {
+        name: JOSH_COMMIT_NAME.into(),
+        email: JOSH_COMMIT_EMAIL.into(),
+        time,
+    })
+}
+
 /// Parse a date string from `GIT_COMMITTER_DATE` / `GIT_AUTHOR_DATE`. Accepts the
 /// formats git typically uses: raw (`<unix> <offset>`), RFC 2822 (what `date -R`
 /// emits) and RFC 3339 / ISO 8601.
-fn parse_git_env_date(s: &str) -> Option<git2::Time> {
+fn parse_git_env_date(s: &str) -> Option<gix_actor::date::Time> {
     let s = s.trim();
     if let Some((secs, offset)) = s.split_once(' ') {
-        if let (Ok(secs), Ok(offset)) = (secs.parse::<i64>(), offset.parse::<i32>()) {
+        if let (Ok(seconds), Ok(offset)) = (secs.parse::<i64>(), offset.parse::<i32>()) {
             let offset_minutes = (offset / 100) * 60 + (offset % 100);
-            return Some(git2::Time::new(secs, offset_minutes));
+            return Some(gix_actor::date::Time {
+                seconds,
+                offset: offset_minutes * 60,
+            });
         }
     }
     if let Ok(dt) = chrono::DateTime::parse_from_rfc2822(s) {
-        return Some(git2::Time::new(
-            dt.timestamp(),
-            dt.offset().local_minus_utc() / 60,
-        ));
+        return Some(gix_actor::date::Time {
+            seconds: dt.timestamp(),
+            offset: dt.offset().local_minus_utc(),
+        });
     }
     if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
-        return Some(git2::Time::new(
-            dt.timestamp(),
-            dt.offset().local_minus_utc() / 60,
-        ));
+        return Some(gix_actor::date::Time {
+            seconds: dt.timestamp(),
+            offset: dt.offset().local_minus_utc(),
+        });
     }
     None
 }
 
-/// Like `repo.signature()` but honors `GIT_COMMITTER_*` / `GIT_AUTHOR_*` env vars
-/// the way `git` itself does. git2's `Repository::signature` ignores the date
-/// env vars, which breaks reproducibility in tests.
+/// Like [`crate::cache::Transaction::signature`] but honors
+/// `GIT_COMMITTER_*` / `GIT_AUTHOR_*` environment variables, including the date.
 pub fn user_signature(
     transaction: &crate::cache::Transaction,
-) -> anyhow::Result<git2::Signature<'static>> {
+) -> anyhow::Result<gix_actor::Signature> {
     let default = transaction.signature()?;
     let name = std::env::var("GIT_COMMITTER_NAME")
         .or_else(|_| std::env::var("GIT_AUTHOR_NAME"))
-        .ok();
+        .map(Into::into)
+        .unwrap_or(default.name);
     let email = std::env::var("GIT_COMMITTER_EMAIL")
         .or_else(|_| std::env::var("GIT_AUTHOR_EMAIL"))
-        .ok();
-    let date = std::env::var("GIT_COMMITTER_DATE")
+        .map(Into::into)
+        .unwrap_or(default.email);
+    let time = std::env::var("GIT_COMMITTER_DATE")
         .ok()
-        .or_else(|| std::env::var("GIT_AUTHOR_DATE").ok());
-    let date = date.as_deref().and_then(parse_git_env_date);
+        .or_else(|| std::env::var("GIT_AUTHOR_DATE").ok())
+        .as_deref()
+        .and_then(parse_git_env_date)
+        .unwrap_or(default.time);
 
-    let name = name
-        .as_deref()
-        .unwrap_or_else(|| default.name().unwrap_or(""));
-    let email = email
-        .as_deref()
-        .unwrap_or_else(|| default.email().unwrap_or(""));
-    let time = date.unwrap_or_else(|| default.when());
-    Ok(git2::Signature::new(name, email, &time)?)
+    Ok(gix_actor::Signature { name, email, time })
 }
 
 /// Resolve a repository path to its working directory.

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -247,22 +247,21 @@ pub fn write_blob(out: &impl gix_object::Write, data: &[u8]) -> anyhow::Result<g
     Ok(id)
 }
 
-/// Serialize a new commit and write it to `out`. Signatures carry the seconds and UTC
-/// offset of the given git2 signatures; the message is written verbatim, so any cleanup is
-/// the caller's business.
+/// Serialize a new commit and write it to `out`. The message is written verbatim, so any
+/// cleanup is the caller's business.
 pub fn write_commit(
     out: &impl gix_object::Write,
     tree: gix_hash::ObjectId,
     parents: &[gix_hash::ObjectId],
-    author: &git2::Signature<'_>,
-    committer: &git2::Signature<'_>,
+    author: &gix_actor::Signature,
+    committer: &gix_actor::Signature,
     message: &str,
 ) -> anyhow::Result<gix_hash::ObjectId> {
     let commit = gix_object::Commit {
         tree,
         parents: parents.to_vec().into(),
-        author: gix_signature(author)?,
-        committer: gix_signature(committer)?,
+        author: author.clone(),
+        committer: committer.clone(),
         encoding: None,
         message: message.into(),
         extra_headers: vec![],
@@ -300,20 +299,6 @@ pub fn write_commit_with_signatures_of(
         .write_buf(gix_object::Kind::Commit, &buffer)
         .map_err(|e| anyhow::anyhow!("write_commit: {e}"))?;
     Ok(id)
-}
-
-/// The gix spelling of a git2 signature: name and email verbatim, and the timestamp as
-/// seconds plus a UTC offset in seconds.
-pub fn gix_signature(sig: &git2::Signature<'_>) -> anyhow::Result<gix_actor::Signature> {
-    let when = sig.when();
-    Ok(gix_actor::Signature {
-        name: sig.name_bytes().into(),
-        email: sig.email_bytes().into(),
-        time: gix_actor::date::Time {
-            seconds: when.seconds(),
-            offset: i32::from(when.offset_minutes()) * 60,
-        },
-    })
 }
 
 /// A commit's id + raw odb bytes, owned. Send + Sync plain data; never stored in a transaction.
@@ -659,6 +644,17 @@ mod tests {
         let sig = |name: &str, email: &str, secs: i64, offset: i32| {
             git2::Signature::new(name, email, &git2::Time::new(secs, offset)).unwrap()
         };
+        let actor = |sig: &git2::Signature<'_>| {
+            let when = sig.when();
+            gix_actor::Signature {
+                name: sig.name_bytes().into(),
+                email: sig.email_bytes().into(),
+                time: gix_actor::date::Time {
+                    seconds: when.seconds(),
+                    offset: i32::from(when.offset_minutes()) * 60,
+                },
+            }
+        };
 
         let cases: Vec<(git2::Signature, git2::Signature, &str, gix_hash::ObjectId)> = vec![
             (
@@ -712,12 +708,14 @@ mod tests {
                     )
                     .unwrap(),
                 );
+                let author_actor = actor(author);
+                let committer_actor = actor(committer);
                 let got = write_commit(
                     &Git2Odb(&odb),
                     *tree,
                     &parent_ids,
-                    author,
-                    committer,
+                    &author_actor,
+                    &committer_actor,
                     message,
                 )
                 .unwrap();

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -4205,6 +4205,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "git2",
+ "gix-actor",
  "gix-hash",
  "josh-core",
  "josh-git-serde",

--- a/josh-link/Cargo.toml
+++ b/josh-link/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/josh-project/josh"
 keywords = ["git", "monorepo", "workflow", "scm"]
 
 [dependencies]
-git2.workspace = true
+gix-actor.workspace = true
 gix-hash.workspace = true
 anyhow.workspace = true
 

--- a/josh-link/src/lib.rs
+++ b/josh-link/src/lib.rs
@@ -16,7 +16,7 @@ impl PreparedLinkAdd {
         self,
         transaction: &josh_core::cache::Transaction,
         head_commit: gix_hash::ObjectId,
-        signature: &git2::Signature,
+        signature: &gix_actor::Signature,
     ) -> anyhow::Result<gix_hash::ObjectId> {
         josh_core::objects::write_commit(
             transaction.odb(),
@@ -101,17 +101,18 @@ pub fn collect_all_link_refs(
 
 pub fn make_signature(
     transaction: &josh_core::cache::Transaction,
-) -> anyhow::Result<git2::Signature<'static>> {
+) -> anyhow::Result<gix_actor::Signature> {
     if let Ok(time) = std::env::var("JOSH_COMMIT_TIME") {
-        git2::Signature::new(
-            "JOSH",
-            "josh@josh-project.dev",
-            &git2::Time::new(time.parse().context("Failed to parse JOSH_COMMIT_TIME")?, 0),
-        )
-        .context("Failed to create signature")
+        Ok(gix_actor::Signature {
+            name: "JOSH".into(),
+            email: "josh@josh-project.dev".into(),
+            time: gix_actor::date::Time {
+                seconds: time.parse().context("Failed to parse JOSH_COMMIT_TIME")?,
+                offset: 0,
+            },
+        })
     } else {
-        let sig = transaction.signature().context("Failed to get signature")?;
-        Ok(sig.to_owned())
+        transaction.signature().context("Failed to get signature")
     }
 }
 
@@ -149,14 +150,8 @@ pub fn prepare_link_add(
     let link_blob = josh_core::objects::write_blob(odb, link_content.as_bytes())?;
     let link_path = path.join(".link.josh");
 
-    let new_tree = tree::insert_oid(
-        odb,
-        head_tree,
-        &link_path,
-        link_blob,
-        git2::FileMode::Blob.into(),
-    )
-    .context("Failed to insert link file into tree")?;
+    let new_tree = tree::insert_oid(odb, head_tree, &link_path, link_blob, 0o0100644)
+        .context("Failed to insert link file into tree")?;
 
     Ok(PreparedLinkAdd {
         tree_oid: new_tree,
@@ -168,7 +163,7 @@ pub fn update_links(
     transaction: &josh_core::cache::Transaction,
     head_commit: gix_hash::ObjectId,
     links_to_update: Vec<(PathBuf, gix_hash::ObjectId)>,
-    signature: &git2::Signature,
+    signature: &gix_actor::Signature,
 ) -> anyhow::Result<Option<UpdateLinksResult>> {
     let odb = transaction.odb();
     let head_tree_id =

--- a/josh-proxy/src/lib.rs
+++ b/josh-proxy/src/lib.rs
@@ -326,7 +326,7 @@ pub fn merge_meta(
         tree = josh_core::filter::tree::insert_oid(odb, tree, path, blob, 0o0100644)?;
     }
 
-    let signature = josh_core::git::josh_commit_signature()?;
+    let signature = josh_core::git::josh_actor_signature()?;
     let oid =
         josh_core::objects::write_commit(odb, tree, &parents, &signature, &signature, "marker")?;
 

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -442,7 +442,7 @@ pub fn process_repo_update(repo_update: RepoUpdate) -> anyhow::Result<String> {
 
         let oid_to_push = if push_options.merge {
             if let Some(base_commit_id) = transaction_mirror.resolve_ref(&original_target_ref)? {
-                let signature = josh_core::git::josh_commit_signature()?;
+                let signature = josh_core::git::josh_actor_signature()?;
                 let odb = transaction.odb();
                 let merged_tree =
                     josh_core::objects::merge_commits(odb, base_commit_id, backward_new_oid, None)?;


### PR DESCRIPTION
Port signatures and runtime file modes to gitoxide

Change: gix-signatures-file-modes
Assisted-By: openai-codex/gpt-5.6-sol