### PR TITLE
Port signatures, file modes, and change refs to gitoxide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,7 +3312,6 @@ version = "26.7.28"
 dependencies = [
  "anyhow",
  "chrono",
- "git2",
  "gix-actor",
  "gix-hash",
  "josh-core",

--- a/josh-changes/Cargo.toml
+++ b/josh-changes/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["git", "monorepo", "workflow", "scm"]
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-git2.workspace = true
+
 gix-actor.workspace = true
 gix-hash.workspace = true
 serde.workspace = true

--- a/josh-changes/src/refs.rs
+++ b/josh-changes/src/refs.rs
@@ -256,11 +256,11 @@ impl ChangesRef {
 }
 
 /// Return the changes ref's target OID, if it exists.
-pub fn read_ref_oid(repo: &git2::Repository, scope: &ChangesRef) -> Option<gix_hash::ObjectId> {
-    repo.find_reference(&scope.ref_name())
-        .ok()
-        .and_then(|r| r.target())
-        .map(josh_core::objects::gix_oid)
+pub fn read_ref_oid(
+    transaction: &josh_core::cache::Transaction,
+    scope: &ChangesRef,
+) -> Option<gix_hash::ObjectId> {
+    transaction.resolve_ref(&scope.ref_name()).ok().flatten()
 }
 
 /// Read HEAD and return the current branch shorthand. Errors on a

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -4204,7 +4204,6 @@ version = "26.7.28"
 dependencies = [
  "anyhow",
  "chrono",
- "git2",
  "gix-actor",
  "gix-hash",
  "josh-core",

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -437,9 +437,9 @@ pub fn bump_changes_ref_oid(
     mut changes_ref_oid: Signal<Option<gix_hash::ObjectId>>,
     scope: &josh_changes::ChangesRef,
 ) {
-    let new_oid = git2::Repository::discover(".")
+    let new_oid = crate::common::open_transaction()
         .ok()
-        .and_then(|r| josh_changes::read_ref_oid(&r, scope));
+        .and_then(|transaction| josh_changes::read_ref_oid(&transaction, scope));
     if new_oid != *changes_ref_oid.peek() {
         changes_ref_oid.set(new_oid);
     }

--- a/josh-gui/src/main.rs
+++ b/josh-gui/src/main.rs
@@ -77,9 +77,9 @@ fn app() -> Element {
 
     // Views subscribe to this signal to invalidate ref-derived data.
     let mut changes_ref_oid: Signal<Option<gix_hash::ObjectId>> = use_signal(|| {
-        git2::Repository::discover(".")
+        common::open_transaction()
             .ok()
-            .and_then(|r| josh_changes::read_ref_oid(&r, &current_scope.read()))
+            .and_then(|transaction| josh_changes::read_ref_oid(&transaction, &current_scope.read()))
     });
     use_context_provider(|| changes_ref_oid);
 
@@ -99,9 +99,9 @@ fn app() -> Element {
     // Avoid waiting for the poll after switching scopes.
     use_effect(move || {
         let scope = current_scope.read().clone();
-        let new_oid = git2::Repository::discover(".")
+        let new_oid = common::open_transaction()
             .ok()
-            .and_then(|r| josh_changes::read_ref_oid(&r, &scope));
+            .and_then(|transaction| josh_changes::read_ref_oid(&transaction, &scope));
         if new_oid != *changes_ref_oid.peek() {
             changes_ref_oid.set(new_oid);
         }
@@ -112,9 +112,9 @@ fn app() -> Element {
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             let scope = current_scope.peek().clone();
-            let new_oid = git2::Repository::discover(".")
+            let new_oid = common::open_transaction()
                 .ok()
-                .and_then(|r| josh_changes::read_ref_oid(&r, &scope));
+                .and_then(|transaction| josh_changes::read_ref_oid(&transaction, &scope));
             if new_oid != *changes_ref_oid.peek() {
                 changes_ref_oid.set(new_oid);
             }


### PR DESCRIPTION
Port signatures, file modes, and change refs to gitoxide

Use gitoxide actors and entry modes throughout runtime object handling, keeping libgit2 conversions only at remaining porcelain boundaries.

Route changes-ref polling through the Transaction ref API and remove josh-changes direct git2 dependency.

Change: gix-runtime-types-and-refs

Assisted-By: openai-codex/gpt-5.6-sol