### PR TITLE
Remove GraphQL's direct libgit2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,8 +3643,8 @@ version = "26.7.28"
 dependencies = [
  "anyhow",
  "chrono",
- "git2",
  "gix-hash",
+ "gix-object",
  "glob",
  "josh-core",
  "josh-search",

--- a/josh-graphql/Cargo.toml
+++ b/josh-graphql/Cargo.toml
@@ -14,8 +14,8 @@ strfmt = "0.2.5"
 
 anyhow.workspace = true
 juniper.workspace = true
-git2.workspace = true
 gix-hash.workspace = true
+gix-object.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/josh-graphql/src/graphql.rs
+++ b/josh-graphql/src/graphql.rs
@@ -20,7 +20,7 @@ fn find_paths(
     tree: gix_hash::ObjectId,
     at: Option<String>,
     depth: Option<i32>,
-    kind: git2::ObjectType,
+    kind: gix_object::Kind,
 ) -> anyhow::Result<Vec<std::path::PathBuf>> {
     let tree = match at.as_deref() {
         Some(at) if !at.is_empty() => {
@@ -50,7 +50,7 @@ fn collect_paths(
     prefix: &std::path::Path,
     level: i32,
     depth: Option<i32>,
-    kind: git2::ObjectType,
+    kind: gix_object::Kind,
     out: &mut Vec<std::path::PathBuf>,
 ) -> anyhow::Result<()> {
     let reader = tree::read_tree(transaction, odb, tree)?;
@@ -62,9 +62,9 @@ fn collect_paths(
         let is_tree = entry.mode.is_tree();
         // Gitlinks are neither blobs nor trees, so they are never listed.
         let matches = if is_tree {
-            kind == git2::ObjectType::Tree
+            kind == gix_object::Kind::Tree
         } else {
-            kind == git2::ObjectType::Blob && !entry.mode.is_commit()
+            kind == gix_object::Kind::Blob && !entry.mode.is_commit()
         };
         if matches && depth.is_none_or(|limit| level <= limit) {
             out.push(path.clone());
@@ -117,7 +117,7 @@ impl Revision {
         at: Option<String>,
         depth: Option<i32>,
         context: &Context,
-        kind: git2::ObjectType,
+        kind: gix_object::Kind,
     ) -> FieldResult<Option<Vec<Path>>> {
         let transaction = context.transaction.lock().unwrap();
         let odb = transaction.odb();
@@ -295,7 +295,7 @@ impl Revision {
         depth: Option<i32>,
         context: &Context,
     ) -> FieldResult<Option<Vec<Path>>> {
-        self.files_or_dirs(at, depth, context, git2::ObjectType::Blob)
+        self.files_or_dirs(at, depth, context, gix_object::Kind::Blob)
     }
 
     fn dirs(
@@ -304,7 +304,7 @@ impl Revision {
         depth: Option<i32>,
         context: &Context,
     ) -> FieldResult<Option<Vec<Path>>> {
-        self.files_or_dirs(at, depth, context, git2::ObjectType::Tree)
+        self.files_or_dirs(at, depth, context, gix_object::Kind::Tree)
     }
 
     fn changed_files(


### PR DESCRIPTION
Remove GraphQL's direct libgit2 dependency

Use gix_object::Kind for GraphQL file and directory traversal now that all object reads already go through the gitoxide-backed transaction facade. This removes josh-graphql's direct git2 dependency without changing path classification, including gitlink exclusion.

Change: gix-graphql-object-kinds

Assisted-By: openai-codex/gpt-5.6-sol