### PR TITLE
Remove josh-gui's direct libgit2 dependency

### DIFF
--- a/josh-core/src/git.rs
+++ b/josh-core/src/git.rs
@@ -212,6 +212,62 @@ pub fn file_stats(
     Ok(files)
 }
 
+/// One line from a commit's patch, or a hunk header when `origin` is `@`.
+pub struct PatchLine {
+    pub origin: char,
+    pub content: String,
+}
+
+/// Compare `commit_oid` with its first parent and return the patch for `path`.
+pub fn file_patch(
+    transaction: &crate::cache::Transaction,
+    commit_oid: gix_hash::ObjectId,
+    path: &str,
+    context_lines: u32,
+) -> anyhow::Result<Vec<PatchLine>> {
+    let repo = transaction.git2_repo();
+    let commit = repo.find_commit(crate::objects::git2_oid(&commit_oid))?;
+    let parent_tree = commit.parent(0).ok().and_then(|parent| parent.tree().ok());
+    let mut options = git2::DiffOptions::new();
+    options.context_lines(context_lines);
+    let diff = repo.diff_tree_to_tree(
+        parent_tree.as_ref(),
+        Some(&commit.tree()?),
+        Some(&mut options),
+    )?;
+
+    let Some(index) = diff.deltas().position(|delta| {
+        delta
+            .new_file()
+            .path()
+            .or_else(|| delta.old_file().path())
+            .and_then(std::path::Path::to_str)
+            == Some(path)
+    }) else {
+        return Ok(Vec::new());
+    };
+    let Some(patch) = git2::Patch::from_diff(&diff, index)? else {
+        return Ok(Vec::new());
+    };
+
+    let mut lines = Vec::new();
+    for hunk_index in 0..patch.num_hunks() {
+        let (hunk, hunk_lines) = patch.hunk(hunk_index)?;
+        lines.push(PatchLine {
+            origin: '@',
+            content: String::from_utf8_lossy(hunk.header()).into_owned(),
+        });
+        for line_index in 0..hunk_lines {
+            let line = patch.line_in_hunk(hunk_index, line_index)?;
+            lines.push(PatchLine {
+                origin: line.origin(),
+                content: String::from_utf8_lossy(line.content()).into_owned(),
+            });
+        }
+    }
+    Ok(lines)
+}
+
 /// Safely update the worktree to `commit_oid` without overwriting conflicting changes.
 pub fn checkout_commit(
     transaction: &crate::cache::Transaction,
@@ -433,6 +489,52 @@ mod tests {
                     .unwrap()
                     .tree_id()
             )
+        );
+    }
+
+    #[test]
+    fn file_patch_returns_selected_file_hunks() {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let sig = git2::Signature::new("t", "t@example.com", &git2::Time::new(0, 0)).unwrap();
+
+        let old_blob = repo.blob(b"old\n").unwrap();
+        let mut old_builder = repo.treebuilder(None).unwrap();
+        old_builder.insert("file", old_blob, 0o100644).unwrap();
+        let old_tree = repo.find_tree(old_builder.write().unwrap()).unwrap();
+        let parent = repo
+            .find_commit(
+                repo.commit(None, &sig, &sig, "parent", &old_tree, &[])
+                    .unwrap(),
+            )
+            .unwrap();
+
+        let new_blob = repo.blob(b"new\n").unwrap();
+        let mut new_builder = repo.treebuilder(None).unwrap();
+        new_builder.insert("file", new_blob, 0o100644).unwrap();
+        let new_tree = repo.find_tree(new_builder.write().unwrap()).unwrap();
+        let commit = crate::objects::gix_oid(
+            repo.commit(None, &sig, &sig, "commit", &new_tree, &[&parent])
+                .unwrap(),
+        );
+
+        let cache = std::sync::Arc::new(crate::cache::CacheStack::new());
+        let transaction = crate::cache::TransactionContext::new(repo.path(), cache)
+            .open()
+            .unwrap();
+        let patch = super::file_patch(&transaction, commit, "file", 3).unwrap();
+
+        assert_eq!(
+            patch
+                .iter()
+                .map(|line| (line.origin, line.content.as_str()))
+                .collect::<Vec<_>>(),
+            vec![('@', "@@ -1 +1 @@\n"), ('-', "old\n"), ('+', "new\n")]
+        );
+        assert!(
+            super::file_patch(&transaction, commit, "missing", 3)
+                .unwrap()
+                .is_empty()
         );
     }
 }

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -4408,7 +4408,6 @@ dependencies = [
  "chrono",
  "clap",
  "dioxus",
- "git2",
  "gix-hash",
  "josh-changes",
  "josh-core",

--- a/josh-gui/Cargo.toml
+++ b/josh-gui/Cargo.toml
@@ -19,7 +19,6 @@ serde_json = "1.0"
 josh-changes = { path = "../josh-changes" }
 josh-core = { path = "../josh-core" }
 josh-github-changes = { path = "../forges/josh-github-changes" }
-git2 = { version = "0.21.0", default-features = false, features = ["vendored-libgit2"] }
 gix-hash = { version = "^0.26", features = ["sha1"] }
 tokio = { version = "1", features = ["time"] }
 

--- a/josh-gui/src/common.rs
+++ b/josh-gui/src/common.rs
@@ -3,9 +3,9 @@ use std::sync::OnceLock;
 use dioxus::prelude::*;
 
 pub fn open_transaction() -> anyhow::Result<josh_core::cache::Transaction> {
-    let repo = git2::Repository::discover(".")?;
+    let paths = josh_core::git::discover_repository_paths()?;
     let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new());
-    josh_core::cache::TransactionContext::new(repo.path(), cache).open()
+    josh_core::cache::TransactionContext::new(paths.git_dir, cache).open()
 }
 
 pub fn vote_state_label(state: &str) -> &'static str {

