### PR TITLE
Remove josh-core's direct libgit2 dependency

### DIFF
--- a/devtools/josh-test-support/src/bench.rs
+++ b/devtools/josh-test-support/src/bench.rs
@@ -14,6 +14,25 @@ pub fn gix_oid(oid: git2::Oid) -> gix::ObjectId {
 pub fn git2_oid(oid: impl AsRef<gix::hash::oid>) -> git2::Oid {
     git2::Oid::from_bytes(oid.as_ref().as_bytes()).expect("gitoxide repository uses SHA-1")
 }
+/// Open a benchmark's libgit2 reference-model view without repository discovery.
+pub fn open_git2_repo(path: impl AsRef<std::path::Path>) -> Result<git2::Repository> {
+    Ok(git2::Repository::open_ext(
+        path,
+        git2::RepositoryOpenFlags::NO_SEARCH,
+        &[] as &[&std::ffi::OsStr],
+    )?)
+}
+
+/// Josh's fixed libgit2 identity for deterministic benchmark fixtures.
+pub fn josh_commit_signature<'a>() -> Result<git2::Signature<'a>> {
+    const NAME: &str = "JOSH";
+    const EMAIL: &str = "josh@josh-project.dev";
+
+    Ok(match std::env::var("JOSH_COMMIT_TIME") {
+        Ok(time) => git2::Signature::new(NAME, EMAIL, &git2::Time::new(time.parse()?, 0))?,
+        Err(_) => git2::Signature::now(NAME, EMAIL)?,
+    })
+}
 
 /// Deterministic lowercase alphabetic string, used as churned blob content.
 pub fn random_string(rng: &mut StdRng, len: usize) -> String {

--- a/josh-cli/src/commands/fetch.rs
+++ b/josh-cli/src/commands/fetch.rs
@@ -25,8 +25,7 @@ pub fn handle_fetch(
     transaction: &josh_core::cache::Transaction,
     distributed_cache: bool,
 ) -> anyhow::Result<Vec<RefUpdate>> {
-    let repo = transaction.git2_repo();
-    let repo_path = normalize_repo_path(repo.path());
+    let repo_path = normalize_repo_path(transaction.path());
 
     let config = read_remote_config(&repo_path, &args.remote)
         .with_context(|| format!("Failed to read remote config for '{}'", args.remote))?;
@@ -55,7 +54,7 @@ pub fn handle_fetch(
     // ls-remote --symref output format: "ref: refs/heads/main\t<commit-hash>"
     let output = std::process::Command::new("git")
         .args(["ls-remote", "--symref", &url, "HEAD"])
-        .current_dir(normalize_repo_path(repo.path()))
+        .current_dir(&repo_path)
         .output()?;
 
     if !output.status.success() {

--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -86,8 +86,6 @@ fn handle_link_add(
     args: &LinkAddArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.git2_repo();
-
     // Validate the path (should not be empty and should be a valid path)
     if args.path.is_empty() {
         return Err(anyhow!("Path cannot be empty"));
@@ -134,14 +132,8 @@ fn handle_link_add(
             .spawn_git(&["fetch", &args.url, target], &[])
             .context("Failed to execute git fetch")?;
 
-        // Preserve libgit2's multi-entry FETCH_HEAD resolution.
-        let fetched_oid = josh_core::objects::gix_oid(
-            repo.find_reference("FETCH_HEAD")
-                .context("Failed to find FETCH_HEAD after fetch")?
-                .peel_to_commit()
-                .context("Failed to peel FETCH_HEAD to commit")?
-                .id(),
-        );
+        let fetched_oid = josh_core::git::resolve_fetch_head(transaction)
+            .context("Failed to resolve FETCH_HEAD after fetch")?;
 
         eprintln!("Using fetched commit {}", fetched_oid);
         fetched_oid
@@ -188,8 +180,6 @@ fn handle_link_fetch(
     args: &LinkFetchArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.git2_repo();
-
     let head_commit = transaction.head().context("Failed to get HEAD")?.commit;
 
     let commit_oid = if let Some(filter_str) = &args.filter {
@@ -218,7 +208,7 @@ fn handle_link_fetch(
         link_refs.len()
     );
 
-    let odb = repo.odb().context("Failed to open object database")?;
+    let odb = transaction.odb();
 
     let mut fetched = 0;
     let mut skipped = 0;
@@ -227,7 +217,7 @@ fn handle_link_fetch(
         let oid = gix_hash::ObjectId::from_str(&link_ref.commit)
             .with_context(|| format!("Invalid commit SHA in link file: {}", link_ref.commit))?;
 
-        if odb.exists(josh_core::objects::git2_oid(&oid)) {
+        if odb.contains(oid) {
             skipped += 1;
             continue;
         }
@@ -265,8 +255,6 @@ fn handle_link_update(
     args: &LinkUpdateArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.git2_repo();
-
     let head_commit = transaction.head().context("Failed to get HEAD")?.commit;
     let head_tree = josh_core::objects::CommitData::read(transaction.odb(), head_commit)?
         .tree_id()
@@ -321,14 +309,8 @@ fn handle_link_update(
             .spawn_git(&["fetch", &remote, &branch], &[])
             .with_context(|| format!("git fetch failed for '{}'", path.display()))?;
 
-        // Preserve libgit2's multi-entry FETCH_HEAD resolution.
-        let new_oid = josh_core::objects::gix_oid(
-            repo.find_reference("FETCH_HEAD")
-                .context("Failed to find FETCH_HEAD")?
-                .peel_to_commit()
-                .context("Failed to get FETCH_HEAD commit")?
-                .id(),
-        );
+        let new_oid = josh_core::git::resolve_fetch_head(transaction)
+            .context("Failed to resolve FETCH_HEAD")?;
 
         links_to_update.push((path.clone(), new_oid));
     }

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -499,8 +499,7 @@ fn orchestrate_push(
     push_mode: PushMode,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let repo = transaction.git2_repo();
-    let repo_path = normalize_repo_path(repo.path());
+    let repo_path = normalize_repo_path(transaction.path());
 
     let remote_name = remote.unwrap_or("origin");
 

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -65,7 +65,7 @@ smallvec = "1.15.2"
 
 anyhow.workspace = true
 chrono.workspace = true
-git2.workspace = true
+tempfile.workspace = true
 gix.workspace = true
 gix-actor.workspace = true
 gix-object.workspace = true
@@ -90,7 +90,6 @@ josh-starlark.workspace = true
 [dev-dependencies]
 rand = "0.10.2"
 criterion = "0.5"
-tempfile.workspace = true
 git2.workspace = true
 josh-gix-ext = { workspace = true, features = ["git2"] }
 josh-test-support = { path = "../devtools/josh-test-support" }

--- a/josh-core/benches/deephistory_glob.rs
+++ b/josh-core/benches/deephistory_glob.rs
@@ -1,6 +1,6 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::josh_commit_signature;
 use josh_test_support::bench::{
     EntryKind, build_index, expected_tree, git2_oid, gix_oid, random_string,
 };
@@ -168,7 +168,7 @@ impl GlobBench {
         {
             let transaction = context.open()?;
             let case = cases.first().expect("at least one case");
-            let repo = transaction.git2_repo();
+            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
 
             // The tripwire only means something if the dotfiles actually exist in the raw tree.
             let raw_tree = repo.find_commit(git2_oid(case.head))?.tree()?;
@@ -186,7 +186,7 @@ impl GlobBench {
                 // sees what is on disk.
                 transaction.flush_mem_odb()?;
                 let got = repo.find_commit(git2_oid(filtered))?.tree_id();
-                let (want, kept) = expected_tree(repo, case.head, &glob_pred(pattern))?;
+                let (want, kept) = expected_tree(&repo, case.head, &glob_pred(pattern))?;
                 anyhow::ensure!(
                     kept > 0,
                     "`::{pattern}` gate kept no blobs -- benchmark would be a no-op"
@@ -508,8 +508,10 @@ fn deephistory_glob(c: &mut Criterion) {
                 .unwrap()
                 .tree_id()
                 .unwrap();
-            let (want, _) = expected_tree(transaction.git2_repo(), probe, &glob_pred(pattern))
-                .expect("expected");
+            let reference_repo =
+                josh_test_support::bench::open_git2_repo(transaction.path()).expect("open repo");
+            let (want, _) =
+                expected_tree(&reference_repo, probe, &glob_pred(pattern)).expect("expected");
             assert_eq!(
                 got, want,
                 "incremental `::{pattern}` diverged from the independent expectation"

--- a/josh-core/benches/deephistory_prefix_flush.rs
+++ b/josh-core/benches/deephistory_prefix_flush.rs
@@ -1,6 +1,6 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::josh_commit_signature;
 use josh_test_support::bench::{EntryKind, build_index, git2_oid, gix_oid, random_string};
 use rand::prelude::*;
 use std::path::{Path, PathBuf};

--- a/josh-core/benches/deephistory_subdir.rs
+++ b/josh-core/benches/deephistory_subdir.rs
@@ -1,6 +1,6 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::{Filter, RevMatch};
-use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::josh_commit_signature;
 use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
@@ -130,7 +130,7 @@ impl SubdirBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = transaction.git2_repo();
+            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
             let filtered_tree = repo.find_commit(git2_oid(filtered))?.tree()?.id();
             let raw_subdir_tree = repo
                 .find_commit(git2_oid(case.head))?

--- a/josh-core/benches/deephistory_subdir_distributed.rs
+++ b/josh-core/benches/deephistory_subdir_distributed.rs
@@ -1,6 +1,6 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::josh_commit_signature;
 use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
@@ -120,7 +120,7 @@ impl SubdirBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = transaction.git2_repo();
+            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
             let filtered_tree = repo.find_commit(git2_oid(filtered))?.tree()?.id();
             let raw_subdir_tree = repo
                 .find_commit(git2_oid(case.head))?
@@ -132,7 +132,7 @@ impl SubdirBench {
                 "subdir filter did not select `{SUBDIR}` -- benchmark would measure the wrong thing"
             );
             let input = case.n_commits + 1;
-            let output = count_history(repo, filtered)?;
+            let output = count_history(&repo, filtered)?;
             anyhow::ensure!(
                 output * 10 < input,
                 "expected input >> output, got {input} input / {output} output commits"

--- a/josh-core/benches/deephistory_subdir_sparse.rs
+++ b/josh-core/benches/deephistory_subdir_sparse.rs
@@ -1,6 +1,6 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::josh_commit_signature;
 use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
@@ -129,7 +129,7 @@ impl SubdirBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = transaction.git2_repo();
+            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
             let filtered_tree = repo.find_commit(git2_oid(filtered))?.tree()?.id();
             let raw_subdir_tree = repo
                 .find_commit(git2_oid(case.head))?
@@ -141,7 +141,7 @@ impl SubdirBench {
                 "subdir filter did not select `{SUBDIR}` -- benchmark would measure the wrong thing"
             );
             let input = case.n_commits + 1;
-            let output = count_history(repo, filtered)?;
+            let output = count_history(&repo, filtered)?;
             anyhow::ensure!(
                 output * 10 < input,
                 "expected input >> output, got {input} input / {output} output commits"

--- a/josh-core/benches/refs_filter_update.rs
+++ b/josh-core/benches/refs_filter_update.rs
@@ -1,6 +1,6 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::josh_commit_signature;
 use josh_test_support::bench::{EntryKind, build_index, git2_oid, gix_oid, random_string};
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
@@ -138,7 +138,7 @@ impl RefsBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = transaction.git2_repo();
+            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
             let filtered_tree = repo.find_commit(git2_oid(filtered))?.tree()?.id();
             let raw_subdir_tree = repo
                 .find_commit(git2_oid(case.head))?

--- a/josh-core/benches/ultrawide_pin.rs
+++ b/josh-core/benches/ultrawide_pin.rs
@@ -1,5 +1,5 @@
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::josh_commit_signature;
 use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
 use rand::prelude::*;
 use std::cell::RefCell;

--- a/josh-core/benches/ultrawide_pin_hook.rs
+++ b/josh-core/benches/ultrawide_pin_hook.rs
@@ -1,5 +1,5 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::josh_commit_signature;
 use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
 use rand::prelude::*;
 use std::collections::HashMap;

--- a/josh-core/benches/unapply.rs
+++ b/josh-core/benches/unapply.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_core::git::josh_commit_signature;
 use josh_core::history::{OrphansMode, unapply_filter};
+use josh_test_support::bench::josh_commit_signature;
 use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
 use rand::prelude::*;
 use std::path::PathBuf;
@@ -101,7 +101,7 @@ impl UnapplyBench {
         let mut cases = vec![];
         {
             let transaction = context.open()?;
-            let repo = transaction.git2_repo();
+            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
             for &n_commits in HISTORY_SIZES {
                 let head = gix_oid(repo.refname_to_id(&format!("refs/heads/case_{n_commits}"))?);
                 let filtered_head = josh_core::filter_commit(&transaction, filter, head)?;
@@ -280,7 +280,9 @@ fn unapply_extend(c: &mut Criterion) {
     {
         let case = bench.cases.first().expect("at least one case");
         let transaction = bench.context.open().expect("open transaction");
-        let tip = extend_filtered(transaction.git2_repo(), case.filtered_head, usize::MAX)
+        let reference_repo =
+            josh_test_support::bench::open_git2_repo(transaction.path()).expect("open repo");
+        let tip = extend_filtered(&reference_repo, case.filtered_head, usize::MAX)
             .expect("extend filtered");
         let unapplied = unapply_filter(
             &transaction,
@@ -310,8 +312,11 @@ fn unapply_extend(c: &mut Criterion) {
                 // for the history stay warm -- only the push delta is new, as in a real push.
                 || {
                     let transaction = bench.context.open().expect("open transaction");
+                    let reference_repo =
+                        josh_test_support::bench::open_git2_repo(transaction.path())
+                            .expect("open repo");
                     let tip = extend_filtered(
-                        transaction.git2_repo(),
+                        &reference_repo,
                         case.filtered_head,
                         salt.fetch_add(1, Ordering::Relaxed),
                     )

--- a/josh-core/benches/widetree_glob.rs
+++ b/josh-core/benches/widetree_glob.rs
@@ -1,6 +1,6 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_core::git::josh_commit_signature;
+use josh_test_support::bench::josh_commit_signature;
 use josh_test_support::bench::{
     EntryKind, build_index, expected_tree, git2_oid, gix_oid, random_string,
 };
@@ -146,7 +146,7 @@ impl GlobBench {
         // runs.
         {
             let transaction = context.open()?;
-            let repo = transaction.git2_repo();
+            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
             for case in &cases {
                 // Recursive pattern: keeps exactly the `.rs` blobs everywhere (string predicate is
                 // exact -- see the no-dot-component invariant above).
@@ -158,7 +158,7 @@ impl GlobBench {
                 // sees what is on disk.
                 transaction.flush_mem_odb()?;
                 let got = repo.find_commit(git2_oid(filtered))?.tree_id();
-                let (want, kept) = expected_tree(repo, case.head, &|p| p.ends_with(".rs"))?;
+                let (want, kept) = expected_tree(&repo, case.head, &|p| p.ends_with(".rs"))?;
                 anyhow::ensure!(kept > 0, "recursive gate kept no blobs -- would be a no-op");
                 anyhow::ensure!(
                     gix_oid(got) == want,
@@ -193,7 +193,7 @@ impl GlobBench {
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
                 transaction.flush_mem_odb()?;
                 let got = repo.find_commit(git2_oid(filtered))?.tree_id();
-                let (want, kept) = expected_tree(repo, case.head, &|p| p.ends_with(".toml"))?;
+                let (want, kept) = expected_tree(&repo, case.head, &|p| p.ends_with(".toml"))?;
                 anyhow::ensure!(
                     kept == N_SPARSE,
                     "sparse gate kept {kept} blobs, expected exactly {N_SPARSE}"

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -13,7 +13,7 @@ const FLUSH_AFTER: usize = 1000;
 pub struct DistributedCacheBackend {
     new_entries:
         std::sync::Mutex<HashMap<(Filter, u64), HashMap<gix_hash::ObjectId, gix_hash::ObjectId>>>,
-    repo: std::sync::Mutex<git2::Repository>,
+    repo: std::sync::Arc<gix::ThreadSafeRepository>,
     // Whether this backend accepts writes. The default ([`Self::new`]) is read-only: regular
     // sessions consume the fetched cache but should not each grow the shard chains with a
     // commit, pack and ref update for the few entries they produce -- the local sled cache
@@ -24,8 +24,8 @@ pub struct DistributedCacheBackend {
     // packed instead of being written synchronously as loose objects.
     mem_odb: std::sync::Arc<josh_memodb::MemOdb>,
     // The facade over `mem_odb` and this repository's objects, held rather than built per call
-    // so its store's pack indices are loaded once. Behind a mutex like `repo`: the backend is
-    // shared between threads, a facade is not.
+    // so its store's pack indices are loaded once. Behind a mutex because the facade is not
+    // `Sync`.
     odb: std::sync::Mutex<josh_memodb::Odb>,
     // Shard commits built by non-forced flushes, keyed by ref name. Their objects may still be
     // in `mem_odb` only, so the refs are published exclusively by a forced flush, after a drain
@@ -60,12 +60,15 @@ impl DistributedCacheBackend {
     }
 
     fn open(repo_path: impl AsRef<std::path::Path>, writable: bool) -> anyhow::Result<Self> {
-        let repo = git2::Repository::open(repo_path.as_ref())?;
-        let objects_dir = repo.commondir().join("objects");
+        let repo = std::sync::Arc::new(gix::ThreadSafeRepository::open_opts(
+            repo_path.as_ref(),
+            gix::open::Options::isolated(),
+        )?);
+        let objects_dir = repo.objects.path().to_owned();
         let mem_odb = josh_memodb::MemOdb::new(None, objects_dir.clone());
         let odb = josh_memodb::Odb::at(mem_odb.clone(), &objects_dir)?;
         Ok(Self {
-            repo: std::sync::Mutex::new(repo),
+            repo,
             mem_odb,
             odb: std::sync::Mutex::new(odb),
             writable,
@@ -89,7 +92,7 @@ impl DistributedCacheBackend {
     }
 
     pub fn flush(&self, force: bool) -> anyhow::Result<()> {
-        let repo = self.repo.lock().unwrap();
+        let repo = self.repo.to_thread_local();
         let odb = self.odb.lock().unwrap();
         let odb = &*odb;
 
@@ -107,10 +110,9 @@ impl DistributedCacheBackend {
             // Include earlier unpublished batches.
             let base = if let Some(oid) = pending.get(&rp) {
                 Some(*oid)
-            } else if let Ok(r) = repo.revparse_single(&rp) {
-                Some(objects::gix_oid(r.peel_to_commit()?.id()))
             } else {
-                None
+                repo.try_find_reference(&rp)?
+                    .and_then(|reference| reference.target().try_id().map(ToOwned::to_owned))
             };
 
             let mut buf = Vec::new();
@@ -180,7 +182,19 @@ impl DistributedCacheBackend {
         self.mem_odb.flush()?;
 
         for (rp, commit) in pending.drain() {
-            repo.reference(&rp, objects::git2_oid(&commit), true, "cache")?;
+            repo.edit_reference(gix::refs::transaction::RefEdit {
+                change: gix::refs::transaction::Change::Update {
+                    log: gix::refs::transaction::LogChange {
+                        mode: gix::refs::transaction::RefLog::AndReference,
+                        force_create_reflog: false,
+                        message: "cache".into(),
+                    },
+                    expected: gix::refs::transaction::PreviousValue::Any,
+                    new: gix::refs::Target::Object(commit),
+                },
+                name: gix::refs::FullName::try_from(rp.as_str())?,
+                deref: false,
+            })?;
         }
 
         Ok(())
@@ -233,7 +247,7 @@ impl CacheBackend for DistributedCacheBackend {
         if !tree_keyed && !hint.is_sample_point() {
             return Ok(None);
         }
-        let repo = self.repo.lock().unwrap();
+        let repo = self.repo.to_thread_local();
 
         let guard = self.new_entries.lock().unwrap();
 
@@ -254,8 +268,10 @@ impl CacheBackend for DistributedCacheBackend {
         let pending = self.pending_refs.lock().unwrap();
         let tree = if let Some(oid) = pending.get(&rp) {
             objects::CommitData::read(odb, *oid)?.tree_id()?
-        } else if let Ok(r) = repo.revparse_single(&rp) {
-            objects::gix_oid(r.peel_to_tree()?.id())
+        } else if let Ok(Some(reference)) = repo.try_find_reference(&rp)
+            && let Some(commit) = reference.target().try_id()
+        {
+            objects::CommitData::read(odb, commit.to_owned())?.tree_id()?
         } else {
             return Ok(None);
         };

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -173,9 +173,11 @@ fn shared_gix_repo(
 
 impl TransactionContext {
     pub fn from_env(cache: std::sync::Arc<CacheStack>) -> anyhow::Result<Self> {
-        let repo = git2::Repository::open_from_env()?;
+        let repo = gix::ThreadSafeRepository::discover_with_environment_overrides(
+            std::env::current_dir()?,
+        )
+        .map_err(crate::git::map_discovery_error)?;
         let path = repo.path().to_owned();
-
         Ok(Self {
             path,
             cache,
@@ -219,11 +221,6 @@ impl TransactionContext {
         let gix_repo = shared_gix_repo(&self.path)?;
 
         Ok(Transaction::new(
-            git2::Repository::open_ext(
-                &self.path,
-                git2::RepositoryOpenFlags::NO_SEARCH,
-                &[] as &[&std::ffi::OsStr],
-            )?,
             gix_repo,
             self.cache.clone(),
             self.ref_prefix.as_deref(),
@@ -264,7 +261,6 @@ pub struct Transaction {
     /// commits reuses the merge work of earlier commits. Its own cell because `trigram_index`
     /// borrows it for the entire call while also borrowing other caches through `t2`.
     trigram_indexer: std::cell::RefCell<josh_search::Indexer>,
-    repo: git2::Repository,
     /// The primary repository view for object and ref reads. Held in its thread-safe form:
     /// a transaction crosses threads (josh-graphql requires `Send`) while a `gix::Repository`
     /// holds `Rc` snapshots of packed-refs and shallow state and does not.
@@ -325,23 +321,12 @@ impl Drop for Transaction {
 
 impl Transaction {
     fn new(
-        repo: git2::Repository,
         gix_repo: std::sync::Arc<gix::ThreadSafeRepository>,
         cache: std::sync::Arc<CacheStack>,
         ref_prefix: Option<&str>,
         mem_odb_limit: Option<usize>,
         ephemeral: bool,
     ) -> Transaction {
-        // Configure the remaining porcelain handle once; these options are process-wide.
-        static GIT2_OPTIONS: std::sync::Once = std::sync::Once::new();
-        GIT2_OPTIONS.call_once(|| {
-            // Josh only writes objects whose references it has just produced or read.
-            git2::opts::strict_object_creation(false);
-            // Objects are produced locally or verified on transfer, so hashing every read adds
-            // work without strengthening this trust boundary.
-            git2::opts::strict_hash_verification(false);
-        });
-
         // An ephemeral transaction must not contribute to a store that outlives it, so it
         // buffers privately and reads through to the shared one.
         let objects_dir = gix_repo.objects.path().to_owned();
@@ -381,7 +366,6 @@ impl Transaction {
                 nesting_level: 0,
             }),
             trigram_indexer: Default::default(),
-            repo,
             gix_repo,
             mem_odb,
             odb,
@@ -411,12 +395,14 @@ impl Transaction {
     pub fn repo(&self) -> gix::Repository {
         self.gix_repo.to_thread_local()
     }
-
-    /// The porcelain repository handle, limited to worktree and index operations,
-    /// `FETCH_HEAD`'s multi-entry semantics and notes. It must not read or write objects Josh
-    /// produces; those can remain buffered in the transaction store (use [`Transaction::odb`]).
-    pub fn git2_repo(&self) -> &git2::Repository {
-        &self.repo
+    #[cfg(test)]
+    pub(crate) fn git2_repo(&self) -> git2::Repository {
+        git2::Repository::open_ext(
+            self.path(),
+            git2::RepositoryOpenFlags::NO_SEARCH,
+            &[] as &[&std::ffi::OsStr],
+        )
+        .expect("open test repository with libgit2")
     }
 
     /// The transaction's object-database facade: memory store first, repository objects
@@ -426,10 +412,8 @@ impl Transaction {
     }
 
     /// Add `path` (an objects directory) as a runtime alternate: the facade reads through it
-    /// and never buffers what it holds (see [`josh_memodb::Odb::write`]). The porcelain handle
-    /// is told separately, since it resolves objects of its own.
+    /// and never buffers what it holds (see [`josh_memodb::Odb::write`]).
     pub fn add_disk_alternate(&self, path: &str) -> anyhow::Result<()> {
-        self.repo.odb()?.add_disk_alternate(path)?;
         self.odb.add_alternate(std::path::Path::new(path))?;
         Ok(())
     }
@@ -1524,7 +1508,7 @@ mod tests {
             .find_tree(repo.treebuilder(None).unwrap().write().unwrap())
             .unwrap();
         let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
-        crate::objects::gix_oid(repo.commit(None, &sig, &sig, msg, &tree, &[]).unwrap())
+        josh_gix_ext::gix_oid(repo.commit(None, &sig, &sig, msg, &tree, &[]).unwrap())
     }
 
     #[test]
@@ -1921,8 +1905,8 @@ mod tests {
             .find_tree(repo.treebuilder(None).unwrap().write().unwrap())
             .unwrap();
         let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
-        let parent_commit = repo.find_commit(crate::objects::git2_oid(&parent)).unwrap();
-        let tip = crate::objects::gix_oid(
+        let parent_commit = repo.find_commit(josh_gix_ext::git2_oid(&parent)).unwrap();
+        let tip = josh_gix_ext::gix_oid(
             repo.commit(None, &sig, &sig, "tip", &tree, &[&parent_commit])
                 .unwrap(),
         );

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -2827,7 +2827,7 @@ mod tests {
             b.upsert(p, oid, git2::FileMode::Blob);
         }
         let empty = repo.treebuilder(None).unwrap().write().unwrap();
-        let tree = objects::gix_oid(
+        let tree = josh_gix_ext::gix_oid(
             b.create_updated(&repo, &repo.find_tree(empty).unwrap())
                 .unwrap(),
         );
@@ -2954,7 +2954,7 @@ mod tests {
                 b.upsert(*p, oid, git2::FileMode::Blob);
             }
             let empty = repo.treebuilder(None).unwrap().write().unwrap();
-            objects::gix_oid(
+            josh_gix_ext::gix_oid(
                 b.create_updated(&repo, &repo.find_tree(empty).unwrap())
                     .unwrap(),
             )
@@ -2965,13 +2965,13 @@ mod tests {
                          parents: &[gix_hash::ObjectId],
                          msg: &str|
          -> gix_hash::ObjectId {
-            let tree = repo.find_tree(objects::git2_oid(&tree)).unwrap();
+            let tree = repo.find_tree(josh_gix_ext::git2_oid(&tree)).unwrap();
             let parent_commits: Vec<git2::Commit> = parents
                 .iter()
-                .map(|p| repo.find_commit(objects::git2_oid(p)).unwrap())
+                .map(|p| repo.find_commit(josh_gix_ext::git2_oid(p)).unwrap())
                 .collect();
             let parent_refs: Vec<&git2::Commit> = parent_commits.iter().collect();
-            objects::gix_oid(
+            josh_gix_ext::gix_oid(
                 repo.commit(None, &sig, &sig, msg, &tree, &parent_refs)
                     .unwrap(),
             )
@@ -2993,7 +2993,7 @@ mod tests {
         let t = ctx.open().unwrap();
 
         let out = repo
-            .find_commit(objects::git2_oid(&downstack(&t, merge, base).unwrap()))
+            .find_commit(josh_gix_ext::git2_oid(&downstack(&t, merge, base).unwrap()))
             .unwrap();
         assert_eq!(out.parent_count(), 2, "merge change lost its second parent");
         assert_eq!(
@@ -3010,7 +3010,9 @@ mod tests {
         // A single-parent change is unaffected by the parent-preserving rewrite.
         let linear = mk_commit(mk_tree(&[("a", "1"), ("n", "n")]), &[base], "linear change");
         let out_linear = repo
-            .find_commit(objects::git2_oid(&downstack(&t, linear, base).unwrap()))
+            .find_commit(josh_gix_ext::git2_oid(
+                &downstack(&t, linear, base).unwrap(),
+            ))
             .unwrap();
         assert_eq!(out_linear.parent_count(), 1);
     }

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -1273,11 +1273,11 @@ mod tests {
     fn make_tree(repo: &git2::Repository, paths: &[&str]) -> gix_hash::ObjectId {
         let mut b = git2::build::TreeUpdateBuilder::new();
         for p in paths {
-            let oid = objects::gix_oid(repo.blob(p.as_bytes()).unwrap());
-            b.upsert(*p, objects::git2_oid(&oid), git2::FileMode::Blob);
+            let oid = josh_gix_ext::gix_oid(repo.blob(p.as_bytes()).unwrap());
+            b.upsert(*p, josh_gix_ext::git2_oid(&oid), git2::FileMode::Blob);
         }
         let base = repo.treebuilder(None).unwrap().write().unwrap();
-        objects::gix_oid(
+        josh_gix_ext::gix_oid(
             b.create_updated(repo, &repo.find_tree(base).unwrap())
                 .unwrap(),
         )
@@ -1298,19 +1298,20 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init_bare(td.path()).unwrap();
 
-        let blob = objects::gix_oid(repo.blob(b"content").unwrap());
-        let link = objects::gix_oid(repo.blob(b"target").unwrap());
+        let blob = josh_gix_ext::gix_oid(repo.blob(b"content").unwrap());
+        let link = josh_gix_ext::gix_oid(repo.blob(b"target").unwrap());
         // Gitlinks reference commits in other repositories; git does not require the oid
         // to exist locally.
         let sub = gix_hash::ObjectId::from_str("0123456789012345678901234567890123456789").unwrap();
 
         let mut b = repo.treebuilder(None).unwrap();
-        b.insert("keep.rs", objects::git2_oid(&blob), 0o100644)
+        b.insert("keep.rs", josh_gix_ext::git2_oid(&blob), 0o100644)
             .unwrap();
-        b.insert("link.rs", objects::git2_oid(&link), 0o120000)
+        b.insert("link.rs", josh_gix_ext::git2_oid(&link), 0o120000)
             .unwrap();
-        b.insert("sub", objects::git2_oid(&sub), 0o160000).unwrap();
-        let input = objects::gix_oid(b.write().unwrap());
+        b.insert("sub", josh_gix_ext::git2_oid(&sub), 0o160000)
+            .unwrap();
+        let input = josh_gix_ext::gix_oid(b.write().unwrap());
 
         let t = open_transaction(&td);
         let key = gix_hash::ObjectId::from_str("1111111111111111111111111111111111111111").unwrap();
@@ -1409,7 +1410,7 @@ mod tests {
             data.push(0);
             data.extend_from_slice(oid.as_bytes());
         }
-        objects::gix_oid(
+        josh_gix_ext::gix_oid(
             repo.odb()
                 .unwrap()
                 .write(git2::ObjectType::Tree, &data)
@@ -1424,8 +1425,8 @@ mod tests {
     fn remove_pred_preserves_fsck_invalid_trees() {
         let td = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init_bare(td.path()).unwrap();
-        let blob = objects::gix_oid(repo.blob(b"content").unwrap());
-        let blob2 = objects::gix_oid(repo.blob(b"other").unwrap());
+        let blob = josh_gix_ext::gix_oid(repo.blob(b"content").unwrap());
+        let blob2 = josh_gix_ext::gix_oid(repo.blob(b"other").unwrap());
         let t = open_transaction(&td);
 
         let sub = write_raw_tree(&repo, &[("100644", "inner.rs", blob)]);
@@ -1450,8 +1451,8 @@ mod tests {
     fn remove_pred_rebuild_preserves_survivors() {
         let td = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init_bare(td.path()).unwrap();
-        let blob = objects::gix_oid(repo.blob(b"content").unwrap());
-        let blob2 = objects::gix_oid(repo.blob(b"other").unwrap());
+        let blob = josh_gix_ext::gix_oid(repo.blob(b"content").unwrap());
+        let blob2 = josh_gix_ext::gix_oid(repo.blob(b"other").unwrap());
         let t = open_transaction(&td);
 
         let input = write_raw_tree(
@@ -1495,7 +1496,7 @@ mod tests {
     fn protected_names_are_not_special() {
         let td = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init_bare(td.path()).unwrap();
-        let blob = objects::gix_oid(repo.blob(b"content").unwrap());
+        let blob = josh_gix_ext::gix_oid(repo.blob(b"content").unwrap());
         let t = open_transaction(&td);
 
         let input = write_raw_tree(
@@ -1524,17 +1525,17 @@ mod tests {
     fn subtract_overlay_tolerate_non_canonical_order() {
         let td = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init_bare(td.path()).unwrap();
-        let blob = objects::gix_oid(repo.blob(b"content").unwrap());
-        let blob2 = objects::gix_oid(repo.blob(b"other").unwrap());
+        let blob = josh_gix_ext::gix_oid(repo.blob(b"content").unwrap());
+        let blob2 = josh_gix_ext::gix_oid(repo.blob(b"other").unwrap());
         let t = open_transaction(&td);
 
         // "z.rs" first: canonically misplaced, so a bisect for it fails.
         let unsorted = write_raw_tree(&repo, &[("100644", "z.rs", blob), ("100644", "a.rs", blob)]);
 
         let mut b = repo.treebuilder(None).unwrap();
-        b.insert("z.rs", objects::git2_oid(&blob), 0o100644)
+        b.insert("z.rs", josh_gix_ext::git2_oid(&blob), 0o100644)
             .unwrap();
-        let selector = objects::gix_oid(b.write().unwrap());
+        let selector = josh_gix_ext::gix_oid(b.write().unwrap());
 
         let out = subtract(&t, unsorted, selector).unwrap();
         let out_tree = out_entries(&t, out);
@@ -1548,9 +1549,9 @@ mod tests {
         // the new entry lands after the last entry that canonically precedes it (here: at
         // the end, after a.rs).
         let mut b = repo.treebuilder(None).unwrap();
-        b.insert("m.rs", objects::git2_oid(&blob2), 0o100644)
+        b.insert("m.rs", josh_gix_ext::git2_oid(&blob2), 0o100644)
             .unwrap();
-        let addition = objects::gix_oid(b.write().unwrap());
+        let addition = josh_gix_ext::gix_oid(b.write().unwrap());
         let out = overlay(&t, unsorted, addition).unwrap();
         let expected = write_raw_tree(
             &repo,
@@ -1573,11 +1574,15 @@ mod tests {
         let mut b = git2::build::TreeUpdateBuilder::new();
         for p in paths {
             let name = p.rsplit('/').next().unwrap();
-            let oid = objects::gix_oid(repo.blob(name.as_bytes()).unwrap());
-            b.upsert(p.as_str(), objects::git2_oid(&oid), git2::FileMode::Blob);
+            let oid = josh_gix_ext::gix_oid(repo.blob(name.as_bytes()).unwrap());
+            b.upsert(
+                p.as_str(),
+                josh_gix_ext::git2_oid(&oid),
+                git2::FileMode::Blob,
+            );
         }
         let base = repo.treebuilder(None).unwrap().write().unwrap();
-        objects::gix_oid(
+        josh_gix_ext::gix_oid(
             b.create_updated(repo, &repo.find_tree(base).unwrap())
                 .unwrap(),
         )
@@ -1594,7 +1599,7 @@ mod tests {
         pattern: &str,
     ) -> gix_hash::ObjectId {
         let glob = glob::Pattern::new(pattern).unwrap();
-        let tree = repo.find_tree(objects::git2_oid(&input)).unwrap();
+        let tree = repo.find_tree(josh_gix_ext::git2_oid(&input)).unwrap();
         let mut kept = vec![];
         tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
             if entry.kind() == Some(git2::ObjectType::Blob) {
@@ -1611,7 +1616,7 @@ mod tests {
             b.upsert(path.as_str(), *oid, git2::FileMode::Blob);
         }
         let base = repo.treebuilder(None).unwrap().write().unwrap();
-        objects::gix_oid(
+        josh_gix_ext::gix_oid(
             b.create_updated(repo, &repo.find_tree(base).unwrap())
                 .unwrap(),
         )
@@ -1685,7 +1690,7 @@ mod tests {
 
         let input = make_named_tree(&repo, &paths);
 
-        let tree = repo.find_tree(objects::git2_oid(&input)).unwrap();
+        let tree = repo.find_tree(josh_gix_ext::git2_oid(&input)).unwrap();
         assert_eq!(
             tree.get_path(Path::new("a/x")).unwrap().id(),
             tree.get_path(Path::new("c/x")).unwrap().id(),
@@ -1722,7 +1727,7 @@ mod tests {
             assert!(!cp.fallback, "`{pattern}` must not need the fallback");
             let got =
                 remove_pattern(&t, input, &cp, key, CompiledPattern::initial_state()).unwrap();
-            let want = ground_truth_tree(t.git2_repo(), input, pattern);
+            let want = ground_truth_tree(&t.git2_repo(), input, pattern);
             assert_eq!(
                 got, want,
                 "`{pattern}` diverged from full-path glob matching"
@@ -1782,7 +1787,7 @@ mod tests {
         let repo = git2::Repository::init_bare(td.path()).unwrap();
         let paths: Vec<String> = ["a/f.txt", "b/f.txt"].map(String::from).to_vec();
         let input = make_named_tree(&repo, &paths);
-        let tree = repo.find_tree(objects::git2_oid(&input)).unwrap();
+        let tree = repo.find_tree(josh_gix_ext::git2_oid(&input)).unwrap();
         assert_eq!(
             tree.get_path(Path::new("a")).unwrap().id(),
             tree.get_path(Path::new("b")).unwrap().id()
@@ -1799,7 +1804,7 @@ mod tests {
             key,
         )
         .unwrap();
-        let want = ground_truth_tree(t.git2_repo(), input, "a/*.txt");
+        let want = ground_truth_tree(&t.git2_repo(), input, "a/*.txt");
         assert_eq!(out, want, "b/f.txt must not be kept via the a/ cache entry");
     }
 
@@ -1811,7 +1816,7 @@ mod tests {
     fn get_path_entry_contract() {
         let td = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init_bare(td.path()).unwrap();
-        let blob = objects::gix_oid(repo.blob(b"content").unwrap());
+        let blob = josh_gix_ext::gix_oid(repo.blob(b"content").unwrap());
         let t = open_transaction(&td);
         let odb = t.odb();
 
@@ -1820,13 +1825,21 @@ mod tests {
         let mut b = git2::build::TreeUpdateBuilder::new();
         b.upsert(
             "a/b/deep.txt",
-            objects::git2_oid(&blob),
+            josh_gix_ext::git2_oid(&blob),
             git2::FileMode::Blob,
         );
-        b.upsert("top.txt", objects::git2_oid(&blob), git2::FileMode::Blob);
-        b.upsert("a/sub", objects::git2_oid(&gitlink), git2::FileMode::Commit);
+        b.upsert(
+            "top.txt",
+            josh_gix_ext::git2_oid(&blob),
+            git2::FileMode::Blob,
+        );
+        b.upsert(
+            "a/sub",
+            josh_gix_ext::git2_oid(&gitlink),
+            git2::FileMode::Commit,
+        );
         let base = repo.treebuilder(None).unwrap().write().unwrap();
-        let root = objects::gix_oid(
+        let root = josh_gix_ext::gix_oid(
             b.create_updated(&repo, &repo.find_tree(base).unwrap())
                 .unwrap(),
         );
@@ -1911,10 +1924,10 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init_bare(td.path()).unwrap();
 
-        let blob = objects::gix_oid(repo.blob(b"legacy").unwrap());
+        let blob = josh_gix_ext::gix_oid(repo.blob(b"legacy").unwrap());
         let sub_tree = make_tree(&repo, &["dir/a.txt", "dir/b.txt"]);
-        let dir = objects::gix_oid(
-            repo.find_tree(objects::git2_oid(&sub_tree))
+        let dir = josh_gix_ext::gix_oid(
+            repo.find_tree(josh_gix_ext::git2_oid(&sub_tree))
                 .unwrap()
                 .get_name("dir")
                 .unwrap()
@@ -1953,15 +1966,15 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init_bare(td.path()).unwrap();
 
-        let ours = objects::gix_oid(repo.blob(b"ours").unwrap());
-        let theirs = objects::gix_oid(repo.blob(b"theirs").unwrap());
+        let ours = josh_gix_ext::gix_oid(repo.blob(b"ours").unwrap());
+        let theirs = josh_gix_ext::gix_oid(repo.blob(b"theirs").unwrap());
         let input1 = write_raw_tree(&repo, &[("100664", "shared.rs", ours)]);
         let mut b = repo.treebuilder(None).unwrap();
-        b.insert("new.rs", objects::git2_oid(&theirs), 0o100644)
+        b.insert("new.rs", josh_gix_ext::git2_oid(&theirs), 0o100644)
             .unwrap();
-        b.insert("shared.rs", objects::git2_oid(&theirs), 0o100644)
+        b.insert("shared.rs", josh_gix_ext::git2_oid(&theirs), 0o100644)
             .unwrap();
-        let input2 = objects::gix_oid(b.write().unwrap());
+        let input2 = josh_gix_ext::gix_oid(b.write().unwrap());
 
         let t = open_transaction(&td);
         let out = overlay(&t, input1, input2).unwrap();

--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -15,34 +15,36 @@ pub fn resolve_snapshot_input(
     transaction: &crate::cache::Transaction,
     input_ref: &str,
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    let repo = transaction.git2_repo();
     if input_ref == "+" || input_ref == "." {
-        let mut index = repo.index()?;
-        let tree_oid = if input_ref == "+" {
-            index.write_tree_to(repo)?
+        let tree = if input_ref == "+" {
+            parse_oid(&git_stdout(transaction, &["write-tree"], &[])?)?
         } else {
-            let head_tree = repo.head()?.peel_to_tree()?;
-            index.read_tree(&head_tree)?;
-            index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)?;
-            index.update_all(["*"].iter(), None)?;
-            index.write_tree_to(repo)?
+            let temp = tempfile::tempdir()?;
+            let index = temp.path().join("index");
+            let index = index
+                .to_str()
+                .context("temporary index path is not valid UTF-8")?;
+            let env = [("GIT_INDEX_FILE", index)];
+            git_stdout(transaction, &["read-tree", "HEAD"], &env)?;
+            git_stdout(transaction, &["add", "--all"], &env)?;
+            parse_oid(&git_stdout(transaction, &["write-tree"], &env)?)?
         };
-        let tree = repo.find_tree(tree_oid)?;
-        let sig = crate::git::josh_commit_signature()?;
-        let head_commit = repo.head()?.peel_to_commit()?;
-        let commit_oid = repo.commit(None, &sig, &sig, "WIP", &tree, &[&head_commit])?;
-        Ok(crate::objects::gix_oid(commit_oid))
-    } else if let Ok(oid) = gix_hash::ObjectId::from_str(input_ref) {
-        Ok(crate::objects::gix_oid(
-            repo.find_object(crate::objects::git2_oid(&oid), None)?
-                .peel_to_commit()?
-                .id(),
-        ))
+        let head = transaction.head().context("could not resolve HEAD")?.commit;
+        let signature = josh_actor_signature()?;
+        crate::objects::write_commit(
+            transaction.odb(),
+            tree,
+            &[head],
+            &signature,
+            &signature,
+            "WIP",
+        )
     } else {
-        let obj = repo
-            .revparse_single(input_ref)
-            .with_context(|| format!("could not resolve input: {:?}", input_ref))?;
-        Ok(crate::objects::gix_oid(obj.peel_to_commit()?.id()))
+        let oid = transaction
+            .rev_parse(input_ref)?
+            .with_context(|| format!("could not resolve input: {input_ref:?}"))?;
+        crate::objects::peel_to_commit(transaction.odb(), oid)
+            .with_context(|| format!("could not peel input to a commit: {input_ref:?}"))
     }
 }
 
@@ -50,17 +52,13 @@ const JOSH_COMMIT_TIME_ENV: &str = "JOSH_COMMIT_TIME";
 const JOSH_COMMIT_NAME: &str = "JOSH";
 const JOSH_COMMIT_EMAIL: &str = "josh@josh-project.dev";
 
-/// The libgit2 spelling of Josh's fixed commit identity, for porcelain and fixture seams.
-pub fn josh_commit_signature<'a>() -> anyhow::Result<git2::Signature<'a>> {
-    Ok(if let Ok(time) = std::env::var(JOSH_COMMIT_TIME_ENV) {
-        git2::Signature::new(
-            JOSH_COMMIT_NAME,
-            JOSH_COMMIT_EMAIL,
-            &git2::Time::new(time.parse()?, 0),
-        )?
-    } else {
-        git2::Signature::now(JOSH_COMMIT_NAME, JOSH_COMMIT_EMAIL)?
-    })
+fn parse_oid(bytes: &[u8]) -> anyhow::Result<gix_hash::ObjectId> {
+    gix_hash::ObjectId::from_str(
+        std::str::from_utf8(bytes)
+            .context("git returned a non-UTF-8 object ID")?
+            .trim(),
+    )
+    .context("git returned an invalid object ID")
 }
 
 /// Josh's fixed commit identity for commits written through the object store.
@@ -144,9 +142,12 @@ pub fn user_signature(
 /// Falls back to stripping a trailing `.git` component when the path cannot be
 /// opened as a repository or the repository is bare (no working tree).
 pub fn normalize_repo_path(repo_path: &std::path::Path) -> PathBuf {
-    if let Ok(repo) = git2::Repository::open(repo_path)
+    if let Ok(repo) = gix::open(repo_path)
         && let Some(workdir) = repo.workdir()
     {
+        let workdir = std::fs::canonicalize(workdir).unwrap_or_else(|_| workdir.into());
+        let mut workdir = workdir.into_os_string();
+        workdir.push(std::path::MAIN_SEPARATOR_STR);
         return workdir.into();
     }
 
@@ -161,6 +162,19 @@ pub fn normalize_repo_path(repo_path: &std::path::Path) -> PathBuf {
     }
 }
 
+pub(crate) fn map_discovery_error(error: gix::discover::Error) -> anyhow::Error {
+    // Preserve the long-standing CLI error for "not in a repository"; gix's discovery error
+    // embeds the absolute current directory, which makes the message unstable.
+    if error
+        .to_string()
+        .starts_with("Could not find a git repository")
+    {
+        anyhow!("could not find repository at '.'; class=Repository (6); code=NotFound (-3)")
+    } else {
+        anyhow::Error::new(error)
+    }
+}
+
 /// Repository paths discovered with Git's environment overrides.
 pub struct RepositoryPaths {
     pub workdir_or_gitdir: PathBuf,
@@ -169,11 +183,12 @@ pub struct RepositoryPaths {
 }
 
 pub fn discover_repository_paths() -> anyhow::Result<RepositoryPaths> {
-    let repo = git2::Repository::open_from_env()?;
+    let repo = gix::discover_with_environment_overrides(std::env::current_dir()?)
+        .map_err(map_discovery_error)?;
     Ok(RepositoryPaths {
         workdir_or_gitdir: repo.workdir().unwrap_or_else(|| repo.path()).to_owned(),
         git_dir: repo.path().to_owned(),
-        common_dir: repo.commondir().to_owned(),
+        common_dir: repo.common_dir().to_owned(),
     })
 }
 
@@ -189,24 +204,32 @@ pub fn file_stats(
     transaction: &crate::cache::Transaction,
     commit_oid: gix_hash::ObjectId,
 ) -> anyhow::Result<Vec<FileStat>> {
-    let repo = transaction.git2_repo();
-    let commit = repo.find_commit(crate::objects::git2_oid(&commit_oid))?;
-    let parent_tree = commit.parent(0).ok().and_then(|parent| parent.tree().ok());
-    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
-    let mut files = Vec::with_capacity(diff.deltas().len());
-    for (index, delta) in diff.deltas().enumerate() {
-        let path = delta
-            .new_file()
-            .path()
-            .or_else(|| delta.old_file().path())
-            .and_then(|path| path.to_str())
-            .unwrap_or("")
-            .to_string();
-        let patch = git2::Patch::from_diff(&diff, index)?;
-        let (_, adds, dels) = patch
-            .as_ref()
-            .map(|patch| patch.line_stats().unwrap_or((0, 0, 0)))
-            .unwrap_or((0, 0, 0));
+    let oid = commit_oid.to_string();
+    let output = git_stdout(
+        transaction,
+        &[
+            "diff-tree",
+            "--root",
+            "--no-commit-id",
+            "--numstat",
+            "-r",
+            "--no-renames",
+            "-z",
+            &oid,
+        ],
+        &[],
+    )?;
+    let mut files = Vec::new();
+    for record in output
+        .split(|byte| *byte == 0)
+        .filter(|record| !record.is_empty())
+    {
+        let mut fields = record.splitn(3, |byte| *byte == b'\t');
+        let adds = parse_numstat(fields.next())?;
+        let dels = parse_numstat(fields.next())?;
+        let path =
+            String::from_utf8_lossy(fields.next().context("git numstat record has no path")?)
+                .into_owned();
         files.push(FileStat { path, adds, dels });
     }
     Ok(files)
@@ -225,43 +248,37 @@ pub fn file_patch(
     path: &str,
     context_lines: u32,
 ) -> anyhow::Result<Vec<PatchLine>> {
-    let repo = transaction.git2_repo();
-    let commit = repo.find_commit(crate::objects::git2_oid(&commit_oid))?;
-    let parent_tree = commit.parent(0).ok().and_then(|parent| parent.tree().ok());
-    let mut options = git2::DiffOptions::new();
-    options.context_lines(context_lines);
-    let diff = repo.diff_tree_to_tree(
-        parent_tree.as_ref(),
-        Some(&commit.tree()?),
-        Some(&mut options),
+    let oid = commit_oid.to_string();
+    let unified = format!("--unified={context_lines}");
+    let output = git_stdout(
+        transaction,
+        &[
+            "diff-tree",
+            "--root",
+            "--no-commit-id",
+            "-p",
+            "--no-ext-diff",
+            "--no-renames",
+            &unified,
+            &oid,
+            "--",
+            path,
+        ],
+        &[],
     )?;
-
-    let Some(index) = diff.deltas().position(|delta| {
-        delta
-            .new_file()
-            .path()
-            .or_else(|| delta.old_file().path())
-            .and_then(std::path::Path::to_str)
-            == Some(path)
-    }) else {
-        return Ok(Vec::new());
-    };
-    let Some(patch) = git2::Patch::from_diff(&diff, index)? else {
-        return Ok(Vec::new());
-    };
-
+    let mut in_hunk = false;
     let mut lines = Vec::new();
-    for hunk_index in 0..patch.num_hunks() {
-        let (hunk, hunk_lines) = patch.hunk(hunk_index)?;
-        lines.push(PatchLine {
-            origin: '@',
-            content: String::from_utf8_lossy(hunk.header()).into_owned(),
-        });
-        for line_index in 0..hunk_lines {
-            let line = patch.line_in_hunk(hunk_index, line_index)?;
+    for line in output.split_inclusive(|byte| *byte == b'\n') {
+        if line.starts_with(b"@@") {
+            in_hunk = true;
             lines.push(PatchLine {
-                origin: line.origin(),
-                content: String::from_utf8_lossy(line.content()).into_owned(),
+                origin: '@',
+                content: String::from_utf8_lossy(line).into_owned(),
+            });
+        } else if in_hunk && let Some((&origin, content)) = line.split_first() {
+            lines.push(PatchLine {
+                origin: origin as char,
+                content: String::from_utf8_lossy(content).into_owned(),
             });
         }
     }
@@ -273,38 +290,31 @@ pub fn checkout_commit(
     transaction: &crate::cache::Transaction,
     commit_oid: gix_hash::ObjectId,
 ) -> anyhow::Result<()> {
-    let repo = transaction.git2_repo();
-    let commit = repo.find_commit(crate::objects::git2_oid(&commit_oid))?;
-    repo.checkout_tree(
-        commit.as_object(),
-        Some(git2::build::CheckoutBuilder::new().safe()),
-    )?;
+    let oid = commit_oid.to_string();
+    transaction.spawn_git(&["read-tree", "-m", "-u", "HEAD", &oid], &[])?;
     Ok(())
 }
 
 /// Whether tracked files differ from the index or worktree.
 pub fn has_tracked_changes(transaction: &crate::cache::Transaction) -> anyhow::Result<bool> {
-    let mut options = git2::StatusOptions::new();
-    options.include_untracked(false);
-    Ok(!transaction
-        .git2_repo()
-        .statuses(Some(&mut options))?
-        .is_empty())
+    Ok(!git_stdout(
+        transaction,
+        &["status", "--porcelain", "--untracked-files=no"],
+        &[],
+    )?
+    .is_empty())
 }
 
-/// A reusable reader for Git notes at the remaining libgit2 porcelain boundary.
+/// A reusable reader for Git notes.
 pub struct NoteReader {
-    repo: std::sync::Mutex<git2::Repository>,
+    repo_path: PathBuf,
 }
 
 impl NoteReader {
     pub fn open(repo_path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
+        let repo = gix::open(repo_path.as_ref())?;
         Ok(Self {
-            repo: std::sync::Mutex::new(git2::Repository::open_ext(
-                repo_path,
-                git2::RepositoryOpenFlags::NO_SEARCH,
-                &[] as &[&std::ffi::OsStr],
-            )?),
+            repo_path: repo.path().to_owned(),
         })
     }
 
@@ -313,11 +323,15 @@ impl NoteReader {
         notes_ref: &str,
         commit_oid: gix_hash::ObjectId,
     ) -> anyhow::Result<String> {
-        let repo = self.repo.lock().unwrap();
-        let note = repo
-            .find_note(Some(notes_ref), crate::objects::git2_oid(&commit_oid))
-            .context("missing git note for commit")?;
-        Ok(note.message().context("empty git note")?.to_owned())
+        let output = GitCommand::new(
+            &self.repo_path,
+            ["notes", "--ref", notes_ref, "show", &commit_oid.to_string()],
+            [] as [(&str, &str); 0],
+        )
+        .with_stdout(std::process::Stdio::piped())
+        .spawn()
+        .context("missing git note for commit")?;
+        String::from_utf8(output.stdout).context("git note is not valid UTF-8")
     }
 }
 
@@ -423,18 +437,47 @@ impl GitCommand {
         }
     }
 }
+fn git_stdout(
+    transaction: &crate::cache::Transaction,
+    args: &[&str],
+    env: &[(&str, &str)],
+) -> anyhow::Result<Vec<u8>> {
+    Ok(transaction
+        .git_command(args, env)?
+        .with_stdout(std::process::Stdio::piped())
+        .spawn()?
+        .stdout)
+}
+
+fn parse_numstat(field: Option<&[u8]>) -> anyhow::Result<usize> {
+    let field = field.context("git numstat record is incomplete")?;
+    if field == b"-" {
+        return Ok(0);
+    }
+    std::str::from_utf8(field)?
+        .parse()
+        .context("git numstat returned an invalid line count")
+}
+
+/// Resolve the commit selected by Git's `FETCH_HEAD` pseudo-ref.
+pub fn resolve_fetch_head(
+    transaction: &crate::cache::Transaction,
+) -> anyhow::Result<gix_hash::ObjectId> {
+    parse_oid(&git_stdout(
+        transaction,
+        &["rev-parse", "--verify", "FETCH_HEAD^{commit}"],
+        &[],
+    )?)
+}
 
 /// Read a commit's parent OIDs directly from the raw object bytes, parsing only the parent
-/// lines via `gix_object::CommitRefIter`. This avoids libgit2's commit parse cache (a
-/// lock-guarded global that also decodes author/committer/message) whenever a caller only
-/// needs the parent ids; memory-store hits are zero-copy.
+/// lines via `gix_object::CommitRefIter`; memory-store hits are zero-copy.
 pub fn read_parent_ids(
     odb: &josh_memodb::Odb,
     oid: gix_hash::ObjectId,
 ) -> anyhow::Result<Vec<gix_hash::ObjectId>> {
     let (kind, bytes) = odb.read(oid)?;
-    // A hard error, not an assert: this is reachable from inside git2 callback frames,
-    // where unwinding across the FFI boundary would abort.
+    // A hard error rather than an assert because repository corruption is user input.
     if kind != gix_object::Kind::Commit {
         return Err(anyhow::anyhow!(
             "object {} is not a commit but a {:?}",
@@ -477,7 +520,7 @@ mod tests {
         let tree_id = repo.treebuilder(None).unwrap().write().unwrap();
         let tree = repo.find_tree(tree_id).unwrap();
         let commit_id =
-            crate::objects::gix_oid(repo.commit(None, &sig, &sig, "test", &tree, &[]).unwrap());
+            josh_gix_ext::gix_oid(repo.commit(None, &sig, &sig, "test", &tree, &[]).unwrap());
 
         let objects_dir = repo.commondir().join("objects");
         let store = josh_memodb::MemOdb::new(None, objects_dir.clone());
@@ -513,7 +556,7 @@ mod tests {
         let mut new_builder = repo.treebuilder(None).unwrap();
         new_builder.insert("file", new_blob, 0o100644).unwrap();
         let new_tree = repo.find_tree(new_builder.write().unwrap()).unwrap();
-        let commit = crate::objects::gix_oid(
+        let commit = josh_gix_ext::gix_oid(
             repo.commit(None, &sig, &sig, "commit", &new_tree, &[&parent])
                 .unwrap(),
         );
@@ -531,10 +574,86 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![('@', "@@ -1 +1 @@\n"), ('-', "old\n"), ('+', "new\n")]
         );
+        assert_eq!(
+            super::file_stats(&transaction, commit)
+                .unwrap()
+                .into_iter()
+                .map(|stat| (stat.path, stat.adds, stat.dels))
+                .collect::<Vec<_>>(),
+            vec![("file".to_owned(), 1, 1)]
+        );
         assert!(
             super::file_patch(&transaction, commit, "missing", 3)
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn worktree_porcelain_preserves_local_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
+        let path = dir.path().join("file");
+
+        std::fs::write(&path, b"old\n").unwrap();
+        let mut index = repo.index().unwrap();
+        index.add_path(std::path::Path::new("file")).unwrap();
+        index.write().unwrap();
+        let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+        let old = repo
+            .commit(Some("HEAD"), &sig, &sig, "old", &tree, &[])
+            .unwrap();
+
+        std::fs::write(&path, b"new\n").unwrap();
+        index.add_path(std::path::Path::new("file")).unwrap();
+        index.write().unwrap();
+        let tree = repo.find_tree(index.write_tree().unwrap()).unwrap();
+        let parent = repo.find_commit(old).unwrap();
+        let new = repo
+            .commit(Some("HEAD"), &sig, &sig, "new", &tree, &[&parent])
+            .unwrap();
+
+        let cache = std::sync::Arc::new(crate::cache::CacheStack::new());
+        let transaction = crate::cache::TransactionContext::new(repo.path(), cache)
+            .open()
+            .unwrap();
+        assert!(!super::has_tracked_changes(&transaction).unwrap());
+
+        let old = josh_gix_ext::gix_oid(old);
+        super::checkout_commit(&transaction, old).unwrap();
+        let head = transaction.head().unwrap();
+        transaction
+            .update_ref(
+                &head.reference,
+                crate::cache::Expected::At(josh_gix_ext::gix_oid(new)),
+                old,
+                "test checkout",
+            )
+            .unwrap();
+        assert!(!super::has_tracked_changes(&transaction).unwrap());
+        assert_eq!(std::fs::read(&path).unwrap(), b"old\n");
+
+        std::fs::write(&path, b"local\n").unwrap();
+        assert!(super::has_tracked_changes(&transaction).unwrap());
+        let snapshot = super::resolve_snapshot_input(&transaction, ".").unwrap();
+        let tree = crate::objects::CommitData::read(transaction.odb(), snapshot)
+            .unwrap()
+            .tree_id()
+            .unwrap();
+        let entry =
+            crate::objects::path_entry(transaction.odb(), tree, std::path::Path::new("file"))
+                .unwrap()
+                .unwrap();
+        assert_eq!(
+            crate::objects::blob_text(transaction.odb(), entry.oid),
+            "local\n"
+        );
+
+        assert!(
+            super::checkout_commit(&transaction, josh_gix_ext::gix_oid(new)).is_err(),
+            "checkout must not overwrite a conflicting local edit"
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), b"local\n");
     }
 }

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -982,7 +982,7 @@ mod tests {
         data.extend_from_slice(b"40000 sub");
         data.push(0);
         data.extend_from_slice(empty.as_bytes());
-        let chain = objects::gix_oid(
+        let chain = josh_gix_ext::gix_oid(
             repo.odb()
                 .unwrap()
                 .write(git2::ObjectType::Tree, &data)
@@ -992,7 +992,7 @@ mod tests {
         data.extend_from_slice(b"40000 nested");
         data.push(0);
         data.extend_from_slice(chain.as_bytes());
-        let chain2 = objects::gix_oid(
+        let chain2 = josh_gix_ext::gix_oid(
             repo.odb()
                 .unwrap()
                 .write(git2::ObjectType::Tree, &data)
@@ -1005,7 +1005,7 @@ mod tests {
         let mut b = git2::build::TreeUpdateBuilder::new();
         b.upsert("a/b/file.txt", blob, git2::FileMode::Blob);
         let base = repo.treebuilder(None).unwrap().write().unwrap();
-        let with_blob = objects::gix_oid(
+        let with_blob = josh_gix_ext::gix_oid(
             b.create_updated(&repo, &repo.find_tree(base).unwrap())
                 .unwrap(),
         );
@@ -1014,9 +1014,9 @@ mod tests {
         let gitlink =
             gix_hash::ObjectId::from_str("0123456789012345678901234567890123456789").unwrap();
         let mut b = repo.treebuilder(None).unwrap();
-        b.insert("sub", objects::git2_oid(&gitlink), 0o160000)
+        b.insert("sub", josh_gix_ext::git2_oid(&gitlink), 0o160000)
             .unwrap();
-        let with_gitlink = objects::gix_oid(b.write().unwrap());
+        let with_gitlink = josh_gix_ext::gix_oid(b.write().unwrap());
         assert!(!is_empty_root(&t, odb, with_gitlink).unwrap());
     }
 }

--- a/josh-core/src/housekeeping.rs
+++ b/josh-core/src/housekeeping.rs
@@ -128,7 +128,6 @@ regex_parsed!(
  * expensive to build from scratch using heuristics.
  */
 pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::Result<()> {
-    let repo = transaction.git2_repo();
     let mut known_filters = KNOWN_FILTERS.lock().unwrap();
     let trace_s = span!(Level::TRACE, "discover_filter_candidates");
     let _e = trace_s.enter();
@@ -153,11 +152,8 @@ pub fn discover_filter_candidates(transaction: &cache::Transaction) -> anyhow::R
         });
 
         if known_f.0 != target {
-            // Fetched targets may be annotated tags.
-            let tree = repo
-                .find_object(objects::git2_oid(&target), None)?
-                .peel(git2::ObjectType::Tree)?;
-            let hs = find_all_workspaces_and_subdirectories(odb, objects::gix_oid(tree.id()))?;
+            let tree = objects::peel_to_tree(odb, target)?;
+            let hs = find_all_workspaces_and_subdirectories(odb, tree)?;
             known_f.0 = target;
             for i in hs {
                 known_f.1.insert(i);

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -25,16 +25,6 @@ pub mod trailers;
 
 pub mod objects {
     pub use josh_gix_ext::*;
-
-    /// Convert a libgit2 SHA-1 object ID at the remaining porcelain boundary.
-    pub fn gix_oid(oid: git2::Oid) -> gix_hash::ObjectId {
-        gix_hash::ObjectId::from_bytes_or_panic(oid.as_bytes())
-    }
-
-    /// Convert a gitoxide SHA-1 object ID at the remaining porcelain boundary.
-    pub fn git2_oid(oid: &gix_hash::oid) -> git2::Oid {
-        git2::Oid::from_bytes(oid.as_bytes()).expect("oid sizes match")
-    }
 }
 pub use josh_memodb as memodb;
 

--- a/josh-core/tests/cache_lock.rs
+++ b/josh-core/tests/cache_lock.rs
@@ -32,13 +32,12 @@ fn sled_lock_follows_transaction_lifetime() {
     // holds the exclusive lock on the cache directory. Scoped so the git borrows of `transaction`
     // end before it is dropped below.
     {
-        let git = transaction.git2_repo();
+        let git = git2::Repository::open(transaction.path()).unwrap();
         let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
         let tree = git
             .find_tree(git.treebuilder(None).unwrap().write().unwrap())
             .unwrap();
-        let commit =
-            josh_core::objects::gix_oid(git.commit(None, &sig, &sig, "c", &tree, &[]).unwrap());
+        let commit = josh_gix_ext::gix_oid(git.commit(None, &sig, &sig, "c", &tree, &[]).unwrap());
         transaction
             .insert(filter::parse(":/").unwrap(), commit, commit, true)
             .unwrap();

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -82,6 +82,41 @@ pub fn peel_to_commit(
         }
     }
 }
+/// Follow `oid` to the tree it names, unwrapping annotated tags and commits on the way.
+/// Errors when the object is missing or resolves to something that is not tree-ish.
+pub fn peel_to_tree(
+    src: &(impl gix_object::Find + ?Sized),
+    oid: gix_hash::ObjectId,
+) -> anyhow::Result<gix_hash::ObjectId> {
+    let mut current = oid;
+    let mut buffer = Vec::new();
+    loop {
+        let data = src
+            .try_find(&current, &mut buffer)
+            .map_err(|e| anyhow::anyhow!("peel {}: {}", current, e))?
+            .ok_or_else(|| anyhow::anyhow!("object {} not found", current))?;
+        match data.kind {
+            gix_object::Kind::Tree => return Ok(current),
+            gix_object::Kind::Commit => {
+                return Ok(
+                    gix_object::CommitRefIter::from_bytes(&buffer, gix_hash::Kind::Sha1)
+                        .tree_id()?,
+                );
+            }
+            gix_object::Kind::Tag => {
+                current = gix_object::TagRefIter::from_bytes(&buffer, gix_hash::Kind::Sha1)
+                    .target_id()?;
+            }
+            kind => {
+                return Err(anyhow::anyhow!(
+                    "object {} is not tree-ish but a {:?}",
+                    current,
+                    kind
+                ));
+            }
+        }
+    }
+}
 
 /// The entries of the tree `oid`, owned so several trees can be walked side by side.
 /// Errors when the object is missing or is not a tree.

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -2545,18 +2545,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
-dependencies = [
- "bitflags 2.13.1",
- "libc",
- "libgit2-sys",
- "log",
-]
-
-[[package]]
 name = "gix"
 version = "0.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4230,7 +4218,6 @@ dependencies = [
  "bitvec",
  "chrono",
  "git-version",
- "git2",
  "gix",
  "gix-actor",
  "gix-config",
@@ -4257,6 +4244,7 @@ dependencies = [
  "sled",
  "smallvec",
  "strfmt",
+ "tempfile",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
 ]
@@ -4580,18 +4568,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.8+1.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4643,18 +4619,6 @@ checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
 dependencies = [
  "libc",
  "x11",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]

--- a/josh-gui/src/list.rs
+++ b/josh-gui/src/list.rs
@@ -325,16 +325,9 @@ pub fn load_rows(scope: &josh_changes::ChangesRef) -> anyhow::Result<ListData> {
     let mut dependencies: HashMap<String, Vec<String>> = HashMap::new();
 
     for change in &changes {
-        let commit = transaction
-            .git2_repo()
-            .find_commit(josh_core::objects::git2_oid(&change.commit()))?;
-        let subject = commit
-            .message()
-            .unwrap_or("")
-            .lines()
-            .next()
-            .unwrap_or("")
-            .to_string();
+        let subject = josh_core::objects::CommitData::read(transaction.odb(), change.commit())?
+            .summary()
+            .unwrap_or_default();
 
         let change_id = change.id().unwrap_or("").to_string();
 


### PR DESCRIPTION
Remove josh-core's direct libgit2 dependency

Move repository discovery, distributed cache refs, worktree porcelain, and remaining object access onto gitoxide-backed transactions or explicit git commands. Keep libgit2 only in dev dependencies as the independent benchmark and compatibility reference model.

Change: gix-core-direct-dependency

Assisted-By: openai-codex/gpt-5.6-sol