### PR TITLE
Remove josh-gix-ext's libgit2 test dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,6 +3625,7 @@ version = "26.7.28"
 dependencies = [
  "anyhow",
  "git2",
+ "gix",
  "gix-actor",
  "gix-command",
  "gix-diff",

--- a/josh-gix-ext/Cargo.toml
+++ b/josh-gix-ext/Cargo.toml
@@ -28,6 +28,5 @@ gix-object.workspace = true
 gix-revision.workspace = true
 
 [dev-dependencies]
-git2.workspace = true
-
+gix.workspace = true
 tempfile.workspace = true

--- a/josh-gix-ext/src/graph.rs
+++ b/josh-gix-ext/src/graph.rs
@@ -85,34 +85,45 @@ mod tests {
 
     struct TestRepo {
         _dir: tempfile::TempDir,
-        repo: git2::Repository,
+        repo: gix::Repository,
+        tree: gix_hash::ObjectId,
     }
 
     impl TestRepo {
         fn new() -> Self {
             let dir = tempfile::tempdir().unwrap();
-            let repo = git2::Repository::init_bare(dir.path()).unwrap();
-            TestRepo { _dir: dir, repo }
+            let repo = gix::init_bare(dir.path()).unwrap();
+            let tree = gix_object::Write::write(
+                &repo.objects,
+                &gix_object::Tree {
+                    entries: Vec::new(),
+                },
+            )
+            .unwrap();
+            TestRepo {
+                _dir: dir,
+                repo,
+                tree,
+            }
         }
 
         /// Commits are dated by their index so the merge-base walk sees a plausible history;
         /// equal timestamps would still be correct, just slower to settle.
         fn commit(&self, seconds: i64, parents: &[gix_hash::ObjectId]) -> gix_hash::ObjectId {
-            let sig =
-                git2::Signature::new("Test", "test@example.com", &git2::Time::new(seconds, 0))
-                    .unwrap();
-            let tree_id = self.repo.treebuilder(None).unwrap().write().unwrap();
-            let tree = self.repo.find_tree(tree_id).unwrap();
-            let parents: Vec<_> = parents
-                .iter()
-                .map(|p| self.repo.find_commit(crate::git2_oid(p)).unwrap())
-                .collect();
-            let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
-            crate::gix_oid(
-                self.repo
-                    .commit(None, &sig, &sig, "c", &tree, &parent_refs)
-                    .unwrap(),
+            let signature = gix_actor::Signature {
+                name: "Test".into(),
+                email: "test@example.com".into(),
+                time: gix_actor::date::Time { seconds, offset: 0 },
+            };
+            crate::write_commit(
+                &self.repo.objects,
+                self.tree,
+                parents,
+                &signature,
+                &signature,
+                "c",
             )
+            .unwrap()
         }
     }
 
@@ -122,13 +133,11 @@ mod tests {
         let root = t.commit(1000, &[]);
         let mid = t.commit(1001, &[root]);
         let tip = t.commit(1002, &[mid]);
-        let odb = t.repo.odb().unwrap();
-        let objects = crate::Git2Odb(&odb);
 
-        assert!(is_descendant_of(&objects, tip, root).unwrap());
-        assert!(is_descendant_of(&objects, tip, mid).unwrap());
-        assert!(!is_descendant_of(&objects, root, tip).unwrap());
-        assert!(!is_descendant_of(&objects, tip, tip).unwrap());
+        assert!(is_descendant_of(&t.repo.objects, tip, root).unwrap());
+        assert!(is_descendant_of(&t.repo.objects, tip, mid).unwrap());
+        assert!(!is_descendant_of(&t.repo.objects, root, tip).unwrap());
+        assert!(!is_descendant_of(&t.repo.objects, tip, tip).unwrap());
     }
 
     #[test]
@@ -137,29 +146,25 @@ mod tests {
         let root = t.commit(1000, &[]);
         let a = t.commit(1001, &[root]);
         let b = t.commit(1002, &[root]);
-        let odb = t.repo.odb().unwrap();
-        let objects = crate::Git2Odb(&odb);
 
-        assert_eq!(merge_base(&objects, a, b).unwrap(), root);
-        assert_eq!(merge_base(&objects, a, root).unwrap(), root);
-        assert_eq!(merge_base(&objects, a, a).unwrap(), a);
+        assert_eq!(merge_base(&t.repo.objects, a, b).unwrap(), root);
+        assert_eq!(merge_base(&t.repo.objects, a, root).unwrap(), root);
+        assert_eq!(merge_base(&t.repo.objects, a, a).unwrap(), a);
 
         let unrelated = t.commit(1003, &[]);
-        assert!(merge_base(&objects, a, unrelated).is_err());
+        assert!(merge_base(&t.repo.objects, a, unrelated).is_err());
     }
 
     #[test]
     fn a_missing_commit_is_an_error() {
         let t = TestRepo::new();
         let root = t.commit(1000, &[]);
-        let odb = t.repo.odb().unwrap();
-        let objects = crate::Git2Odb(&odb);
         let missing =
             gix_hash::ObjectId::from_str("1234567890123456789012345678901234567890").unwrap();
 
-        assert!(is_descendant_of(&objects, missing, root).is_err());
-        assert!(merge_base_octopus(&objects, &[root, missing]).is_err());
+        assert!(is_descendant_of(&t.repo.objects, missing, root).is_err());
+        assert!(merge_base_octopus(&t.repo.objects, &[root, missing]).is_err());
 
-        assert!(merge_base_octopus(&objects, &[]).is_err());
+        assert!(merge_base_octopus(&t.repo.objects, &[]).is_err());
     }
 }

--- a/josh-gix-ext/src/lib.rs
+++ b/josh-gix-ext/src/lib.rs
@@ -12,7 +12,7 @@ pub use graph::{is_descendant_of, merge_base, merge_base_octopus};
 pub use merge::{merge_commits, merge_trees};
 pub use revwalk::{RangeWalk, RevWalk};
 
-#[cfg(any(test, feature = "git2"))]
+#[cfg(feature = "git2")]
 /// Convert a gitoxide object kind to libgit2.
 pub fn git2_kind(kind: gix_object::Kind) -> git2::ObjectType {
     match kind {
@@ -23,7 +23,7 @@ pub fn git2_kind(kind: gix_object::Kind) -> git2::ObjectType {
     }
 }
 
-#[cfg(any(test, feature = "git2"))]
+#[cfg(feature = "git2")]
 /// Convert a libgit2 object kind when it represents an object.
 pub fn gix_kind(kind: git2::ObjectType) -> Option<gix_object::Kind> {
     match kind {
@@ -35,13 +35,13 @@ pub fn gix_kind(kind: git2::ObjectType) -> Option<gix_object::Kind> {
     }
 }
 
-#[cfg(any(test, feature = "git2"))]
+#[cfg(feature = "git2")]
 /// Convert a SHA-1 object ID to gitoxide.
 pub fn gix_oid(oid: git2::Oid) -> gix_hash::ObjectId {
     gix_hash::ObjectId::from_bytes_or_panic(oid.as_bytes())
 }
 
-#[cfg(any(test, feature = "git2"))]
+#[cfg(feature = "git2")]
 /// Convert a SHA-1 object ID to libgit2.
 pub fn git2_oid(oid: &gix_hash::oid) -> git2::Oid {
     git2::Oid::from_bytes(oid.as_bytes()).expect("oid sizes match")
@@ -547,12 +547,12 @@ impl gix_object::Exists for StagingOdb {
     }
 }
 
-#[cfg(any(test, feature = "git2"))]
+#[cfg(feature = "git2")]
 /// [`gix_object`] object access over a bare `git2::Odb` for compatibility tests. Reads and
 /// existence checks resolve through the odb's configured backends; writes use `git_odb_write`.
 pub struct Git2Odb<'a>(pub &'a git2::Odb<'a>);
 
-#[cfg(any(test, feature = "git2"))]
+#[cfg(feature = "git2")]
 impl gix_object::Find for Git2Odb<'_> {
     fn try_find<'b>(
         &self,
@@ -577,7 +577,7 @@ impl gix_object::Find for Git2Odb<'_> {
     }
 }
 
-#[cfg(any(test, feature = "git2"))]
+#[cfg(feature = "git2")]
 impl gix_object::FindHeader for Git2Odb<'_> {
     fn try_header(
         &self,
@@ -598,14 +598,14 @@ impl gix_object::FindHeader for Git2Odb<'_> {
     }
 }
 
-#[cfg(any(test, feature = "git2"))]
+#[cfg(feature = "git2")]
 impl gix_object::Exists for Git2Odb<'_> {
     fn exists(&self, id: &gix_hash::oid) -> bool {
         self.0.exists(git2_oid(id))
     }
 }
 