--- a/josh-gui/src/detail.rs
+++ b/josh-gui/src/detail.rs
@@ -291,41 +291,27 @@ pub fn DetailView(sha: String, scope: josh_changes::ChangesRef, mut page: Signal
 pub fn load_detail(sha: &str, scope: &josh_changes::ChangesRef) -> anyhow::Result<DetailData> {
     let transaction = crate::common::open_transaction()?;
     let oid = gix_hash::ObjectId::from_str(sha)?;
-    let repo = transaction.git2_repo();
-    let commit = repo.find_commit(josh_core::objects::git2_oid(&oid))?;
-
-    let msg = commit.message().unwrap_or("");
+    let commit = josh_core::objects::CommitData::read(transaction.odb(), oid)?;
+    let parsed = commit.parsed()?;
+    let msg = std::str::from_utf8(commit.message_raw()?.as_ref()).unwrap_or("");
     let subject = msg.lines().next().unwrap_or("").to_string();
     let message = msg.to_string();
-    let author = commit.author().email().unwrap_or("").to_string();
-    let date = chrono::DateTime::from_timestamp(commit.time().seconds(), 0)
+    let author = std::str::from_utf8(parsed.author()?.email.as_ref())
+        .unwrap_or("")
+        .to_string();
+    let date = chrono::DateTime::from_timestamp(parsed.time()?.seconds, 0)
         .map(|dt| dt.format("%Y-%m-%d %H:%M").to_string())
         .unwrap_or_default();
     let (change_id, series) = josh_changes::parse_change_meta(msg);
 
-    let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
-    let diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?;
-
-    let mut files: Vec<FileStat> = Vec::new();
-    for i in 0..diff.deltas().len() {
-        let delta = diff.deltas().nth(i).unwrap();
-        let path = delta
-            .new_file()
-            .path()
-            .or_else(|| delta.old_file().path())
-            .and_then(|p| p.to_str())
-            .unwrap_or("");
-        let patch = git2::Patch::from_diff(&diff, i)?;
-        let (_, adds, dels) = patch
-            .as_ref()
-            .map(|p| p.line_stats().unwrap_or((0, 0, 0)))
-            .unwrap_or((0, 0, 0));
-        files.push(FileStat {
-            path: path.to_string(),
-            adds,
-            dels,
-        });
-    }
+    let files = josh_core::git::file_stats(&transaction, oid)?
+        .into_iter()
+        .map(|stat| FileStat {
+            path: stat.path,
+            adds: stat.adds,
+            dels: stat.dels,
+        })
+        .collect();
 
     let mut change = josh_changes::Change::new(&transaction, oid)?;
 
@@ -352,10 +338,21 @@ pub fn load_detail(sha: &str, scope: &josh_changes::ChangesRef) -> anyhow::Resul
             }
         }
         for oid in change.contributing(&transaction).unwrap_or_default() {
-            if let Ok(c) = repo.find_commit(josh_core::objects::git2_oid(&oid)) {
-                let msg = c.message().unwrap_or("");
+            if let Ok(commit) = josh_core::objects::CommitData::read(transaction.odb(), oid)
+                && let Ok(parsed) = commit.parsed()
+            {
+                let msg = commit
+                    .message_raw()
+                    .ok()
+                    .and_then(|msg| std::str::from_utf8(msg.as_ref()).ok())
+                    .unwrap_or("");
                 let c_subject = msg.lines().next().unwrap_or("").to_string();
-                let c_author = c.author().email().unwrap_or("").to_string();
+                let c_author = parsed
+                    .author()
+                    .ok()
+                    .and_then(|signature| std::str::from_utf8(signature.email.as_ref()).ok())
+                    .unwrap_or("")
+                    .to_string();
                 let (_, c_series) = josh_changes::parse_change_meta(msg);
                 stack.push(StackCommit {
                     sha: oid.to_string(),

--- a/josh-gui/src/diff.rs
+++ b/josh-gui/src/diff.rs
@@ -49,82 +49,53 @@ fn selected_file_line(items: &[DiffItem], sel: Option<usize>) -> Option<u32> {
 }
 
 fn load_file_diff(sha: &str, path: &str, context_lines: u32) -> anyhow::Result<Vec<DiffLine>> {
-    let repo = git2::Repository::discover(".")?;
+    let transaction = crate::common::open_transaction()?;
     let oid = gix_hash::ObjectId::from_str(sha)?;
-    let commit = repo.find_commit(josh_core::objects::git2_oid(&oid))?;
+    let patch = josh_core::git::file_patch(&transaction, oid, path, context_lines)?;
+    let mut lines = Vec::with_capacity(patch.len());
+    let mut old_ln = 0;
+    let mut new_ln = 0;
 
-    let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
-    let mut opts = git2::DiffOptions::new();
-    opts.context_lines(context_lines);
-    let diff =
-        repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), Some(&mut opts))?;
-
-    let mut patch_idx = None;
-    for i in 0..diff.deltas().len() {
-        let delta = diff.deltas().nth(i).unwrap();
-        let p = delta
-            .new_file()
-            .path()
-            .or_else(|| delta.old_file().path())
-            .and_then(|p| p.to_str())
-            .unwrap_or("");
-        if p == path {
-            patch_idx = Some(i);
-            break;
+    for (index, line) in patch.into_iter().enumerate() {
+        if line.origin == '@' {
+            (old_ln, new_ln) = parse_hunk_header(&line.content);
+            lines.push(DiffLine {
+                kind: DiffLineKind::Hunk,
+                text: line.content,
+                old_ln: None,
+                new_ln: None,
+                line_number: index + 1,
+            });
+            continue;
         }
-    }
 
-    let mut lines = Vec::new();
-    if let Some(idx) = patch_idx {
-        let patch = git2::Patch::from_diff(&diff, idx)?;
-        if let Some(patch) = patch {
-            let mut n = 0;
-            for h in 0..patch.num_hunks() {
-                let (hunk, hunk_lines) = patch.hunk(h)?;
-                let header = String::from_utf8_lossy(hunk.header());
-                let (mut old_ln, mut new_ln) = parse_hunk_header(&header);
-                n += 1;
-                lines.push(DiffLine {
-                    kind: DiffLineKind::Hunk,
-                    text: header.to_string(),
-                    old_ln: None,
-                    new_ln: None,
-                    line_number: n,
-                });
-                for l in 0..hunk_lines {
-                    n += 1;
-                    let line = patch.line_in_hunk(h, l)?;
-                    let origin = line.origin();
-                    let (kind, old, new) = match origin {
-                        '+' => {
-                            let curr = new_ln;
-                            new_ln += 1;
-                            (DiffLineKind::Add, None, Some(curr))
-                        }
-                        '-' => {
-                            let curr = old_ln;
-                            old_ln += 1;
-                            (DiffLineKind::Del, Some(curr), None)
-                        }
-                        ' ' => {
-                            let o = old_ln;
-                            let n = new_ln;
-                            old_ln += 1;
-                            new_ln += 1;
-                            (DiffLineKind::Context, Some(o), Some(n))
-                        }
-                        _ => (DiffLineKind::Context, None, None),
-                    };
-                    lines.push(DiffLine {
-                        kind,
-                        text: String::from_utf8_lossy(line.content()).to_string(),
-                        old_ln: old,
-                        new_ln: new,
-                        line_number: n,
-                    });
-                }
+        let (kind, old, new) = match line.origin {
+            '+' => {
+                let current = new_ln;
+                new_ln += 1;
+                (DiffLineKind::Add, None, Some(current))
             }
-        }
+            '-' => {
+                let current = old_ln;
+                old_ln += 1;
+                (DiffLineKind::Del, Some(current), None)
+            }
+            ' ' => {
+                let old = old_ln;
+                let new = new_ln;
+                old_ln += 1;
+                new_ln += 1;
+                (DiffLineKind::Context, Some(old), Some(new))
+            }
+            _ => (DiffLineKind::Context, None, None),
+        };
+        lines.push(DiffLine {
+            kind,
+            text: line.content,
+            old_ln: old,
+            new_ln: new,
+            line_number: index + 1,
+        });
     }
 
     Ok(lines)


### PR DESCRIPTION
Remove josh-gui's direct libgit2 dependency

Read commits through the gitoxide-backed transaction object facade and centralize the remaining patch generation behind josh-core's porcelain boundary. Discover repository paths through josh-core so GUI production builds no longer depend directly on libgit2.

Change: gix-gui-direct-dependency

Assisted-By: openai-codex/gpt-5.6-sol