### PR TITLE
Remove josh-search's libgit2 test dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3753,7 +3753,6 @@ version = "26.7.28"
 dependencies = [
  "anyhow",
  "criterion2",
- "git2",
  "gix",
  "gix-hash",
  "gix-object",

--- a/josh-search/Cargo.toml
+++ b/josh-search/Cargo.toml
@@ -19,8 +19,7 @@ gix-hash.workspace = true
 gix-object.workspace = true
 
 [dev-dependencies]
-git2.workspace = true
-josh-gix-ext = { workspace = true, features = ["git2"] }
+josh-gix-ext.workspace = true
 gix.workspace = true
 criterion2 = { version = "3.0.4" }
 rand = "0.10.2"

--- a/josh-search/benches/trigram.rs
+++ b/josh-search/benches/trigram.rs
@@ -1,6 +1,6 @@
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use josh_core::git::josh_commit_signature;
-use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
+use josh_core::git::josh_actor_signature;
+use josh_test_support::bench::EntryKind;
 use rand::prelude::*;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -167,120 +167,138 @@ fn file_content(vocab: &[String], n_files: usize, i: usize, revision: usize) -> 
 /// tip is tagged `refs/heads/case_<n_files>` so the chain is recoverable after the repo
 /// round-trips through the provision cache.
 fn build_case(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     vocab: &[String],
     n_files: usize,
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+    let baseline = gix_object::Write::write(
+        &repo.objects,
+        &gix_object::Tree {
+            entries: Vec::new(),
+        },
+    )
+    .map_err(|err| anyhow::anyhow!("write empty benchmark tree: {err}"))?;
+    let mut builder = repo.edit_tree(baseline)?;
     for i in 0..n_files {
-        let oid = repo.blob(file_content(vocab, n_files, i, 0).as_bytes())?;
+        let oid =
+            josh_gix_ext::write_blob(&repo.objects, file_content(vocab, n_files, i, 0).as_bytes())?;
         builder.upsert(
             path_for(i).to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
     }
 
-    let root_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-
-    let sig = josh_commit_signature()?;
+    let root_tree = builder.write()?.detach();
+    let sig = josh_actor_signature()?;
     // No ref update yet -- the tip ref is set once the history is complete.
-    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+    let mut head =
+        josh_gix_ext::write_commit(&repo.objects, root_tree, &[], &sig, &sig, "content")?;
 
     let n_churn_files = std::cmp::max(1, (n_files as f64 * CHURN_FRACTION) as usize);
     let mut rng = StdRng::seed_from_u64(n_files as u64);
     for revision in 1..=K_CHURN {
-        let parent = repo.find_commit(head)?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let mut builder = repo.edit_tree(parent.tree_id()?)?;
 
         // Deduplicate the random indices so each path is rewritten once per commit.
         let churned: std::collections::BTreeSet<usize> = (0..n_churn_files)
             .map(|_| rng.random_range(0..n_files))
             .collect();
         for i in churned {
-            let oid = repo.blob(file_content(vocab, n_files, i, revision).as_bytes())?;
+            let oid = josh_gix_ext::write_blob(
+                &repo.objects,
+                file_content(vocab, n_files, i, revision).as_bytes(),
+            )?;
             builder.upsert(
                 path_for(i).to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(oid),
+                oid,
             )?;
         }
 
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = repo.commit(
-            None,
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("churn {revision}"),
-            &new_tree,
-            &[&parent],
         )?;
     }
 
     repo.reference(
-        &format!("refs/heads/case_{n_files}"),
+        format!("refs/heads/case_{n_files}"),
         head,
-        true,
+        gix::refs::transaction::PreviousValue::Any,
         "bench case tip",
     )?;
 
-    Ok(gix_oid(head))
+    Ok(head)
 }
 
 /// Aggregate every case tip under one index commit. Its oid changes whenever any case head
 /// changes, making it a faithful content-addressed cache stamp for the entire repo, and it keeps
 /// all cases reachable so provision_repo's `git prune` retains the full history.
 fn build_index(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     heads: &[gix_hash::ObjectId],
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    let sig = josh_commit_signature()?;
-    let empty_tree = repo.find_tree(repo.treebuilder(None)?.write()?)?;
-    let parents = heads
-        .iter()
-        .map(|oid| repo.find_commit(git2_oid(*oid)))
-        .collect::<Result<Vec<_>, _>>()?;
-    let parent_refs = parents.iter().collect::<Vec<_>>();
-    let index = repo.commit(
-        Some("refs/heads/bench-index"),
-        &sig,
-        &sig,
+    let sig = josh_actor_signature()?;
+    let empty_tree = gix_object::Write::write(
+        &repo.objects,
+        &gix_object::Tree {
+            entries: Vec::new(),
+        },
+    )
+    .map_err(|err| anyhow::anyhow!("write empty benchmark tree: {err}"))?;
+    let index =
+        josh_gix_ext::write_commit(&repo.objects, empty_tree, heads, &sig, &sig, "bench index")?;
+    repo.reference(
+        "refs/heads/bench-index",
+        index,
+        gix::refs::transaction::PreviousValue::Any,
         "bench index",
-        &empty_tree,
-        &parent_refs,
     )?;
-    Ok(gix_oid(index))
+    Ok(index)
 }
 
 /// Sum of all blob sizes in `tree`, the throughput denominator for the indexing groups.
-fn tree_content_bytes(repo: &git2::Repository, tree: &git2::Tree) -> anyhow::Result<u64> {
+fn tree_content_bytes(
+    objects: &impl gix_object::Find,
+    tree: gix_hash::ObjectId,
+) -> anyhow::Result<u64> {
     let mut total = 0u64;
-    tree.walk(git2::TreeWalkMode::PreOrder, |_, entry| {
-        if entry.kind() == Some(git2::ObjectType::Blob) {
-            if let Ok(blob) = repo.find_blob(entry.id()) {
-                total += blob.size() as u64;
-            }
+    josh_gix_ext::walk_tree_preorder(objects, tree, &mut |_, entry| {
+        if entry.mode.is_blob() {
+            let mut buffer = Vec::new();
+            let object = objects
+                .try_find(&entry.oid, &mut buffer)
+                .map_err(|err| anyhow::anyhow!("read benchmark blob {}: {err}", entry.oid))?
+                .ok_or_else(|| anyhow::anyhow!("benchmark blob {} is missing", entry.oid))?;
+            total += object.data.len() as u64;
         }
-        git2::TreeWalkResult::Ok
+        Ok(())
     })?;
     Ok(total)
 }
 
 /// Recover the first-parent chain (root first, tip last) of a case from its tip ref.
 fn recover_chain(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     n_files: usize,
 ) -> anyhow::Result<Vec<gix_hash::ObjectId>> {
     let mut chain = vec![];
-    let mut oid = repo.refname_to_id(&format!("refs/heads/case_{n_files}"))?;
+    let mut oid = repo
+        .rev_parse_single(format!("refs/heads/case_{n_files}").as_str())?
+        .detach();
     loop {
-        chain.push(gix_oid(oid));
-        match repo.find_commit(oid)?.parent_id(0) {
-            Ok(parent) => oid = parent,
-            Err(_) => break,
+        chain.push(oid);
+        let commit = josh_gix_ext::CommitData::read(&repo.objects, oid)?;
+        match commit.first_parent_id() {
+            Some(parent) => oid = parent,
+            None => break,
         }
     }
     chain.reverse();
@@ -322,14 +340,15 @@ impl TrigramBench {
             &gix_hash::ObjectId::from_str(EXPECTED_HEAD)
                 .expect("EXPECTED_HEAD must be a valid oid"),
             |repo| {
+                let repo = gix::open(repo.path())?;
                 let vocab = vocabulary();
                 let mut heads = vec![];
                 for &n_files in CASE_SIZES {
                     let head = tracing::info_span!(target: "bench", "build_case", n_files)
-                        .in_scope(|| build_case(repo, &vocab, n_files))?;
+                        .in_scope(|| build_case(&repo, &vocab, n_files))?;
                     heads.push(head);
                 }
-                build_index(repo, &heads)
+                build_index(&repo, &heads)
             },
         )?;
 
@@ -339,6 +358,7 @@ impl TrigramBench {
         sled.pin()?;
         let cache = std::sync::Arc::new(josh_core::cache::CacheStack::new().with_backend(sled));
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
+        let disk_repo = gix::open(provisioned.path())?;
 
         // Per case (untimed): pre-build the tip's index tree for the search group and run the
         // correctness gates, so we never silently bench an indexer or search that stopped
@@ -346,14 +366,13 @@ impl TrigramBench {
         // silent by default).
         let mut cases = vec![];
         for &n_files in CASE_SIZES {
-            let chain = recover_chain(&provisioned.repo, n_files)?;
+            let chain = recover_chain(&disk_repo, n_files)?;
             let tip = *chain.last().unwrap();
 
             josh_core::reset_caches()?;
             let transaction = context.open()?;
-            let repo = transaction.git2_repo();
-            let tip_tree = repo.find_commit(git2_oid(tip))?.tree()?;
-            let total_bytes = tree_content_bytes(repo, &tip_tree)?;
+            let tip_tree = josh_gix_ext::CommitData::read(transaction.odb(), tip)?.tree_id()?;
+            let total_bytes = tree_content_bytes(transaction.odb(), tip_tree)?;
             let odb = transaction.odb();
 
             // Cold-build the tip index, then flush: the timed groups reopen the repository and
@@ -362,7 +381,7 @@ impl TrigramBench {
                 odb,
                 &transaction.trigram_index_cache(tip),
                 &mut josh_search::Indexer::default(),
-                gix_oid(tip_tree.id()),
+                tip_tree,
             )?;
             transaction.flush_mem_odb()?;
 
@@ -371,8 +390,7 @@ impl TrigramBench {
             // degenerated and the search numbers would be meaningless. (The bound is kept at
             // the pre-rework value of 5; the exact index should always produce exactly 1.)
             let rare_path = path_for(n_files / 2).to_string_lossy().into_owned();
-            let (candidates, matches) =
-                search(odb, index_tree_oid, gix_oid(tip_tree.id()), NEEDLE_RARE)?;
+            let (candidates, matches) = search(odb, index_tree_oid, tip_tree, NEEDLE_RARE)?;
             anyhow::ensure!(
                 matches.len() == 1 && matches[0].0 == rare_path,
                 "rare needle not found in exactly its planted file {rare_path}: {matches:?}"
@@ -385,13 +403,13 @@ impl TrigramBench {
 
             // Gate: the common needle is found in every planted file, the absent one nowhere.
             let common_count = n_files.div_ceil(COMMON_EVERY);
-            let (_, matches) = search(odb, index_tree_oid, gix_oid(tip_tree.id()), NEEDLE_COMMON)?;
+            let (_, matches) = search(odb, index_tree_oid, tip_tree, NEEDLE_COMMON)?;
             anyhow::ensure!(
                 matches.len() == common_count,
                 "common needle found in {} files, expected {common_count}",
                 matches.len()
             );
-            let (_, matches) = search(odb, index_tree_oid, gix_oid(tip_tree.id()), NEEDLE_ABSENT)?;
+            let (_, matches) = search(odb, index_tree_oid, tip_tree, NEEDLE_ABSENT)?;
             anyhow::ensure!(
                 matches.is_empty(),
                 "absent needle found in {} files",
@@ -403,14 +421,13 @@ impl TrigramBench {
             // have changed the index. This is the property the planned rework must preserve.
             josh_core::reset_caches()?;
             let transaction = context.open()?;
-            let repo = transaction.git2_repo();
-            let root_tree = repo.find_commit(git2_oid(chain[0]))?.tree()?;
             let odb = transaction.odb();
+            let root_tree = josh_gix_ext::CommitData::read(odb, chain[0])?.tree_id()?;
             // One indexer state for the whole chain, matching how josh keeps one per
             // transaction. Collect the per-commit (source tree, index tree) pairs on the way:
             // the history search group iterates them.
             let mut indexer = josh_search::Indexer::default();
-            let root_tree_oid = gix_oid(root_tree.id());
+            let root_tree_oid = root_tree;
             let mut chain_indexes = vec![(
                 root_tree_oid,
                 josh_search::trigram_index(
@@ -421,7 +438,7 @@ impl TrigramBench {
                 )?,
             )];
             for &oid in &chain[1..] {
-                let tree_oid = gix_oid(repo.find_commit(git2_oid(oid))?.tree_id());
+                let tree_oid = josh_gix_ext::CommitData::read(odb, oid)?.tree_id()?;
                 let index_oid = josh_search::trigram_index(
                     odb,
                     &transaction.trigram_index_cache(oid),
@@ -478,13 +495,11 @@ fn trigram_benches(c: &mut Criterion) {
             b.iter_with_setup_wrapper(|runner| {
                 josh_core::reset_caches().expect("reset caches");
                 let transaction = bench.context.open().expect("open transaction");
-                let repo = transaction.git2_repo();
-                let tip_tree = gix_oid(
-                    repo.find_commit(git2_oid(case.tip()))
-                        .expect("find tip")
-                        .tree_id(),
-                );
                 let odb = transaction.odb();
+                let tip_tree = josh_gix_ext::CommitData::read(odb, case.tip())
+                    .expect("find tip")
+                    .tree_id()
+                    .expect("read tip tree");
 
                 let mut indexer = josh_search::Indexer::default();
 
@@ -515,13 +530,11 @@ fn trigram_benches(c: &mut Criterion) {
             b.iter_with_setup_wrapper(|runner| {
                 josh_core::reset_caches().expect("reset caches");
                 let transaction = bench.context.open().expect("open transaction");
-                let repo = transaction.git2_repo();
-                let root_tree = gix_oid(
-                    repo.find_commit(git2_oid(case.chain[0]))
-                        .expect("find root")
-                        .tree_id(),
-                );
                 let odb = transaction.odb();
+                let root_tree = josh_gix_ext::CommitData::read(odb, case.chain[0])
+                    .expect("find root")
+                    .tree_id()
+                    .expect("read root tree");
                 // One indexer state across the warm root and the whole chain, matching how
                 // josh keeps one per transaction.
                 let mut indexer = josh_search::Indexer::default();
@@ -535,11 +548,10 @@ fn trigram_benches(c: &mut Criterion) {
 
                 runner.run(|| {
                     for &oid in &case.chain[1..] {
-                        let tree = gix_oid(
-                            repo.find_commit(git2_oid(oid))
-                                .expect("find churn commit")
-                                .tree_id(),
-                        );
+                        let tree = josh_gix_ext::CommitData::read(odb, oid)
+                            .expect("find churn commit")
+                            .tree_id()
+                            .expect("read churn tree");
                         josh_search::trigram_index(
                             odb,
                             &transaction.trigram_index_cache(oid),
@@ -571,13 +583,11 @@ fn trigram_benches(c: &mut Criterion) {
                 b.iter_with_setup_wrapper(|runner| {
                     josh_core::reset_caches().expect("reset caches");
                     let transaction = bench.context.open().expect("open transaction");
-                    let repo = transaction.git2_repo();
-                    let source_tree = gix_oid(
-                        repo.find_commit(git2_oid(case.tip()))
-                            .expect("find tip")
-                            .tree_id(),
-                    );
                     let odb = transaction.odb();
+                    let source_tree = josh_gix_ext::CommitData::read(odb, case.tip())
+                        .expect("find tip")
+                        .tree_id()
+                        .expect("read tip tree");
 
                     runner.run(|| {
                         search(odb, case.index_tree_oid, source_tree, needle).expect("search")

--- a/josh-search/src/lib.rs
+++ b/josh-search/src/lib.rs
@@ -30,8 +30,8 @@
 //! intersects the mirror subtrees; the resulting candidate files are exact (files containing all
 //! query trigrams), leaving only string-level verification to [`search_matches`].
 //!
-//! This crate is independent of the josh filter machinery: it operates on plain [`git2`] objects
-//! and memoizes tree-to-index mappings through the [`IndexCache`] trait the caller provides.
+//! This crate is independent of the josh filter machinery: it operates on plain Git objects and
+//! memoizes tree-to-index mappings through the [`IndexCache`] trait the caller provides.
 
 use gix_object::WriteTo;
 use gix_object::bstr::BString;
@@ -867,12 +867,10 @@ fn path_entry(
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn gix(oid: git2::Oid) -> gix_hash::ObjectId {
-        gix_hash::ObjectId::from_bytes_or_panic(oid.as_bytes())
-    }
-
-    fn git2(oid: gix_hash::ObjectId) -> git2::Oid {
-        git2::Oid::from_bytes(oid.as_bytes()).expect("SHA-1 object id")
+    fn test_repo() -> (tempfile::TempDir, gix::Repository) {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(tmp.path()).unwrap();
+        (tmp, repo)
     }
 
     #[test]
@@ -915,28 +913,26 @@ mod tests {
         }
     }
 
-    fn test_repo() -> (tempfile::TempDir, git2::Repository) {
-        let tmp = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init_bare(tmp.path()).unwrap();
-        (tmp, repo)
+    fn objects(repo: &gix::Repository) -> &impl Objects {
+        &repo.objects
     }
 
-    /// Object access over a test repository's odb.
-    fn objects(repo: &git2::Repository) -> josh_gix_ext::Git2Odb<'_> {
-        josh_gix_ext::Git2Odb(Box::leak(Box::new(repo.odb().unwrap())))
-    }
-
-    fn commit_tree<'a>(repo: &'a git2::Repository, files: &[(&str, &str)]) -> git2::Tree<'a> {
-        let mut builder = git2::build::TreeUpdateBuilder::new();
+    fn commit_tree(repo: &gix::Repository, files: &[(&str, &str)]) -> gix_hash::ObjectId {
+        let empty = gix_object::Write::write(
+            &repo.objects,
+            &gix_object::Tree {
+                entries: Vec::new(),
+            },
+        )
+        .unwrap();
+        let mut builder = repo.edit_tree(empty).unwrap();
         for (path, content) in files {
-            let oid = repo.blob(content.as_bytes()).unwrap();
-            builder.upsert(std::path::Path::new(path), oid, git2::FileMode::Blob);
+            let oid = josh_gix_ext::write_blob(&repo.objects, content.as_bytes()).unwrap();
+            builder
+                .upsert(*path, gix::objs::tree::EntryKind::Blob, oid)
+                .unwrap();
         }
-        let baseline = repo
-            .find_tree(repo.treebuilder(None).unwrap().write().unwrap())
-            .unwrap();
-        let oid = builder.create_updated(repo, &baseline).unwrap();
-        repo.find_tree(oid).unwrap()
+        builder.write().unwrap().detach()
     }
 
     #[test]
@@ -953,13 +949,7 @@ mod tests {
             ],
         );
 
-        let index = trigram_index(
-            &objects(&repo),
-            &cache,
-            &mut Indexer::default(),
-            gix(tree.id()),
-        )
-        .unwrap();
+        let index = trigram_index(objects(&repo), &cache, &mut Indexer::default(), tree).unwrap();
 
         // The index format is pinned: cached indexes of older josh versions stay valid only as
         // long as this oid does not change.
@@ -970,50 +960,40 @@ mod tests {
 
         // "Tes" folds to "tes", which lives at 74/65/73 in the hex spine. sub1 is a small
         // directory, so the mirror records it as one coarse blob leaf.
-        let leaf = path_entry(
-            &objects(&repo),
-            index,
-            std::path::Path::new("74/65/73/sub1"),
-        )
-        .unwrap()
-        .unwrap();
+        let leaf = path_entry(objects(&repo), index, std::path::Path::new("74/65/73/sub1"))
+            .unwrap()
+            .unwrap();
         assert_eq!(
-            repo.find_object(git2(leaf), None).unwrap().kind(),
-            Some(git2::ObjectType::Blob)
+            gix_object::FindHeader::try_header(&repo.objects, &leaf)
+                .unwrap()
+                .unwrap()
+                .kind,
+            gix_object::Kind::Blob
         );
 
         // Coarse hits expand to every file under the directory; verification is exact.
-        let candidates =
-            search_candidates(&objects(&repo), index, gix(tree.id()), "document").unwrap();
+        let candidates = search_candidates(objects(&repo), index, tree, "document").unwrap();
         assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
-        let matches =
-            search_matches(&objects(&repo), gix(tree.id()), "document", &candidates).unwrap();
+        let matches = search_matches(objects(&repo), tree, "document", &candidates).unwrap();
         assert_eq!(matches.len(), 2);
 
         // Trigrams are case-folded, so candidates are a case-insensitive superset ("Test" in
         // file1 makes sub1 a candidate for "test") while match verification stays byte-exact.
-        let candidates = search_candidates(&objects(&repo), index, gix(tree.id()), "test").unwrap();
+        let candidates = search_candidates(objects(&repo), index, tree, "test").unwrap();
         assert_eq!(candidates, vec!["sub1/file1", "sub1/file2"]);
-        let matches = search_matches(&objects(&repo), gix(tree.id()), "test", &candidates).unwrap();
+        let matches = search_matches(objects(&repo), tree, "test", &candidates).unwrap();
         assert!(matches.is_empty());
 
-        let candidates =
-            search_candidates(&objects(&repo), index, gix(tree.id()), "missingword").unwrap();
+        let candidates = search_candidates(objects(&repo), index, tree, "missingword").unwrap();
         assert!(candidates.is_empty());
 
         // Short query: every file is a candidate.
-        let candidates = search_candidates(&objects(&repo), index, gix(tree.id()), "e").unwrap();
+        let candidates = search_candidates(objects(&repo), index, tree, "e").unwrap();
         assert_eq!(candidates.len(), 3);
 
         // Indexing is deterministic and memoization-independent.
         let cold = MapCache::default();
-        let index2 = trigram_index(
-            &objects(&repo),
-            &cold,
-            &mut Indexer::default(),
-            gix(tree.id()),
-        )
-        .unwrap();
+        let index2 = trigram_index(objects(&repo), &cold, &mut Indexer::default(), tree).unwrap();
         assert_eq!(index, index2);
     }
 
@@ -1037,69 +1017,55 @@ mod tests {
         let files: Vec<(&str, &str)> = files.iter().map(|(p, c)| (&p[..], &c[..])).collect();
         let tree = commit_tree(&repo, &files);
 
-        let index = trigram_index(
-            &objects(&repo),
-            &cache,
-            &mut Indexer::default(),
-            gix(tree.id()),
-        )
-        .unwrap();
+        let index = trigram_index(objects(&repo), &cache, &mut Indexer::default(), tree).unwrap();
 
         // Fine: "d07" (from uniqueword07) mirrors big's structure down to the file.
         let leaf = path_entry(
-            &objects(&repo),
+            objects(&repo),
             index,
             std::path::Path::new("64/30/37/big/file_07"),
         )
         .unwrap()
         .unwrap();
         assert_eq!(
-            repo.find_object(git2(leaf), None).unwrap().kind(),
-            Some(git2::ObjectType::Blob)
+            gix_object::FindHeader::try_header(&repo.objects, &leaf)
+                .unwrap()
+                .unwrap()
+                .kind,
+            gix_object::Kind::Blob
         );
 
         // Coarse: "nee" (from needleinsmall) records small as a blob leaf, not a subtree.
         let leaf = path_entry(
-            &objects(&repo),
+            objects(&repo),
             index,
             std::path::Path::new("6e/65/65/small"),
         )
         .unwrap()
         .unwrap();
         assert_eq!(
-            repo.find_object(git2(leaf), None).unwrap().kind(),
-            Some(git2::ObjectType::Blob)
+            gix_object::FindHeader::try_header(&repo.objects, &leaf)
+                .unwrap()
+                .unwrap()
+                .kind,
+            gix_object::Kind::Blob
         );
 
         // Fine candidates stay per-file and exact.
-        let candidates =
-            search_candidates(&objects(&repo), index, gix(tree.id()), "uniqueword07").unwrap();
+        let candidates = search_candidates(objects(&repo), index, tree, "uniqueword07").unwrap();
         assert_eq!(candidates, vec!["big/file_07"]);
 
         // A coarse hit makes every file under the directory a candidate; verification is
         // exact.
-        let candidates =
-            search_candidates(&objects(&repo), index, gix(tree.id()), "needleinsmall").unwrap();
+        let candidates = search_candidates(objects(&repo), index, tree, "needleinsmall").unwrap();
         assert_eq!(candidates, vec!["small/a", "small/b"]);
-        let matches = search_matches(
-            &objects(&repo),
-            gix(tree.id()),
-            "needleinsmall",
-            &candidates,
-        )
-        .unwrap();
+        let matches = search_matches(objects(&repo), tree, "needleinsmall", &candidates).unwrap();
         assert_eq!(matches.len(), 1);
         assert_eq!(matches[0].0, "small/a");
 
         // Determinism across memoization states, coarse dirs included.
         let cold = MapCache::default();
-        let index2 = trigram_index(
-            &objects(&repo),
-            &cold,
-            &mut Indexer::default(),
-            gix(tree.id()),
-        )
-        .unwrap();
+        let index2 = trigram_index(objects(&repo), &cold, &mut Indexer::default(), tree).unwrap();
         assert_eq!(index, index2);
     }
 
@@ -1120,7 +1086,7 @@ mod tests {
                 ("sub2/mod", "alpha beta gamma"),
             ],
         );
-        trigram_index(&objects(&repo), &cache, &mut indexer, gix(tree_a.id())).unwrap();
+        trigram_index(objects(&repo), &cache, &mut indexer, tree_a).unwrap();
 
         // One file modified, one removed (its unique trigrams must vanish from the spine), one
         // added in a fresh directory.
@@ -1132,32 +1098,25 @@ mod tests {
                 ("sub3/new", "fresh addition here"),
             ],
         );
-        let index_b =
-            trigram_index(&objects(&repo), &cache, &mut indexer, gix(tree_b.id())).unwrap();
+        let index_b = trigram_index(objects(&repo), &cache, &mut indexer, tree_b).unwrap();
 
         // The roots are memoized in the persistent cache. (The sub dirs are below the coarse
         // threshold and live in the Indexer's coarse memo instead — only fine-grained indexes
         // go through the IndexCache.)
-        assert!(cache.get_index(gix(tree_b.id())).is_some());
+        assert!(cache.get_index(tree_b).is_some());
 
         // Warm (incremental) and cold-built indexes agree bit for bit.
         let cold = MapCache::default();
-        let index_b_cold = trigram_index(
-            &objects(&repo),
-            &cold,
-            &mut Indexer::default(),
-            gix(tree_b.id()),
-        )
-        .unwrap();
+        let index_b_cold =
+            trigram_index(objects(&repo), &cold, &mut Indexer::default(), tree_b).unwrap();
         assert_eq!(index_b, index_b_cold);
 
         // The incremental index searches correctly.
-        let hits = search_candidates(&objects(&repo), index_b, gix(tree_b.id()), "delta").unwrap();
+        let hits = search_candidates(objects(&repo), index_b, tree_b, "delta").unwrap();
         assert_eq!(hits, vec!["sub2/mod"]);
-        let hits = search_candidates(&objects(&repo), index_b, gix(tree_b.id()), "zebra").unwrap();
+        let hits = search_candidates(objects(&repo), index_b, tree_b, "zebra").unwrap();
         assert!(hits.is_empty());
-        let hits =
-            search_candidates(&objects(&repo), index_b, gix(tree_b.id()), "addition").unwrap();
+        let hits = search_candidates(objects(&repo), index_b, tree_b, "addition").unwrap();
         assert_eq!(hits, vec!["sub3/new"]);
     }
 }


### PR DESCRIPTION
Remove josh-search's libgit2 test dependency

Build search test trees and trigram benchmark histories through gitoxide object, tree, commit, and reference APIs. The benchmark's pinned aggregate head remains unchanged, while its timed commit reads now use the transaction object facade.

Change: gix-search-test-dependency

Assisted-By: openai-codex/gpt-5.6-sol