### PR TITLE
Remove libgit2 from josh-gix-ext production builds

### DIFF
--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -92,6 +92,7 @@ rand = "0.10.2"
 criterion = "0.5"
 tempfile.workspace = true
 git2.workspace = true
+josh-gix-ext = { workspace = true, features = ["git2"] }
 josh-test-support = { path = "../devtools/josh-test-support" }
 # Used by tests/cache_lock.rs to probe the sled file lock directly.
 sled = "0.34.7"

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -23,7 +23,19 @@ pub mod link;
 pub mod submodules;
 pub mod trailers;
 
-pub use josh_gix_ext as objects;
+pub mod objects {
+    pub use josh_gix_ext::*;
+
+    /// Convert a libgit2 SHA-1 object ID at the remaining porcelain boundary.
+    pub fn gix_oid(oid: git2::Oid) -> gix_hash::ObjectId {
+        gix_hash::ObjectId::from_bytes_or_panic(oid.as_bytes())
+    }
+
+    /// Convert a gitoxide SHA-1 object ID at the remaining porcelain boundary.
+    pub fn git2_oid(oid: &gix_hash::oid) -> git2::Oid {
+        git2::Oid::from_bytes(oid.as_bytes()).expect("oid sizes match")
+    }
+}
 pub use josh_memodb as memodb;
 
 /// Determine the josh version number with the following precedence:

--- a/josh-gix-ext/Cargo.toml
+++ b/josh-gix-ext/Cargo.toml
@@ -9,9 +9,12 @@ keywords = ["git", "gitoxide", "odb"]
 readme = "../README.md"
 edition = "2024"
 
+[features]
+git2 = ["dep:git2"]
+
 [dependencies]
 anyhow.workspace = true
-git2.workspace = true
+git2 = { workspace = true, optional = true }
 gix-actor.workspace = true
 gix-hash.workspace = true
 gix-command.workspace = true
@@ -25,4 +28,6 @@ gix-object.workspace = true
 gix-revision.workspace = true
 
 [dev-dependencies]
+git2.workspace = true
+
 tempfile.workspace = true

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -12,6 +12,7 @@ pub use graph::{is_descendant_of, merge_base, merge_base_octopus};
 pub use merge::{merge_commits, merge_trees};
 pub use revwalk::{RangeWalk, RevWalk};
 
+#[cfg(any(test, feature = "git2"))]
 /// Convert a gitoxide object kind to libgit2.
 pub fn git2_kind(kind: gix_object::Kind) -> git2::ObjectType {
     match kind {
@@ -22,6 +23,7 @@ pub fn git2_kind(kind: gix_object::Kind) -> git2::ObjectType {
     }
 }
 
+#[cfg(any(test, feature = "git2"))]
 /// Convert a libgit2 object kind when it represents an object.
 pub fn gix_kind(kind: git2::ObjectType) -> Option<gix_object::Kind> {
     match kind {
@@ -33,11 +35,13 @@ pub fn gix_kind(kind: git2::ObjectType) -> Option<gix_object::Kind> {
     }
 }
 
+#[cfg(any(test, feature = "git2"))]
 /// Convert a SHA-1 object ID to gitoxide.
 pub fn gix_oid(oid: git2::Oid) -> gix_hash::ObjectId {
     gix_hash::ObjectId::from_bytes_or_panic(oid.as_bytes())
 }
 
+#[cfg(any(test, feature = "git2"))]
 /// Convert a SHA-1 object ID to libgit2.
 pub fn git2_oid(oid: &gix_hash::oid) -> git2::Oid {
     git2::Oid::from_bytes(oid.as_bytes()).expect("oid sizes match")
@@ -508,12 +512,12 @@ impl gix_object::Exists for StagingOdb {
     }
 }
 
-/// [`gix_object`] object access over a bare `git2::Odb`: reads/exists resolve through the
-/// odb's backends (including a registered memodb and alternates), writes go through
-/// `git_odb_write`. The bridge for code that has a git2 odb handle but no memodb store —
-/// walker unit tests, and `persist::as_tree` on repositories below the cache stack.
+#[cfg(any(test, feature = "git2"))]
+/// [`gix_object`] object access over a bare `git2::Odb` for compatibility tests. Reads and
+/// existence checks resolve through the odb's configured backends; writes use `git_odb_write`.
 pub struct Git2Odb<'a>(pub &'a git2::Odb<'a>);
 
+#[cfg(any(test, feature = "git2"))]
 impl gix_object::Find for Git2Odb<'_> {
     fn try_find<'b>(
         &self,
@@ -538,6 +542,7 @@ impl gix_object::Find for Git2Odb<'_> {
     }
 }
 
+#[cfg(any(test, feature = "git2"))]
 impl gix_object::FindHeader for Git2Odb<'_> {
     fn try_header(
         &self,
@@ -558,12 +563,14 @@ impl gix_object::FindHeader for Git2Odb<'_> {
     }
 }
 
+#[cfg(any(test, feature = "git2"))]
 impl gix_object::Exists for Git2Odb<'_> {
     fn exists(&self, id: &gix_hash::oid) -> bool {
         self.0.exists(git2_oid(id))
     }
 }
 
+#[cfg(any(test, feature = "git2"))]
 impl gix_object::Write for Git2Odb<'_> {
     fn write_buf(
         &self,

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -4387,7 +4387,6 @@ name = "josh-gix-ext"
 version = "26.7.28"
 dependencies = [
  "anyhow",
- "git2",
  "gix-actor",
  "gix-command",
  "gix-diff",

--- a/josh-memodb/Cargo.toml
+++ b/josh-memodb/Cargo.toml
@@ -23,4 +23,4 @@ tempfile.workspace = true
 
 [dev-dependencies]
 git2.workspace = true
-josh-gix-ext.workspace = true
+josh-gix-ext = { workspace = true, features = ["git2"] }

--- a/josh-search/Cargo.toml
+++ b/josh-search/Cargo.toml
@@ -20,7 +20,7 @@ gix-object.workspace = true
 
 [dev-dependencies]
 git2.workspace = true
-josh-gix-ext.workspace = true
+josh-gix-ext = { workspace = true, features = ["git2"] }
 gix.workspace = true
 criterion2 = { version = "3.0.4" }
 rand = "0.10.2"

--- a/josh-starlark/Cargo.toml
+++ b/josh-starlark/Cargo.toml
@@ -23,4 +23,5 @@ gix-object.workspace = true
 
 [dev-dependencies]
 git2.workspace = true
+josh-gix-ext = { workspace = true, features = ["git2"] }
 


### PR DESCRIPTION
Remove libgit2 from josh-gix-ext production builds

Make the git2 adapter and conversion helpers opt-in for compatibility tests. Keep the remaining production OID conversion boundary in josh-core, where libgit2 porcelain is still used.

Change: gix-ext-optional-git2
Assisted-By: openai-codex/gpt-5.6-sol