-#[cfg(any(test, feature = "git2"))]
+#[cfg(feature = "git2")]
 impl gix_object::Write for Git2Odb<'_> {
     fn write_buf(
         &self,
@@ -651,150 +651,176 @@ impl gix_object::Write for Git2Odb<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
+
+    fn test_repo() -> (tempfile::TempDir, gix::Repository) {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(dir.path()).unwrap();
+        (dir, repo)
+    }
+
+    fn write_raw(
+        repo: &gix::Repository,
+        kind: gix_object::Kind,
+        data: &[u8],
+    ) -> gix_hash::ObjectId {
+        gix_object::Write::write_buf(&repo.objects, kind, data).unwrap()
+    }
+
+    fn write_raw_tree(
+        repo: &gix::Repository,
+        entries: &[(&str, &[u8], gix_hash::ObjectId)],
+    ) -> gix_hash::ObjectId {
+        let mut data = Vec::new();
+        for (mode, name, oid) in entries {
+            data.extend_from_slice(mode.as_bytes());
+            data.push(b' ');
+            data.extend_from_slice(name);
+            data.push(0);
+            data.extend_from_slice(oid.as_bytes());
+        }
+        write_raw(repo, gix_object::Kind::Tree, &data)
+    }
 
     /// Write raw commit bytes, including non-UTF-8 messages.
-    fn commit_with_message(repo: &git2::Repository, message: &[u8]) -> gix_hash::ObjectId {
-        let tree = repo.treebuilder(None).unwrap().write().unwrap();
+    fn commit_with_message(repo: &gix::Repository, message: &[u8]) -> gix_hash::ObjectId {
+        let tree = write_raw_tree(repo, &[]);
         let mut data = Vec::new();
         data.extend_from_slice(format!("tree {}\n", tree).as_bytes());
         data.extend_from_slice(b"author t <t@e> 0 +0000\n");
         data.extend_from_slice(b"committer t <t@e> 0 +0000\n\n");
         data.extend_from_slice(message);
-        gix_oid(
-            repo.odb()
-                .unwrap()
-                .write(git2::ObjectType::Commit, &data)
-                .unwrap(),
-        )
+        write_raw(repo, gix_object::Kind::Commit, &data)
     }
 
-    /// Commits written here must be byte-identical to the ones libgit2 writes for the same
-    /// inputs -- every ref josh publishes is content-addressed, so a formatting difference
-    /// would renumber history.
+    /// Commit bytes must remain identical to libgit2's. These object IDs were captured from
+    /// libgit2 before its test dependency was removed; every ref josh publishes is
+    /// content-addressed, so a formatting difference would renumber history.
     #[test]
-    fn write_commit_matches_git2() {
-        let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init_bare(dir.path()).unwrap();
-        let odb = repo.odb().unwrap();
+    fn write_commit_preserves_libgit2_bytes() {
+        let (_dir, repo) = test_repo();
+        let empty_tree = write_raw_tree(&repo, &[]);
+        let blob = write_blob(&repo.objects, b"x").unwrap();
+        let tree_with_blob = write_raw_tree(&repo, &[("100644", b"f", blob)]);
 
-        let tree = gix_oid(repo.treebuilder(None).unwrap().write().unwrap());
-        let blob = repo.blob(b"x").unwrap();
-        let mut b = repo.treebuilder(None).unwrap();
-        b.insert("f", blob, 0o100644).unwrap();
-        let tree2 = gix_oid(b.write().unwrap());
+        assert_eq!(
+            empty_tree,
+            gix_hash::ObjectId::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap()
+        );
+        assert_eq!(
+            tree_with_blob,
+            gix_hash::ObjectId::from_str("2561a62d4223eb7660d3b6b02b707048382f4019").unwrap()
+        );
 
-        let sig = |name: &str, email: &str, secs: i64, offset: i32| {
-            git2::Signature::new(name, email, &git2::Time::new(secs, offset)).unwrap()
-        };
-        let actor = |sig: &git2::Signature<'_>| {
-            let when = sig.when();
-            gix_actor::Signature {
-                name: sig.name_bytes().into(),
-                email: sig.email_bytes().into(),
+        let signature =
+            |name: &str, email: &str, seconds: i64, offset_minutes: i32| gix_actor::Signature {
+                name: name.into(),
+                email: email.into(),
                 time: gix_actor::date::Time {
-                    seconds: when.seconds(),
-                    offset: i32::from(when.offset_minutes()) * 60,
+                    seconds,
+                    offset: offset_minutes * 60,
                 },
-            }
-        };
+            };
 
-        let cases: Vec<(git2::Signature, git2::Signature, &str, gix_hash::ObjectId)> = vec![
+        let cases = [
             (
-                sig("A", "a@e", 0, 0),
-                sig("A", "a@e", 0, 0),
+                signature("A", "a@e", 0, 0),
+                signature("A", "a@e", 0, 0),
                 "subject\n",
-                tree,
+                empty_tree,
+                [
+                    "57576bb048f350bfefc5462a145126ed569a0acb",
+                    "e605f51a16159b651aa82171f5a5efbfdd96692a",
+                    "b4067ee9a49f8e65bffe7fe097d2d1546348a0c2",
+                ],
             ),
             (
-                sig("A", "a@e", 1234567890, 120),
-                sig("B", "b@e", 1234567899, -330),
+                signature("A", "a@e", 1234567890, 120),
+                signature("B", "b@e", 1234567899, -330),
                 "subject\n\nbody with trailing newline\n",
-                tree2,
+                tree_with_blob,
+                [
+                    "3511106bdc497584ea13c5c21b7d620274bee8f9",
+                    "a56d8d48bbe9d48c87ae7028246090b76fa5581d",
+                    "0cdefeea57471caebdb468cfde5e1c054a4da1ec",
+                ],
             ),
             (
-                sig("Ünïcode Nàme", "u@e", 42, -60),
-                sig("Ünïcode Nàme", "u@e", 42, -60),
+                signature("Ünïcode Nàme", "u@e", 42, -60),
+                signature("Ünïcode Nàme", "u@e", 42, -60),
                 "no trailing newline",
-                tree2,
+                tree_with_blob,
+                [
+                    "a7af75bbbbf53f1cea9a1eab5eda7930ebdb9e57",
+                    "c54129e4d0368d79d15caf5d9424436b8d57a716",
+                    "20e7afd96224d8e1db8bb77d646255296bb2eaf3",
+                ],
             ),
-            (sig("A", "a@e", 99, 0), sig("A", "a@e", 99, 0), "", tree),
+            (
+                signature("A", "a@e", 99, 0),
+                signature("A", "a@e", 99, 0),
+                "",
+                empty_tree,
+                [
+                    "c3c5ea7d435de37f631f94befb80cd50eeb36954",
+                    "c5052ca1e27fe67bd35350052018049182bd5cb8",
+                    "c1a08f5fa90b18367f75988bf6c94bf065b0867a",
+                ],
+            ),
         ];
 
-        for (author, committer, message, tree) in &cases {
-            for parents in [vec![], vec![0usize], vec![0, 1]] {
-                // Build the parent commits with git2 so both writers see identical inputs.
-                let parent_ids: Vec<gix_hash::ObjectId> = parents
-                    .iter()
+        for (author, committer, message, tree, expected) in cases {
+            for parent_count in 0..=2 {
+                let parent_ids = (0..parent_count)
                     .map(|i| {
-                        let t = repo.find_tree(git2_oid(tree)).unwrap();
-                        gix_oid(
-                            repo.commit(None, author, committer, &format!("parent {i}"), &t, &[])
-                                .unwrap(),
+                        write_commit(
+                            &repo.objects,
+                            tree,
+                            &[],
+                            &author,
+                            &committer,
+                            &format!("parent {i}"),
                         )
+                        .unwrap()
                     })
-                    .collect();
-                let parent_commits: Vec<git2::Commit> = parent_ids
-                    .iter()
-                    .map(|id| repo.find_commit(git2_oid(id)).unwrap())
-                    .collect();
-                let parent_refs: Vec<&git2::Commit> = parent_commits.iter().collect();
-
-                let want = gix_oid(
-                    repo.commit(
-                        None,
-                        author,
-                        committer,
-                        message,
-                        &repo.find_tree(git2_oid(tree)).unwrap(),
-                        &parent_refs,
-                    )
-                    .unwrap(),
-                );
-                let author_actor = actor(author);
-                let committer_actor = actor(committer);
+                    .collect::<Vec<_>>();
                 let got = write_commit(
-                    &Git2Odb(&odb),
-                    *tree,
+                    &repo.objects,
+                    tree,
                     &parent_ids,
-                    &author_actor,
-                    &committer_actor,
+                    &author,
+                    &committer,
                     message,
                 )
                 .unwrap();
+                let want = gix_hash::ObjectId::from_str(expected[parent_count]).unwrap();
                 assert_eq!(
-                    want,
-                    got,
-                    "commit id diverged for {:?} with {} parents",
-                    message,
-                    parent_ids.len()
+                    want, got,
+                    "commit id diverged for {message:?} with {parent_count} parents"
                 );
 
-                // The signature-copying variant reproduces the same commit when the
-                // signatures it copies are the ones git2 was given.
-                let base = CommitData::read(&Git2Odb(&odb), want).unwrap();
+                let base = CommitData::read(&repo.objects, got).unwrap();
                 let copied = write_commit_with_signatures_of(
-                    &Git2Odb(&odb),
+                    &repo.objects,
                     &base,
-                    *tree,
+                    tree,
                     &parent_ids,
                     message,
                 )
                 .unwrap();
-                assert_eq!(want, copied, "signature-copying writer diverged");
+                assert_eq!(got, copied, "signature-copying writer diverged");
             }
         }
     }
 
     #[test]
     fn message_trims_leading_newlines() {
-        let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init_bare(dir.path()).unwrap();
-        let odb = repo.odb().unwrap();
+        let (_dir, repo) = test_repo();
 
         // Load-bearing for the tree-level `:unapply`, which parses an oid out of the
         // message.
         let oid = commit_with_message(&repo, b"\n\n0123456789012345678901234567890123456789");
-        let data = CommitData::read(&Git2Odb(&odb), oid).unwrap();
+        let data = CommitData::read(&repo.objects, oid).unwrap();
         assert_eq!(
             data.message().unwrap(),
             "0123456789012345678901234567890123456789"
@@ -810,40 +836,27 @@ mod tests {
     /// directory's slash-separated path.
     #[test]
     fn walk_tree_preorder_yields_stored_order_paths() {
-        let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init_bare(dir.path()).unwrap();
-        let odb = repo.odb().unwrap();
-        let blob = gix_oid(repo.blob(b"x").unwrap());
+        let (_dir, repo) = test_repo();
+        let blob = write_blob(&repo.objects, b"x").unwrap();
 
-        let write_tree = |entries: &[(&str, &str, gix_hash::ObjectId)]| -> gix_hash::ObjectId {
-            let mut data = Vec::new();
-            for (mode, name, oid) in entries {
-                data.extend_from_slice(mode.as_bytes());
-                data.push(b' ');
-                data.extend_from_slice(name.as_bytes());
-                data.push(0);
-                data.extend_from_slice(oid.as_bytes());
-            }
-            gix_oid(
-                repo.odb()
-                    .unwrap()
-                    .write(git2::ObjectType::Tree, &data)
-                    .unwrap(),
-            )
-        };
-
-        let deep = write_tree(&[("100644", "leaf.txt", blob)]);
-        let sub = write_tree(&[("40000", "deep", deep), ("100644", "f.txt", blob)]);
+        let deep = write_raw_tree(&repo, &[("100644", b"leaf.txt", blob)]);
+        let sub = write_raw_tree(
+            &repo,
+            &[("40000", b"deep", deep), ("100644", b"f.txt", blob)],
+        );
         // Stored order is deliberately non-canonical ("z.txt" before "a", and the tree "a"
         // before the blob "a.txt" that canonical order would sort first).
-        let root = write_tree(&[
-            ("100644", "z.txt", blob),
-            ("40000", "a", sub),
-            ("100644", "a.txt", blob),
-        ]);
+        let root = write_raw_tree(
+            &repo,
+            &[
+                ("100644", b"z.txt", blob),
+                ("40000", b"a", sub),
+                ("100644", b"a.txt", blob),
+            ],
+        );
 
         let mut seen = vec![];
-        walk_tree_preorder(&Git2Odb(&odb), root, &mut |parent, entry| {
+        walk_tree_preorder(&repo.objects, root, &mut |parent, entry| {
             seen.push(format!(
                 "{}|{}",
                 parent,
@@ -870,26 +883,11 @@ mod tests {
     /// descending into it errors the whole walk.
     #[test]
     fn walk_tree_preorder_errors_on_non_utf8_directory() {
-        let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init_bare(dir.path()).unwrap();
-        let odb = repo.odb().unwrap();
-        let blob = gix_oid(repo.blob(b"x").unwrap());
+        let (_dir, repo) = test_repo();
+        let blob = write_blob(&repo.objects, b"x").unwrap();
+        let inner = write_raw_tree(&repo, &[("100644", b"f.txt", blob)]);
+        let root = write_raw_tree(&repo, &[("40000", b"bad\xff", inner)]);
 
-        let mut inner = repo.treebuilder(None).unwrap();
-        inner.insert("f.txt", git2_oid(&blob), 0o100644).unwrap();
-        let inner = inner.write().unwrap();
-
-        let mut data = Vec::new();
-        data.extend_from_slice(b"40000 bad\xff");
-        data.push(0);
-        data.extend_from_slice(inner.as_bytes());
-        let root = gix_oid(
-            repo.odb()
-                .unwrap()
-                .write(git2::ObjectType::Tree, &data)
-                .unwrap(),
-        );
-
-        assert!(walk_tree_preorder(&Git2Odb(&odb), root, &mut |_, _| Ok(())).is_err());
+        assert!(walk_tree_preorder(&repo.objects, root, &mut |_, _| Ok(())).is_err());
     }
 }

--- a/josh-gix-ext/src/merge.rs
+++ b/josh-gix-ext/src/merge.rs
@@ -187,23 +187,27 @@ mod tests {
 
     struct TestRepo {
         _dir: tempfile::TempDir,
-        repo: git2::Repository,
+        repo: gix::Repository,
     }
 
     impl TestRepo {
         fn new() -> Self {
             let dir = tempfile::tempdir().unwrap();
-            let repo = git2::Repository::init_bare(dir.path()).unwrap();
+            let repo = gix::init_bare(dir.path()).unwrap();
             TestRepo { _dir: dir, repo }
         }
 
         fn tree(&self, files: &[(&str, &str)]) -> gix_hash::ObjectId {
-            let mut builder = self.repo.treebuilder(None).unwrap();
-            for (name, content) in files {
-                let blob = self.repo.blob(content.as_bytes()).unwrap();
-                builder.insert(name, blob, 0o100644).unwrap();
-            }
-            crate::gix_oid(builder.write().unwrap())
+            let mut entries = files
+                .iter()
+                .map(|(name, content)| gix_object::tree::Entry {
+                    mode: gix_object::tree::EntryKind::Blob.into(),
+                    filename: (*name).into(),
+                    oid: crate::write_blob(&self.repo.objects, content.as_bytes()).unwrap(),
+                })
+                .collect::<Vec<_>>();
+            entries.sort();
+            crate::write_tree_now(&self.repo.objects, entries).unwrap()
         }
 
         fn commit(
@@ -211,30 +215,30 @@ mod tests {
             tree: gix_hash::ObjectId,
             parents: &[gix_hash::ObjectId],
         ) -> gix_hash::ObjectId {
-            let sig = git2::Signature::new("Test", "test@example.com", &git2::Time::new(1000, 0))
-                .unwrap();
-            let tree = self.repo.find_tree(crate::git2_oid(&tree)).unwrap();
-            let parents: Vec<_> = parents
-                .iter()
-                .map(|p| self.repo.find_commit(crate::git2_oid(p)).unwrap())
-                .collect();
-            let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
-            crate::gix_oid(
-                self.repo
-                    .commit(None, &sig, &sig, "c", &tree, &parent_refs)
-                    .unwrap(),
+            let signature = gix_actor::Signature {
+                name: "Test".into(),
+                email: "test@example.com".into(),
+                time: gix_actor::date::Time {
+                    seconds: 1000,
+                    offset: 0,
+                },
+            };
+            crate::write_commit(
+                &self.repo.objects,
+                tree,
+                parents,
+                &signature,
+                &signature,
+                "c",
             )
+            .unwrap()
         }
 
         fn file(&self, tree: gix_hash::ObjectId, name: &str) -> String {
-            let entry = self
-                .repo
-                .find_tree(crate::git2_oid(&tree))
+            let entry = crate::path_entry(&self.repo.objects, tree, std::path::Path::new(name))
                 .unwrap()
-                .get_name(name)
-                .unwrap_or_else(|| panic!("{name} not in tree"))
-                .id();
-            String::from_utf8(self.repo.find_blob(entry).unwrap().content().to_vec()).unwrap()
+                .unwrap_or_else(|| panic!("{name} not in tree"));
+            crate::blob_text(&self.repo.objects, entry.oid)
         }
     }
 
@@ -244,10 +248,8 @@ mod tests {
         let base = t.tree(&[("a", "1\n")]);
         let ours = t.tree(&[("a", "ours\n")]);
         let theirs = t.tree(&[("a", "theirs\n")]);
-        let odb = t.repo.odb().unwrap();
-        let objects = crate::Git2Odb(&odb);
 
-        let err = merge_trees(&objects, base, ours, theirs)
+        let err = merge_trees(&t.repo.objects, base, ours, theirs)
             .unwrap_err()
             .to_string();
         assert!(err.contains("conflicts in a"), "{err}");
@@ -259,13 +261,11 @@ mod tests {
         let base = t.commit(t.tree(&[("a", "1\n")]), &[]);
         let ours = t.commit(t.tree(&[("a", "ours\n")]), &[base]);
         let theirs = t.commit(t.tree(&[("a", "theirs\n")]), &[base]);
-        let odb = t.repo.odb().unwrap();
-        let objects = crate::Git2Odb(&odb);
 
-        let merged = merge_commits(&objects, ours, theirs, Some(Favor::Ours)).unwrap();
+        let merged = merge_commits(&t.repo.objects, ours, theirs, Some(Favor::Ours)).unwrap();
         assert_eq!(t.file(merged, "a"), "ours\n");
 
-        let merged = merge_commits(&objects, ours, theirs, Some(Favor::Theirs)).unwrap();
+        let merged = merge_commits(&t.repo.objects, ours, theirs, Some(Favor::Theirs)).unwrap();
         assert_eq!(t.file(merged, "a"), "theirs\n");
     }
 
@@ -275,10 +275,8 @@ mod tests {
         let base = t.commit(t.tree(&[("a", "1\n"), ("b", "1\n")]), &[]);
         let ours = t.commit(t.tree(&[("b", "1\n")]), &[base]);
         let theirs = t.commit(t.tree(&[("a", "modified\n"), ("b", "1\n")]), &[base]);
-        let odb = t.repo.odb().unwrap();
-        let objects = crate::Git2Odb(&odb);
 
-        let err = merge_commits(&objects, ours, theirs, Some(Favor::Ours))
+        let err = merge_commits(&t.repo.objects, ours, theirs, Some(Favor::Ours))
             .unwrap_err()
             .to_string();
         assert!(err.contains("conflicts in a"), "{err}");

--- a/josh-gix-ext/src/revwalk.rs
+++ b/josh-gix-ext/src/revwalk.rs
@@ -18,10 +18,8 @@
 //! are NOT peeled: any non-commit input is an error (josh only ever walks
 //! commit oids; the git2 walks this module replaces peeled).
 //!
-//! Differential tests below pin the yield sets against an independent
-//! reference model (and against `git2::Revwalk` for [`RevWalk`], where the
-//! sets provably coincide), and pin topological validity and order
-//! determinism, over fixed shapes and seeded random DAGs.
+//! Differential tests pin the yield sets against an independent reference model, and pin
+//! topological validity and order determinism, over fixed shapes and seeded random DAGs.
 
 use std::collections::HashMap;
 use std::ops::ControlFlow;
@@ -469,38 +467,52 @@ mod tests {
 
     struct TestRepo {
         _dir: tempfile::TempDir,
-        repo: git2::Repository,
+        repo: gix::Repository,
+        tree: gix_hash::ObjectId,
     }
 
     impl TestRepo {
         fn new() -> Self {
             let dir = tempfile::tempdir().unwrap();
-            let repo = git2::Repository::init_bare(dir.path()).unwrap();
-            TestRepo { _dir: dir, repo }
+            let repo = gix::init_bare(dir.path()).unwrap();
+            let tree = gix_object::Write::write(
+                &repo.objects,
+                &gix_object::Tree {
+                    entries: Vec::new(),
+                },
+            )
+            .unwrap();
+            TestRepo {
+                _dir: dir,
+                repo,
+                tree,
+            }
         }
 
         fn commit(&self, msg: &str, parents: &[gix_hash::ObjectId]) -> gix_hash::ObjectId {
-            let sig = git2::Signature::new("Test", "test@example.com", &git2::Time::new(1000, 0))
-                .unwrap();
-            let tree_id = self.repo.treebuilder(None).unwrap().write().unwrap();
-            let tree = self.repo.find_tree(tree_id).unwrap();
-            let parents: Vec<_> = parents
-                .iter()
-                .map(|p| self.repo.find_commit(crate::git2_oid(p)).unwrap())
-                .collect();
-            let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
-            crate::gix_oid(
-                self.repo
-                    .commit(None, &sig, &sig, msg, &tree, &parent_refs)
-                    .unwrap(),
+            let signature = gix_actor::Signature {
+                name: "Test".into(),
+                email: "test@example.com".into(),
+                time: gix_actor::date::Time {
+                    seconds: 1000,
+                    offset: 0,
+                },
+            };
+            crate::write_commit(
+                &self.repo.objects,
+                self.tree,
+                parents,
+                &signature,
+                &signature,
+                msg,
             )
+            .unwrap()
         }
 
         /// Write raw commit bytes so parents don't have to exist in the odb
-        /// (and may repeat -- git2's commit builder can produce neither).
+        /// (and may repeat).
         fn raw_commit(&self, msg: &str, parents: &[gix_hash::ObjectId]) -> gix_hash::ObjectId {
-            let tree_id = self.repo.treebuilder(None).unwrap().write().unwrap();
-            let mut buf = format!("tree {}\n", tree_id);
+            let mut buf = format!("tree {}\n", self.tree);
             for p in parents {
                 buf.push_str(&format!("parent {}\n", p));
             }
@@ -508,34 +520,32 @@ mod tests {
                 "author Test <test@example.com> 1000 +0000\n\
                  committer Test <test@example.com> 1000 +0000\n\n{msg}\n"
             ));
-            crate::gix_oid(
-                self.repo
-                    .odb()
-                    .unwrap()
-                    .write(git2::ObjectType::Commit, buf.as_bytes())
-                    .unwrap(),
+            gix_object::Write::write_buf(
+                &self.repo.objects,
+                gix_object::Kind::Commit,
+                buf.as_bytes(),
             )
+            .unwrap()
         }
     }
 
-    /// An exact sequence number over git2 objects: `1 + max(parent seqs)`,
+    fn parents(repo: &gix::Repository, oid: gix_hash::ObjectId) -> Vec<gix_hash::ObjectId> {
+        read_parent_oids(&repo.objects, oid, &mut Vec::new()).unwrap()
+    }
+
+    /// An exact sequence number over git objects: `1 + max(parent seqs)`,
     /// memoized -- the property josh's cached sequence numbers guarantee.
     /// Errors on missing ancestors, like the real lookup.
     fn exact_seq(
-        repo: &git2::Repository,
+        repo: &gix::Repository,
         memo: &std::cell::RefCell<HashMap<gix_hash::ObjectId, u64>>,
         oid: gix_hash::ObjectId,
     ) -> anyhow::Result<u64> {
         if let Some(&s) = memo.borrow().get(&oid) {
             return Ok(s);
         }
-        let parents: Vec<gix_hash::ObjectId> = repo
-            .find_commit(crate::git2_oid(&oid))?
-            .parent_ids()
-            .map(crate::gix_oid)
-            .collect();
         let mut max = 0;
-        for p in parents {
+        for p in read_parent_oids(&repo.objects, oid, &mut Vec::new())? {
             max = max.max(exact_seq(repo, memo, p)?);
         }
         memo.borrow_mut().insert(oid, max + 1);
@@ -545,27 +555,20 @@ mod tests {
     /// Independent reference model of both walkers' yield sets: the excluded
     /// closure is full ancestor reachability from `base`; the yield set is
     /// what a naive traversal from the tips reaches without stepping on
-    /// excluded or pruned commits. Uses git2's object API throughout, sharing
-    /// no code with the walkers.
+    /// excluded or pruned commits. It parses raw commit parents directly,
+    /// sharing no traversal code with the walkers.
     fn reference_set(
-        repo: &git2::Repository,
+        repo: &gix::Repository,
         tips: &[gix_hash::ObjectId],
         base: Option<gix_hash::ObjectId>,
         pruned: &HashSet<gix_hash::ObjectId>,
         first_parent: bool,
     ) -> HashSet<gix_hash::ObjectId> {
-        let parents_of = |oid: gix_hash::ObjectId| -> Vec<gix_hash::ObjectId> {
-            repo.find_commit(crate::git2_oid(&oid))
-                .unwrap()
-                .parent_ids()
-                .map(crate::gix_oid)
-                .collect()
-        };
         let mut hidden: HashSet<gix_hash::ObjectId> = HashSet::new();
         let mut stack: Vec<gix_hash::ObjectId> = base.into_iter().collect();
         while let Some(h) = stack.pop() {
             if hidden.insert(h) {
-                stack.extend(parents_of(h));
+                stack.extend(parents(repo, h));
             }
         }
         let mut out = HashSet::new();
@@ -575,24 +578,22 @@ mod tests {
                 continue;
             }
             out.insert(c);
-            let mut parents = parents_of(c);
+            let mut commit_parents = parents(repo, c);
             if first_parent {
-                parents.truncate(1);
+                commit_parents.truncate(1);
             }
-            stack.extend(parents);
+            stack.extend(commit_parents);
         }
         out
     }
 
     fn rev_walk(
-        repo: &git2::Repository,
+        repo: &gix::Repository,
         tips: &[gix_hash::ObjectId],
         pruned: &HashSet<gix_hash::ObjectId>,
         first_parent: bool,
     ) -> anyhow::Result<Vec<gix_hash::ObjectId>> {
-        let odb = repo.odb().unwrap();
-        let odb = crate::Git2Odb(&odb);
-        let mut walk = RevWalk::new(&odb);
+        let mut walk = RevWalk::new(&repo.objects);
         if first_parent {
             walk.simplify_first_parent();
         }
@@ -603,21 +604,19 @@ mod tests {
     }
 
     fn range_walk(
-        repo: &git2::Repository,
+        repo: &gix::Repository,
         tip: gix_hash::ObjectId,
         base: gix_hash::ObjectId,
     ) -> anyhow::Result<Vec<gix_hash::ObjectId>> {
         let memo = std::cell::RefCell::new(HashMap::new());
-        let odb = repo.odb().unwrap();
-        let odb = crate::Git2Odb(&odb);
-        let walk = RangeWalk::new(&odb, |oid| exact_seq(repo, &memo, oid));
+        let walk = RangeWalk::new(&repo.objects, |oid| exact_seq(repo, &memo, oid));
         walk.into_topo_vec(tip, base)
     }
 
     /// Check a yielded order for topological validity over the followed
     /// edges: every yielded commit precedes its yielded parents.
     fn assert_topo(
-        repo: &git2::Repository,
+        repo: &gix::Repository,
         got: &[gix_hash::ObjectId],
         first_parent: bool,
         mode: &str,
@@ -626,13 +625,11 @@ mod tests {
             got.iter().enumerate().map(|(i, &o)| (o, i)).collect();
         assert_eq!(pos.len(), got.len(), "duplicate yields: {mode}");
         for &c in got {
-            let commit = repo.find_commit(crate::git2_oid(&c)).unwrap();
-            let mut parents: Vec<gix_hash::ObjectId> =
-                commit.parent_ids().map(crate::gix_oid).collect();
+            let mut commit_parents = parents(repo, c);
             if first_parent {
-                parents.truncate(1);
+                commit_parents.truncate(1);
             }
-            for p in parents {
+            for p in commit_parents {
                 if let Some(&pp) = pos.get(&p) {
                     assert!(pos[&c] < pp, "topology violation {c} -> {p}: {mode}");
                 }
@@ -641,10 +638,9 @@ mod tests {
     }
 
     /// Assert [`RevWalk`] against the reference model: exact yield set, valid
-    /// topological order, run-to-run determinism, and (with no pruning) set
-    /// equality with `git2::Revwalk`.
+    /// topological order, and run-to-run determinism.
     fn assert_rev_walk(
-        repo: &git2::Repository,
+        repo: &gix::Repository,
         tips: &[gix_hash::ObjectId],
         pruned: &HashSet<gix_hash::ObjectId>,
         label: &str,
@@ -658,27 +654,13 @@ mod tests {
             assert_topo(repo, &got, first_parent, &mode);
             let again = rev_walk(repo, tips, pruned, first_parent).unwrap();
             assert_eq!(got, again, "non-deterministic order: {mode}");
-
-            if pruned.is_empty() {
-                let mut g2 = repo.revwalk().unwrap();
-                g2.set_sorting(git2::Sort::TOPOLOGICAL).unwrap();
-                if first_parent {
-                    g2.simplify_first_parent().unwrap();
-                }
-                for t in tips {
-                    g2.push(crate::git2_oid(t)).unwrap();
-                }
-                let theirs: HashSet<gix_hash::ObjectId> =
-                    g2.map(|r| crate::gix_oid(r.unwrap())).collect();
-                assert_eq!(got_set, theirs, "git2 set mismatch: {mode}");
-            }
         }
     }
 
     /// Assert [`RangeWalk`] against the reference model: exact yield set,
     /// valid topological order, run-to-run determinism.
     fn assert_range_walk(
-        repo: &git2::Repository,
+        repo: &gix::Repository,
         tip: gix_hash::ObjectId,
         base: gix_hash::ObjectId,
         label: &str,
@@ -843,9 +825,7 @@ mod tests {
 
         let memo = std::cell::RefCell::new(HashMap::new());
         let calls = std::cell::Cell::new(0usize);
-        let odb = t.repo.odb().unwrap();
-        let odb = crate::Git2Odb(&odb);
-        let walk = RangeWalk::new(&odb, |oid| {
+        let walk = RangeWalk::new(&t.repo.objects, |oid| {
             calls.set(calls.get() + 1);
             exact_seq(&t.repo, &memo, oid)
         });
@@ -876,9 +856,7 @@ mod tests {
 
         for blind in [tip, base, b] {
             let memo = std::cell::RefCell::new(HashMap::new());
-            let odb = t.repo.odb().unwrap();
-            let odb = crate::Git2Odb(&odb);
-            let walk = RangeWalk::new(&odb, |oid| {
+            let walk = RangeWalk::new(&t.repo.objects, |oid| {
                 if oid == blind {
                     anyhow::bail!("no sequence number for {}", oid);
                 }
@@ -916,9 +894,7 @@ mod tests {
         // The callback fires once per commit, even with duplicate edges.
         let dup = t.raw_commit("dup", &[b, b, a]);
         let mut calls = Vec::new();
-        let odb = t.repo.odb().unwrap();
-        let odb = crate::Git2Odb(&odb);
-        let mut w = RevWalk::new(&odb);
+        let mut w = RevWalk::new(&t.repo.objects);
         w.push(dup).unwrap();
         w.into_topo_vec(|oid| {
             calls.push(oid);
@@ -966,28 +942,27 @@ mod tests {
         let a = t.commit("a", &[]);
         let missing =
             gix_hash::ObjectId::from_str("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef").unwrap();
-        let blob = crate::gix_oid(
-            t.repo
-                .odb()
-                .unwrap()
-                .write(git2::ObjectType::Blob, b"x")
-                .unwrap(),
+        let blob =
+            gix_object::Write::write_buf(&t.repo.objects, gix_object::Kind::Blob, b"x").unwrap();
+        let tree = t.tree;
+        let tag_bytes = format!(
+            "object {a}\ntype commit\ntag v1\ntagger Test <test@example.com> 1000 +0000\n\nannotated"
         );
-        let tree = crate::gix_oid(t.repo.treebuilder(None).unwrap().write().unwrap());
-        let sig =
-            git2::Signature::new("Test", "test@example.com", &git2::Time::new(1000, 0)).unwrap();
-        let obj = t.repo.find_object(crate::git2_oid(&a), None).unwrap();
-        let tag = crate::gix_oid(t.repo.tag("v1", &obj, &sig, "annotated", false).unwrap());
+        let tag = gix_object::Write::write_buf(
+            &t.repo.objects,
+            gix_object::Kind::Tag,
+            tag_bytes.as_bytes(),
+        )
+        .unwrap();
 
-        let odb = t.repo.odb().unwrap();
-        let odb = crate::Git2Odb(&odb);
+        let objects = &t.repo.objects;
         // Missing oids and non-commits (including annotated tags, which are
         // NOT peeled) error immediately.
         for bad in [missing, blob, tree, tag] {
-            assert!(RevWalk::new(&odb).push(bad).is_err());
-            let w = RangeWalk::new(&odb, |_| anyhow::bail!("unused"));
+            assert!(RevWalk::new(objects).push(bad).is_err());
+            let w = RangeWalk::new(objects, |_| anyhow::bail!("unused"));
             assert!(w.into_topo_vec(bad, a).is_err());
-            let w = RangeWalk::new(&odb, |_| anyhow::bail!("unused"));
+            let w = RangeWalk::new(objects, |_| anyhow::bail!("unused"));
             assert!(w.into_topo_vec(a, bad).is_err());
         }
     }
@@ -1000,9 +975,8 @@ mod tests {
         let dangling = t.raw_commit("dangling", &[missing]);
 
         // A pushed commit with a missing parent errors during the walk.
-        let odb = t.repo.odb().unwrap();
-        let odb = crate::Git2Odb(&odb);
-        let mut w = RevWalk::new(&odb);
+        let objects = &t.repo.objects;
+        let mut w = RevWalk::new(objects);
         w.push(dangling).unwrap();
         assert!(w.into_topo_vec(|_| false).is_err());
 
@@ -1010,14 +984,14 @@ mod tests {
         // must rank it (the real lookup walks the ancestry)...
         let tip = t.commit("tip", &[]);
         let memo = std::cell::RefCell::new(HashMap::new());
-        let w = RangeWalk::new(&odb, |oid| exact_seq(&t.repo, &memo, oid));
+        let w = RangeWalk::new(objects, |oid| exact_seq(&t.repo, &memo, oid));
         assert!(w.into_topo_vec(tip, dangling).is_err());
 
         // ...but not when the fast-forward path answers without touching the
         // base's ancestry: the walk stays lazy.
         let base = t.commit("base", &[dangling]);
         let top = t.commit("top", &[base]);
-        let w = RangeWalk::new(&odb, |_| anyhow::bail!("must not be consulted"));
+        let w = RangeWalk::new(objects, |_| anyhow::bail!("must not be consulted"));
         assert_eq!(w.into_topo_vec(top, base).unwrap(), vec![top]);
     }
 
@@ -1027,18 +1001,14 @@ mod tests {
         // commits walk fine (fsck-invalid objects; the old git2-backed walk
         // was partially lenient here too, in different places).
         let t = TestRepo::new();
-        let tree_id = t.repo.treebuilder(None).unwrap().write().unwrap();
-        let odb = t.repo.odb().unwrap();
-        let trunc = crate::gix_oid(
-            odb.write(
-                git2::ObjectType::Commit,
-                format!("tree {}\n", tree_id).as_bytes(),
-            )
-            .unwrap(),
-        );
-        let odb = crate::Git2Odb(&odb);
+        let trunc = gix_object::Write::write_buf(
+            &t.repo.objects,
+            gix_object::Kind::Commit,
+            format!("tree {}\n", t.tree).as_bytes(),
+        )
+        .unwrap();
         let tip = t.raw_commit("tip", &[trunc]);
-        let mut w = RevWalk::new(&odb);
+        let mut w = RevWalk::new(&t.repo.objects);
         w.push(tip).unwrap();
         assert_eq!(w.into_topo_vec(|_| false).unwrap(), vec![tip, trunc]);
     }
@@ -1050,12 +1020,11 @@ mod tests {
         let b = t.commit("b", &[a]);
         let c = t.commit("c", &[a]);
         let m = t.commit("m", &[b, c]);
-        let odb = t.repo.odb().unwrap();
-        let odb = crate::Git2Odb(&odb);
+        let objects = &t.repo.objects;
 
         // Pre-order: each commit before its parents, first parent's subgraph
         // before the second's.
-        let mut w = RevWalk::new(&odb);
+        let mut w = RevWalk::new(objects);
         w.push(m).unwrap();
         let mut visited = Vec::new();
         w.discover(|oid| {
@@ -1066,7 +1035,7 @@ mod tests {
         assert_eq!(visited, vec![m, b, a, c]);
 
         // Break aborts the walk.
-        let mut w = RevWalk::new(&odb);
+        let mut w = RevWalk::new(objects);
         w.push(m).unwrap();
         let mut visited = Vec::new();
         w.discover(|oid| {
@@ -1081,7 +1050,7 @@ mod tests {
         assert_eq!(visited, vec![m, b, a]);
 
         // first_parent confines discovery to the first-parent chain.
-        let mut w = RevWalk::new(&odb);
+        let mut w = RevWalk::new(objects);
         w.push(m).unwrap();
         w.simplify_first_parent();
         let mut visited = Vec::new();
@@ -1093,12 +1062,12 @@ mod tests {
         assert_eq!(visited, vec![m, b, a]);
 
         // Errors from the visit callback propagate.
-        let mut w = RevWalk::new(&odb);
+        let mut w = RevWalk::new(objects);
         w.push(m).unwrap();
         assert!(w.discover(|_| anyhow::bail!("boom")).is_err());
 
         // No pushes: no visits, clean return.
-        let w = RevWalk::new(&odb);
+        let w = RevWalk::new(objects);
         w.discover(|_| panic!("must not be visited")).unwrap();
     }
 


### PR DESCRIPTION
Remove josh-gix-ext's libgit2 test dependency

Build graph, merge, revwalk, commit, and tree-walk fixtures through gitoxide's object store. Commit byte compatibility remains pinned to object IDs captured from the former libgit2 differential test, while the revwalk tests keep their independent raw-parent reference model.

Change: gix-ext-test-dependency

Assisted-By: openai-codex/gpt-5.6-sol