### PR TITLE
Write changes refs as sparse structs over filter overlays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,11 +3300,14 @@ version = "26.8.28"
 dependencies = [
  "anyhow",
  "chrono",
+ "gix",
  "gix-actor",
  "gix-hash",
  "josh-core",
  "josh-git-serde",
+ "josh-gix-ext",
  "serde",
+ "tempfile",
 ]
 
 [[package]]
@@ -3531,6 +3534,7 @@ name = "josh-github-changes"
 version = "26.8.28"
 dependencies = [
  "anyhow",
+ "gix",
  "gix-hash",
  "josh-changes",
  "josh-core",
@@ -3538,6 +3542,7 @@ dependencies = [
  "josh-github-graphql",
  "josh-github-webhooks",
  "serde",
+ "tempfile",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ secret-vault-value = "^1"
 hmac = "^0.13"
 sha2 = "^0.11"
 http = "^1"
-chrono = { version = "^0", default-features = false, features = ["serde"] }
+chrono = { version = "^0", default-features = false, features = ["serde", "alloc"] }
 dirs = "6"
 jsonwebtoken = "11"
 bytes = "1.12.1"

--- a/forges/josh-github-changes/Cargo.toml
+++ b/forges/josh-github-changes/Cargo.toml
@@ -18,3 +18,7 @@ josh-core.workspace = true
 josh-git-serde.workspace = true
 josh-github-graphql.workspace = true
 josh-github-webhooks.workspace = true
+
+[dev-dependencies]
+gix.workspace = true
+tempfile.workspace = true

--- a/forges/josh-github-changes/src/cache.rs
+++ b/forges/josh-github-changes/src/cache.rs
@@ -3,15 +3,13 @@
 //! Persisted as a josh-git-serde tree at `gh_cache/<change-id>/fingerprint` --
 //! the path is part of the on-disk format and must not change.
 
-use josh_changes::{encode_change_id_path, ChangesRef};
+use josh_changes::ChangesRef;
 
-use crate::layout::{GithubChangesRefData, GITHUB_CACHE_PATH};
+use crate::layout::{GithubChangesRefData, SyncCache, GITHUB_CACHE_PATH};
 use josh_core::cache::Transaction;
 use josh_github_graphql::operations::pull_request::PrSummary;
 
 use serde::{Deserialize, Serialize};
-
-const LEAF: &str = "fingerprint";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SyncFingerprint {
@@ -75,10 +73,24 @@ pub fn store_sync_fingerprint(
     fingerprint: &SyncFingerprint,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let path = std::path::Path::new(GITHUB_CACHE_PATH)
-        .join(encode_change_id_path(change_id))
-        .join(LEAF);
-    josh_changes::write_value(transaction, &path, fingerprint, None, None, scope)?;
+    let data = GithubChangesRefData {
+        gh_cache: [(
+            change_id.to_string(),
+            SyncCache {
+                fingerprint: fingerprint.clone(),
+            },
+        )]
+        .into(),
+        ..Default::default()
+    };
+    josh_changes::write_filtered(
+        transaction,
+        scope,
+        josh_changes::namespace_filter(GITHUB_CACHE_PATH),
+        &data,
+        None,
+        None,
+    )?;
     Ok(())
 }
 

--- a/forges/josh-github-changes/src/comments.rs
+++ b/forges/josh-github-changes/src/comments.rs
@@ -1,6 +1,6 @@
 //! Posting local comments and votes to GitHub, converting fetched PR
 //! comments into the forge-neutral shape `josh-changes` stores, and composing
-//! `josh-changes` storage primitives with the GitHub ID tracking in `ids`.
+//! `josh-changes` storage primitives with the GitHub ID tracking in `node_ids`.
 
 use std::collections::HashMap;
 
@@ -17,12 +17,26 @@ pub fn fetched_comments(pr_data: &PrData) -> Vec<josh_changes::FetchedComment> {
         .map(|c| josh_changes::FetchedComment {
             forge_id: c.id.clone(),
             author: c.author.clone(),
-            body: c.body.clone(),
             timestamp: c.timestamp.clone(),
-            path: c.path.clone(),
-            line: c.line,
             reply_to: c.reply_to.clone(),
-            commit_oid: c.commit_oid.clone(),
+            meta: josh_changes::CommentMeta {
+                message: c.body.clone(),
+                file: c.path.clone(),
+                // GitHub review comments address a single line; it maps to a
+                // full-width `Location` on that line.
+                location: c
+                    .path
+                    .as_ref()
+                    .zip(c.line)
+                    .map(|(_, line)| josh_changes::Location {
+                        start_line: line as u32,
+                        end_line: line as u32,
+                        start_col: 1,
+                        end_col: u32::MAX,
+                    }),
+                reply_to: None,
+                update_of: None,
+            },
         })
         .collect()
 }
@@ -62,7 +76,8 @@ pub async fn post_comments(
         let mut remaining = Vec::new();
 
         for comment in unposted.drain(..) {
-            let can_post = match &comment.reply_to {
+            let meta = &comment.meta;
+            let can_post = match &meta.reply_to {
                 Some(parent_hash) => new_ids.contains_key(parent_hash.as_str()),
                 None => true,
             };
@@ -71,15 +86,12 @@ pub async fn post_comments(
                 continue;
             }
 
-            let result = if let Some(ref file) = comment.file {
-                if let Some(parent_hash) = &comment.reply_to {
+            let result = if let Some(ref file) = meta.file {
+                if let Some(parent_hash) = &meta.reply_to {
                     match new_ids.get(parent_hash.as_str()) {
                         Some(parent_gh_id) => {
                             connection
-                                .add_pull_request_review_thread_reply(
-                                    parent_gh_id,
-                                    &comment.message,
-                                )
+                                .add_pull_request_review_thread_reply(parent_gh_id, &meta.message)
                                 .await
                         }
                         None => {
@@ -88,16 +100,16 @@ pub async fn post_comments(
                         }
                     }
                 } else {
-                    let line = comment
+                    let line = meta
                         .location
                         .as_ref()
                         .map_or(1, |loc| loc.start_line as i64);
                     connection
-                        .add_pull_request_review_thread(pr_node_id, &comment.message, file, line)
+                        .add_pull_request_review_thread(pr_node_id, &meta.message, file, line)
                         .await
                 }
             } else {
-                connection.add_comment(pr_node_id, &comment.message).await
+                connection.add_comment(pr_node_id, &meta.message).await
             };
 
             match result {
@@ -119,21 +131,22 @@ pub async fn post_comments(
         if !progressed {
             // Orphan reply_to references — post remaining as standalone.
             for comment in remaining.drain(..) {
-                let result = if comment.file.is_some() {
-                    let line = comment
+                let meta = &comment.meta;
+                let result = if meta.file.is_some() {
+                    let line = meta
                         .location
                         .as_ref()
                         .map_or(1, |loc| loc.start_line as i64);
                     connection
                         .add_pull_request_review_thread(
                             pr_node_id,
-                            &comment.message,
-                            comment.file.as_deref().unwrap_or(""),
+                            &meta.message,
+                            meta.file.as_deref().unwrap_or(""),
                             line,
                         )
                         .await
                 } else {
-                    connection.add_comment(pr_node_id, &comment.message).await
+                    connection.add_comment(pr_node_id, &meta.message).await
                 };
                 match result {
                     Ok(github_id) => {
@@ -245,15 +258,7 @@ pub fn record_fetched_comments(
     written: &[(String, String)],
     scope: &josh_changes::ChangesRef,
 ) -> anyhow::Result<()> {
-    for (local_hash, github_id) in written {
-        crate::node_ids::store_comment_node_id(
-            transaction,
-            change_id,
-            local_hash,
-            github_id,
-            scope,
-        )?;
-    }
+    crate::node_ids::store_comment_node_ids(transaction, change_id, written, scope)?;
 
     let fetched: std::collections::HashSet<&str> = written
         .iter()
@@ -272,7 +277,7 @@ pub fn record_fetched_comments(
 
 /// Filter `votes` (as loaded by [`josh_changes::list_outbox_votes`]) down to
 /// those not yet posted to GitHub, i.e. whose `(state, sha)` is not already
-/// recorded in `gh_vote_ids`.
+/// recorded in `gh_vote_node_ids`.
 pub fn pending_votes(
     transaction: &Transaction,
     change_id: &str,
@@ -296,21 +301,21 @@ pub fn pending_votes(
 
 /// Remove outbox vote entries from `votes` (as loaded by
 /// [`josh_changes::list_outbox_votes`]) whose `(state, sha)` is recorded in
-/// `gh_vote_ids`, i.e. votes already posted to GitHub. Safe to call
+/// `gh_vote_node_ids`, i.e. votes already posted to GitHub. Safe to call
 /// unconditionally -- it's a no-op when nothing needs cleaning.
 pub fn cleanup_posted_outbox_votes(
     transaction: &Transaction,
     change_id: &str,
     scope: &josh_changes::ChangesRef,
     votes: &[(String, josh_changes::VoteData)],
-) -> anyhow::Result<usize> {
+) -> anyhow::Result<()> {
     if votes.is_empty() {
-        return Ok(0);
+        return Ok(());
     }
 
     let tracked = crate::node_ids::read_vote_node_ids(transaction, change_id, scope)?;
     if tracked.is_empty() {
-        return Ok(0);
+        return Ok(());
     }
 
     let users: Vec<String> = votes

--- a/forges/josh-github-changes/src/layout.rs
+++ b/forges/josh-github-changes/src/layout.rs
@@ -1,7 +1,8 @@
 //! Serde view of the GitHub-owned namespaces on a changes ref.
 //!
-//! Like `josh_changes::layout`, but for the `gh*` subtrees: scope a ref to a
-//! subtree with a josh filter, then deserialize into the matching alias.
+//! Like `josh_changes::layout`, but for the `gh*` subtrees: reads scope a ref
+//! to a subtree with a josh filter, then deserialize; writes populate a
+//! sparse struct and merge it back with `josh_changes::write_filtered`.
 //! Field names are the literal top-level tree entries.
 
 use std::collections::HashMap;

--- a/forges/josh-github-changes/src/lib.rs
+++ b/forges/josh-github-changes/src/lib.rs
@@ -12,7 +12,10 @@ pub use comments::{
     cleanup_posted_outbox_votes, fetched_comments, pending_comments, pending_votes, post_comments,
     post_votes, record_fetched_comments, PostCommentsOutcome, PostVotesOutcome, PostedComment,
 };
-pub use node_ids::{
-    read_comment_node_ids, read_vote_node_ids, store_comment_node_id, store_vote_node_id,
+pub use layout::{
+    GITHUB_CACHE_PATH, GITHUB_COMMENT_NODE_IDS_PATH, GITHUB_PR_DATA_PATH, GITHUB_VOTE_NODE_IDS_PATH,
 };
-pub use prs::{collect_pr_infos, create_or_update_prs, read_pr_data, PrInfo};
+pub use node_ids::{
+    read_comment_node_ids, read_vote_node_ids, store_comment_node_ids, store_vote_node_ids,
+};
+pub use prs::{collect_pr_infos, create_or_update_prs, read_pr_data, store_pr_data, PrInfo};

--- a/forges/josh-github-changes/src/node_ids.rs
+++ b/forges/josh-github-changes/src/node_ids.rs
@@ -2,7 +2,7 @@
 //! when the ID is stored in the tree. The ID is the GraphQL node id
 //! returned by GitHub during create operations.
 
-use josh_changes::{encode_change_id_path, namespace_filter, ChangesRef, VoteData};
+use josh_changes::{namespace_filter, ChangesRef, VoteData};
 use josh_core::cache::Transaction;
 
 use crate::layout::{
@@ -10,21 +10,35 @@ use crate::layout::{
     GITHUB_VOTE_NODE_IDS_PATH,
 };
 
-/// Store a GitHub node ID for a local comment, marking it as posted.
-pub fn store_comment_node_id(
+/// Store GitHub node IDs for a change's local comments, marking them as
+/// posted. One commit regardless of how many `entries` carry; an empty slice
+/// writes nothing.
+pub fn store_comment_node_ids(
     transaction: &Transaction,
     change_id: &str,
-    local_hash: &str,
-    github_id: &str,
+    entries: &[(String, String)],
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let blob_oid = josh_core::objects::write_blob(transaction.odb(), github_id.as_bytes())?;
-    let path = std::path::Path::new(GITHUB_COMMENT_NODE_IDS_PATH)
-        .join(encode_change_id_path(change_id))
-        .join(local_hash);
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let data = GithubChangesRefData {
+        gh_comment_node_ids: [(
+            change_id.to_string(),
+            entries.iter().cloned().collect::<CommentNodeIds>(),
+        )]
+        .into(),
+        ..Default::default()
+    };
 
-    josh_changes::write_changes_tree(transaction, &path, blob_oid, None, None, scope)?;
-    Ok(())
+    josh_changes::write_filtered(
+        transaction,
+        scope,
+        namespace_filter(GITHUB_COMMENT_NODE_IDS_PATH),
+        &data,
+        None,
+        None,
+    )
 }
 
 /// Read all GitHub node IDs for a change's comments.
@@ -50,20 +64,34 @@ pub fn read_comment_node_ids(
         .unwrap_or_default())
 }
 
-/// Record a vote as posted to GitHub for the given user.
-pub fn store_vote_node_id(
+/// Record votes as posted to GitHub for the given users. One commit
+/// regardless of how many `entries` carry; an empty slice writes nothing.
+pub fn store_vote_node_ids(
     transaction: &Transaction,
     change_id: &str,
-    user: &str,
-    vote_data: &VoteData,
+    entries: &[(String, VoteData)],
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let path = std::path::Path::new(GITHUB_VOTE_NODE_IDS_PATH)
-        .join(encode_change_id_path(change_id))
-        .join(user);
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let data = GithubChangesRefData {
+        gh_vote_node_ids: [(
+            change_id.to_string(),
+            entries.iter().cloned().collect::<VoteNodeIds>(),
+        )]
+        .into(),
+        ..Default::default()
+    };
 
-    josh_changes::write_value(transaction, &path, vote_data, None, None, scope)?;
-    Ok(())
+    josh_changes::write_filtered(
+        transaction,
+        scope,
+        namespace_filter(GITHUB_VOTE_NODE_IDS_PATH),
+        &data,
+        None,
+        None,
+    )
 }
 
 /// Read the votes recorded as posted to GitHub for a change.
@@ -87,4 +115,76 @@ pub fn read_vote_node_ids(
         .get(change_id)
         .cloned()
         .unwrap_or_default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use josh_core::cache::{CacheStack, SledCacheBackend, TransactionContext};
+
+    fn open_transaction(td: &tempfile::TempDir) -> Transaction {
+        gix::init_bare(td.path()).unwrap();
+        // Commits need an identity; don't depend on the ambient global git
+        // config (CI containers have none).
+        use std::io::Write as _;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(td.path().join("config"))
+            .unwrap()
+            .write_all(b"\n[user]\n\tname = test\n\temail = test@example.com\n")
+            .unwrap();
+
+        let cachestack =
+            std::sync::Arc::new(CacheStack::new().with_backend(SledCacheBackend::new(td.path())));
+        TransactionContext::new(td.path(), cachestack)
+            .open()
+            .unwrap()
+    }
+
+    /// Sparse writes merge: each store call carries a single entry, and the
+    /// overlay must preserve entries written by earlier calls -- siblings
+    /// under the same change, other changes, and other namespaces.
+    #[test]
+    fn node_id_writes_merge_without_clobbering() {
+        let td = tempfile::tempdir().unwrap();
+        let t = open_transaction(&td);
+        let scope = ChangesRef::Local {
+            branch: "main".to_string(),
+        };
+
+        store_comment_node_ids(&t, "change/1", &[("hash-a".into(), "gid-a".into())], &scope)
+            .unwrap();
+        store_comment_node_ids(&t, "change/1", &[("hash-b".into(), "gid-b".into())], &scope)
+            .unwrap();
+        store_comment_node_ids(&t, "change/2", &[("hash-c".into(), "gid-c".into())], &scope)
+            .unwrap();
+        // Overwriting an existing entry replaces just that leaf.
+        store_comment_node_ids(
+            &t,
+            "change/1",
+            &[("hash-a".into(), "gid-a2".into())],
+            &scope,
+        )
+        .unwrap();
+
+        let ids = read_comment_node_ids(&t, "change/1", &scope).unwrap();
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids.get("hash-a").unwrap(), "gid-a2");
+        assert_eq!(ids.get("hash-b").unwrap(), "gid-b");
+        let other = read_comment_node_ids(&t, "change/2", &scope).unwrap();
+        assert_eq!(other.get("hash-c").unwrap(), "gid-c");
+
+        let vote = VoteData {
+            state: "approve".to_string(),
+            sha: "abc".to_string(),
+        };
+        store_vote_node_ids(&t, "change/1", &[("alice".into(), vote.clone())], &scope).unwrap();
+        store_vote_node_ids(&t, "change/1", &[("bob".into(), vote.clone())], &scope).unwrap();
+
+        let votes = read_vote_node_ids(&t, "change/1", &scope).unwrap();
+        assert_eq!(votes.len(), 2);
+        // Writing votes must not disturb the comment ids.
+        let ids = read_comment_node_ids(&t, "change/1", &scope).unwrap();
+        assert_eq!(ids.len(), 2);
+    }
 }

--- a/forges/josh-github-changes/src/prs.rs
+++ b/forges/josh-github-changes/src/prs.rs
@@ -9,6 +9,29 @@ use josh_github_graphql::operations::pull_request::PrData;
 use crate::display::pr_link;
 use crate::layout::{GithubChangesRefData, GITHUB_PR_DATA_PATH};
 
+/// Store the PR data for a change: a sparse `GithubChangesRefData` carrying
+/// only the `gh/<change-id>` entry, merged into the ref.
+pub fn store_pr_data(
+    transaction: &josh_core::cache::Transaction,
+    change_id: &str,
+    data: &PrData,
+    scope: &josh_changes::ChangesRef,
+) -> anyhow::Result<()> {
+    let sparse = GithubChangesRefData {
+        gh: [(change_id.to_string(), data.clone())].into(),
+        ..Default::default()
+    };
+    josh_changes::write_filtered(
+        transaction,
+        scope,
+        josh_changes::namespace_filter(GITHUB_PR_DATA_PATH),
+        &sparse,
+        None,
+        None,
+    )?;
+    Ok(())
+}
+
 /// Read the stored PR data for a change, if present. Fails when the stored
 /// tree does not decode (`sync --clean` rebuilds the ref).
 pub fn read_pr_data(

--- a/forges/josh-github-graphql/src/operations/pull_request.rs
+++ b/forges/josh-github-graphql/src/operations/pull_request.rs
@@ -12,13 +12,13 @@ use josh_github_codegen_graphql::{
     GetPrReviews, GetPrsBySha, ListOpenPRs, MarkPullRequestReadyForReview, UpdatePullRequest,
 };
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrLabel {
     pub name: String,
     pub color: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PrComment {
     pub id: String,
     pub author: String,
@@ -30,7 +30,7 @@ pub struct PrComment {
     pub commit_oid: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrData {
     pub title: String,
     pub body: Option<String>,
@@ -364,7 +364,7 @@ impl GithubApiConnection {
                 id: node.id.clone(),
                 author: node.author.map(|a| a.login).unwrap_or_default(),
                 body: node.body,
-                timestamp: format!("{}", node.created_at),
+                timestamp: node.created_at.to_rfc3339(),
                 path: None,
                 line: None,
                 reply_to: None,
@@ -389,7 +389,7 @@ impl GithubApiConnection {
                         .map(|a| a.login.clone())
                         .unwrap_or_default(),
                     body: review.body,
-                    timestamp: format!("{}", review.created_at),
+                    timestamp: review.created_at.to_rfc3339(),
                     path: None,
                     line: None,
                     reply_to: None,
@@ -408,7 +408,7 @@ impl GithubApiConnection {
                     id: node.id.clone(),
                     author: node.author.map(|a| a.login).unwrap_or_default(),
                     body: node.body,
-                    timestamp: format!("{}", node.created_at),
+                    timestamp: node.created_at.to_rfc3339(),
                     path: Some(node.path),
                     line: node.line,
                     reply_to: node.reply_to.map(|r| r.id),

--- a/josh-changes/Cargo.toml
+++ b/josh-changes/Cargo.toml
@@ -18,3 +18,8 @@ serde.workspace = true
 
 josh-core.workspace = true
 josh-git-serde.workspace = true
+
+[dev-dependencies]
+gix.workspace = true
+josh-gix-ext.workspace = true
+tempfile.workspace = true

--- a/josh-changes/src/change.rs
+++ b/josh-changes/src/change.rs
@@ -194,7 +194,7 @@ pub fn list_changes(
     let Some(data) = crate::store::read_filtered::<crate::layout::ChangesRefData>(
         transaction,
         scope,
-        crate::store::namespace_filter("diffs"),
+        crate::store::namespace_filter(crate::layout::DIFFS_PATH),
     )
     .with_context(|| "undecodable diff data; run `josh changes sync --clean` to rebuild the ref")?
     else {

--- a/josh-changes/src/comments.rs
+++ b/josh-changes/src/comments.rs
@@ -1,13 +1,10 @@
 use crate::change::{Change, encode_change_id_path};
+use crate::layout::{ChangesRefData, CommentsByChange};
 use crate::refs::ChangesRef;
-use crate::store::{get_tree, place_oid, value_oid};
-use anyhow::{Context, anyhow};
-use josh_core::cache::{Expected, Transaction};
+use crate::store::{get_tree, namespace_filter, value_oid};
+use anyhow::anyhow;
+use josh_core::cache::Transaction;
 use josh_core::filter::tree;
-use josh_core::memodb::Odb;
-use josh_core::objects;
-use josh_git_serde::{from_tree_oid, from_value};
-use std::str::FromStr;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Location {
@@ -17,16 +14,66 @@ pub struct Location {
     pub end_col: u32,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+/// The serialized form of a comment; the comment's id is the tree id of this
+/// value. `None` fields are omitted from the tree, so the id is stable across
+/// layout-irrelevant differences.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CommentMeta {
     pub message: String,
-    #[serde(skip)]
     pub file: Option<String>,
     pub location: Option<Location>,
     pub reply_to: Option<String>,
     pub update_of: Option<String>,
 }
 
+/// Which comments namespace a write targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentNamespace {
+    /// The canonical `comments` tree.
+    Default,
+    /// The `outbox/comments` queue of a `Remote` ref: pending posts to the
+    /// remote, cleaned up on the next fetch that observes them coming back.
+    Outbox,
+}
+
+impl CommentNamespace {
+    pub(crate) fn path(self) -> &'static str {
+        match self {
+            Self::Default => "comments",
+            Self::Outbox => "outbox/comments",
+        }
+    }
+
+    /// This namespace's map inside a (possibly sparsely populated)
+    /// `ChangesRefData`.
+    fn of(self, data: &ChangesRefData) -> &CommentsByChange {
+        match self {
+            Self::Default => &data.comments,
+            Self::Outbox => &data.outbox.comments,
+        }
+    }
+
+    fn of_mut(self, data: &mut ChangesRefData) -> &mut CommentsByChange {
+        match self {
+            Self::Default => &mut data.comments,
+            Self::Outbox => &mut data.outbox.comments,
+        }
+    }
+
+    /// The write namespace for `scope`: local writes go to `Default`, remote
+    /// writes queue in `Outbox`.
+    pub fn for_scope(scope: &ChangesRef) -> Self {
+        match scope {
+            ChangesRef::Local { .. } => Self::Default,
+            ChangesRef::Remote { .. } => Self::Outbox,
+        }
+    }
+}
+
+/// Write `meta` into `namespace` on `scope`'s ref. `Outbox` requires a
+/// `Remote` scope. Returns the comment id: the tree id of the serialized
+/// meta -- content-addressed, so identical metas dedup and the fetch side
+/// recomputes the same id.
 pub fn write_comment(
     transaction: &Transaction,
     change: &Change,
@@ -34,119 +81,49 @@ pub fn write_comment(
     author: Option<&str>,
     timestamp: Option<&str>,
     scope: &ChangesRef,
+    namespace: CommentNamespace,
 ) -> anyhow::Result<String> {
-    write_comment_with_commit(transaction, change, meta, author, timestamp, None, scope)
-}
-
-pub fn write_comment_with_commit(
-    transaction: &Transaction,
-    change: &Change,
-    meta: &CommentMeta,
-    author: Option<&str>,
-    timestamp: Option<&str>,
-    blob_commit_override: Option<&str>,
-    scope: &ChangesRef,
-) -> anyhow::Result<String> {
-    write_comment_inner(
-        transaction,
-        change,
-        meta,
-        author,
-        timestamp,
-        blob_commit_override,
-        scope,
-        "comments",
-    )
-}
-
-/// Write a comment into the outbox subtree of a `Remote` ref. Comments here are
-/// pending posts to the remote; the cleanup runs on the next fetch when the
-/// posted comment is observed coming back from the remote.
-pub fn write_outbox_comment(
-    transaction: &Transaction,
-    change: &Change,
-    meta: &CommentMeta,
-    author: Option<&str>,
-    timestamp: Option<&str>,
-    scope: &ChangesRef,
-) -> anyhow::Result<String> {
-    if !matches!(scope, ChangesRef::Remote { .. }) {
-        return Err(anyhow::anyhow!(
-            "write_outbox_comment requires a Remote scope (got {})",
+    if namespace == CommentNamespace::Outbox && !matches!(scope, ChangesRef::Remote { .. }) {
+        return Err(anyhow!(
+            "outbox comments require a Remote scope (got {})",
             scope.ref_name()
         ));
     }
-    write_comment_inner(
-        transaction,
-        change,
-        meta,
-        author,
-        timestamp,
-        None,
-        scope,
-        "outbox/comments",
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn write_comment_inner(
-    transaction: &Transaction,
-    change: &Change,
-    meta: &CommentMeta,
-    author: Option<&str>,
-    timestamp: Option<&str>,
-    blob_commit_override: Option<&str>,
-    scope: &ChangesRef,
-    path_prefix: &str,
-) -> anyhow::Result<String> {
     if meta.message.trim().is_empty() {
-        return Err(anyhow::anyhow!("comment message must not be empty"));
+        return Err(anyhow!("comment message must not be empty"));
     }
 
     let change_id = change
         .id()
-        .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
+        .ok_or_else(|| anyhow!("commit {} has no Change-Id", change.commit()))?;
 
-    let (root, mode) = value_oid(transaction, meta)?;
+    // The sparse write re-serializes deterministically, so the key matches
+    // the value's tree.
+    let root = value_oid(transaction, meta)?;
     let content_hash = root.to_string();
 
-    let odb = transaction.odb();
-    let prefix = std::path::Path::new(path_prefix);
-    let path = if let Some(ref file) = meta.file {
-        let resolve_commit = match blob_commit_override {
-            Some(s) => gix_hash::ObjectId::from_str(s)?,
-            None => change.commit(),
-        };
-        let commit_tree = objects::CommitData::read(odb, resolve_commit)?.tree_id()?;
-        let file_blob =
-            tree::get_path_entry(transaction, odb, commit_tree, std::path::Path::new(file))?
-                .ok_or_else(|| anyhow!("no such path: {}", file))?
-                .oid
-                .to_string();
-        prefix
-            .join("F")
-            .join(encode_change_id_path(&change_id))
-            .join(&file_blob)
-            .join(file)
-            .join(&content_hash)
-    } else {
-        prefix
-            .join("C")
-            .join(encode_change_id_path(&change_id))
-            .join(&content_hash)
-    };
-    place_oid(transaction, &path, root, mode, author, timestamp, scope)?;
+    let mut data = ChangesRefData::default();
+    namespace.of_mut(&mut data).insert(
+        change_id.to_string(),
+        [(content_hash.clone(), meta.clone())].into(),
+    );
+    crate::store::write_filtered(
+        transaction,
+        scope,
+        namespace_filter(namespace.path()),
+        &data,
+        author,
+        timestamp,
+    )?;
     Ok(content_hash)
 }
 
+/// A comment plus its bookkeeping: `meta` is the serialized form (whose tree
+/// id is `id`); author/timestamp are resolved from the ref history on read.
 #[derive(Debug, Clone)]
 pub struct Comment {
     pub id: String,
-    pub message: String,
-    pub file: Option<String>,
-    pub location: Option<Location>,
-    pub reply_to: Option<String>,
-    pub update_of: Option<String>,
+    pub meta: CommentMeta,
     pub author: Option<String>,
     pub timestamp: Option<String>,
     /// True when the comment was read from the `outbox/` subtree of a Remote
@@ -154,225 +131,81 @@ pub struct Comment {
     pub pending: bool,
 }
 
-pub fn comment_author(
-    transaction: &Transaction,
-    change: &Change,
-    comment_id: &str,
-    file: Option<&str>,
-    scope: &ChangesRef,
-) -> anyhow::Result<(String, String)> {
-    let change_id = match change.id() {
-        Some(id) => id,
-        None => return Err(anyhow!("change has no Change-Id")),
-    };
-
-    let odb = transaction.odb();
-    let ref_name = scope.ref_name();
-    let head = match transaction.resolve_ref(&ref_name)? {
-        Some(oid) => oid,
-        None => return Err(anyhow!("{} not found", ref_name)),
-    };
-
-    let path = if let Some(f) = file {
-        // Find the blob_id for this comment in the current tree.
-        let head_tree = objects::CommitData::read(odb, head)?.tree_id()?;
-        let cid_path = std::path::Path::new("comments")
-            .join("F")
-            .join(encode_change_id_path(change_id));
-        let mut found = None;
-        if let Some(cid_tree) = get_tree(transaction, odb, head_tree, &cid_path) {
-            for blob_entry in tree::read_tree(transaction, odb, cid_tree)?.entries() {
-                let blob_name = std::str::from_utf8(blob_entry.filename).unwrap_or("");
-                let sub = std::path::Path::new(f).join(comment_id);
-                let full = cid_path.join(blob_name).join(&sub);
-                if matches!(
-                    tree::get_path_entry(transaction, odb, head_tree, &full),
-                    Ok(Some(_))
-                ) {
-                    found = Some(full);
-                    break;
-                }
-            }
-        }
-        match found {
-            Some(p) => p,
-            None => {
-                return Err(anyhow!("comment {} not found in {}", comment_id, ref_name));
-            }
-        }
-    } else {
-        std::path::Path::new("comments")
-            .join("C")
-            .join(encode_change_id_path(change_id))
-            .join(comment_id)
-    };
-
-    let mut walk = objects::RevWalk::new(odb);
-    walk.simplify_first_parent();
-    walk.push(head)?;
-
-    for oid in walk.into_topo_vec(|_| false)? {
-        let commit = objects::CommitData::read(odb, oid)?;
-        let tree = commit.tree_id()?;
-        if let Ok(Some(entry)) = tree::get_path_entry(transaction, odb, tree, &path) {
-            // The commit that introduced or last changed this blob authored the comment.
-            let is_new = match commit.first_parent_id() {
-                Some(parent) => josh_core::git::read_tree_id(odb, parent)
-                    .ok()
-                    .and_then(|pt| {
-                        tree::get_path_entry(transaction, odb, pt, &path)
-                            .ok()
-                            .flatten()
-                    })
-                    .is_none_or(|e| e.oid != entry.oid),
-                None => true,
-            };
-            if is_new {
-                let parsed = commit.parsed()?;
-                let date = format!("{}", parsed.committer()?.seconds());
-                let email = parsed.author()?.email;
-                return Ok((String::from_utf8_lossy(email).into_owned(), date));
-            }
-        }
-    }
-
-    Err(anyhow!("comment {} not found in {}", comment_id, ref_name))
-}
-
-/// Decode the comment tree `entry_oid` into a [`Comment`]. `file` comes from
-/// the entry's path, not from the tree.
-fn read_comment(
-    odb: &Odb,
-    id: &str,
-    entry_oid: gix_hash::ObjectId,
-    file: Option<String>,
-) -> anyhow::Result<Comment> {
-    let value = from_tree_oid(odb, entry_oid)?;
-    let meta: CommentMeta = from_value(&value)?;
-    Ok(Comment {
-        id: id.to_string(),
-        message: meta.message,
-        file,
-        location: meta.location,
-        reply_to: meta.reply_to,
-        update_of: meta.update_of,
-        author: None,
-        timestamp: None,
-        pending: false,
-    })
-}
-
 pub fn read_comments(
     transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<Comment>> {
-    let odb = transaction.odb();
     let ref_name = scope.ref_name();
-    let head_commit = match transaction.resolve_ref(&ref_name)? {
-        Some(oid) => oid,
-        None => return Ok(Vec::new()),
+    let Some(head_commit) = transaction.resolve_ref(&ref_name)? else {
+        return Ok(Vec::new());
     };
-    let tree = objects::CommitData::read(odb, head_commit)?.tree_id()?;
 
+    // Posted first, then pending outbox (only meaningful on Remote refs),
+    // each group ordered by comment id for stable display.
     let mut comments = Vec::new();
+    for namespace in [CommentNamespace::Default, CommentNamespace::Outbox] {
+        let Some(data) = crate::store::read_filtered::<ChangesRefData>(
+            transaction,
+            scope,
+            namespace_filter(namespace.path()),
+        )?
+        else {
+            continue;
+        };
+        let Some(per_change) = namespace.of(&data).get(change_id) else {
+            continue;
+        };
+        let mut group: Vec<_> = per_change
+            .iter()
+            .map(|(id, meta)| Comment {
+                id: id.clone(),
+                meta: meta.clone(),
+                author: None,
+                timestamp: None,
+                pending: namespace == CommentNamespace::Outbox,
+            })
+            .collect();
+        group.sort_by(|a, b| a.id.cmp(&b.id));
+        comments.extend(group);
+    }
 
-    // Posted/fetched: comments/{C,F}/...
-    collect_comments_at_prefix(
-        transaction,
-        odb,
-        tree,
-        change_id,
-        "comments",
-        false,
-        &mut comments,
-    )?;
-    // Pending outbox (only meaningful on Remote refs): outbox/comments/{C,F}/...
-    collect_comments_at_prefix(
-        transaction,
-        odb,
-        tree,
-        change_id,
-        "outbox/comments",
-        true,
-        &mut comments,
-    )?;
+    // Walk history once to resolve author/timestamp. A comment's id is the
+    // tree id of its meta, so an entry can only appear, never change: the ids
+    // a ref commit introduced are the subtract of its namespace view against
+    // its parent's.
+    let encoded = encode_change_id_path(change_id);
+    let namespaces = [CommentNamespace::Default, CommentNamespace::Outbox].map(|ns| {
+        (
+            ns,
+            namespace_filter(&format!("{}/{}", ns.path(), encoded)),
+            std::path::Path::new(ns.path()).join(&encoded),
+        )
+    });
 
-    // Walk history once to resolve author/timestamp for all comments.
-    let mut walk = objects::RevWalk::new(odb);
-    walk.simplify_first_parent();
-    let _ = walk.push(head_commit);
-    'outer: for oid in walk.into_topo_vec(|_| false)?.into_iter() {
-        if let Ok(commit) = objects::CommitData::read(odb, oid) {
-            let Ok(tree) = commit.tree_id() else { continue };
-            let parent_tree = commit
-                .first_parent_id()
-                .and_then(|p| josh_core::git::read_tree_id(odb, p).ok());
-            for c in &mut comments {
-                if c.author.is_some() {
-                    continue;
+    for entry in crate::store::walk_ref_history(transaction, head_commit)? {
+        if comments.iter().all(|c| c.author.is_some()) {
+            break;
+        }
+        let Ok(parsed) = entry.commit.parsed() else {
+            continue;
+        };
+
+        for (namespace, filter, dir) in &namespaces {
+            for id in
+                introduced_comment_ids(transaction, *filter, dir, entry.tree, entry.parent_tree)?
+            {
+                if let Some(c) = comments.iter_mut().find(|c| {
+                    c.author.is_none()
+                        && c.pending == (*namespace == CommentNamespace::Outbox)
+                        && c.id == id
+                }) {
+                    c.timestamp = parsed.committer().ok().map(|t| t.seconds().to_string());
+                    c.author = parsed
+                        .author()
+                        .ok()
+                        .map(|a| String::from_utf8_lossy(a.email).into_owned());
                 }
-                let prefix = if c.pending {
-                    "outbox/comments"
-                } else {
-                    "comments"
-                };
-                if c.file.is_none() {
-                    let p = std::path::Path::new(prefix)
-                        .join("C")
-                        .join(encode_change_id_path(change_id))
-                        .join(&c.id);
-                    if let Ok(Some(entry)) = tree::get_path_entry(transaction, odb, tree, &p) {
-                        let is_new = parent_tree
-                            .and_then(|pt| {
-                                tree::get_path_entry(transaction, odb, pt, &p)
-                                    .ok()
-                                    .flatten()
-                            })
-                            .is_none_or(|e| e.oid != entry.oid);
-                        if is_new && let Ok(parsed) = commit.parsed() {
-                            c.timestamp = parsed.committer().ok().map(|t| t.seconds().to_string());
-                            c.author = parsed
-                                .author()
-                                .ok()
-                                .map(|a| String::from_utf8_lossy(a.email).into_owned());
-                        }
-                    }
-                } else {
-                    let cid_path = std::path::Path::new(prefix)
-                        .join("F")
-                        .join(encode_change_id_path(change_id));
-                    if let Some(cid_tree) = get_tree(transaction, odb, tree, &cid_path)
-                        && let Ok(reader) = tree::read_tree(transaction, odb, cid_tree)
-                    {
-                        for blob_entry in reader.entries() {
-                            let blob_name = std::str::from_utf8(blob_entry.filename).unwrap_or("");
-                            let sub = std::path::Path::new(c.file.as_ref().unwrap()).join(&c.id);
-                            let full_path = cid_path.join(blob_name).join(&sub);
-                            if let Ok(Some(entry)) =
-                                tree::get_path_entry(transaction, odb, tree, &full_path)
-                            {
-                                let parent_entry = parent_tree.and_then(|pt| {
-                                    tree::get_path_entry(transaction, odb, pt, &full_path)
-                                        .ok()
-                                        .flatten()
-                                });
-                                let is_new = parent_entry.is_none_or(|e| e.oid != entry.oid);
-                                if is_new && let Ok(parsed) = commit.parsed() {
-                                    c.timestamp =
-                                        parsed.committer().ok().map(|t| t.seconds().to_string());
-                                    c.author = parsed
-                                        .author()
-                                        .ok()
-                                        .map(|a| String::from_utf8_lossy(a.email).into_owned());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            if comments.iter().all(|c| c.author.is_some()) {
-                break 'outer;
             }
         }
     }
@@ -380,182 +213,61 @@ pub fn read_comments(
     Ok(comments)
 }
 
-#[allow(clippy::too_many_arguments)]
-fn collect_comments_at_prefix(
+/// Ids of comments under `dir` that `tree` carries and `parent_tree` lacks,
+/// both narrowed by `filter`.
+fn introduced_comment_ids(
     transaction: &Transaction,
-    odb: &Odb,
+    filter: josh_core::filter::Filter,
+    dir: &std::path::Path,
     tree: gix_hash::ObjectId,
-    change_id: &str,
-    prefix: &str,
-    pending: bool,
-    out: &mut Vec<Comment>,
-) -> anyhow::Result<()> {
-    let root = match get_tree(transaction, odb, tree, std::path::Path::new(prefix)) {
-        Some(t) => t,
-        None => return Ok(()),
+    parent_tree: Option<gix_hash::ObjectId>,
+) -> anyhow::Result<Vec<String>> {
+    let view = |t: gix_hash::ObjectId| {
+        josh_core::filter::apply(
+            transaction,
+            filter,
+            josh_core::filter::Rewrite::from_tree(t),
+        )
+        .map(|r| r.tree_id())
     };
-
-    // Non-file: <prefix>/C/<change_id>/
-    if let Some(cid_tree) = get_tree(
-        transaction,
-        odb,
-        root,
-        &std::path::Path::new("C").join(encode_change_id_path(change_id)),
-    ) {
-        for entry in tree::read_tree(transaction, odb, cid_tree)?.entries() {
-            let id = String::from_utf8_lossy(entry.filename).into_owned();
-            let mut c = read_comment(odb, &id, entry.oid.to_owned(), None)
-                .with_context(|| format!("undecodable comment {} on change {}", id, change_id))?;
-            c.pending = pending;
-            out.push(c);
-        }
-    }
-
-    // File: <prefix>/F/<change_id>/<blob_id>/<path>/<to>/<file>/<content_hash>
-    if let Some(cid_tree) = get_tree(
-        transaction,
-        odb,
-        root,
-        &std::path::Path::new("F").join(encode_change_id_path(change_id)),
-    ) {
-        for blob_entry in tree::read_tree(transaction, odb, cid_tree)?.entries() {
-            let blob_name = std::str::from_utf8(blob_entry.filename).unwrap_or("");
-            if let Some(blob_tree) =
-                get_tree(transaction, odb, cid_tree, std::path::Path::new(blob_name))
-            {
-                let mut found = Vec::new();
-                collect_comments_under_into(
-                    transaction,
-                    odb,
-                    change_id,
-                    blob_tree,
-                    std::path::Path::new(""),
-                    &mut found,
-                )?;
-                for mut c in found {
-                    c.pending = pending;
-                    out.push(c);
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn collect_comments_under_into(
-    transaction: &Transaction,
-    odb: &Odb,
-    change_id: &str,
-    tree: gix_hash::ObjectId,
-    file_prefix: &std::path::Path,
-    out: &mut Vec<Comment>,
-) -> anyhow::Result<()> {
-    for entry in tree::read_tree(transaction, odb, tree)?.entries() {
-        let name = std::str::from_utf8(entry.filename).unwrap_or("");
-        let entry_oid = entry.oid.to_owned();
-        let file = if file_prefix.as_os_str().is_empty() {
-            None
-        } else {
-            Some(file_prefix.to_string_lossy().to_string())
-        };
-        if entry.mode.is_tree() {
-            match read_comment(odb, name, entry_oid, file) {
-                Ok(c) => out.push(c),
-                // Path-component directory, not a comment leaf: descend.
-                Err(_) => collect_comments_under_into(
-                    transaction,
-                    odb,
-                    change_id,
-                    entry_oid,
-                    &file_prefix.join(name),
-                    out,
-                )?,
-            }
-        } else if !entry.mode.is_commit() {
-            out.push(read_comment(odb, name, entry_oid, file).with_context(|| {
-                format!("undecodable comment {} on change {}", name, change_id)
-            })?);
-        }
-    }
-    Ok(())
+    let cur = view(tree)?;
+    let parent = match parent_tree {
+        Some(pt) => view(pt)?,
+        None => tree::empty_id(),
+    };
+    let added = tree::subtract(transaction, cur, parent)?;
+    let Some(added_dir) = get_tree(transaction, transaction.odb(), added, dir) else {
+        return Ok(Vec::new());
+    };
+    Ok(tree::read_tree(transaction, transaction.odb(), added_dir)?
+        .entries()
+        .filter_map(|entry| std::str::from_utf8(entry.filename).ok().map(str::to_string))
+        .collect())
 }
 
 /// Remove specific outbox comment entries by content hash. Used by forge
 /// sync paths to drop entries whose posted counterparts have been observed
-/// on the forge and stored under `comments/...` already.
+/// on the forge and stored under `comments/...` already. The hash is the
+/// entry's key, so no tree walk is needed; missing entries are a no-op.
 pub fn delete_outbox_comments(
     transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
     content_hashes: &[String],
-) -> anyhow::Result<usize> {
+) -> anyhow::Result<()> {
     if content_hashes.is_empty() {
-        return Ok(0);
+        return Ok(());
     }
-    let odb = transaction.odb();
-    let want: std::collections::HashSet<&str> = content_hashes.iter().map(|s| s.as_str()).collect();
-
-    let ref_name = scope.ref_name();
-    let prev_commit = match transaction.resolve_ref(&ref_name)? {
-        Some(oid) => oid,
-        None => return Ok(0),
-    };
-    let mut tree = objects::CommitData::read(odb, prev_commit)?.tree_id()?;
-
     let encoded = encode_change_id_path(change_id);
-    let mut paths_to_remove: Vec<std::path::PathBuf> = Vec::new();
-
-    // Non-file: outbox/comments/C/<change>/<hash>
-    let c_prefix = std::path::Path::new("outbox/comments/C").join(&encoded);
-    if let Some(c_tree) = get_tree(transaction, odb, tree, &c_prefix) {
-        for entry in tree::read_tree(transaction, odb, c_tree)?.entries() {
-            if let Ok(name) = std::str::from_utf8(entry.filename) {
-                if want.contains(name) {
-                    paths_to_remove.push(c_prefix.join(name));
-                }
-            }
-        }
-    }
-
-    // File: outbox/comments/F/<change>/<blob_id>/<path>/<to>/<file>/<hash>
-    let f_prefix = std::path::Path::new("outbox/comments/F").join(&encoded);
-    if let Some(f_tree) = get_tree(transaction, odb, tree, &f_prefix) {
-        collect_outbox_file_paths(
-            transaction,
-            odb,
-            f_tree,
-            &f_prefix,
-            &want,
-            &mut paths_to_remove,
-        )?;
-    }
-
-    if paths_to_remove.is_empty() {
-        return Ok(0);
-    }
-
-    for path in &paths_to_remove {
-        if matches!(
-            tree::get_path_entry(transaction, odb, tree, path),
-            Ok(Some(_))
-        ) {
-            tree = tree::insert_oid(
-                odb,
-                tree,
-                path,
-                gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
-                0,
-            )?;
-        }
-    }
-
-    let sig = transaction.signature()?;
-    let msg = format!("cleanup posted outbox comments on {}\n", ref_name);
-    let new_oid = objects::write_commit(odb, tree, &[prev_commit], &sig, &sig, &msg)?;
-    transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;
-
-    Ok(paths_to_remove.len())
+    let paths: Vec<std::path::PathBuf> = content_hashes
+        .iter()
+        .map(|hash| {
+            std::path::Path::new(CommentNamespace::Outbox.path())
+                .join(&encoded)
+                .join(hash)
+        })
+        .collect();
+    crate::store::delete_filtered(transaction, &paths, scope)
 }
 
 /// Pending (not yet posted to the forge) comments for a change, loaded from
@@ -571,18 +283,18 @@ pub struct PendingComments {
     pub posted_ids: std::collections::HashMap<String, String>,
 }
 
-/// A comment fetched from a forge, in forge-neutral form. `forge_id` is the
-/// remote's node/comment ID; `reply_to`, when set, refers to a parent's
-/// `forge_id`.
+/// A comment fetched from a forge: the forge envelope (its id, the author and
+/// timestamp used to attribute the ref commit) around the meta payload to
+/// store. `reply_to`, when set, refers to a parent's `forge_id`; it is
+/// resolved to the parent's local comment id during storage.
 pub struct FetchedComment {
     pub forge_id: String,
     pub author: String,
-    pub body: String,
     pub timestamp: String,
-    pub path: Option<String>,
-    pub line: Option<i64>,
     pub reply_to: Option<String>,
-    pub commit_oid: Option<String>,
+    /// The comment content to store; `reply_to` and `update_of` are set by
+    /// the store, not the forge.
+    pub meta: CommentMeta,
 }
 
 /// Write comments fetched from a forge into the given changes ref.
@@ -601,76 +313,25 @@ pub fn store_fetched_comments(
     let mut written = Vec::with_capacity(comments.len());
     let mut id_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     for comment in comments {
-        let location = comment
-            .path
-            .as_ref()
-            .zip(comment.line)
-            .map(|(_, line)| Location {
-                start_line: line as u32,
-                end_line: line as u32,
-                start_col: 1,
-                end_col: u32::MAX,
-            });
-        let reply_to = comment
+        let mut meta = comment.meta.clone();
+        meta.reply_to = comment
             .reply_to
             .as_ref()
             .and_then(|forge_id| id_map.get(forge_id))
             .cloned();
-        let meta = CommentMeta {
-            message: comment.body.clone(),
-            file: comment.path.clone(),
-            location,
-            reply_to,
-            update_of: None,
-        };
 
-        let hash = write_comment_with_commit(
+        let hash = write_comment(
             transaction,
             change,
             &meta,
             Some(&comment.author),
             Some(&comment.timestamp),
-            comment.commit_oid.as_deref(),
             scope,
+            CommentNamespace::Default,
         )?;
         id_map.insert(comment.forge_id.clone(), hash.clone());
         written.push((hash, comment.forge_id.clone()));
     }
 
     Ok(written)
-}
-
-fn collect_outbox_file_paths(
-    transaction: &Transaction,
-    odb: &Odb,
-    tree: gix_hash::ObjectId,
-    cur: &std::path::Path,
-    want: &std::collections::HashSet<&str>,
-    out: &mut Vec<std::path::PathBuf>,
-) -> anyhow::Result<()> {
-    for entry in tree::read_tree(transaction, odb, tree)?.entries() {
-        let name = match std::str::from_utf8(entry.filename) {
-            Ok(n) => n,
-            Err(_) => continue,
-        };
-        match () {
-            _ if entry.mode.is_tree() => {
-                collect_outbox_file_paths(
-                    transaction,
-                    odb,
-                    entry.oid.to_owned(),
-                    &cur.join(name),
-                    want,
-                    out,
-                )?;
-            }
-            _ if !entry.mode.is_commit() => {
-                if want.contains(name) {
-                    out.push(cur.join(name));
-                }
-            }
-            _ => {}
-        }
-    }
-    Ok(())
 }

--- a/josh-changes/src/layout.rs
+++ b/josh-changes/src/layout.rs
@@ -2,23 +2,28 @@
 //!
 //! Serialized maps are trees keyed by entry name, so a ref tree narrowed by
 //! `namespace_filter` deserializes directly into the struct below; readers
-//! select the populated field. Writes still place values by path.
-//!
-//! Comments are absent: the file-comment branch embeds the file's blob id
-//! and path components between the change id and the comment hash, which a
-//! map cannot key. Typing comments needs a layout change first.
+//! select the populated field. Writes populate a sparse struct and merge it
+//! back through the same filter (see `store::write_filtered`).
 
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+use crate::comments::CommentMeta;
 use crate::{DiffData, VoteData};
 
 /// change id → user → vote.
 pub type VotesByChange = HashMap<String, HashMap<String, VoteData>>;
 
+/// The diffs namespace name.
+pub(crate) const DIFFS_PATH: &str = "diffs";
+
 /// change id → diff metadata.
 pub type DiffsByChange = HashMap<String, DiffData>;
+
+/// change id → comment tree id → comment. The comment id is the tree id of
+/// the serialized `CommentMeta` it names.
+pub type CommentsByChange = HashMap<String, HashMap<String, CommentMeta>>;
 
 /// Writes queued locally, awaiting forge publication. Mirrors the
 /// corresponding top-level namespaces.
@@ -26,6 +31,8 @@ pub type DiffsByChange = HashMap<String, DiffData>;
 pub struct Outbox {
     #[serde(default)]
     pub votes: VotesByChange,
+    #[serde(default)]
+    pub comments: CommentsByChange,
 }
 
 /// Core namespaces of a changes ref. Field names are the literal top-level
@@ -36,6 +43,8 @@ pub struct ChangesRefData {
     pub votes: VotesByChange,
     #[serde(default)]
     pub diffs: DiffsByChange,
+    #[serde(default)]
+    pub comments: CommentsByChange,
     #[serde(default)]
     pub outbox: Outbox,
 }

--- a/josh-changes/src/revisions.rs
+++ b/josh-changes/src/revisions.rs
@@ -1,10 +1,13 @@
 use crate::change::{Change, encode_change_id_path};
 use crate::refs::ChangesRef;
-use josh_core::objects;
+use crate::store::DiffData;
 
+/// One stored state of a change: the diff metadata plus the author and time
+/// of the ref write that introduced it. Identity is the serialized `diff`'s
+/// tree id (content-addressed, so identical diffs collapse).
 #[derive(Debug, Clone)]
 pub struct Revision {
-    pub commit_oid: String,
+    pub diff: DiffData,
     pub author: String,
     pub timestamp: String,
 }
@@ -31,42 +34,35 @@ pub fn read_revisions(
             transaction,
             odb,
             tree,
-            &std::path::Path::new("diffs").join(encode_change_id_path(change_id)),
+            &std::path::Path::new(crate::layout::DIFFS_PATH).join(encode_change_id_path(change_id)),
         )
     };
 
     let mut revs: Vec<Revision> = Vec::new();
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut walk = objects::RevWalk::new(odb);
-    walk.simplify_first_parent();
-    walk.push(head)?;
+    let mut seen: std::collections::HashSet<gix_hash::ObjectId> = std::collections::HashSet::new();
 
-    for oid in walk.into_topo_vec(|_| false)? {
-        let commit = objects::CommitData::read(odb, oid)?;
-        let Ok(cur_tree) = commit.tree_id() else {
+    for entry in crate::store::walk_ref_history(transaction, head)? {
+        let Some(cid_tree) = diffs_of(entry.tree) else {
             continue;
         };
-        let cid_tree = match diffs_of(cur_tree) {
-            Some(t) => t,
-            None => continue,
-        };
-        let parent_cid_tree = commit
-            .first_parent_id()
-            .and_then(|p| josh_core::git::read_tree_id(odb, p).ok())
-            .and_then(diffs_of);
-        if parent_cid_tree == Some(cid_tree) {
+        if entry.parent_tree.and_then(diffs_of) == Some(cid_tree) {
             continue;
         }
-        let Ok(parsed) = commit.parsed() else {
-            continue;
-        };
         // The subtree is content-addressed by the (commit, base) pair, so its
         // oid identifies the revision.
-        if !seen.insert(cid_tree.to_string()) {
+        if !seen.insert(cid_tree) {
             continue;
         }
+        let Ok(parsed) = entry.commit.parsed() else {
+            continue;
+        };
+        // Advisory display data: an undecodable historical entry is skipped,
+        // not fatal.
+        let Ok(diff) = crate::store::deserialize_tree::<DiffData>(transaction, cid_tree) else {
+            continue;
+        };
         revs.push(Revision {
-            commit_oid: cid_tree.to_string(),
+            diff,
             author: parsed
                 .author()
                 .map(|a| String::from_utf8_lossy(a.email).into_owned())

--- a/josh-changes/src/store.rs
+++ b/josh-changes/src/store.rs
@@ -1,5 +1,8 @@
 use crate::change::{Change, encode_change_id_path};
+use crate::comments::CommentNamespace;
+use crate::layout::DIFFS_PATH;
 use crate::refs::ChangesRef;
+use crate::votes::VoteNamespace;
 use josh_core::cache::{Expected, Transaction};
 use josh_core::filter::tree;
 use josh_core::memodb::Odb;
@@ -32,6 +35,58 @@ pub fn scope_tree(
     }
 }
 
+/// One commit of a changes ref's history: the commit plus its tree and
+/// first-parent tree, resolved.
+pub(crate) struct RefHistoryEntry {
+    pub commit: objects::CommitData,
+    pub tree: gix_hash::ObjectId,
+    pub parent_tree: Option<gix_hash::ObjectId>,
+}
+
+/// First-parent walk of `head`'s history, newest first. Commits with
+/// unreadable data or trees are skipped.
+pub(crate) fn walk_ref_history(
+    transaction: &Transaction,
+    head: gix_hash::ObjectId,
+) -> anyhow::Result<Vec<RefHistoryEntry>> {
+    let odb = transaction.odb();
+    let mut walk = objects::RevWalk::new(odb);
+    walk.simplify_first_parent();
+    walk.push(head)?;
+    let mut out = Vec::new();
+    for oid in walk.into_topo_vec(|_| false)? {
+        let Ok(commit) = objects::CommitData::read(odb, oid) else {
+            continue;
+        };
+        let Ok(tree) = commit.tree_id() else {
+            continue;
+        };
+        let parent_tree = commit
+            .first_parent_id()
+            .and_then(|p| josh_core::git::read_tree_id(odb, p).ok());
+        out.push(RefHistoryEntry {
+            commit,
+            tree,
+            parent_tree,
+        });
+    }
+    Ok(out)
+}
+
+/// Resolve `scope`'s ref to its tip commit and tree -- the empty tree when
+/// the ref does not exist.
+pub(crate) fn scope_base(
+    transaction: &Transaction,
+    scope: &ChangesRef,
+) -> anyhow::Result<(Option<gix_hash::ObjectId>, gix_hash::ObjectId)> {
+    let prev_commit = transaction.resolve_ref(&scope.ref_name())?;
+    let tree = match prev_commit {
+        Some(oid) => objects::CommitData::read(transaction.odb(), oid)?.tree_id()?,
+        None => tree::empty_id(),
+    };
+    Ok((prev_commit, tree))
+}
+
 pub(crate) fn parse_timestamp(s: Option<&str>) -> gix_actor::date::Time {
     let Some(s) = s else {
         return gix_actor::date::Time {
@@ -51,36 +106,94 @@ pub(crate) fn parse_timestamp(s: Option<&str>) -> gix_actor::date::Time {
     }
 }
 
-/// Write `blob_oid` at `path` inside `scope`'s ref, committing the updated
-/// tree onto the ref. No-op when the same blob is already present at `path`.
-///
-/// This is the generic write primitive for path-keyed metadata on changes
-/// refs; forge crates build their on-ref layouts on top of it.
-pub fn write_changes_tree(
+/// Serialize `data` into git objects and merge the value tree into `scope`'s
+/// ref, narrowed by `filter` -- the inverse of `read_filtered`: the value
+/// tree is embedded into full-ref shape with the filter's inverse and
+/// overlaid onto the ref tree, committing the result onto the ref. The
+/// overlay is a recursive merge where the value's entries win, so a sparsely
+/// populated struct adds or replaces only the entries it carries and
+/// everything else survives. Deletion is `delete_filtered`; a value that is the
+/// complete content of the filter's scope simply carries every entry.
+/// No-op when nothing changes.
+pub fn write_filtered<T: serde::Serialize>(
     transaction: &Transaction,
-    path: &std::path::Path,
-    blob_oid: gix_hash::ObjectId,
+    scope: &ChangesRef,
+    filter: josh_core::filter::Filter,
+    data: &T,
     author: Option<&str>,
     timestamp: Option<&str>,
+) -> anyhow::Result<()> {
+    let Some((prev_commit, merged)) = merge_into_ref(transaction, scope, filter, data)? else {
+        return Ok(());
+    };
+    commit_tree(
+        transaction,
+        &scope.ref_name(),
+        prev_commit,
+        merged,
+        author,
+        timestamp,
+        &[],
+    )
+}
+
+/// Serialize `data` into git objects and merge the value tree into `scope`'s
+/// ref tree, narrowed by `filter` -- the `write_filtered` front half, without
+/// committing. Returns the ref's tip commit and the merged tree, or `None`
+/// when nothing changes.
+fn merge_into_ref<T: serde::Serialize>(
+    transaction: &Transaction,
     scope: &ChangesRef,
+    filter: josh_core::filter::Filter,
+    data: &T,
+) -> anyhow::Result<Option<(Option<gix_hash::ObjectId>, gix_hash::ObjectId)>> {
+    let value = josh_git_serde::to_value(data)?;
+    anyhow::ensure!(
+        matches!(value, GitValue::Tree(_)),
+        "changes-ref writes require a tree-shaped value"
+    );
+    let root = josh_git_serde::to_tree_oid(transaction.odb(), &value)?;
+
+    let (prev_commit, base_tree) = scope_base(transaction, scope)?;
+
+    let merged = merge_value_tree(transaction, filter, root, base_tree)?;
+    if merged == base_tree {
+        return Ok(None);
+    }
+    Ok(Some((prev_commit, merged)))
+}
+
+/// Embed the value tree `root` into full-ref shape with `filter`'s inverse
+/// and overlay it onto `base_tree` -- the tail of `filter::unapply` minus
+/// its `subtract` step: the filter's location gains `root`'s entries,
+/// recursively merged so everything else survives.
+fn merge_value_tree(
+    transaction: &Transaction,
+    filter: josh_core::filter::Filter,
+    root: gix_hash::ObjectId,
+    base_tree: gix_hash::ObjectId,
+) -> anyhow::Result<gix_hash::ObjectId> {
+    let embedded = josh_core::filter::apply(
+        transaction,
+        josh_core::filter::invert(filter)?,
+        josh_core::filter::Rewrite::from_tree(root),
+    )?;
+    tree::overlay(transaction, embedded.tree_id(), base_tree)
+}
+
+/// Commit `tree` onto `ref_name` (creating the ref when absent), signed by
+/// `author`/`timestamp` or the transaction's user. The commit's parents are
+/// `prev_commit` (when present) followed by `extra_parents`.
+pub(crate) fn commit_tree(
+    transaction: &Transaction,
+    ref_name: &str,
+    prev_commit: Option<gix_hash::ObjectId>,
+    tree: gix_hash::ObjectId,
+    author: Option<&str>,
+    timestamp: Option<&str>,
+    extra_parents: &[gix_hash::ObjectId],
 ) -> anyhow::Result<()> {
     let odb = transaction.odb();
-    let ref_name = scope.ref_name();
-    let prev_commit = transaction.resolve_ref(&ref_name)?;
-    let base_tree = match prev_commit {
-        Some(oid) => objects::CommitData::read(odb, oid)?.tree_id()?,
-        None => tree::empty_id(),
-    };
-
-    // Skip if the blob already exists at this path.
-    if let Ok(Some(existing)) = tree::get_path_entry(transaction, odb, base_tree, path) {
-        if existing.oid.to_owned() == blob_oid {
-            return Ok(());
-        }
-    }
-
-    let tree = tree::insert_oid(odb, base_tree, path, blob_oid, 0o0100644)?;
-
     let sig = match author {
         Some(name) => gix_actor::Signature {
             name: name.into(),
@@ -90,9 +203,13 @@ pub fn write_changes_tree(
         None => josh_core::git::user_signature(transaction)?,
     };
     let msg = format!("update {}\n", ref_name);
-    let new_oid = objects::write_commit(odb, tree, prev_commit.as_slice(), &sig, &sig, &msg)?;
+    let parents: Vec<gix_hash::ObjectId> = prev_commit
+        .into_iter()
+        .chain(extra_parents.iter().copied())
+        .collect();
+    let new_oid = objects::write_commit(odb, tree, &parents, &sig, &sig, &msg)?;
     transaction.update_ref(
-        &ref_name,
+        ref_name,
         prev_commit.map_or(Expected::Absent, Expected::At),
         new_oid,
         &msg,
@@ -100,92 +217,70 @@ pub fn write_changes_tree(
     Ok(())
 }
 
-/// Write `value` at `path` inside `scope`'s ref as git objects -- structs and
-/// maps become trees, scalars blobs -- committing the updated tree onto the
-/// ref. Returns the root object id: the value's canonical identity, usable as
-/// a dedup key. No-op (returning the same id) when an identical value already
-/// sits at `path`.
-pub fn write_value<T: serde::Serialize>(
+/// Remove `paths` from `scope`'s ref in a single commit by applying one
+/// `:exclude[::path]` chain to the ref tree -- the delete half of the
+/// `read_filtered`/`write_filtered` family: subtraction where writes
+/// overlay. Excluding a missing path is a no-op; when the tree does not
+/// change, no commit is made.
+pub fn delete_filtered(
     transaction: &Transaction,
-    path: &std::path::Path,
-    data: &T,
-    author: Option<&str>,
-    timestamp: Option<&str>,
+    paths: &[std::path::PathBuf],
     scope: &ChangesRef,
-) -> anyhow::Result<gix_hash::ObjectId> {
-    let (root, mode) = value_oid(transaction, data)?;
-    place_oid(transaction, path, root, mode, author, timestamp, scope)?;
-    Ok(root)
+) -> anyhow::Result<()> {
+    let ref_name = scope.ref_name();
+    let (prev_commit, base_tree) = scope_base(transaction, scope)?;
+
+    let mut filter = josh_core::filter::Filter::new();
+    for path in paths {
+        filter = filter.exclude(josh_core::filter::Filter::new().file(path_str(path)?));
+    }
+
+    let tree = josh_core::filter::apply(
+        transaction,
+        filter,
+        josh_core::filter::Rewrite::from_tree(base_tree),
+    )?
+    .tree_id();
+    if tree == base_tree {
+        return Ok(());
+    }
+    commit_tree(transaction, &ref_name, prev_commit, tree, None, None, &[])
+}
+
+pub(crate) fn path_str(path: &std::path::Path) -> anyhow::Result<&str> {
+    path.to_str()
+        .ok_or_else(|| anyhow::anyhow!("non-UTF-8 path {}", path.display()))
 }
 
 /// Serialize `data` into git objects without placing them at any path,
-/// returning the root object id and its tree-entry mode. For content-addressed
-/// layouts where the id is a path component (e.g. comments); pair with
-/// [`place_oid`].
+/// returning the root object id. For content-addressed layouts where the id
+/// is a path component (e.g. comments, which place the result with their own
+/// private helper).
 pub fn value_oid<T: serde::Serialize>(
     transaction: &Transaction,
     data: &T,
-) -> anyhow::Result<(gix_hash::ObjectId, i32)> {
+) -> anyhow::Result<gix_hash::ObjectId> {
     let odb = transaction.odb();
     let value = josh_git_serde::to_value(data)?;
-    let root = josh_git_serde::to_tree_oid(odb, &value)?;
-    let mode: i32 = match &value {
-        GitValue::Tree(_) => 0o0040000,
-        GitValue::Blob(_) => 0o0100644,
-    };
-    Ok((root, mode))
+    josh_git_serde::to_tree_oid(odb, &value)
 }
 
-/// Place the already-written object `root` at `path` inside `scope`'s ref and
-/// commit the updated tree. No-op when `root` already sits at `path`.
-pub fn place_oid(
+/// Deserialize the tree `root` into `T`.
+pub(crate) fn deserialize_tree<T: serde::de::DeserializeOwned>(
     transaction: &Transaction,
-    path: &std::path::Path,
     root: gix_hash::ObjectId,
-    mode: i32,
-    author: Option<&str>,
-    timestamp: Option<&str>,
-    scope: &ChangesRef,
-) -> anyhow::Result<()> {
-    let odb = transaction.odb();
-    let ref_name = scope.ref_name();
-    let prev_commit = transaction.resolve_ref(&ref_name)?;
-    let base_tree = match prev_commit {
-        Some(oid) => objects::CommitData::read(odb, oid)?.tree_id()?,
-        None => tree::empty_id(),
-    };
-
-    if let Ok(Some(existing)) = tree::get_path_entry(transaction, odb, base_tree, path) {
-        if existing.oid.to_owned() == root {
-            return Ok(());
-        }
-    }
-
-    let tree = tree::insert_oid(odb, base_tree, path, root, mode)?;
-
-    let sig = match author {
-        Some(name) => gix_actor::Signature {
-            name: name.into(),
-            email: format!("{}@github", name).into(),
-            time: parse_timestamp(timestamp),
-        },
-        None => josh_core::git::user_signature(transaction)?,
-    };
-    let msg = format!("update {}\n", ref_name);
-    let new_oid = objects::write_commit(&odb, tree, prev_commit.as_slice(), &sig, &sig, &msg)?;
-    transaction.update_ref(
-        &ref_name,
-        prev_commit.map_or(Expected::Absent, Expected::At),
-        new_oid,
-        &msg,
-    )?;
-    Ok(())
+) -> anyhow::Result<T> {
+    let value = josh_git_serde::from_tree_oid(transaction.odb(), root)?;
+    Ok(josh_git_serde::from_value(&value)?)
 }
 
-/// Select `dir` in place: the filtered tree keeps the entry under its name,
+/// Select `path` in place: the filtered tree keeps the entry under its name,
 /// so the matching field of a layout struct populates and the rest default.
-pub fn namespace_filter(dir: &str) -> josh_core::filter::Filter {
-    josh_core::filter::Filter::new().subdir(dir).prefix(dir)
+/// The `subdir(path).prefix(path)` chain is self-inverse, so the same filter
+/// embeds a serialized value tree back into full-ref shape on write
+/// (`write_filtered`).
+pub fn namespace_filter(path: &str) -> josh_core::filter::Filter {
+    josh_core::filter::Filter::new().subdir(path).prefix(path)
 }
 
 /// Deserialize `scope`'s ref tree, narrowed by `filter`, into `T`. `None`
@@ -206,8 +301,7 @@ pub fn read_filtered<T: serde::de::DeserializeOwned>(
         filter,
         josh_core::filter::Rewrite::from_tree(root),
     )?;
-    let value = josh_git_serde::from_tree_oid(odb, filtered.tree_id())?;
-    Ok(Some(josh_git_serde::from_value(&value)?))
+    Ok(Some(deserialize_tree(transaction, filtered.tree_id())?))
 }
 
 /// The change's tip and base commits, stored as a tree at `diffs/<change-id>`.
@@ -217,41 +311,31 @@ pub struct DiffData {
     pub base: String,
 }
 
+/// Merge the change's `diffs/` entry into `scope`'s ref. The commit carries
+/// an anchor parent on the change's tip commit so the ref's history keeps the
+/// change reachable.
 pub fn store_diff_data(
     transaction: &Transaction,
     change: &Change,
     scope: &ChangesRef,
 ) -> anyhow::Result<()> {
-    let odb = transaction.odb();
     let change_id = change
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
 
-    let data = DiffData {
-        commit: change.commit().to_string(),
-        base: change.base().to_string(),
+    let mut data = crate::layout::ChangesRefData::default();
+    data.diffs.insert(
+        change_id.to_string(),
+        DiffData {
+            commit: change.commit().to_string(),
+            base: change.base().to_string(),
+        },
+    );
+    let Some((prev_tip, tree)) =
+        merge_into_ref(transaction, scope, namespace_filter(DIFFS_PATH), &data)?
+    else {
+        return Ok(());
     };
-    let value = josh_git_serde::to_value(&data)?;
-    let tree_oid = josh_git_serde::to_tree_oid(odb, &value)?;
-
-    let ref_name = scope.ref_name();
-    let prev_tip = transaction.resolve_ref(&ref_name)?;
-    let base_tree = match prev_tip {
-        Some(oid) => objects::CommitData::read(odb, oid)?.tree_id()?,
-        None => tree::empty_id(),
-    };
-
-    let path = std::path::Path::new("diffs").join(encode_change_id_path(&change_id));
-
-    if let Ok(Some(existing)) = tree::get_path_entry(transaction, odb, base_tree, &path) {
-        if existing.oid == tree_oid {
-            return Ok(());
-        }
-    }
-
-    let tree = tree::insert_oid(odb, base_tree, &path, tree_oid, 0o0040000)?;
-
-    let sig = transaction.signature()?;
 
     let anchor_sig = gix_actor::Signature {
         name: "JOSH".into(),
@@ -262,7 +346,7 @@ pub fn store_diff_data(
         },
     };
     let anchor_oid = objects::write_commit(
-        odb,
+        transaction.odb(),
         tree::empty_id(),
         &[change.commit()],
         &anchor_sig,
@@ -270,81 +354,195 @@ pub fn store_diff_data(
         "josh\n",
     )?;
 
-    let mut parents: Vec<gix_hash::ObjectId> = Vec::new();
-    parents.extend(prev_tip);
-    parents.push(anchor_oid);
-    let msg = format!("update {}\n", ref_name);
-    let new_oid = objects::write_commit(odb, tree, &parents, &sig, &sig, &msg)?;
-    transaction.update_ref(
-        &ref_name,
-        prev_tip.map_or(Expected::Absent, Expected::At),
-        new_oid,
-        &msg,
-    )?;
-
-    Ok(())
+    commit_tree(
+        transaction,
+        &scope.ref_name(),
+        prev_tip,
+        tree,
+        None,
+        None,
+        &[anchor_oid],
+    )
 }
 
-pub fn store_pr_data<T: serde::Serialize>(
-    transaction: &Transaction,
-    change_id: &str,
-    data: &T,
-    scope: &ChangesRef,
-) -> anyhow::Result<()> {
-    let path = std::path::Path::new("gh").join(encode_change_id_path(change_id));
-    write_value(transaction, &path, data, None, None, scope)?;
-    Ok(())
-}
-
-/// Delete all stored data for a change from the given changes ref.
-/// Removes entries from diffs/, comments/{C,F}/, outbox/comments/{C,F}/,
-/// gh/, and gh_ids/ subtrees.
+/// Delete all stored data for a change from the given changes ref: the
+/// change's entry under every core namespace (diffs, votes, comments, and
+/// their outbox counterparts) plus any caller-supplied forge namespaces in
+/// `extra_namespaces`.
 pub fn delete_change(
     transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
+    extra_namespaces: &[&str],
 ) -> anyhow::Result<()> {
-    let odb = transaction.odb();
     let encoded = encode_change_id_path(change_id);
+    let core = [
+        DIFFS_PATH,
+        CommentNamespace::Default.path(),
+        CommentNamespace::Outbox.path(),
+        VoteNamespace::Default.path(),
+        VoteNamespace::Outbox.path(),
+    ];
+    let paths: Vec<std::path::PathBuf> = core
+        .into_iter()
+        .chain(extra_namespaces.iter().copied())
+        .map(|prefix| std::path::Path::new(prefix).join(&encoded))
+        .collect();
+    delete_filtered(transaction, &paths, scope)?;
+    Ok(())
+}
 
-    let ref_name = scope.ref_name();
-    let prev_commit = match transaction.resolve_ref(&ref_name)? {
-        Some(oid) => oid,
-        None => return Ok(()),
-    };
-    let mut tree = objects::CommitData::read(odb, prev_commit)?.tree_id()?;
-    for prefix in &[
-        "diffs",
-        "comments/C",
-        "comments/F",
-        "outbox/comments/C",
-        "outbox/comments/F",
-        "gh",
-        "gh_ids",
-        "gh_vote_ids",
-        "gh_cache",
-        "votes",
-        "outbox/votes",
-    ] {
-        let path = std::path::Path::new(prefix).join(&encoded);
-        if matches!(
-            tree::get_path_entry(transaction, odb, tree, &path),
-            Ok(Some(_))
-        ) {
-            tree = tree::insert_oid(
-                odb,
-                tree,
-                &path,
-                gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
-                0,
-            )?;
-        }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::change::Change;
+    use crate::layout::ChangesRefData;
+    use josh_core::cache::{CacheStack, SledCacheBackend, TransactionContext};
+
+    fn open_transaction(td: &tempfile::TempDir) -> Transaction {
+        gix::init_bare(td.path()).unwrap();
+        // Commits need an identity; don't depend on the ambient global git
+        // config (CI containers have none).
+        use std::io::Write as _;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(td.path().join("config"))
+            .unwrap()
+            .write_all(b"\n[user]\n\tname = test\n\temail = test@example.com\n")
+            .unwrap();
+
+        let cachestack =
+            std::sync::Arc::new(CacheStack::new().with_backend(SledCacheBackend::new(td.path())));
+        TransactionContext::new(td.path(), cachestack)
+            .open()
+            .unwrap()
     }
 
-    let sig = transaction.signature()?;
-    let msg = format!("update {}\n", ref_name);
-    let new_oid = objects::write_commit(odb, tree, &[prev_commit], &sig, &sig, &msg)?;
-    transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;
+    fn commit_with_change_id(
+        td: &tempfile::TempDir,
+        change_id: &str,
+        subject: &str,
+    ) -> gix_hash::ObjectId {
+        let repo = gix::open(td.path()).unwrap();
+        let sig = gix_actor::Signature {
+            name: "test".into(),
+            email: "test@example.com".into(),
+            time: gix_actor::date::Time {
+                seconds: 0,
+                offset: 0,
+            },
+        };
+        josh_gix_ext::write_commit(
+            &repo.objects,
+            tree::empty_id(),
+            &[],
+            &sig,
+            &sig,
+            &format!("{}\n\nChange-Id: {}\n", subject, change_id),
+        )
+        .unwrap()
+    }
 
-    Ok(())
+    #[test]
+    fn diff_and_vote_writes_merge_and_roundtrip() {
+        let td = tempfile::tempdir().unwrap();
+        let t = open_transaction(&td);
+        let scope = ChangesRef::Local {
+            branch: "main".to_string(),
+        };
+        let change = Change::new(&t, commit_with_change_id(&td, "change/1", "subject")).unwrap();
+
+        // Diff write: lands, is idempotent, and carries the anchor parent.
+        store_diff_data(&t, &change, &scope).unwrap();
+        let tip = t.resolve_ref(&scope.ref_name()).unwrap().unwrap();
+        store_diff_data(&t, &change, &scope).unwrap();
+        assert_eq!(Some(tip), t.resolve_ref(&scope.ref_name()).unwrap());
+        let tip_data = objects::CommitData::read(t.odb(), tip).unwrap();
+        let tip_parsed = tip_data.parsed().unwrap();
+        let tip_parents: Vec<_> = tip_parsed.parents().collect();
+        assert_eq!(tip_parents.len(), 1);
+        // The anchor commit pins the change's tip commit in the ref history.
+        let anchor = objects::CommitData::read(t.odb(), tip_parents[0]).unwrap();
+        let anchor_parsed = anchor.parsed().unwrap();
+        let anchor_parents: Vec<_> = anchor_parsed.parents().collect();
+        assert_eq!(anchor_parents.len(), 1);
+        assert_eq!(anchor_parents[0].to_string(), change.commit().to_string());
+
+        // Vote writes: merge across users, replace per user.
+        let default = VoteNamespace::Default;
+        crate::votes::write_vote(&t, &change, "approve", Some("alice"), None, &scope, default)
+            .unwrap();
+        crate::votes::write_vote(&t, &change, "reject", Some("bob"), None, &scope, default)
+            .unwrap();
+        crate::votes::write_vote(&t, &change, "approve", Some("alice"), None, &scope, default)
+            .unwrap();
+
+        let votes = read_filtered::<ChangesRefData>(&t, &scope, namespace_filter(default.path()))
+            .unwrap()
+            .unwrap();
+        let per_change = votes.votes.get("change/1").unwrap();
+        assert_eq!(per_change.len(), 2);
+        assert_eq!(per_change.get("alice").unwrap().state, "approve");
+        assert_eq!(per_change.get("bob").unwrap().state, "reject");
+
+        // The diff entry survives the vote writes.
+        let diffs = read_filtered::<ChangesRefData>(&t, &scope, namespace_filter(DIFFS_PATH))
+            .unwrap()
+            .unwrap();
+        assert!(diffs.diffs.contains_key("change/1"));
+
+        // Outbox votes land in their own namespace and delete cleanly.
+        let remote = ChangesRef::Remote {
+            remote: "origin".to_string(),
+            branch: "main".to_string(),
+        };
+        crate::votes::write_vote(
+            &t,
+            &change,
+            "approve",
+            Some("alice"),
+            None,
+            &remote,
+            VoteNamespace::Outbox,
+        )
+        .unwrap();
+        crate::votes::delete_outbox_votes(
+            &t,
+            change.id().unwrap(),
+            &remote,
+            &["alice".to_string()],
+        )
+        .unwrap();
+        let outbox = read_filtered::<ChangesRefData>(
+            &t,
+            &remote,
+            namespace_filter(VoteNamespace::Outbox.path()),
+        )
+        .unwrap()
+        .unwrap();
+        assert!(outbox.outbox.votes.is_empty());
+    }
+
+    /// Each distinct diff write is a revision; re-writing the same diff adds
+    /// none.
+    #[test]
+    fn revisions_track_diff_updates() {
+        let td = tempfile::tempdir().unwrap();
+        let t = open_transaction(&td);
+        let scope = ChangesRef::Local {
+            branch: "main".to_string(),
+        };
+
+        let change_v1 = Change::new(&t, commit_with_change_id(&td, "change/9", "v1")).unwrap();
+        store_diff_data(&t, &change_v1, &scope).unwrap();
+        let change_v2 = Change::new(&t, commit_with_change_id(&td, "change/9", "v2")).unwrap();
+        store_diff_data(&t, &change_v2, &scope).unwrap();
+        store_diff_data(&t, &change_v2, &scope).unwrap();
+
+        let revs = crate::revisions::read_revisions(&t, &change_v2, &scope).unwrap();
+        assert_eq!(revs.len(), 2);
+        // Oldest first, carrying the actual change commits.
+        assert_eq!(revs[0].diff.commit, change_v1.commit().to_string());
+        assert_eq!(revs[1].diff.commit, change_v2.commit().to_string());
+    }
 }

--- a/josh-changes/src/votes.rs
+++ b/josh-changes/src/votes.rs
@@ -1,68 +1,62 @@
 use std::collections::HashMap;
 
 use crate::change::{Change, encode_change_id_path};
-use crate::layout::ChangesRefData;
+use crate::layout::{ChangesRefData, VotesByChange};
 use crate::refs::ChangesRef;
 use crate::store::{namespace_filter, read_filtered};
 
-use josh_core::cache::{Expected, Transaction};
-use josh_core::filter::tree;
-use josh_core::objects;
-
+use josh_core::cache::Transaction;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct VoteData {
     pub state: String,
     pub sha: String,
 }
 
-pub fn write_vote(
-    transaction: &Transaction,
-    change: &Change,
-    state: &str,
-    author: Option<&str>,
-    timestamp: Option<&str>,
-    scope: &ChangesRef,
-) -> anyhow::Result<String> {
-    write_vote_inner(
-        transaction,
-        change,
-        state,
-        author,
-        timestamp,
-        scope,
-        "votes",
-    )
+/// Which votes namespace a write targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VoteNamespace {
+    /// The canonical `votes` tree.
+    Default,
+    /// The `outbox/votes` queue of a `Remote` ref: pending posts to the
+    /// remote, cleaned up on the next fetch that observes them coming back.
+    Outbox,
 }
 
-/// Write a vote into the outbox subtree of a `Remote` ref. The vote is queued
-/// for the next `sync --push` to post to the forge, after which the forge's
-/// posted-vote tracking records the post and the outbox entry can be cleaned
-/// up.
-pub fn write_outbox_vote(
-    transaction: &Transaction,
-    change: &Change,
-    state: &str,
-    author: Option<&str>,
-    timestamp: Option<&str>,
-    scope: &ChangesRef,
-) -> anyhow::Result<String> {
-    if !matches!(scope, ChangesRef::Remote { .. }) {
-        return Err(anyhow::anyhow!(
-            "write_outbox_vote requires a Remote scope (got {})",
-            scope.ref_name()
-        ));
+impl VoteNamespace {
+    pub(crate) fn path(self) -> &'static str {
+        match self {
+            Self::Default => "votes",
+            Self::Outbox => "outbox/votes",
+        }
     }
-    write_vote_inner(
-        transaction,
-        change,
-        state,
-        author,
-        timestamp,
-        scope,
-        "outbox/votes",
-    )
+
+    /// This namespace's map inside a (possibly sparsely populated)
+    /// `ChangesRefData`.
+    fn of(self, data: &ChangesRefData) -> &VotesByChange {
+        match self {
+            Self::Default => &data.votes,
+            Self::Outbox => &data.outbox.votes,
+        }
+    }
+
+    fn of_mut(self, data: &mut ChangesRefData) -> &mut VotesByChange {
+        match self {
+            Self::Default => &mut data.votes,
+            Self::Outbox => &mut data.outbox.votes,
+        }
+    }
+
+    /// The write namespace for `scope`: local writes go to `Default`, remote
+    /// writes queue in `Outbox`.
+    pub fn for_scope(scope: &ChangesRef) -> Self {
+        match scope {
+            ChangesRef::Local { .. } => Self::Default,
+            ChangesRef::Remote { .. } => Self::Outbox,
+        }
+    }
 }
 
+/// Write a vote into `namespace` on `scope`'s ref. `Outbox` requires a
 fn configured_email(transaction: &Transaction) -> anyhow::Result<String> {
     let signature = transaction.signature()?;
     Ok(std::str::from_utf8(signature.email.as_ref())
@@ -70,15 +64,26 @@ fn configured_email(transaction: &Transaction) -> anyhow::Result<String> {
         .to_owned())
 }
 
-fn write_vote_inner(
+/// Write a vote into `namespace` on `scope`'s ref. `Outbox` requires a
+/// `Remote` scope. Outbox votes are queued for the next `sync --push` to
+/// post to the forge, after which the forge's posted-vote tracking records
+/// the post and the outbox entry can be cleaned up.
+pub fn write_vote(
     transaction: &Transaction,
     change: &Change,
     state: &str,
     author: Option<&str>,
     timestamp: Option<&str>,
     scope: &ChangesRef,
-    path_prefix: &str,
-) -> anyhow::Result<String> {
+    namespace: VoteNamespace,
+) -> anyhow::Result<()> {
+    if namespace == VoteNamespace::Outbox && !matches!(scope, ChangesRef::Remote { .. }) {
+        return Err(anyhow::anyhow!(
+            "outbox votes require a Remote scope (got {})",
+            scope.ref_name()
+        ));
+    }
+
     let change_id = change
         .id()
         .ok_or_else(|| anyhow::anyhow!("commit {} has no Change-Id", change.commit()))?;
@@ -93,12 +98,21 @@ fn write_vote_inner(
         None => configured_email(transaction)?,
     };
 
-    let path = std::path::Path::new(path_prefix)
-        .join(encode_change_id_path(&change_id))
-        .join(&user);
+    let inner: HashMap<String, VoteData> = [(user, data)].into();
+    let mut ref_data = ChangesRefData::default();
+    namespace
+        .of_mut(&mut ref_data)
+        .insert(change_id.to_string(), inner);
 
-    let root = crate::store::write_value(transaction, &path, &data, author, timestamp, scope)?;
-    Ok(root.to_string())
+    crate::store::write_filtered(
+        transaction,
+        scope,
+        namespace_filter(namespace.path()),
+        &ref_data,
+        author,
+        timestamp,
+    )?;
+    Ok(())
 }
 
 pub fn read_vote(
@@ -112,13 +126,16 @@ pub fn read_vote(
         None => configured_email(transaction)?,
     };
 
-    let Some(data) =
-        read_filtered::<ChangesRefData>(transaction, scope, namespace_filter("votes"))?
+    let Some(data) = read_filtered::<ChangesRefData>(
+        transaction,
+        scope,
+        namespace_filter(VoteNamespace::Default.path()),
+    )?
     else {
         return Ok(None);
     };
-    Ok(data
-        .votes
+    Ok(VoteNamespace::Default
+        .of(&data)
         .get(change_id)
         .and_then(|votes| votes.get(&user))
         .cloned())
@@ -129,9 +146,14 @@ pub fn list_votes(
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<(String, VoteData)>> {
-    let data = read_filtered::<ChangesRefData>(transaction, scope, namespace_filter("votes"))?;
+    let data = read_filtered::<ChangesRefData>(
+        transaction,
+        scope,
+        namespace_filter(VoteNamespace::Default.path()),
+    )?;
     Ok(sorted_votes(
-        data.as_ref().and_then(|d| d.votes.get(change_id)),
+        data.as_ref()
+            .and_then(|d| VoteNamespace::Default.of(d).get(change_id)),
     ))
 }
 
@@ -142,10 +164,14 @@ pub fn list_outbox_votes(
     change_id: &str,
     scope: &ChangesRef,
 ) -> anyhow::Result<Vec<(String, VoteData)>> {
-    let data =
-        read_filtered::<ChangesRefData>(transaction, scope, namespace_filter("outbox/votes"))?;
+    let data = read_filtered::<ChangesRefData>(
+        transaction,
+        scope,
+        namespace_filter(VoteNamespace::Outbox.path()),
+    )?;
     Ok(sorted_votes(
-        data.as_ref().and_then(|d| d.outbox.votes.get(change_id)),
+        data.as_ref()
+            .and_then(|d| VoteNamespace::Outbox.of(d).get(change_id)),
     ))
 }
 
@@ -160,54 +186,20 @@ fn sorted_votes(votes: Option<&HashMap<String, VoteData>>) -> Vec<(String, VoteD
 }
 
 /// Delete the outbox vote entries of the given users from `scope`'s ref.
-/// Returns the number of entries removed.
 pub fn delete_outbox_votes(
     transaction: &Transaction,
     change_id: &str,
     scope: &ChangesRef,
     users: &[String],
-) -> anyhow::Result<usize> {
-    if users.is_empty() {
-        return Ok(0);
-    }
-
-    let odb = transaction.odb();
+) -> anyhow::Result<()> {
     let encoded = encode_change_id_path(change_id);
-    let ref_name = scope.ref_name();
-    let prev_commit = match transaction.resolve_ref(&ref_name)? {
-        Some(oid) => oid,
-        None => return Ok(0),
-    };
-    let mut tree = objects::CommitData::read(odb, prev_commit)?.tree_id()?;
-
-    let mut removed = 0usize;
-    for user in users {
-        let path = std::path::Path::new("outbox/votes")
-            .join(&encoded)
-            .join(user);
-        if matches!(
-            tree::get_path_entry(transaction, odb, tree, &path),
-            Ok(Some(_))
-        ) {
-            tree = tree::insert_oid(
-                odb,
-                tree,
-                &path,
-                gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
-                0,
-            )?;
-            removed += 1;
-        }
-    }
-
-    if removed == 0 {
-        return Ok(0);
-    }
-
-    let sig = transaction.signature()?;
-    let msg = format!("delete outbox votes on {}\n", ref_name);
-    let new_oid = objects::write_commit(odb, tree, &[prev_commit], &sig, &sig, &msg)?;
-    transaction.update_ref(&ref_name, Expected::At(prev_commit), new_oid, &msg)?;
-
-    Ok(removed)
+    let paths: Vec<std::path::PathBuf> = users
+        .iter()
+        .map(|user| {
+            std::path::Path::new(VoteNamespace::Outbox.path())
+                .join(&encoded)
+                .join(user)
+        })
+        .collect();
+    crate::store::delete_filtered(transaction, &paths, scope)
 }

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -289,7 +289,7 @@ fn print_comment_threads(comments: &[josh_changes::Comment]) {
     let mut roots: Vec<usize> = comments
         .iter()
         .enumerate()
-        .filter(|(_, c)| c.reply_to.is_none())
+        .filter(|(_, c)| c.meta.reply_to.is_none())
         .map(|(i, _)| i)
         .collect();
     roots.sort_by(|&a, &b| {
@@ -316,10 +316,12 @@ fn print_comment(comments: &[josh_changes::Comment], idx: usize, depth: usize) {
         .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
         .unwrap_or_default();
     let loc = c
+        .meta
         .file
         .as_deref()
         .map(|f| {
             let line = c
+                .meta
                 .location
                 .as_ref()
                 .map(|l| format!(":{}", l.start_line))
@@ -328,13 +330,13 @@ fn print_comment(comments: &[josh_changes::Comment], idx: usize, depth: usize) {
         })
         .unwrap_or_default();
     println!("{}[{}] {}{}", indent, author, ts, loc);
-    for line in c.message.lines() {
+    for line in c.meta.message.lines() {
         println!("{}  {}", indent, line);
     }
     let children: Vec<usize> = comments
         .iter()
         .enumerate()
-        .filter(|(_, child)| child.reply_to.as_deref() == Some(&c.id))
+        .filter(|(_, child)| child.meta.reply_to.as_deref() == Some(&c.id))
         .map(|(i, _)| i)
         .collect();
     for child in children {

--- a/josh-cli/src/commands/comment.rs
+++ b/josh-cli/src/commands/comment.rs
@@ -121,13 +121,13 @@ pub fn handle_comment(
     let scope = args.scope.resolve(transaction)?;
     match &scope {
         josh_changes::ChangesRef::Remote { remote, .. } => {
-            josh_changes::write_outbox_comment(transaction, &change, &meta, None, None, &scope)?;
             println!("Comment queued in outbox for remote '{}'.", remote);
         }
         josh_changes::ChangesRef::Local { .. } => {
-            josh_changes::write_comment(transaction, &change, &meta, None, None, &scope)?;
             println!("Comment saved (private to local ref).");
         }
     }
+    let namespace = josh_changes::CommentNamespace::for_scope(&scope);
+    josh_changes::write_comment(transaction, &change, &meta, None, None, &scope, namespace)?;
     Ok(())
 }

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -30,6 +30,7 @@ pub fn handle_sync(
     args: &SyncArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
+    josh_core::filter::check_experimental_features_enabled("josh changes sync")?;
     let head = transaction.head()?;
     let branch = head.short_branch().map(|s| s.to_string());
 

--- a/josh-cli/src/forge/github/changes.rs
+++ b/josh-cli/src/forge/github/changes.rs
@@ -371,7 +371,7 @@ impl GithubSyncCtx<'_> {
 
         josh_changes::store_diff_data(self.transaction, &change, &meta.remote_scope)?;
 
-        josh_changes::store_pr_data(
+        josh_github_changes::store_pr_data(
             self.transaction,
             &meta.change_id,
             &meta.pr_data,
@@ -538,9 +538,12 @@ impl GithubSyncCtx<'_> {
 
             // Record the final PR state for every candidate, open or closed;
             // a failed ref write skips the candidate like any other failure.
-            if let Err(e) =
-                josh_changes::store_pr_data(self.transaction, change_id, &pr_data, remote_scope)
-            {
+            if let Err(e) = josh_github_changes::store_pr_data(
+                self.transaction,
+                change_id,
+                &pr_data,
+                remote_scope,
+            ) {
                 stats.track_gc_skipped(
                     change_id,
                     pr_number,
@@ -561,7 +564,17 @@ impl GithubSyncCtx<'_> {
             }
 
             // Delete the change from the remote changes ref.
-            match josh_changes::delete_change(self.transaction, change_id, remote_scope) {
+            match josh_changes::delete_change(
+                self.transaction,
+                change_id,
+                remote_scope,
+                &[
+                    josh_github_changes::GITHUB_PR_DATA_PATH,
+                    josh_github_changes::GITHUB_COMMENT_NODE_IDS_PATH,
+                    josh_github_changes::GITHUB_VOTE_NODE_IDS_PATH,
+                    josh_github_changes::GITHUB_CACHE_PATH,
+                ],
+            ) {
                 Ok(()) => stats.track_cleaned(change_id, pr_number, &pr_data.state),
                 Err(e) => {
                     stats.track_gc_skipped(change_id, pr_number, format!("failed to delete: {}", e))
@@ -671,19 +684,21 @@ impl GithubSyncCtx<'_> {
 
         if let Some(c) = comments {
             let post = josh_github_changes::post_comments(self.api, &pr_node_id, c).await;
-            for p in &post.posted {
-                match josh_github_changes::store_comment_node_id(
-                    self.transaction,
-                    &pending.change_id,
-                    &p.local_id,
-                    &p.github_id,
-                    &pending.remote_scope,
-                ) {
-                    Ok(()) => outcome.posted_comments += 1,
-                    Err(e) => outcome
-                        .errors
-                        .push(format!("failed to record posted comment: {}", e)),
-                }
+            let written: Vec<(String, String)> = post
+                .posted
+                .iter()
+                .map(|p| (p.local_id.clone(), p.github_id.clone()))
+                .collect();
+            match josh_github_changes::store_comment_node_ids(
+                self.transaction,
+                &pending.change_id,
+                &written,
+                &pending.remote_scope,
+            ) {
+                Ok(()) => outcome.posted_comments += post.posted.len(),
+                Err(e) => outcome
+                    .errors
+                    .push(format!("failed to record posted comments: {}", e)),
             }
             if let Some(e) = post.error {
                 outcome
@@ -700,21 +715,18 @@ impl GithubSyncCtx<'_> {
                 &v.pending,
             )
             .await;
-            for (user, data) in &post.posted {
-                match josh_github_changes::store_vote_node_id(
-                    self.transaction,
-                    &pending.change_id,
-                    user,
-                    data,
-                    &pending.remote_scope,
-                ) {
-                    Ok(()) => outcome.posted_votes += 1,
-                    Err(e) => outcome
-                        .errors
-                        .push(format!("failed to record posted vote: {}", e)),
-                }
+            match josh_github_changes::store_vote_node_ids(
+                self.transaction,
+                &pending.change_id,
+                &post.posted,
+                &pending.remote_scope,
+            ) {
+                Ok(()) => outcome.posted_votes += post.posted.len(),
+                Err(e) => outcome
+                    .errors
+                    .push(format!("failed to record posted votes: {}", e)),
             }
-            // Drop outbox entries whose post is now reflected in gh_vote_ids.
+            // Drop outbox entries whose post is now reflected in gh_vote_node_ids.
             // Safe unconditionally -- no-op when nothing needs cleaning.
             if let Err(e) = josh_github_changes::cleanup_posted_outbox_votes(
                 self.transaction,

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 use anyhow::anyhow;
 use gix_object::bstr::BString;
-use josh_filter::check_experimental_features_enabled;
+pub use josh_filter::check_experimental_features_enabled;
 pub use josh_filter::experimental_features_enabled;
 
 use std::path::Path;
@@ -3004,5 +3004,135 @@ mod tests {
         let out_linear =
             objects::CommitData::read(&repo.objects, downstack(&t, linear, base).unwrap()).unwrap();
         assert_eq!(out_linear.parent_count(), 1);
+    }
+    // josh-changes builds changes-ref writes on `unapply` with a
+    // `subdir(p).prefix(p)` filter (self-inverse: "exclude previous value under
+    // p, overlay the new view"). These cover the edges the push path never
+    // hits: an absent base ref, and deletion via an empty view.
+    #[test]
+    fn unapply_subdir_prefix_leaf_write_and_delete() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(td.path()).unwrap();
+
+        let cachestack = std::sync::Arc::new(
+            cache::CacheStack::new().with_backend(cache::SledCacheBackend::new(td.path())),
+        );
+        let ctx = cache::TransactionContext::new(td.path(), cachestack);
+        let t = ctx.open().unwrap();
+
+        let f = Filter::new().subdir("a/b").prefix("a/b");
+        // The filter must be invertible for the generic unapply path.
+        assert!(invert(f).is_ok());
+
+        // Result trees live in the transaction's odb, so assert through
+        // get_path_entry rather than walking the tree.
+        let blob_id = |content: &str| {
+            josh_gix_ext::write_blob(&repo.objects, content.as_bytes())
+                .unwrap()
+                .to_string()
+        };
+        let entry_id = |tree: gix_hash::ObjectId, path: &str| -> Option<String> {
+            tree::get_path_entry(&t, t.odb(), tree, Path::new(path))
+                .unwrap()
+                .map(|e| e.oid.to_string())
+        };
+
+        // Leaf write onto an absent base (ref does not exist yet): the result
+        // is the view itself.
+        let view = build_tree(&repo, &[("a/b/c.txt", "new")]);
+        let merged = unapply(&t, f, view, tree::empty_id(), None).unwrap();
+        assert_eq!(merged, view);
+
+        // Leaf write over an existing base: content under a/b is replaced,
+        // everything else is preserved.
+        let base = build_tree(&repo, &[("x.txt", "keep"), ("a/b/old.txt", "old")]);
+        let merged = unapply(&t, f, view, base, None).unwrap();
+        assert_eq!(entry_id(merged, "x.txt"), Some(blob_id("keep")));
+        assert_eq!(entry_id(merged, "a/b/c.txt"), Some(blob_id("new")));
+        assert_eq!(entry_id(merged, "a/b/old.txt"), None);
+        // Leaf write where the base exists but the selected path does not
+        // (the common new-change case): the view is merged in, the rest kept.
+        let base_no_ns = build_tree(&repo, &[("x.txt", "keep")]);
+        let merged = unapply(&t, f, view, base_no_ns, None).unwrap();
+        assert_eq!(entry_id(merged, "x.txt"), Some(blob_id("keep")));
+        assert_eq!(entry_id(merged, "a/b/c.txt"), Some(blob_id("new")));
+        // Round-trip: applying the filter to the merged tree yields the view.
+        let roundtrip = apply(&t, f, Rewrite::from_tree(merged)).unwrap();
+        assert_eq!(roundtrip.tree_id(), view);
+
+        // Empty view deletes the selected path only.
+        let deleted = unapply(&t, f, tree::empty_id(), base, None).unwrap();
+        assert_eq!(entry_id(deleted, "x.txt"), Some(blob_id("keep")));
+        assert_eq!(entry_id(deleted, "a/b"), None);
+
+        // The write shape store.rs uses for blob leaves: filter on the parent
+        // directory (`subdir` on the leaf itself yields an empty tree for
+        // blobs), insert the leaf into the filtered subset, merge back.
+        let subset = apply(&t, f, Rewrite::from_tree(base)).unwrap().tree_id();
+        let view = tree::insert_oid(
+            t.odb(),
+            subset,
+            Path::new("a/b/c.txt"),
+            josh_gix_ext::write_blob(&repo.objects, b"new").unwrap(),
+            0o0100644,
+        )
+        .unwrap();
+        let merged = unapply(&t, f, view, base, None).unwrap();
+        assert_eq!(entry_id(merged, "x.txt"), Some(blob_id("keep")));
+        assert_eq!(entry_id(merged, "a/b/old.txt"), Some(blob_id("old")));
+        assert_eq!(entry_id(merged, "a/b/c.txt"), Some(blob_id("new")));
+
+        // Blob-leaf deletion in the same shape: zero-oid insert into the
+        // subset removes the entry.
+        let view = tree::insert_oid(
+            t.odb(),
+            subset,
+            Path::new("a/b/old.txt"),
+            gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
+            0,
+        )
+        .unwrap();
+        let deleted = unapply(&t, f, view, base, None).unwrap();
+        assert_eq!(entry_id(deleted, "x.txt"), Some(blob_id("keep")));
+        assert_eq!(entry_id(deleted, "a/b/old.txt"), None);
+    }
+
+    // Same contract for a deeper, multi-component path (`outbox/votes`-style):
+    // subdir/prefix accept slashes, and so does their inverse.
+    #[test]
+    fn unapply_multi_component_path() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(td.path()).unwrap();
+
+        let cachestack = std::sync::Arc::new(
+            cache::CacheStack::new().with_backend(cache::SledCacheBackend::new(td.path())),
+        );
+        let ctx = cache::TransactionContext::new(td.path(), cachestack);
+        let t = ctx.open().unwrap();
+
+        let f = Filter::new().subdir("ns/sub/leaf").prefix("ns/sub/leaf");
+        assert!(invert(f).is_ok());
+
+        let base = build_tree(
+            &repo,
+            &[("ns/sub/leaf/old", "old"), ("ns/keep/f.txt", "keep")],
+        );
+        let view = build_tree(&repo, &[("ns/sub/leaf/new", "new")]);
+        let merged = unapply(&t, f, view, base, None).unwrap();
+
+        let roundtrip = apply(&t, f, Rewrite::from_tree(merged)).unwrap();
+        assert_eq!(roundtrip.tree_id(), view);
+
+        let sibling = apply(
+            &t,
+            Filter::new().subdir("ns/keep").prefix("ns/keep"),
+            Rewrite::from_tree(merged),
+        )
+        .unwrap();
+        assert_eq!(
+            sibling.tree_id(),
+            build_tree(&repo, &[("ns/keep/f.txt", "keep")]),
+            "sibling subtree must survive"
+        );
     }
 }

--- a/josh-gui/src/common.rs
+++ b/josh-gui/src/common.rs
@@ -191,7 +191,7 @@ pub fn flatten_thread(
         let children: Vec<usize> = all
             .iter()
             .enumerate()
-            .filter(|(_, x)| x.reply_to.as_deref() == Some(&c.id))
+            .filter(|(_, x)| x.meta.reply_to.as_deref() == Some(&c.id))
             .map(|(i, _)| i)
             .collect();
         if !children.is_empty() {
@@ -224,7 +224,7 @@ pub fn render_threads(
         .map(|c| {
             let children: Vec<&josh_changes::Comment> = all
                 .iter()
-                .filter(|x| x.reply_to.as_deref() == Some(&c.id))
+                .filter(|x| x.meta.reply_to.as_deref() == Some(&c.id))
                 .collect();
             let indent = depth * 16;
             let author = c.author.as_deref().unwrap_or_default();
@@ -241,7 +241,7 @@ pub fn render_threads(
             rsx! {
                 div { style: "margin-left: {indent}px",
                     div { class: "diff-comment-inline",
-                        {render_comment_card(author, &ts, &c.message)}
+                        {render_comment_card(author, &ts, &c.meta.message)}
                     }
                     {render_threads(all, &children, depth + 1)}
                 }

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -119,13 +119,13 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
                             div { class: "revision-list",
                                 for rev in data.revisions.iter() {
                                     {
-                                        let is_current = rev.commit_oid == data.sha;
+                                        let is_current = rev.diff.commit == data.sha;
                                         let row_class = if is_current {
                                             "revision-item current"
                                         } else {
                                             "revision-item"
                                         };
-                                        let short_sha = &rev.commit_oid[..rev.commit_oid.len().min(8)];
+                                        let short_sha = &rev.diff.commit[..rev.diff.commit.len().min(8)];
                                         let ts = rev.timestamp.parse::<i64>().ok()
                                             .and_then(|s| chrono::DateTime::from_timestamp(s, 0))
                                             .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
@@ -150,7 +150,7 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
                             let top_roots: Vec<&josh_changes::Comment> = data
                                 .comments
                                 .iter()
-                                .filter(|c| c.file.is_none() && c.reply_to.is_none())
+                                .filter(|c| c.meta.file.is_none() && c.meta.reply_to.is_none())
                                 .collect();
                             if !top_roots.is_empty() {
                                 rsx! {
@@ -178,8 +178,8 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
                                         let file_roots: Vec<&josh_changes::Comment> = data
                                             .comments
                                             .iter()
-                                            .filter(|c| c.file.as_deref() == Some(p.as_str())
-                                                && c.reply_to.is_none())
+                                            .filter(|c| c.meta.file.as_deref() == Some(p.as_str())
+                                                && c.meta.reply_to.is_none())
                                             .collect();
                                         let has_comments = !file_roots.is_empty();
                                         rsx! {
@@ -415,14 +415,9 @@ pub fn save_comment(
         update_of: None,
     };
 
-    let content_hash = match scope {
-        josh_changes::ChangesRef::Remote { .. } => {
-            josh_changes::write_outbox_comment(&transaction, &change, &meta, None, None, scope)?
-        }
-        josh_changes::ChangesRef::Local { .. } => {
-            josh_changes::write_comment(&transaction, &change, &meta, None, None, scope)?
-        }
-    };
+    let namespace = josh_changes::CommentNamespace::for_scope(scope);
+    let content_hash =
+        josh_changes::write_comment(&transaction, &change, &meta, None, None, scope, namespace)?;
     // The write went into the transaction's in-memory odb; make it durable (and
     // surface flush errors) before reporting success.
     transaction.flush_mem_odb()?;
@@ -447,7 +442,7 @@ pub fn save_vote(
     state: &str,
     body: &str,
     scope: &josh_changes::ChangesRef,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<()> {
     let transaction = crate::common::open_transaction()?;
     let oid = gix_hash::ObjectId::from_str(sha)?;
     let change = josh_changes::Change::new(&transaction, oid)?;
@@ -460,36 +455,28 @@ pub fn save_vote(
         update_of: None,
     };
 
-    let content_hash = match scope {
-        josh_changes::ChangesRef::Remote { .. } => {
-            if !body.trim().is_empty() {
-                josh_changes::write_outbox_comment(
-                    &transaction,
-                    &change,
-                    &body_meta(),
-                    None,
-                    None,
-                    scope,
-                )?;
-            }
-            josh_changes::write_outbox_vote(&transaction, &change, state, None, None, scope)?
-        }
-        josh_changes::ChangesRef::Local { .. } => {
-            if !body.trim().is_empty() {
-                josh_changes::write_comment(
-                    &transaction,
-                    &change,
-                    &body_meta(),
-                    None,
-                    None,
-                    scope,
-                )?;
-            }
-            josh_changes::write_vote(&transaction, &change, state, None, None, scope)?
-        }
-    };
+    if !body.trim().is_empty() {
+        josh_changes::write_comment(
+            &transaction,
+            &change,
+            &body_meta(),
+            None,
+            None,
+            scope,
+            josh_changes::CommentNamespace::for_scope(scope),
+        )?;
+    }
+    josh_changes::write_vote(
+        &transaction,
+        &change,
+        state,
+        None,
+        None,
+        scope,
+        josh_changes::VoteNamespace::for_scope(scope),
+    )?;
     // The write went into the transaction's in-memory odb; make it durable (and
     // surface flush errors) before reporting success.
     transaction.flush_mem_odb()?;
-    Ok(content_hash)
+    Ok(())
 }

--- a/josh-gui/src/diff.rs
+++ b/josh-gui/src/diff.rs
@@ -32,7 +32,7 @@ fn estimate_item_height(item: &DiffItem) -> u32 {
     match item {
         DiffItem::Line(_) => 20,
         DiffItem::Comment(c) => {
-            let lines = c.comment.message.lines().count().max(1) as u32;
+            let lines = c.comment.meta.message.lines().count().max(1) as u32;
             40 + lines * 20
         }
     }
@@ -108,7 +108,7 @@ fn build_diff_with_comments(
 ) -> Vec<DiffItem> {
     let matching: Vec<&josh_changes::Comment> = comments
         .iter()
-        .filter(|c| c.file.as_deref() == Some(file_path))
+        .filter(|c| c.meta.file.as_deref() == Some(file_path))
         .collect();
     if matching.is_empty() {
         return lines.iter().map(|l| DiffItem::Line(l.clone())).collect();
@@ -119,16 +119,17 @@ fn build_diff_with_comments(
     let mut flat: Vec<(u32, FlatComment)> = Vec::new();
     let file_indices: Vec<usize> = all_comment_indices
         .iter()
-        .filter(|&&i| comments[i].file.as_deref() == Some(file_path))
+        .filter(|&&i| comments[i].meta.file.as_deref() == Some(file_path))
         .copied()
         .collect();
     let roots: Vec<usize> = file_indices
         .iter()
-        .filter(|&&i| comments[i].reply_to.is_none())
+        .filter(|&&i| comments[i].meta.reply_to.is_none())
         .copied()
         .collect();
     for &root in &roots {
         let target = comments[root]
+            .meta
             .location
             .as_ref()
             .map(|loc| loc.start_line)
@@ -468,7 +469,7 @@ pub fn FileDiffView(
                                                             div {
                                                                 class: "diff-comment-inline",
                                                                 style: "margin-left: {indent}px",
-                                                                {render_comment_card(&author, &ts, &flat.comment.message)}
+                                                                {render_comment_card(&author, &ts, &flat.comment.meta.message)}
                                                             }
                                                         }
                                                     }

--- a/tests/cli/changes_cli.t
+++ b/tests/cli/changes_cli.t
@@ -42,8 +42,12 @@ Build a three-commit stack:
   $ git add fileB
   $ printf "C change\n\nChange-Id: c3\n" | git commit -q -F -
 
-Populate the Local changes ref (refs/josh/changes/master).
+Populate the Local changes ref (refs/josh/changes/master). The command is
+experimental and refused without the environment opt-in.
 
+  $ josh changes sync 2>&1 | head -1
+  Error: josh changes sync requires JOSH_EXPERIMENTAL_FEATURES=1
+  $ export JOSH_EXPERIMENTAL_FEATURES=1
   $ josh changes sync
 
 list: one summary row per change, sorted by deps descending. c2 depends on c1
@@ -104,6 +108,63 @@ the ref's history walk so we glob it too for robustness.
       another comment
     [josh@example.com] * (glob)
       hello on c1
+
+  $ git-tree-pretty "refs/josh/changes/master:comments"
+  .
+  └── c1/
+      ├── bc5a59c9c2a17aa93d932557072907108a6cc202/
+      │   └── message
+      │       ╵  another comment
+      └── e56f33b144214b80924a395e9d540fb57ae28642/
+          └── message
+              ╵  hello on c1
+
+Votes have no CLI writer (the GUI and forge sync write them), so craft one
+directly:
+
+  $ c1_sha=$(git log --format=%H --grep="Change-Id: c1" -1)
+  $ state_oid=$(printf approve | git hash-object -w --stdin)
+  $ sha_oid=$(printf %s "$c1_sha" | git hash-object -w --stdin)
+  $ vote_tree=$(printf "100644 blob %s\tstate\n100644 blob %s\tsha\n" "$state_oid" "$sha_oid" | git mktree)
+  $ votes_mid=$(printf "040000 tree %s\tjosh%%40example%%2Ecom\n" "$vote_tree" | git mktree)
+  $ votes_top=$(printf "040000 tree %s\tc1\n" "$votes_mid" | git mktree)
+  $ new_root=$( { git ls-tree refs/josh/changes/master; printf "040000 tree %s\tvotes\n" "$votes_top"; } | git mktree )
+  $ new_commit=$(git commit-tree "$new_root" -p refs/josh/changes/master -m "update refs/josh/changes/master")
+  $ git update-ref refs/josh/changes/master "$new_commit"
+
+  $ josh changes list
+  Changes on Local [master]:
+  
+  c2  D=  1  C=  0  V=         B change
+  c1  D=  0  C=  2  V=approve  A change
+  c3  D=  0  C=  0  V=         C change
+
+  $ josh changes show c1
+  Change-Id: c1
+  Commit:    28e4ce506f82826559185773e0b04e57c4f3a596
+  Author:    josh@example.com
+  Date:      2005-04-07 22:13
+  Vote:      approve
+  
+  Subject:   A change
+  
+  Files (1, +1 / -0):
+    +1    -0     fileA
+  
+  Comments (2):
+    [josh@example.com] 2005-04-07 22:13
+      another comment
+    [josh@example.com] 2005-04-07 22:13
+      hello on c1
+
+  $ git-tree-pretty "refs/josh/changes/master:votes"
+  .
+  └── c1/
+      └── josh%40example%2Ecom/
+          ├── sha
+          │   ╵  28e4ce506f82826559185773e0b04e57c4f3a596
+          └── state
+              ╵  approve
 
 show: an id with no comments still prints a "Comments (0):" header.
 


### PR DESCRIPTION
Write changes refs as sparse structs over filter overlays

Writes on changes refs now build a sparse layout struct, serialize it,
embed the value tree with the namespace filter's inverse, and overlay it
onto the ref tree -- the inverse of the read side's read_filtered. The
overlay merges recursively, so a write adds or replaces only the entries
it carries. Deletions apply an exclude filter chain to the ref tree.
Path surgery, the zero-oid removal idiom, and the unapply-based write
helpers leave the write surface.

Comments move to a flat typed layout, comments/<change>/<id> with the
file path in the serialized meta, replacing the blob-id and
path-component levels nothing consumed. Fetched-comment commits now get
real timestamps: the GraphQL layer emitted chrono Display strings that
the ref-write signature parse rejected.

`josh changes sync` now requires `JOSH_EXPERIMENTAL_FEATURES=1`, and
tests writing changes refs configure their identity repo-locally instead
of depending on the ambient git config.

Assisted-By: kimi-code/k3-256k
Assisted-By: z-ai/glm-5.3-flash
Change: changes-refs-write-unapply