### PR TITLE
Remove josh-memodb's libgit2 test dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3674,14 +3674,13 @@ name = "josh-memodb"
 version = "26.7.28"
 dependencies = [
  "anyhow",
- "git2",
+ "gix",
  "gix-features",
  "gix-hash",
  "gix-object",
  "gix-odb",
  "gix-pack",
  "gix-zlib",
- "josh-gix-ext",
  "log",
  "parking_lot 0.12.5",
  "tempfile",

--- a/josh-memodb/Cargo.toml
+++ b/josh-memodb/Cargo.toml
@@ -22,5 +22,4 @@ parking_lot.workspace = true
 tempfile.workspace = true
 
 [dev-dependencies]
-git2.workspace = true
-josh-gix-ext = { workspace = true, features = ["git2"] }
+gix.workspace = true

--- a/josh-memodb/src/mem_odb.rs
+++ b/josh-memodb/src/mem_odb.rs
@@ -281,7 +281,7 @@ mod tests {
     #[test]
     fn flush_writes_objects_to_disk() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init(dir.path()).unwrap();
+        let repo = gix::init(dir.path()).unwrap();
 
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
 
@@ -292,7 +292,7 @@ mod tests {
         for id in &ids {
             assert!(store.contains(id));
             assert!(
-                !repo.odb().unwrap().exists(josh_gix_ext::git2_oid(id)),
+                disk_blob(dir.path(), *id).is_none(),
                 "buffered object must not be on disk before the flush"
             );
         }
@@ -300,10 +300,11 @@ mod tests {
         store.flush().unwrap();
 
         // A fresh repo can only see objects that made it to disk.
-        let on_disk = git2::Repository::open(dir.path()).unwrap();
         for (i, id) in ids.iter().enumerate() {
-            let blob = on_disk.find_blob(josh_gix_ext::git2_oid(id)).unwrap();
-            assert_eq!(blob.content(), format!("in-memory blob {i}").as_bytes());
+            assert_eq!(
+                disk_blob(dir.path(), *id).unwrap(),
+                format!("in-memory blob {i}").as_bytes()
+            );
         }
 
         // The store is drained: a second flush is a no-op.
@@ -317,32 +318,40 @@ mod tests {
     fn flush_writes_to_common_dir_for_worktree() {
         let tmp = tempfile::tempdir().unwrap();
         let main_path = tmp.path().join("main");
-        let repo = git2::Repository::init(&main_path).unwrap();
+        let repo = gix::init(&main_path).unwrap();
 
-        // A worktree can only be added once HEAD points at a commit.
-        let sig = git2::Signature::now("t", "t@t").unwrap();
-        let tree_id = repo.index().unwrap().write_tree().unwrap();
-        let tree = repo.find_tree(tree_id).unwrap();
-        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
-            .unwrap();
-        drop(tree);
-
+        // Set up the on-disk linked-worktree metadata. Gitoxide reads the same `gitdir` and
+        // `commondir` files that `git worktree add` creates; no checkout is needed for this test.
         let wt_path = tmp.path().join("wt");
-        repo.worktree("wt", &wt_path, None).unwrap();
-        let wt_repo = git2::Repository::open(&wt_path).unwrap();
+        let wt_admin = repo.git_dir().join("worktrees").join("wt");
+        std::fs::create_dir_all(&wt_path).unwrap();
+        std::fs::create_dir_all(&wt_admin).unwrap();
+        std::fs::write(
+            wt_path.join(".git"),
+            format!("gitdir: {}\n", wt_admin.display()),
+        )
+        .unwrap();
+        std::fs::write(wt_admin.join("commondir"), "../..\n").unwrap();
+        std::fs::write(
+            wt_admin.join("gitdir"),
+            format!("{}\n", wt_path.join(".git").display()),
+        )
+        .unwrap();
+        std::fs::write(wt_admin.join("HEAD"), "ref: refs/heads/master\n").unwrap();
+
+        let wt_repo = gix::open(&wt_path).unwrap();
 
         // The worktree's gitdir differs from its common dir (the main gitdir).
-        assert_ne!(wt_repo.path(), wt_repo.commondir());
+        assert_ne!(wt_repo.git_dir(), wt_repo.common_dir());
 
         let store = MemOdb::new(None, crate::pack::objects_dir(&wt_repo));
-        let id = josh_gix_ext::git2_oid(&store.write(Kind::Blob, b"worktree blob"));
+        let id = store.write(Kind::Blob, b"worktree blob");
 
         // Must not fail on the (nonexistent) per-worktree objects/pack directory.
         store.flush().unwrap();
 
         // The pack landed in the common object dir, so the main repo can read the blob from disk.
-        let main = git2::Repository::open(&main_path).unwrap();
-        assert_eq!(main.find_blob(id).unwrap().content(), b"worktree blob");
+        assert_eq!(disk_blob(&main_path, id).unwrap(), b"worktree blob");
     }
 
     /// When `limit` is set, writing enough data to exceed it enqueues a background pack from inside
@@ -351,21 +360,21 @@ mod tests {
     #[test]
     fn flushes_on_overflow_during_writes() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init(dir.path()).unwrap();
+        let repo = gix::init(dir.path()).unwrap();
 
         // A 16-byte limit: each 100-byte blob overflows it, so every write enqueues a pack.
         let store = MemOdb::new(Some(16), crate::pack::objects_dir(&repo));
 
         // The write overflowed and enqueued a background pack; it lands on the flusher thread, so
         // poll a fresh on-disk view until the object appears.
-        let id1 = josh_gix_ext::git2_oid(&store.write(Kind::Blob, &b"x".repeat(100)));
+        let id1 = store.write(Kind::Blob, &b"x".repeat(100));
         assert!(
             wait_on_disk(dir.path(), id1),
             "overflow pack never reached disk"
         );
 
         // A second object overflows again, enqueueing another pack.
-        let id2 = josh_gix_ext::git2_oid(&store.write(Kind::Blob, &b"y".repeat(100)));
+        let id2 = store.write(Kind::Blob, &b"y".repeat(100));
         assert!(
             wait_on_disk(dir.path(), id2),
             "second overflow pack never reached disk"
@@ -378,7 +387,7 @@ mod tests {
     #[test]
     fn flush_leaves_only_pack_and_idx() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init(dir.path()).unwrap();
+        let repo = gix::init(dir.path()).unwrap();
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
 
         store.write(Kind::Blob, b"some blob");
@@ -402,7 +411,7 @@ mod tests {
     #[test]
     fn chained_store_reads_through_and_packs_separately() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init(dir.path()).unwrap();
+        let repo = gix::init(dir.path()).unwrap();
 
         let shared = MemOdb::new(None, crate::pack::objects_dir(&repo));
         let behind = shared.write(Kind::Blob, b"shared blob");
@@ -417,16 +426,14 @@ mod tests {
 
         // Packing the private store writes only its own objects.
         private.pack_to_disk().unwrap();
-        let on_disk = git2::Repository::open(dir.path()).unwrap();
-        assert!(on_disk.find_blob(josh_gix_ext::git2_oid(&own)).is_ok());
-        assert!(on_disk.find_blob(josh_gix_ext::git2_oid(&behind)).is_err());
+        assert!(disk_blob(dir.path(), own).is_some());
+        assert!(disk_blob(dir.path(), behind).is_none());
         assert!(shared.contains(&behind));
 
         // A flush is a barrier for everything the store can see, chain included.
         private.flush().unwrap();
         assert!(!shared.contains(&behind));
-        let on_disk = git2::Repository::open(dir.path()).unwrap();
-        assert!(on_disk.find_blob(josh_gix_ext::git2_oid(&behind)).is_ok());
+        assert!(disk_blob(dir.path(), behind).is_some());
     }
 
     /// The limit only ever tightens, whatever order attachers ask in, so a shared store honours
@@ -434,7 +441,7 @@ mod tests {
     #[test]
     fn limit_only_tightens() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init(dir.path()).unwrap();
+        let repo = gix::init(dir.path()).unwrap();
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
 
         assert_eq!(store.limit.load(Ordering::Acquire), UNBOUNDED);
@@ -450,15 +457,22 @@ mod tests {
 
     /// Poll a freshly-opened view of the repository until `id` is readable from disk,
     /// up to ~2s. Used to observe asynchronous background packs without racing the flusher thread.
-    fn wait_on_disk(repo_path: &std::path::Path, id: git2::Oid) -> bool {
+    fn wait_on_disk(repo_path: &std::path::Path, id: ObjectId) -> bool {
         for _ in 0..200 {
-            if let Ok(repo) = git2::Repository::open(repo_path) {
-                if repo.find_blob(id).is_ok() {
-                    return true;
-                }
+            if disk_blob(repo_path, id).is_some() {
+                return true;
             }
             std::thread::sleep(std::time::Duration::from_millis(10));
         }
         false
+    }
+
+    fn disk_blob(repo_path: &std::path::Path, id: ObjectId) -> Option<Vec<u8>> {
+        let repo = gix::open(repo_path).ok()?;
+        let mut buf = Vec::new();
+        let data = gix_object::Find::try_find(&repo.objects, &id, &mut buf)
+            .ok()??
+            .data;
+        Some(data.to_vec())
     }
 }

--- a/josh-memodb/src/odb.rs
+++ b/josh-memodb/src/odb.rs
@@ -334,7 +334,7 @@ impl gix_object::Write for Odb {
 mod tests {
     use super::*;
 
-    fn facade(store: &Arc<MemOdb>, repo: &git2::Repository) -> Odb {
+    fn facade(store: &Arc<MemOdb>, repo: &gix::Repository) -> Odb {
         Odb::at(store.clone(), &crate::pack::objects_dir(repo)).unwrap()
     }
 
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn facade_write_visible_before_flush_durable_after() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init(dir.path()).unwrap();
+        let repo = gix::init(dir.path()).unwrap();
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
 
         let odb = facade(&store, &repo);
@@ -356,18 +356,10 @@ mod tests {
         assert!(odb.contains(oid));
 
         // Not yet on disk.
-        let fresh = git2::Repository::open(dir.path()).unwrap();
-        assert!(fresh.find_blob(josh_gix_ext::git2_oid(&oid)).is_err());
+        assert!(disk_blob(dir.path(), oid).is_none());
 
         store.flush().unwrap();
-        let fresh = git2::Repository::open(dir.path()).unwrap();
-        assert_eq!(
-            fresh
-                .find_blob(josh_gix_ext::git2_oid(&oid))
-                .unwrap()
-                .content(),
-            b"facade blob"
-        );
+        assert_eq!(disk_blob(dir.path(), oid).unwrap(), b"facade blob");
     }
 
     /// The write gate: an object already in a registered runtime alternate is not buffered
@@ -377,13 +369,13 @@ mod tests {
     fn facade_write_gate_matches_freshen() {
         let tmp = tempfile::tempdir().unwrap();
         // "Mirror" repo holding the alternate-resident object.
-        let mirror = git2::Repository::init(tmp.path().join("mirror")).unwrap();
-        let in_alternate = mirror.blob(b"mirror blob").unwrap();
+        let mirror = gix::init(tmp.path().join("mirror")).unwrap();
+        let in_alternate = write_disk_blob(&mirror, b"mirror blob");
 
         let dir = tmp.path().join("overlay");
-        let repo = git2::Repository::init(&dir).unwrap();
+        let repo = gix::init(&dir).unwrap();
         // A loose blob, so it is main-disk-only.
-        let on_disk = repo.blob(b"already on disk").unwrap();
+        let on_disk = write_disk_blob(&repo, b"already on disk");
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
 
         let odb = facade(&store, &repo);
@@ -392,13 +384,13 @@ mod tests {
 
         // Alternate hit: skipped, still readable through the alternate.
         let oid = odb.write(Kind::Blob, b"mirror blob");
-        assert_eq!(oid, josh_gix_ext::gix_oid(in_alternate));
+        assert_eq!(oid, in_alternate);
         assert!(!store.contains(&oid));
         assert!(matches!(odb.read(oid).unwrap().1, Bytes::Disk(_)));
 
         // Main-disk object: buffered — the gate does not probe the repository's own objects.
         let oid = odb.write(Kind::Blob, b"already on disk");
-        assert_eq!(oid, josh_gix_ext::gix_oid(on_disk));
+        assert_eq!(oid, on_disk);
         assert!(store.contains(&oid));
         assert!(matches!(odb.read(oid).unwrap().1, Bytes::Mem(_)));
     }
@@ -408,14 +400,14 @@ mod tests {
     #[test]
     fn facade_write_gate_sees_packed_alternates() {
         let tmp = tempfile::tempdir().unwrap();
-        let mirror = git2::Repository::init(tmp.path().join("mirror")).unwrap();
+        let mirror = gix::init(tmp.path().join("mirror")).unwrap();
         let mirror_dir = crate::pack::objects_dir(&mirror);
         // Packed before the alternate is registered.
         let mirror_store = MemOdb::new(None, mirror_dir.clone());
         let packed = mirror_store.write(Kind::Blob, b"packed in mirror");
         mirror_store.flush().unwrap();
 
-        let repo = git2::Repository::init(tmp.path().join("overlay")).unwrap();
+        let repo = gix::init(tmp.path().join("overlay")).unwrap();
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
         let odb = facade(&store, &repo);
         odb.add_alternate(&mirror_dir).unwrap();
@@ -440,13 +432,11 @@ mod tests {
     #[test]
     fn try_kind_virtualizes_empty_tree() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init(dir.path()).unwrap();
+        let repo = gix::init(dir.path()).unwrap();
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
         let odb = facade(&store, &repo);
 
-        let empty_tree = josh_gix_ext::gix_oid(
-            git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap(),
-        );
+        let empty_tree = ObjectId::from_hex(b"4b825dc642cb6eb9a060e54bf8d69288fbee4904").unwrap();
         assert!(!store.contains(&empty_tree));
         assert_eq!(odb.try_kind(empty_tree).unwrap(), Some(Kind::Tree));
         assert_eq!(odb.read(empty_tree).unwrap().0, Kind::Tree);
@@ -454,9 +444,7 @@ mod tests {
         assert!(!odb.contains(empty_tree));
 
         // A genuinely absent object is None; a buffered object reports its memory kind.
-        let absent = josh_gix_ext::gix_oid(
-            git2::Oid::from_str("0123456789012345678901234567890123456789").unwrap(),
-        );
+        let absent = ObjectId::from_hex(b"0123456789012345678901234567890123456789").unwrap();
         assert_eq!(odb.try_kind(absent).unwrap(), None);
         assert!(odb.read(absent).is_err());
         let blob = odb.write(Kind::Blob, b"probe");
@@ -468,7 +456,7 @@ mod tests {
     #[test]
     fn buffered_objects_resolve_through_the_gix_traits() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init(dir.path()).unwrap();
+        let repo = gix::init(dir.path()).unwrap();
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
         let odb = facade(&store, &repo);
 
@@ -486,7 +474,7 @@ mod tests {
     #[test]
     fn objects_packed_after_the_facade_was_built_are_found() {
         let dir = tempfile::tempdir().unwrap();
-        let repo = git2::Repository::init(dir.path()).unwrap();
+        let repo = gix::init(dir.path()).unwrap();
         let store = MemOdb::new(None, crate::pack::objects_dir(&repo));
         let odb = facade(&store, &repo);
 
@@ -502,5 +490,18 @@ mod tests {
 
         assert!(odb.contains(oid));
         assert_eq!(&*odb.read(oid).unwrap().1, b"packed later");
+    }
+
+    fn write_disk_blob(repo: &gix::Repository, data: &[u8]) -> ObjectId {
+        gix_object::Write::write_buf(&repo.objects, Kind::Blob, data).unwrap()
+    }
+
+    fn disk_blob(repo_path: &std::path::Path, id: ObjectId) -> Option<Vec<u8>> {
+        let repo = gix::open(repo_path).ok()?;
+        let mut buf = Vec::new();
+        let data = gix_object::Find::try_find(&repo.objects, &id, &mut buf)
+            .ok()??
+            .data;
+        Some(data.to_vec())
     }
 }

--- a/josh-memodb/src/pack.rs
+++ b/josh-memodb/src/pack.rs
@@ -17,8 +17,8 @@ use gix_pack::data::output;
 use crate::mem_odb::Snapshot;
 
 #[cfg(test)]
-pub(crate) fn objects_dir(repo: &git2::Repository) -> std::path::PathBuf {
-    repo.commondir().join("objects")
+pub(crate) fn objects_dir(repo: &gix::Repository) -> std::path::PathBuf {
+    repo.common_dir().join("objects")
 }
 
 /// Compress and write the objects of `snapshot` that are not already present in `objects_dir`


### PR DESCRIPTION
Remove josh-memodb's libgit2 test dependency

Exercise the memory store and object facade through gitoxide repositories, including linked-worktree common-directory resolution and fresh on-disk pack reads. This removes josh-memodb's remaining libgit2 and compatibility-helper dependencies.

Change: gix-memodb-test-dependency

Assisted-By: openai-codex/gpt-5.6-sol