### PR TITLE
Remove josh-cli's direct libgit2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,6 +3331,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "git2",
+ "gix",
  "gix-actor",
  "gix-hash",
  "glob",

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -18,7 +18,7 @@ serde_json.workspace = true
 defer.workspace = true
 clap.workspace = true
 juniper.workspace = true
-git2.workspace = true
+gix.workspace = true
 gix-hash.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 serde.workspace = true
@@ -44,6 +44,7 @@ josh-templates.workspace = true
 
 [dev-dependencies]
 gix-actor.workspace = true
+git2.workspace = true
 tempfile.workspace = true
 
 [features]

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -139,7 +139,7 @@ fn make_app() -> clap::Command {
 }
 
 struct GitNotesFilterHook {
-    repo: std::sync::Mutex<git2::Repository>,
+    notes: josh_core::git::NoteReader,
 }
 
 impl josh_core::cache::FilterHook for GitNotesFilterHook {
@@ -153,15 +153,8 @@ impl josh_core::cache::FilterHook for GitNotesFilterHook {
         } else {
             format!("refs/notes/{}", arg)
         };
-        let repo = self.repo.lock().unwrap();
-        let note = repo
-            .find_note(
-                Some(notes_ref.as_str()),
-                josh_core::objects::git2_oid(&commit_oid),
-            )
-            .context("missing git note for commit")?;
-        let msg = note.message().context("empty git note")?;
-        josh_core::filter::parse(msg)
+        let msg = self.notes.message(&notes_ref, commit_oid)?;
+        josh_core::filter::parse(&msg)
     }
 }
 
@@ -179,8 +172,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         .and_then(|f| read_to_string(f).ok())
         .unwrap_or(specstr.to_string());
 
