### PR TITLE
Remove josh-proxy's direct libgit2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,7 +3700,6 @@ dependencies = [
  "bon",
  "clap",
  "futures",
- "git2",
  "gix",
  "gix-hash",
  "gix-packetline",

--- a/josh-proxy/Cargo.toml
+++ b/josh-proxy/Cargo.toml
@@ -50,7 +50,6 @@ tokio-util.workspace = true
 tempfile.workspace = true
 gix.workspace = true
 juniper.workspace = true
-git2.workspace = true
 gix-hash.workspace = true
 url.workspace = true
 

--- a/josh-proxy/benches/push_upstream.rs
+++ b/josh-proxy/benches/push_upstream.rs
@@ -121,24 +121,31 @@ async fn main() -> anyhow::Result<()> {
         })
     };
 
-    let source_repo = git2::Repository::open(&args.local_dir)?;
+    let source_repo = gix::open(&args.local_dir)?;
+    let current_commit = source_repo
+        .rev_parse_single(args.source_ref.as_str())?
+        .object()?
+        .peel_to_commit()?;
+    let current_commit_oid = current_commit.id().detach();
+    let tree_oid = current_commit.tree_id()?.detach();
 
-    let source_ref = source_repo.find_reference(&args.source_ref)?;
-    let current_commit = source_ref.peel_to_commit()?;
-    let tree = current_commit.tree()?;
-
-    let sig = git2::Signature::now("Benchmark", "benchmark@example.com")?;
-
-    let new_commit_oid = source_repo.commit(
-        None,
-        &sig,
-        &sig,
-        "Benchmark commit",
-        &tree,
-        &[&current_commit],
-    )?;
-
-    source_repo.reference("refs/heads/benchmark", new_commit_oid, true, "benchmark")?;
+    let sig = gix::actor::Signature {
+        name: "Benchmark".into(),
+        email: "benchmark@example.com".into(),
+        time: gix::date::Time::now_local_or_utc(),
+    };
+    let mut committer_time = gix::date::parse::TimeBuf::default();
+    let mut author_time = gix::date::parse::TimeBuf::default();
+    let new_commit_oid = source_repo
+        .commit_as(
+            sig.to_ref(&mut committer_time),
+            sig.to_ref(&mut author_time),
+            "refs/heads/benchmark",
+            "Benchmark commit",
+            tree_oid,
+            [current_commit_oid],
+        )?
+        .detach();
 
     println!("Created benchmark commit: {}", new_commit_oid);
     let branch = args

--- a/josh-proxy/src/serve.rs
+++ b/josh-proxy/src/serve.rs
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn test_git_cap_discovery() -> anyhow::Result<()> {
         let dir = tempfile::TempDir::new()?;
-        let _repo = git2::Repository::init_bare(&dir)?;
+        let _repo = gix::init_bare(&dir)?;
 
         let receive_pack_caps =
             git_list_capabilities(dir.as_ref(), CapabilitiesDirection::ReceivePack).unwrap();


### PR DESCRIPTION
Remove josh-proxy's direct libgit2 dependency

Use gitoxide to initialize the capability-discovery test repository and to create the push benchmark's source commit. Preserve source revisions that resolve through annotated tags by peeling them to commits before reusing their trees.

Change: gix-proxy-direct-dependency

Assisted-By: openai-codex/gpt-5.6-sol