### PR TITLE
Remove josh-cli's libgit2 test dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,7 +3330,6 @@ dependencies = [
  "defer",
  "dirs",
  "env_logger",
- "git2",
  "gix",
  "gix-actor",
  "gix-hash",

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -44,7 +44,6 @@ josh-templates.workspace = true
 
 [dev-dependencies]
 gix-actor.workspace = true
-git2.workspace = true
 tempfile.workspace = true
 
 [features]

--- a/josh-cli/src/commands/pull.rs
+++ b/josh-cli/src/commands/pull.rs
@@ -547,7 +547,7 @@ mod tests {
     #[test]
     fn upstream_change_ids_walks_every_parent_between_base_and_tip() {
         let dir = tempfile::tempdir().unwrap();
-        git2::Repository::init_bare(dir.path()).unwrap();
+        gix::init_bare(dir.path()).unwrap();
         let context = josh_core::cache::TransactionContext::new(
             dir.path(),
             std::sync::Arc::new(josh_core::cache::CacheStack::new()),


### PR DESCRIPTION
Remove josh-cli's libgit2 test dependency

Initialize the pull history fixture with gitoxide so josh-cli no longer needs libgit2 even for unit tests.

Change: gix-cli-test-dependency

Assisted-By: openai-codex/gpt-5.6-sol