-    let repo = git2::Repository::open_from_env()?;
-    let repo_path = repo.path().to_path_buf();
+    let repo_path = josh_core::git::discover_repository_paths()?.git_dir;
 
     let cache = std::sync::Arc::new({
         let mut cache = josh_core::cache::CacheStack::new();
@@ -200,13 +192,8 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         .with_mem_odb_limit(josh_cli::MAX_MEM_PACK_SIZE)
         .open()?;
 
-    let repo_for_hook = git2::Repository::open_ext(
-        transaction.path(),
-        git2::RepositoryOpenFlags::NO_SEARCH,
-        &[] as &[&std::ffi::OsStr],
-    )?;
     let hook = GitNotesFilterHook {
-        repo: std::sync::Mutex::new(repo_for_hook),
+        notes: josh_core::git::NoteReader::open(transaction.path())?,
     };
     transaction = transaction.with_filter_hook(std::sync::Arc::new(hook));
 

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -223,23 +223,18 @@ fn run_standalone(cmd: &StandaloneCommand) -> anyhow::Result<()> {
 }
 
 fn run_repo(cmd: &RepoCommand, distributed_cache: bool) -> anyhow::Result<()> {
-    // For clone, do the initial repo setup before creating transaction
-    let repo_path = if let RepoCommand::Clone(args) = cmd {
-        // For clone, we're not in a git repo initially, so clone first and use that path
-        clone_repo(args)?
+    let (repo_path, git_common_dir) = if let RepoCommand::Clone(args) = cmd {
+        // For clone, we're not in a git repo initially, so clone first.
+        let repo = gix::open(clone_repo(args)?)?;
+        (
+            repo.workdir().unwrap_or_else(|| repo.git_dir()).to_owned(),
+            repo.common_dir().to_owned(),
+        )
     } else {
-        // For other commands, we need to be in a git repo
-        let repo = git2::Repository::open_from_env().context("Not in a git repository")?;
-        normalize_repo_path(repo.path())
+        let paths =
+            josh_core::git::discover_repository_paths().context("Not in a git repository")?;
+        (paths.workdir_or_gitdir, paths.common_dir)
     };
-
-    // The josh cache lives in the repository's common git directory so it is
-    // shared across linked worktrees. Reconstructing `<workdir>/.git` would be
-    // wrong from a worktree, where the gitdir is shared but located elsewhere.
-    let git_common_dir = git2::Repository::open(&repo_path)
-        .context("Failed to open repository")?
-        .commondir()
-        .to_path_buf();
 
     let is_compose = matches!(cmd, RepoCommand::Compose(_));
 
@@ -352,7 +347,7 @@ fn clone_repo(args: &CloneArgs) -> anyhow::Result<std::path::PathBuf> {
 
     std::fs::create_dir_all(&output_dir)?;
 
-    git2::Repository::init(&output_dir).context("Failed to initialize git repository")?;
+    gix::init(&output_dir).context("Failed to initialize git repository")?;
 
     let remote_add_args = RemoteAddArgs {
         name: "origin".to_string(),
@@ -372,8 +367,6 @@ fn handle_clone(
     transaction: &josh_core::cache::Transaction,
     distributed_cache: bool,
 ) -> anyhow::Result<()> {
-    let repo = transaction.git2_repo();
-
     // Create FetchArgs from CloneArgs
     let fetch_args = FetchArgs {
         remote: "origin".to_string(),
@@ -427,7 +420,7 @@ fn handle_clone(
         )
         .with_context(|| format!("Failed to set upstream for branch {}", default_branch))?;
 
-    let output_dir = normalize_repo_path(repo.path());
+    let output_dir = normalize_repo_path(transaction.path());
     let output_dir = output_dir.display().to_string();
 
     let output_dir = if let Ok(testtmp) = std::env::var("TESTTMP") {
@@ -453,8 +446,8 @@ fn handle_remote(
 }
 
 fn handle_remote_add_repo(args: &RemoteAddArgs, repo_path: &std::path::Path) -> anyhow::Result<()> {
-    let repo = git2::Repository::open(repo_path).context("Failed to open repository")?;
-    let workdir = normalize_repo_path(repo_path);
+    let repo = gix::open(repo_path).context("Failed to open repository")?;
+    let workdir = repo.workdir().unwrap_or_else(|| repo.git_dir()).to_owned();
 
     // Store the remote information in .git/josh/remotes/<name>.josh file
     let remote_url = to_absolute_remote_url(&args.url)?;
@@ -497,7 +490,7 @@ fn handle_remote_add_repo(args: &RemoteAddArgs, repo_path: &std::path::Path) -> 
     // Add remote pointing to current directory
     let repo_remote = to_absolute_remote_url(&workdir.display().to_string())?;
     GitCommand::new(
-        repo.path(),
+        repo.git_dir(),
         ["remote", "add", &args.name, &repo_remote],
         std::iter::empty::<(&str, &str)>(),
     )
@@ -509,7 +502,7 @@ fn handle_remote_add_repo(args: &RemoteAddArgs, repo_path: &std::path::Path) -> 
     let uploadpack_cmd = format!("env GIT_NAMESPACE={} git upload-pack", namespace);
 
     GitCommand::new(
-        repo.path(),
+        repo.git_dir(),
         [
             "config",
             &format!("remote.{}.uploadpack", args.name),

--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -177,12 +177,7 @@ pub fn handle_show(
     println!("Subject:   {}", subject);
 
     println!();
-    // Line statistics still use libgit2's patch machinery.
-    let repo = transaction.git2_repo();
-    let files = file_stats(
-        repo,
-        &repo.find_commit(josh_core::objects::git2_oid(&change.commit()))?,
-    )?;
+    let files = josh_core::git::file_stats(transaction, change.commit())?;
     let total_adds: usize = files.iter().map(|f| f.adds).sum();
     let total_dels: usize = files.iter().map(|f| f.dels).sum();
     println!(
@@ -288,35 +283,6 @@ fn resolve_change_by_id(
                 scope_label(scope)
             )
         })
-}
-
-struct FileStat {
-    path: String,
-    adds: usize,
-    dels: usize,
-}
-
-fn file_stats(repo: &git2::Repository, commit: &git2::Commit) -> anyhow::Result<Vec<FileStat>> {
-    let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
-    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
-    let mut files = Vec::with_capacity(diff.deltas().len());
-    for i in 0..diff.deltas().len() {
-        let delta = diff.deltas().nth(i).unwrap();
-        let path = delta
-            .new_file()
-            .path()
-            .or_else(|| delta.old_file().path())
-            .and_then(|p| p.to_str())
-            .unwrap_or("")
-            .to_string();
-        let patch = git2::Patch::from_diff(&diff, i)?;
-        let (_, adds, dels) = patch
-            .as_ref()
-            .map(|p| p.line_stats().unwrap_or((0, 0, 0)))
-            .unwrap_or((0, 0, 0));
-        files.push(FileStat { path, adds, dels });
-    }
-    Ok(files)
 }
 
 fn print_comment_threads(comments: &[josh_changes::Comment]) {

--- a/josh-cli/src/commands/pull.rs
+++ b/josh-cli/src/commands/pull.rs
@@ -321,8 +321,6 @@ pub fn integrate(
     transaction: &josh_core::cache::Transaction,
     remote: &str,
 ) -> anyhow::Result<IntegrateReport> {
-    let repo = transaction.git2_repo();
-
     let head = transaction.head().context("Failed to resolve HEAD")?;
     let branch_ref = head
         .branch()
@@ -409,12 +407,8 @@ pub fn integrate(
 
     // Update the worktree first (safe: refuses to clobber conflicting local
     // modifications), only then move the branch ref.
-    let new_tip_commit = repo.find_commit(josh_core::objects::git2_oid(&new_tip))?;
-    repo.checkout_tree(
-        new_tip_commit.as_object(),
-        Some(git2::build::CheckoutBuilder::new().safe()),
-    )
-    .context("failed to update working tree; local changes conflict with the pulled state")?;
+    josh_core::git::checkout_commit(transaction, new_tip)
+        .context("failed to update working tree; local changes conflict with the pulled state")?;
     transaction.update_ref(
         &branch_ref,
         josh_core::cache::Expected::At(old_target),
@@ -428,10 +422,7 @@ pub fn integrate(
 /// Stash uncommitted changes to tracked files so the worktree update in
 /// `integrate` cannot conflict with them. Returns true if a stash was created.
 fn autostash_push(transaction: &josh_core::cache::Transaction) -> anyhow::Result<bool> {
-    let repo = transaction.git2_repo();
-    let mut opts = git2::StatusOptions::new();
-    opts.include_untracked(false);
-    if repo.statuses(Some(&mut opts))?.is_empty() {
+    if !josh_core::git::has_tracked_changes(transaction)? {
         return Ok(false);
     }
 

--- a/josh-cli/src/commands/sync.rs
+++ b/josh-cli/src/commands/sync.rs
@@ -30,8 +30,6 @@ pub fn handle_sync(
     args: &SyncArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.git2_repo();
-
     let head = transaction.head()?;
     let branch = head.short_branch().map(|s| s.to_string());
 
@@ -55,9 +53,7 @@ pub fn handle_sync(
     }
 
     match &resolved {
-        josh_changes::ChangesRef::Remote { remote, .. } => {
-            sync_remote(args, transaction, repo, remote)
-        }
+        josh_changes::ChangesRef::Remote { remote, .. } => sync_remote(args, transaction, remote),
         josh_changes::ChangesRef::Local { branch } => {
             sync_local(args, transaction, branch, head.commit, base_oid)
         }
@@ -113,9 +109,8 @@ fn sync_local(
 fn sync_remote(
     args: &SyncArgs,
     transaction: &josh_core::cache::Transaction,
-    repo: &git2::Repository,
     remote_name: &str,
 ) -> anyhow::Result<()> {
     let policy = github::cache::CachePolicy::new(args.no_cache, args.cache_ttl);
-    github::changes::sync(transaction, repo, remote_name, &policy, args.push)
+    github::changes::sync(transaction, remote_name, &policy, args.push)
 }

--- a/josh-cli/src/config.rs
+++ b/josh-cli/src/config.rs
@@ -37,10 +37,21 @@ impl RemoteConfig {
 /// invoked from a worktree, where the gitdir is `<main>/.git/worktrees/<name>`
 /// but the shared config still lives under `<main>/.git`.
 fn remotes_dir(repo_path: &std::path::Path) -> anyhow::Result<std::path::PathBuf> {
-    let repo = git2::Repository::open(repo_path)
+    let repo = gix::open(repo_path)
         .with_context(|| format!("Failed to open repository at {}", repo_path.display()))?;
 
-    Ok(repo.commondir().join("josh").join("remotes"))
+    Ok(repo.common_dir().join("josh").join("remotes"))
+}
+
+fn config_string(repo: &gix::Repository, key: &str) -> anyhow::Result<Option<String>> {
+    repo.config_snapshot()
+        .string(key)
+        .map(|value| {
+            std::str::from_utf8(value.as_ref())
+                .map(ToOwned::to_owned)
+                .map_err(Into::into)
+        })
+        .transpose()
 }
 
 pub fn migrate_legacy_config(
@@ -48,15 +59,14 @@ pub fn migrate_legacy_config(
     remote_name: &str,
 ) -> anyhow::Result<RemoteConfig> {
     // File doesn't exist, try legacy git config
-    let repo = git2::Repository::open(repo_path)
-        .context("Failed to open repository for legacy config migration")?;
-
-    let config = repo.config().context("Failed to get git config")?;
+    let repo =
+        gix::open(repo_path).context("Failed to open repository for legacy config migration")?;
 
     // Try to read from legacy josh-remote config
-    let url = match config.get_string(&format!("josh-remote.{}.url", remote_name)) {
-        Ok(url) => url,
-        Err(_) => {
+    let url_key = format!("josh-remote.{}.url", remote_name);
+    let url = match config_string(&repo, &url_key)? {
+        Some(url) => url,
+        None => {
             let remote_file = remotes_dir(repo_path)?.join(format!("{}.josh", remote_name));
 
             return Err(anyhow!(
@@ -68,12 +78,10 @@ pub fn migrate_legacy_config(
         }
     };
 
-    let filter_str = config
-        .get_string(&format!("josh-remote.{}.filter", remote_name))
+    let filter_str = config_string(&repo, &format!("josh-remote.{}.filter", remote_name))?
         .with_context(|| format!("Legacy config missing filter for remote '{}'", remote_name))?;
 
-    let fetch = config
-        .get_string(&format!("josh-remote.{}.fetch", remote_name))
+    let fetch = config_string(&repo, &format!("josh-remote.{}.fetch", remote_name))?
         .with_context(|| format!("Legacy config missing fetch for remote '{}'", remote_name))?;
 
     // Migrate to new format by writing the file

--- a/josh-cli/src/forge/github/changes.rs
+++ b/josh-cli/src/forge/github/changes.rs
@@ -19,17 +19,15 @@ use crate::forge::Forge;
 /// the async sync on a fresh tokio runtime.
 pub fn sync(
     transaction: &josh_core::cache::Transaction,
-    repo: &git2::Repository,
     remote_name: &str,
     policy: &CachePolicy,
     push: bool,
 ) -> anyhow::Result<()> {
-    let (owner, repo_name) = resolve_github_remote(repo, Some(remote_name))?;
+    let (owner, repo_name) = resolve_github_remote(transaction, Some(remote_name))?;
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(run_sync(
         transaction,
-        repo,
         remote_name,
         &owner,
         &repo_name,
@@ -42,7 +40,6 @@ pub fn sync(
 /// changes whose PRs closed, and optionally push local feedback.
 async fn run_sync(
     transaction: &josh_core::cache::Transaction,
-    repo: &git2::Repository,
     remote_name: &str,
     owner: &str,
     repo_name: &str,
@@ -60,7 +57,7 @@ async fn run_sync(
         return Ok(());
     }
 
-    let target_branch_shas = fetch_sync_objects(transaction, repo, owner, repo_name, &prs)?;
+    let target_branch_shas = fetch_sync_objects(transaction, owner, repo_name, &prs)?;
 
     let ctx = GithubSyncCtx {
         transaction,
@@ -808,11 +805,11 @@ fn remote_scope_for(remote_name: &str, target_branch: &str) -> josh_changes::Cha
 
 /// Read the remote config and return the GitHub (owner, repo) pair.
 fn resolve_github_remote(
-    repo: &git2::Repository,
+    transaction: &josh_core::cache::Transaction,
     remote: Option<&str>,
 ) -> anyhow::Result<(String, String)> {
     let remote_name = remote.unwrap_or("origin");
-    let repo_path = normalize_repo_path(repo.path());
+    let repo_path = normalize_repo_path(transaction.path());
     let remote_config = read_remote_config(&repo_path, remote_name)
         .with_context(|| format!("Failed to read remote config for '{}'", remote_name))?;
 
@@ -825,7 +822,6 @@ fn resolve_github_remote(
 
 fn fetch_sync_objects(
     transaction: &josh_core::cache::Transaction,
-    repo: &git2::Repository,
     owner: &str,
     repo_name: &str,
     prs: &[PrSummary],
@@ -872,7 +868,5 @@ fn fetch_sync_objects(
         tips.insert(target, oid);
     }
 
-    // Refresh ODB so git2 sees the newly fetched objects.
-    repo.odb()?.refresh()?;
     Ok(tips)
 }

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -161,6 +161,110 @@ pub fn normalize_repo_path(repo_path: &std::path::Path) -> PathBuf {
     }
 }
 
+/// Repository paths discovered with Git's environment overrides.
+pub struct RepositoryPaths {
+    pub workdir_or_gitdir: PathBuf,
+    pub git_dir: PathBuf,
+    pub common_dir: PathBuf,
+}
+
+pub fn discover_repository_paths() -> anyhow::Result<RepositoryPaths> {
+    let repo = git2::Repository::open_from_env()?;
+    Ok(RepositoryPaths {
+        workdir_or_gitdir: repo.workdir().unwrap_or_else(|| repo.path()).to_owned(),
+        git_dir: repo.path().to_owned(),
+        common_dir: repo.commondir().to_owned(),
+    })
+}
+
+/// A per-file line-count summary for a commit diff.
+pub struct FileStat {
+    pub path: String,
+    pub adds: usize,
+    pub dels: usize,
+}
+
+/// Compare `commit_oid` with its first parent and count changed lines per path.
+pub fn file_stats(
+    transaction: &crate::cache::Transaction,
+    commit_oid: gix_hash::ObjectId,
+) -> anyhow::Result<Vec<FileStat>> {
+    let repo = transaction.git2_repo();
+    let commit = repo.find_commit(crate::objects::git2_oid(&commit_oid))?;
+    let parent_tree = commit.parent(0).ok().and_then(|parent| parent.tree().ok());
+    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
+    let mut files = Vec::with_capacity(diff.deltas().len());
+    for (index, delta) in diff.deltas().enumerate() {
+        let path = delta
+            .new_file()
+            .path()
+            .or_else(|| delta.old_file().path())
+            .and_then(|path| path.to_str())
+            .unwrap_or("")
+            .to_string();
+        let patch = git2::Patch::from_diff(&diff, index)?;
+        let (_, adds, dels) = patch
+            .as_ref()
+            .map(|patch| patch.line_stats().unwrap_or((0, 0, 0)))
+            .unwrap_or((0, 0, 0));
+        files.push(FileStat { path, adds, dels });
+    }
+    Ok(files)
+}
+
+/// Safely update the worktree to `commit_oid` without overwriting conflicting changes.
+pub fn checkout_commit(
+    transaction: &crate::cache::Transaction,
+    commit_oid: gix_hash::ObjectId,
+) -> anyhow::Result<()> {
+    let repo = transaction.git2_repo();
+    let commit = repo.find_commit(crate::objects::git2_oid(&commit_oid))?;
+    repo.checkout_tree(
+        commit.as_object(),
+        Some(git2::build::CheckoutBuilder::new().safe()),
+    )?;
+    Ok(())
+}
+
+/// Whether tracked files differ from the index or worktree.
+pub fn has_tracked_changes(transaction: &crate::cache::Transaction) -> anyhow::Result<bool> {
+    let mut options = git2::StatusOptions::new();
+    options.include_untracked(false);
+    Ok(!transaction
+        .git2_repo()
+        .statuses(Some(&mut options))?
+        .is_empty())
+}
+
+/// A reusable reader for Git notes at the remaining libgit2 porcelain boundary.
+pub struct NoteReader {
+    repo: std::sync::Mutex<git2::Repository>,
+}
+
+impl NoteReader {
+    pub fn open(repo_path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
+        Ok(Self {
+            repo: std::sync::Mutex::new(git2::Repository::open_ext(
+                repo_path,
+                git2::RepositoryOpenFlags::NO_SEARCH,
+                &[] as &[&std::ffi::OsStr],
+            )?),
+        })
+    }
+
+    pub fn message(
+        &self,
+        notes_ref: &str,
+        commit_oid: gix_hash::ObjectId,
+    ) -> anyhow::Result<String> {
+        let repo = self.repo.lock().unwrap();
+        let note = repo
+            .find_note(Some(notes_ref), crate::objects::git2_oid(&commit_oid))
+            .context("missing git note for commit")?;
+        Ok(note.message().context("empty git note")?.to_owned())
+    }
+}
+
 /// Spawn a git command. By default, when used in TTY environment,
 /// forwards stdout/stderr to user's TTY
 pub struct GitCommand {


### PR DESCRIPTION
Remove josh-cli's direct libgit2 dependency

Use gitoxide for repository initialization, paths, and legacy configuration reads. Keep notes, worktree checkout, status, and patch statistics behind josh-core's remaining porcelain boundary so CLI production builds no longer depend directly on libgit2. Refresh the GUI lockfile after the preceding josh-gix-ext dependency change.

Change: gix-cli-direct-dependency

Assisted-By: openai-codex/gpt-5.6-sol