### PR TITLE
Remove josh-test-support's libgit2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3817,8 +3817,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "dirs",
- "git2",
  "gix",
+ "josh-gix-ext",
  "rand 0.10.2",
  "tempfile",
  "tracing",

--- a/devtools/josh-test-support/Cargo.toml
+++ b/devtools/josh-test-support/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 # workspace's lock during unified builds.
 anyhow = "1"
 dirs = "6"
-git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
 gix = { version = "0.86", default-features = false, features = ["sha1", "tree-editor"] }
+josh-gix-ext = { path = "../../josh-gix-ext" }
 rand = "0.10"
 tempfile = "3"
 tracing = "0.1"

--- a/devtools/josh-test-support/src/bench.rs
+++ b/devtools/josh-test-support/src/bench.rs
@@ -5,33 +5,9 @@ use anyhow::Result;
 pub use gix::objs::tree::EntryKind;
 use rand::prelude::*;
 
-/// Convert the SHA-1 identifier used by the remaining benchmark APIs to gitoxide.
-pub fn gix_oid(oid: git2::Oid) -> gix::ObjectId {
-    gix::ObjectId::from_bytes_or_panic(oid.as_bytes())
-}
-
-/// Convert a gitoxide SHA-1 identifier for the remaining benchmark APIs.
-pub fn git2_oid(oid: impl AsRef<gix::hash::oid>) -> git2::Oid {
-    git2::Oid::from_bytes(oid.as_ref().as_bytes()).expect("gitoxide repository uses SHA-1")
-}
-/// Open a benchmark's libgit2 reference-model view without repository discovery.
-pub fn open_git2_repo(path: impl AsRef<std::path::Path>) -> Result<git2::Repository> {
-    Ok(git2::Repository::open_ext(
-        path,
-        git2::RepositoryOpenFlags::NO_SEARCH,
-        &[] as &[&std::ffi::OsStr],
-    )?)
-}
-
-/// Josh's fixed libgit2 identity for deterministic benchmark fixtures.
-pub fn josh_commit_signature<'a>() -> Result<git2::Signature<'a>> {
-    const NAME: &str = "JOSH";
-    const EMAIL: &str = "josh@josh-project.dev";
-
-    Ok(match std::env::var("JOSH_COMMIT_TIME") {
-        Ok(time) => git2::Signature::new(NAME, EMAIL, &git2::Time::new(time.parse()?, 0))?,
-        Err(_) => git2::Signature::now(NAME, EMAIL)?,
-    })
+/// Open a benchmark's gitoxide view from an explicit repository path.
+pub fn open_repo(path: impl AsRef<std::path::Path>) -> Result<gix::Repository> {
+    Ok(gix::open(path.as_ref())?)
 }
 
 /// Deterministic lowercase alphabetic string, used as churned blob content.
@@ -44,65 +20,96 @@ pub fn random_string(rng: &mut StdRng, len: usize) -> String {
         })
         .collect()
 }
+/// Write the canonical empty tree fixture.
+pub fn empty_tree(repo: &gix::Repository) -> Result<gix::ObjectId> {
+    Ok(repo
+        .write_object(gix::objs::Tree {
+            entries: Vec::new(),
+        })?
+        .detach())
+}
+/// Resolve a benchmark fixture ref to its direct object target.
+pub fn ref_target(repo: &gix::Repository, name: &str) -> Result<gix::ObjectId> {
+    Ok(repo.find_reference(name)?.into_fully_peeled_id()?.detach())
+}
+
+/// Read a commit's root tree identifier.
+pub fn commit_tree(repo: &gix::Repository, commit: gix::ObjectId) -> Result<gix::ObjectId> {
+    josh_gix_ext::CommitData::read(&repo.objects, commit)?.tree_id()
+}
+
+/// Resolve `path` from a commit's root tree.
+pub fn commit_path(
+    repo: &gix::Repository,
+    commit: gix::ObjectId,
+    path: &std::path::Path,
+) -> Result<Option<gix::ObjectId>> {
+    let tree = commit_tree(repo, commit)?;
+    Ok(josh_gix_ext::path_entry(&repo.objects, tree, path)?.map(|entry| entry.oid))
+}
+
+/// Count commits reachable from `head`.
+pub fn count_history(repo: &gix::Repository, head: gix::ObjectId) -> Result<usize> {
+    let mut walk = josh_gix_ext::RevWalk::new(&repo.objects);
+    walk.push(head)?;
+    Ok(walk.into_topo_vec(|_| false)?.len())
+}
 
 /// Aggregate every case tip under one index commit. Its oid changes whenever any case head
 /// changes, making it a faithful content-addressed cache stamp for the entire repo, and it keeps
 /// all cases reachable so provision_repo's `git prune` retains the full history. It is never
 /// filtered.
 pub fn build_index(
-    repo: &git2::Repository,
-    sig: &git2::Signature,
+    repo: &gix::Repository,
+    sig: &gix::actor::Signature,
     heads: &[gix::ObjectId],
 ) -> Result<gix::ObjectId> {
-    let empty_tree = repo.find_tree(repo.treebuilder(None)?.write()?)?;
-    let parents = heads
-        .iter()
-        .map(|oid| repo.find_commit(git2_oid(*oid)))
-        .collect::<Result<Vec<_>, _>>()?;
-    let parent_refs = parents.iter().collect::<Vec<_>>();
-    let index = repo.commit(
-        Some("refs/heads/bench-index"),
-        sig,
-        sig,
+    let empty_tree = empty_tree(repo)?;
+    let index =
+        josh_gix_ext::write_commit(&repo.objects, empty_tree, heads, sig, sig, "bench index")?;
+    repo.reference(
+        "refs/heads/bench-index",
+        index,
+        gix::refs::transaction::PreviousValue::Any,
         "bench index",
-        &empty_tree,
-        &parent_refs,
     )?;
-    Ok(gix_oid(index))
+    Ok(index)
 }
 
-/// Rebuild, with plain git2 tree walking (no josh code), the tree a pattern filter must produce:
-/// keep exactly the blobs whose full path satisfies `keep`, at their ORIGINAL paths (a pattern
-/// filter preserves paths; it does not lift subtrees to the root). Returns the tree oid and the
-/// number of kept blobs. Whether a string predicate is an exact stand-in for glob matching is the
-/// caller's concern (dot-leading path components never match `*`/`**` under
-/// `require_literal_leading_dot`; a glob-based predicate is exact regardless).
+/// Rebuild, with a plain gitoxide tree walk (no josh filtering code), the tree a pattern filter
+/// must produce: keep exactly the blobs whose full path satisfies `keep`, at their original paths.
+/// Returns the tree oid and the number of kept blobs. Whether a string predicate is an exact
+/// stand-in for glob matching is the caller's concern.
 pub fn expected_tree(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     head: gix::ObjectId,
     keep: &dyn Fn(&str) -> bool,
 ) -> Result<(gix::ObjectId, usize)> {
-    let tree = repo.find_commit(git2_oid(head))?.tree()?;
-    let mut kept: Vec<(String, git2::Oid, i32)> = vec![];
-    tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
-        if entry.kind() == Some(git2::ObjectType::Blob) {
-            let path = format!("{}{}", root, entry.name().unwrap_or_default());
+    let tree = josh_gix_ext::CommitData::read(&repo.objects, head)?.tree_id()?;
+    let mut kept = Vec::new();
+    josh_gix_ext::walk_tree_preorder(&repo.objects, tree, &mut |parent, entry| {
+        let mode = entry.mode.kind();
+        if matches!(
+            mode,
+            EntryKind::Blob | EntryKind::BlobExecutable | EntryKind::Link
+        ) {
+            let name = std::str::from_utf8(entry.filename)?;
+            let path = if parent.is_empty() {
+                name.to_owned()
+            } else {
+                format!("{parent}/{name}")
+            };
             if keep(&path) {
-                kept.push((path, entry.id(), entry.filemode()));
+                kept.push((path, entry.oid.to_owned(), mode));
             }
         }
-        git2::TreeWalkResult::Ok
+        Ok(())
     })?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let gix_repo = gix::open(repo.path())?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
-    for (path, oid, filemode) in &kept {
-        let mode = match *filemode {
-            0o100755 => EntryKind::BlobExecutable,
-            0o120000 => EntryKind::Link,
-            _ => EntryKind::Blob,
-        };
-        builder.upsert(path.as_str(), mode, gix_oid(*oid))?;
+
+    let empty_tree = empty_tree(repo)?;
+    let mut builder = repo.edit_tree(empty_tree)?;
+    for (path, oid, mode) in &kept {
+        builder.upsert(path.as_str(), *mode, *oid)?;
     }
     Ok((builder.write()?.detach(), kept.len()))
 }

--- a/devtools/josh-test-support/src/provision_repo.rs
+++ b/devtools/josh-test-support/src/provision_repo.rs
@@ -10,16 +10,16 @@ use anyhow::{anyhow, bail, Context, Result};
 
 /// A benchmark repo provisioned into a throwaway tempdir.
 ///
-/// The canonical form is cached under the user's cache directory; this handle
-/// owns a fresh copy in a tempdir together with the [`git2::Repository`] opened
-/// from it. Drop the value to delete the tempdir.
+/// The canonical form is cached under the user's cache directory; this handle owns a fresh copy
+/// in a tempdir together with the [`gix::Repository`] opened from it. Drop the value to delete the
+/// tempdir.
 pub struct ProvisionedRepo {
     /// Keeps the on-disk tempdir alive for as long as the repo handle is used.
     _tmp: tempfile::TempDir,
     /// A bare repo opened from the tempdir copy.
-    pub repo: git2::Repository,
-    /// The head oid the callback produced (always equal to the `expected` that
-    /// was passed to [`provision_repo`]).
+    pub repo: gix::Repository,
+    /// The head oid the callback produced (always equal to the `expected` that was passed to
+    /// [`provision_repo`]).
     pub head: gix::ObjectId,
 }
 
@@ -33,24 +33,21 @@ impl ProvisionedRepo {
 /// Provision a benchmark repo for `testcase`, caching the canonical build under
 /// `<cache_dir>/josh/benches/<testcase>`.
 ///
-/// If the cache already contains the `expected` object, the cached bare repo is
-/// copied into a fresh tempdir and returned. Otherwise a new bare repo is built
-/// by invoking `callback` (erasing any stale cache), repacked into a single
-/// packfile, verified to produce `expected`, cached, and copied into a tempdir.
+/// If the cache already contains the `expected` object, the cached bare repo is copied into a
+/// fresh tempdir and returned. Otherwise a new bare repo is built by invoking `callback` (erasing
+/// any stale cache), repacked into a single packfile, verified to produce `expected`, cached, and
+/// copied into a tempdir.
 ///
-/// `expected` is a content-addressed version stamp: changing the build (file
-/// counts, history length, etc.) changes the head oid the callback returns,
-/// which no longer matches `expected`, so the strict check fires and the cache
-/// is treated as invalid. On the first run after such a change, the error
-/// message reports the oid the callback produced so it can be pasted in as the
-/// new `expected`.
+/// `expected` is a content-addressed version stamp: changing the build (file counts, history
+/// length, etc.) changes the head oid the callback returns, which no longer matches `expected`, so
+/// the strict check fires and reports the new oid to paste in.
 pub fn provision_repo<C>(
     testcase: &str,
     expected: &gix::ObjectId,
     callback: C,
 ) -> Result<ProvisionedRepo>
 where
-    C: FnMut(&git2::Repository) -> Result<gix::ObjectId>,
+    C: FnMut(&gix::Repository) -> Result<gix::ObjectId>,
 {
     let expected = *expected;
     let cache_root = cache_root_for(testcase)?;
@@ -72,18 +69,17 @@ fn cache_root_for(testcase: &str) -> Result<PathBuf> {
 
 /// A cached repo is reusable if it opens as a bare repo and contains `expected`.
 fn cache_hit(cache_root: &Path, expected: gix::ObjectId) -> bool {
-    let Ok(repo) = git2::Repository::open_bare(cache_root) else {
+    let Ok(repo) = gix::open(cache_root) else {
         return false;
     };
-    repo.odb()
-        .map(|odb| odb.exists(crate::bench::git2_oid(expected)))
-        .unwrap_or(false)
+    let found = repo.find_object(expected).is_ok();
+    found
 }
 
 /// Build `testcase` from scratch into `cache_root`, erasing any prior cache.
 fn rebuild<C>(cache_root: &Path, expected: gix::ObjectId, callback: &mut C) -> Result<()>
 where
-    C: FnMut(&git2::Repository) -> Result<gix::ObjectId>,
+    C: FnMut(&gix::Repository) -> Result<gix::ObjectId>,
 {
     if cache_root.exists() {
         std::fs::remove_dir_all(cache_root)
@@ -94,14 +90,13 @@ where
             .with_context(|| format!("creating cache parent {}", parent.display()))?;
     }
 
-    let repo = git2::Repository::init_bare(cache_root)
+    let repo = gix::init_bare(cache_root)
         .with_context(|| format!("initializing bare repo at {}", cache_root.display()))?;
 
     let produced = callback(&repo)?;
 
-    // Pack everything into a single packfile so the tempdir copy is cheap, then
-    // drop unreachable loose objects the pack did not absorb (e.g. the empty-tree
-    // baseline a treebuilder may leave behind).
+    // Pack everything into a single packfile so the tempdir copy is cheap, then drop unreachable
+    // loose objects the pack did not absorb (for example, temporary tree-editor roots).
     let status = Command::new("git")
         .arg("-C")
         .arg(cache_root)
@@ -136,7 +131,7 @@ fn copy_to_tempdir(cache_root: &Path, expected: gix::ObjectId) -> Result<Provisi
     let tmp = tempfile::tempdir().context("creating tempdir for repo copy")?;
     copy_dir_recursive(cache_root, tmp.path())
         .with_context(|| format!("copying {} to tempdir", cache_root.display()))?;
-    let repo = git2::Repository::open_bare(tmp.path()).context("opening copied bare repo")?;
+    let repo = gix::open(tmp.path()).context("opening copied bare repo")?;
     Ok(ProvisionedRepo {
         _tmp: tmp,
         repo,

--- a/josh-core/benches/deephistory_glob.rs
+++ b/josh-core/benches/deephistory_glob.rs
@@ -1,9 +1,7 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_test_support::bench::josh_commit_signature;
-use josh_test_support::bench::{
-    EntryKind, build_index, expected_tree, git2_oid, gix_oid, random_string,
-};
+use josh_core::git::josh_actor_signature;
+use josh_test_support::bench::{EntryKind, build_index, expected_tree, random_string};
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -83,7 +81,7 @@ const CACHE_NAME: &str = if cfg!(debug_assertions) {
     "deephistory_glob"
 };
 
-/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME` so the built
+/// Fixed commit timestamp fed to `josh_actor_signature()` via `JOSH_COMMIT_TIME` so the built
 /// history is reproducible. Without it the signature uses the wall clock, every run produces
 /// different head oids, and `EXPECTED_HEAD` can never be stable. The value itself is arbitrary.
 const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
@@ -129,7 +127,7 @@ impl GlobBench {
                         .in_scope(|| build_case(repo, n_commits))?;
                     heads.push(head);
                 }
-                build_index(repo, &josh_commit_signature()?, &heads)
+                build_index(repo, &josh_actor_signature()?, &heads)
             },
         )?;
 
@@ -139,10 +137,13 @@ impl GlobBench {
         {
             let repo = &provisioned.repo;
             for &n_commits in HISTORY_SIZES {
-                let head = repo.refname_to_id(&format!("refs/heads/case_{n_commits}"))?;
+                let head = josh_test_support::bench::ref_target(
+                    repo,
+                    &format!("refs/heads/case_{n_commits}"),
+                )?;
                 cases.push(SizeCase {
                     n_commits,
-                    head: gix_oid(head),
+                    head: head,
                 });
             }
         }
@@ -155,7 +156,7 @@ impl GlobBench {
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // Correctness gates (untimed): confirm every benchmarked pattern filter produces exactly
-        // the tree an independent git2 walk + reference glob match predicts, so we never silently
+        // the tree an independent reference walk + glob match predicts, so we never silently
         // measure a filter that drops everything, is a no-op, or diverges from glob semantics. A
         // pattern filter keeps matching blobs at their ORIGINAL paths (it does not lift subtrees
         // to the root like `:/subdir`). The reference predicate is
@@ -168,13 +169,13 @@ impl GlobBench {
         {
             let transaction = context.open()?;
             let case = cases.first().expect("at least one case");
-            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
+            let repo = josh_test_support::bench::open_repo(transaction.path())?;
 
             // The tripwire only means something if the dotfiles actually exist in the raw tree.
-            let raw_tree = repo.find_commit(git2_oid(case.head))?.tree()?;
+            let raw_tree = josh_test_support::bench::commit_tree(&repo, case.head)?;
             for path in ["dir_01/.hidden.rs", "dir_01/.hiddendir/inner.rs"] {
                 anyhow::ensure!(
-                    raw_tree.get_path(Path::new(path)).is_ok(),
+                    josh_gix_ext::path_entry(&repo.objects, raw_tree, Path::new(path))?.is_some(),
                     "raw head tree lost `{path}` -- dotfile gate would be vacuous"
                 );
             }
@@ -182,17 +183,16 @@ impl GlobBench {
             for pattern in [PATTERN_RECURSIVE, PATTERN_PREFIX, PATTERN_LITERAL] {
                 let filter = Filter::new().pattern(pattern).expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
-                // The gate compares against an independent git2 reference model, which only
-                // sees what is on disk.
+                // The reference walk sees only objects already persisted to disk.
                 transaction.flush_mem_odb()?;
-                let got = repo.find_commit(git2_oid(filtered))?.tree_id();
+                let got = josh_test_support::bench::commit_tree(&repo, filtered)?;
                 let (want, kept) = expected_tree(&repo, case.head, &glob_pred(pattern))?;
                 anyhow::ensure!(
                     kept > 0,
                     "`::{pattern}` gate kept no blobs -- benchmark would be a no-op"
                 );
                 anyhow::ensure!(
-                    gix_oid(got) == want,
+                    got == want,
                     "`::{pattern}` produced {got}, expected {want} -- wrong measurement"
                 );
             }
@@ -203,14 +203,22 @@ impl GlobBench {
             // an identity/subtree fast path must reproduce bit-identically.
             let filter = Filter::new().pattern(PATTERN_PREFIX).expect("valid glob");
             let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
-            let got_tree = repo.find_commit(git2_oid(filtered))?.tree()?;
+            let got_tree = josh_test_support::bench::commit_tree(&repo, filtered)?;
+            let got_entries = josh_gix_ext::read_tree_entries(&repo.objects, got_tree)?;
             anyhow::ensure!(
-                got_tree.len() == 1,
+                got_entries.len() == 1,
                 "`::{PATTERN_PREFIX}` result must have exactly one top-level entry"
             );
-            let raw_subtree = raw_tree.get_path(Path::new(PREFIX_DIR))?.id();
+            let raw_subtree =
+                josh_gix_ext::path_entry(&repo.objects, raw_tree, Path::new(PREFIX_DIR))?
+                    .ok_or_else(|| anyhow::anyhow!("raw fixture subtree is missing"))?
+                    .oid;
             anyhow::ensure!(
-                got_tree.get_name(PREFIX_DIR).map(|e| e.id()) == Some(raw_subtree),
+                got_entries
+                    .iter()
+                    .find(|entry| entry.filename == PREFIX_DIR.as_bytes())
+                    .map(|entry| entry.oid)
+                    == Some(raw_subtree),
                 "`::{PATTERN_PREFIX}` must keep `{PREFIX_DIR}` at its original path"
             );
         }
@@ -250,20 +258,19 @@ fn glob_pred(pattern: &str) -> impl Fn(&str) -> bool {
 /// directories, then generate an `n_commits` history that churns ~`CHURN_FRACTION` of the files
 /// per commit. The tip is tagged with `refs/heads/case_<n_commits>` so the head is recoverable
 /// after the repo round-trips through the cache.
-fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
+fn build_case(repo: &gix::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
     use rand::RngExt;
 
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     let mut all_paths = vec![];
     for i in 0..TREE_FILES {
         let path = file_path(i);
-        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.to_string_lossy().as_bytes())?;
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
         all_paths.push(path);
     }
@@ -272,11 +279,11 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
     // stay dot-free -- see the tree-shape invariant at the top of this file).
     for j in 0..N_SUB_FILES {
         let path = PathBuf::from("dir_00").join("sub").join(format!("c_{j}.c"));
-        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.to_string_lossy().as_bytes())?;
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
         all_paths.push(path);
     }
@@ -284,22 +291,23 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
     // The dotfile tripwire under dir_01 (see the tree-shape comment above); static, never
     // churned.
     for path in ["dir_01/.hidden.rs", "dir_01/.hiddendir/inner.rs"] {
-        let oid = repo.blob(path.as_bytes())?;
-        builder.upsert(path, EntryKind::Blob, gix_oid(oid))?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.as_bytes())?;
+        builder.upsert(path, EntryKind::Blob, oid)?;
     }
 
-    let root_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
+    let root_tree = builder.write()?.detach();
 
-    let sig = josh_commit_signature()?;
+    let sig = josh_actor_signature()?;
     // No ref update yet -- the tip ref is set once the history is complete.
-    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+    let mut head =
+        josh_gix_ext::write_commit(&repo.objects, root_tree, &[], &sig, &sig, "content")?;
 
     // Deterministic history: each commit churns a fresh random ~CHURN_FRACTION of the files.
     let mut rng = StdRng::seed_from_u64(1);
     for i in 0..n_commits {
-        let parent = repo.find_commit(head)?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
 
         let churned = all_paths
             .iter()
@@ -309,22 +317,22 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
 
         for path in &churned {
             let content = random_string(&mut rng, CHURN_CONTENT_LEN);
-            let blob = repo.blob(content.as_bytes())?;
+            let blob = josh_gix_ext::write_blob(&repo.objects, content.as_bytes())?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
 
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = repo.commit(
-            None,
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("commit {i}"),
-            &new_tree,
-            &[&parent],
         )?;
     }
 
@@ -332,13 +340,13 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
     // callback never runs. Also keeps the whole history reachable, so provision_repo's `git prune`
     // retains it.
     repo.reference(
-        &format!("refs/heads/case_{n_commits}"),
+        format!("refs/heads/case_{n_commits}"),
         head,
-        true,
+        gix::refs::transaction::PreviousValue::Any,
         "bench case tip",
     )?;
 
-    Ok(gix_oid(head))
+    Ok(head)
 }
 
 // A small fixed edit set for the incremental group, chosen so every commit touches both patterns'
@@ -352,20 +360,20 @@ const EDIT_INDICES: &[usize] = &[0, 1, 10, 11];
 /// advancing parent chain guarantees every commit oid is unique, so no iteration is a pure cache
 /// hit. New objects land only in this run's tempdir copy, never in the provision cache.
 fn make_edit_commit(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     parent: gix_hash::ObjectId,
     n: u64,
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    let parent = repo.find_commit(git2_oid(parent))?;
-    let tree = parent.tree()?;
-    let gix_repo = gix::open(repo.path())?;
-    let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
-    let blob = repo.blob(format!("local edit {n}").as_bytes())?;
+    let parent_id = parent;
+    let tree = josh_test_support::bench::commit_tree(repo, parent_id)?;
+
+    let mut builder = repo.edit_tree(tree)?;
+    let blob = josh_gix_ext::write_blob(&repo.objects, format!("local edit {n}").as_bytes())?;
     for &i in EDIT_INDICES {
         builder.upsert(
             file_path(i).to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(blob),
+            blob,
         )?;
     }
     let rotating = ((n % TREE_FILES as u64) as usize * 7) % TREE_FILES;
@@ -376,19 +384,19 @@ fn make_edit_commit(
                 .to_str()
                 .expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(blob),
+            blob,
         )?;
     }
-    let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-    let sig = josh_commit_signature()?;
-    Ok(gix_oid(repo.commit(
-        None,
+    let new_tree = builder.write()?.detach();
+    let sig = josh_actor_signature()?;
+    Ok(josh_gix_ext::write_commit(
+        &repo.objects,
+        new_tree,
+        &[parent_id],
         &sig,
         &sig,
         &format!("local edit {n}"),
-        &new_tree,
-        &[&parent],
-    )?))
+    )?)
 }
 
 fn deephistory_glob(c: &mut Criterion) {
@@ -509,7 +517,7 @@ fn deephistory_glob(c: &mut Criterion) {
                 .tree_id()
                 .unwrap();
             let reference_repo =
-                josh_test_support::bench::open_git2_repo(transaction.path()).expect("open repo");
+                josh_test_support::bench::open_repo(transaction.path()).expect("open repo");
             let (want, _) =
                 expected_tree(&reference_repo, probe, &glob_pred(pattern)).expect("expected");
             assert_eq!(

--- a/josh-core/benches/deephistory_prefix_flush.rs
+++ b/josh-core/benches/deephistory_prefix_flush.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_test_support::bench::josh_commit_signature;
-use josh_test_support::bench::{EntryKind, build_index, git2_oid, gix_oid, random_string};
+use josh_core::git::josh_actor_signature;
+use josh_test_support::bench::{EntryKind, build_index, random_string};
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -64,7 +64,7 @@ const CACHE_NAME: &str = if cfg!(debug_assertions) {
     "deephistory_prefix_flush"
 };
 
-/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME` so the built
+/// Fixed commit timestamp fed to `josh_actor_signature()` via `JOSH_COMMIT_TIME` so the built
 /// history is reproducible. Without it the signature uses the wall clock, every run produces
 /// different head oids, and `EXPECTED_HEAD` can never be stable. The value itself is arbitrary.
 const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
@@ -111,7 +111,7 @@ impl PrefixFlushBench {
                         .in_scope(|| build_case(repo, n_commits))?;
                     heads.push(head);
                 }
-                build_index(repo, &josh_commit_signature()?, &heads)
+                build_index(repo, &josh_actor_signature()?, &heads)
             },
         )?;
 
@@ -121,10 +121,13 @@ impl PrefixFlushBench {
         {
             let repo = &provisioned.repo;
             for &n_commits in HISTORY_SIZES {
-                let head = repo.refname_to_id(&format!("refs/heads/case_{n_commits}"))?;
+                let head = josh_test_support::bench::ref_target(
+                    repo,
+                    &format!("refs/heads/case_{n_commits}"),
+                )?;
                 cases.push(SizeCase {
                     n_commits,
-                    head: gix_oid(head),
+                    head: head,
                 });
             }
         }
@@ -177,36 +180,36 @@ impl PrefixFlushBench {
 /// directories, then generate an `n_commits` history that churns ~`CHURN_FRACTION` of the files per
 /// commit. The tip is tagged with `refs/heads/case_<n_commits>` so the head is recoverable after
 /// the repo round-trips through the cache.
-fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
+fn build_case(repo: &gix::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
     use rand::RngExt;
 
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     let mut all_paths = vec![];
     for i in 0..TREE_FILES {
         let path = PathBuf::from(format!("dir_{:02}", i % N_DIRS)).join(format!("file_{i:04}"));
-        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.to_string_lossy().as_bytes())?;
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
         all_paths.push(path);
     }
 
-    let root_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
+    let root_tree = builder.write()?.detach();
 
-    let sig = josh_commit_signature()?;
+    let sig = josh_actor_signature()?;
     // No ref update yet -- the tip ref is set once the history is complete.
-    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+    let mut head =
+        josh_gix_ext::write_commit(&repo.objects, root_tree, &[], &sig, &sig, "content")?;
 
     // Deterministic history: each commit churns a fresh random ~CHURN_FRACTION of the files.
     let mut rng = StdRng::seed_from_u64(1);
     for i in 0..n_commits {
-        let parent = repo.find_commit(head)?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
 
         let churned = all_paths
             .iter()
@@ -216,22 +219,22 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
 
         for path in &churned {
             let content = random_string(&mut rng, CHURN_CONTENT_LEN);
-            let blob = repo.blob(content.as_bytes())?;
+            let blob = josh_gix_ext::write_blob(&repo.objects, content.as_bytes())?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
 
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = repo.commit(
-            None,
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("commit {i}"),
-            &new_tree,
-            &[&parent],
         )?;
     }
 
@@ -239,13 +242,13 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
     // callback never runs. Also keeps the whole history reachable, so provision_repo's `git prune`
     // retains it.
     repo.reference(
-        &format!("refs/heads/case_{n_commits}"),
+        format!("refs/heads/case_{n_commits}"),
         head,
-        true,
+        gix::refs::transaction::PreviousValue::Any,
         "bench case tip",
     )?;
 
-    Ok(gix_oid(head))
+    Ok(head)
 }
 
 fn deephistory_prefix_flush(c: &mut Criterion) {

--- a/josh-core/benches/deephistory_subdir.rs
+++ b/josh-core/benches/deephistory_subdir.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::{Filter, RevMatch};
-use josh_test_support::bench::josh_commit_signature;
-use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
+use josh_core::git::josh_actor_signature;
+use josh_test_support::bench::EntryKind;
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -43,7 +43,7 @@ const CHURN_CONTENT_LEN: usize = 10;
 /// by running the bench once after a build change.
 const EXPECTED_HEAD: &str = "335b2d17e53df1f9dc051c512c638a647c09e57c";
 
-/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME` so the built
+/// Fixed commit timestamp fed to `josh_actor_signature()` via `JOSH_COMMIT_TIME` so the built
 /// history is reproducible. Without it the signature uses the wall clock, every run produces different
 /// head oids, and `EXPECTED_HEAD` can never be stable. The value itself is arbitrary.
 const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
@@ -100,10 +100,13 @@ impl SubdirBench {
         {
             let repo = &provisioned.repo;
             for &n_commits in HISTORY_SIZES {
-                let head = repo.refname_to_id(&format!("refs/heads/case_{n_commits}"))?;
+                let head = josh_test_support::bench::ref_target(
+                    repo,
+                    &format!("refs/heads/case_{n_commits}"),
+                )?;
                 cases.push(SizeCase {
                     n_commits,
-                    head: gix_oid(head),
+                    head: head,
                 });
             }
         }
@@ -130,13 +133,11 @@ impl SubdirBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
-            let filtered_tree = repo.find_commit(git2_oid(filtered))?.tree()?.id();
-            let raw_subdir_tree = repo
-                .find_commit(git2_oid(case.head))?
-                .tree()?
-                .get_path(Path::new(SUBDIR))?
-                .id();
+            let repo = josh_test_support::bench::open_repo(transaction.path())?;
+            let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
+            let raw_subdir_tree =
+                josh_test_support::bench::commit_path(&repo, case.head, Path::new(SUBDIR))?
+                    .ok_or_else(|| anyhow::anyhow!("fixture path is missing"))?;
             anyhow::ensure!(
                 filtered_tree == raw_subdir_tree,
                 "subdir filter did not select `{SUBDIR}` -- benchmark would measure the wrong thing"
@@ -167,38 +168,39 @@ fn random_string(rng: &mut StdRng, len: usize) -> String {
 /// directories, then generate an `n_commits` history that churns ~`CHURN_FRACTION` of the files per
 /// commit. The tip is tagged with `refs/heads/case_<n_commits>` so the head is recoverable after the
 /// repo round-trips through the cache.
-fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
+fn build_case(repo: &gix::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
     use rand::RngExt;
 
     // Deterministic root tree: file `i` lives at `dir_{i % N_DIRS}/file_{i}`, so files are spread
     // evenly and `SUBDIR` always holds a share of them.
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     let mut all_paths = vec![];
     for i in 0..TREE_FILES {
         let path = PathBuf::from(format!("dir_{:02}", i % N_DIRS)).join(format!("file_{i:04}"));
-        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.to_string_lossy().as_bytes())?;
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
         all_paths.push(path);
     }
 
-    let root_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
+    let root_tree = builder.write()?.detach();
 
-    let sig = josh_commit_signature()?;
+    let sig = josh_actor_signature()?;
     // No ref update yet -- the tip ref is set once the history is complete.
-    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+    let mut head =
+        josh_gix_ext::write_commit(&repo.objects, root_tree, &[], &sig, &sig, "content")?;
 
     // Deterministic history: each commit churns a fresh random ~CHURN_FRACTION of the files.
     let mut rng = StdRng::seed_from_u64(1);
     for i in 0..n_commits {
-        let parent = repo.find_commit(head)?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
 
         let churned = all_paths
             .iter()
@@ -208,60 +210,45 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
 
         for path in &churned {
             let content = random_string(&mut rng, CHURN_CONTENT_LEN);
-            let blob = repo.blob(content.as_bytes())?;
+            let blob = josh_gix_ext::write_blob(&repo.objects, content.as_bytes())?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
 
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = repo.commit(
-            None,
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("commit {i}"),
-            &new_tree,
-            &[&parent],
         )?;
     }
 
     // Tag the tip so `setup` can find this case's head on the cache-hit path, where the build callback
     // never runs. Also keeps the whole history reachable through `git prune`.
     repo.reference(
-        &format!("refs/heads/case_{n_commits}"),
+        format!("refs/heads/case_{n_commits}"),
         head,
-        true,
+        gix::refs::transaction::PreviousValue::Any,
         "bench case tip",
     )?;
 
-    Ok(gix_oid(head))
+    Ok(head)
 }
 
 /// Aggregate every case tip under one index commit. Its oid changes whenever any case head changes,
 /// making it a faithful content-addressed cache stamp for the entire repo, and it keeps all cases
 /// reachable so provision_repo's `git prune` retains the full history. It is never filtered.
 fn build_index(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     heads: &[gix_hash::ObjectId],
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    let sig = josh_commit_signature()?;
-    let empty_tree = repo.find_tree(repo.treebuilder(None)?.write()?)?;
-    let parents = heads
-        .iter()
-        .map(|oid| repo.find_commit(git2_oid(*oid)))
-        .collect::<Result<Vec<_>, _>>()?;
-    let parent_refs = parents.iter().collect::<Vec<_>>();
-    let index = repo.commit(
-        Some("refs/heads/bench-index"),
-        &sig,
-        &sig,
-        "bench index",
-        &empty_tree,
-        &parent_refs,
-    )?;
-    Ok(gix_oid(index))
+    josh_test_support::bench::build_index(repo, &josh_actor_signature()?, heads)
 }
 
 fn deephistory_subdir(c: &mut Criterion) {

--- a/josh-core/benches/deephistory_subdir_distributed.rs
+++ b/josh-core/benches/deephistory_subdir_distributed.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_test_support::bench::josh_commit_signature;
-use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
+use josh_core::git::josh_actor_signature;
+use josh_test_support::bench::EntryKind;
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -41,7 +41,7 @@ const SUBDIR_CHANGE_PROB: f64 = 0.02;
 /// reports the new value to paste here.
 const EXPECTED_HEAD: &str = "cb9ccbca757fe9707010dde47bed3eeba094679e";
 
-/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME` so the built
+/// Fixed commit timestamp fed to `josh_actor_signature()` via `JOSH_COMMIT_TIME` so the built
 /// history is reproducible and `EXPECTED_HEAD` stays stable. The value itself is arbitrary.
 const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
 
@@ -91,10 +91,13 @@ impl SubdirBench {
         {
             let repo = &provisioned.repo;
             for &n_commits in HISTORY_SIZES {
-                let head = repo.refname_to_id(&format!("refs/heads/case_{n_commits}"))?;
+                let head = josh_test_support::bench::ref_target(
+                    repo,
+                    &format!("refs/heads/case_{n_commits}"),
+                )?;
                 cases.push(SizeCase {
                     n_commits,
-                    head: gix_oid(head),
+                    head: head,
                 });
             }
         }
@@ -120,13 +123,11 @@ impl SubdirBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
-            let filtered_tree = repo.find_commit(git2_oid(filtered))?.tree()?.id();
-            let raw_subdir_tree = repo
-                .find_commit(git2_oid(case.head))?
-                .tree()?
-                .get_path(Path::new(SUBDIR))?
-                .id();
+            let repo = josh_test_support::bench::open_repo(transaction.path())?;
+            let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
+            let raw_subdir_tree =
+                josh_test_support::bench::commit_path(&repo, case.head, Path::new(SUBDIR))?
+                    .ok_or_else(|| anyhow::anyhow!("fixture path is missing"))?;
             anyhow::ensure!(
                 filtered_tree == raw_subdir_tree,
                 "subdir filter did not select `{SUBDIR}` -- benchmark would measure the wrong thing"
@@ -155,18 +156,18 @@ impl SubdirBench {
 }
 
 /// Number of commits reachable from `head`.
-fn count_history(repo: &git2::Repository, head: gix_hash::ObjectId) -> anyhow::Result<usize> {
-    let mut walk = repo.revwalk()?;
-    walk.push(git2_oid(head))?;
-    Ok(walk.count())
+fn count_history(repo: &gix::Repository, head: gix_hash::ObjectId) -> anyhow::Result<usize> {
+    josh_test_support::bench::count_history(repo, head)
 }
 
 /// Delete every `refs/josh/cache/*` ref the distributed backend may have written, so each timed
 /// iteration starts from a genuinely cold distributed cache and not from refs a previous iteration
 /// flushed on drop.
-fn clear_cache_refs(repo: &git2::Repository) -> anyhow::Result<()> {
-    for r in repo.references_glob("refs/josh/cache/*")? {
-        r?.delete()?;
+fn clear_cache_refs(repo: &gix::Repository) -> anyhow::Result<()> {
+    for reference in repo.references()?.prefixed("refs/josh/cache/")? {
+        reference
+            .map_err(|err| anyhow::anyhow!("read cache ref: {err}"))?
+            .delete()?;
     }
     Ok(())
 }
@@ -186,24 +187,24 @@ fn random_string(rng: &mut StdRng, len: usize) -> String {
 /// `CHURN_PER_COMMIT` files outside it, and only with probability `SUBDIR_CHANGE_PROB` also touches a
 /// `dir_00` file. The tip is tagged `refs/heads/case_<n_commits>` so the head survives the cache
 /// round-trip.
-fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
+fn build_case(repo: &gix::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
     use rand::RngExt;
 
     // Deterministic root tree: file `i` lives at `dir_{i % N_DIRS}/file_{i}`; split the paths into the
     // filtered subdir (`dir_00`) and the rest so churn can target each set independently.
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     let mut subdir_paths = vec![];
     let mut other_paths = vec![];
     for i in 0..TREE_FILES {
         let dir = i % N_DIRS;
         let path = PathBuf::from(format!("dir_{dir:02}")).join(format!("file_{i:04}"));
-        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.to_string_lossy().as_bytes())?;
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
         if dir == 0 {
             subdir_paths.push(path);
@@ -212,17 +213,18 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
         }
     }
 
-    let root_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
+    let root_tree = builder.write()?.detach();
 
-    let sig = josh_commit_signature()?;
+    let sig = josh_actor_signature()?;
     // No ref update yet -- the tip ref is set once the history is complete.
-    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+    let mut head =
+        josh_gix_ext::write_commit(&repo.objects, root_tree, &[], &sig, &sig, "content")?;
 
     let mut rng = StdRng::seed_from_u64(1);
     for i in 0..n_commits {
-        let parent = repo.find_commit(head)?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
 
         // Always churn non-dir_00 files (guarantees a real input commit, no effect on the filter).
         // Dedup indices so a path is never upserted twice in the same commit.
@@ -232,65 +234,57 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
         }
         for idx in idxs {
             let path = &other_paths[idx];
-            let blob = repo.blob(random_string(&mut rng, CHURN_CONTENT_LEN).as_bytes())?;
+            let blob = josh_gix_ext::write_blob(
+                &repo.objects,
+                random_string(&mut rng, CHURN_CONTENT_LEN).as_bytes(),
+            )?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
         // Rarely also touch dir_00, producing an output commit.
         if rng.random_bool(SUBDIR_CHANGE_PROB) {
             let path = &subdir_paths[rng.random_range(0..subdir_paths.len())];
-            let blob = repo.blob(random_string(&mut rng, CHURN_CONTENT_LEN).as_bytes())?;
+            let blob = josh_gix_ext::write_blob(
+                &repo.objects,
+                random_string(&mut rng, CHURN_CONTENT_LEN).as_bytes(),
+            )?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
 
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = repo.commit(
-            None,
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("commit {i}"),
-            &new_tree,
-            &[&parent],
         )?;
     }
 
     repo.reference(
-        &format!("refs/heads/case_{n_commits}"),
+        format!("refs/heads/case_{n_commits}"),
         head,
-        true,
+        gix::refs::transaction::PreviousValue::Any,
         "bench case tip",
     )?;
-    Ok(gix_oid(head))
+    Ok(head)
 }
 
 /// Aggregate every case tip under one index commit so its oid is a content-addressed cache stamp for
 /// the whole repo and every case stays reachable through provision_repo's `git prune`. Never filtered.
 fn build_index(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     heads: &[gix_hash::ObjectId],
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    let sig = josh_commit_signature()?;
-    let empty_tree = repo.find_tree(repo.treebuilder(None)?.write()?)?;
-    let parents = heads
-        .iter()
-        .map(|oid| repo.find_commit(git2_oid(*oid)))
-        .collect::<Result<Vec<_>, _>>()?;
-    let parent_refs = parents.iter().collect::<Vec<_>>();
-    Ok(gix_oid(repo.commit(
-        Some("refs/heads/bench-index"),
-        &sig,
-        &sig,
-        "bench index",
-        &empty_tree,
-        &parent_refs,
-    )?))
+    josh_test_support::bench::build_index(repo, &josh_actor_signature()?, heads)
 }
 
 fn deephistory_subdir_distributed(c: &mut Criterion) {

--- a/josh-core/benches/deephistory_subdir_sparse.rs
+++ b/josh-core/benches/deephistory_subdir_sparse.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_test_support::bench::josh_commit_signature;
-use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
+use josh_core::git::josh_actor_signature;
+use josh_test_support::bench::EntryKind;
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -48,7 +48,7 @@ const SUBDIR_CHANGE_PROB: f64 = 0.02;
 /// the new value to paste here. Filled in by running the bench once after a build change.
 const EXPECTED_HEAD: &str = "cb9ccbca757fe9707010dde47bed3eeba094679e";
 
-/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME` so the built
+/// Fixed commit timestamp fed to `josh_actor_signature()` via `JOSH_COMMIT_TIME` so the built
 /// history is reproducible and `EXPECTED_HEAD` stays stable. The value itself is arbitrary.
 const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
 
@@ -100,10 +100,13 @@ impl SubdirBench {
         {
             let repo = &provisioned.repo;
             for &n_commits in HISTORY_SIZES {
-                let head = repo.refname_to_id(&format!("refs/heads/case_{n_commits}"))?;
+                let head = josh_test_support::bench::ref_target(
+                    repo,
+                    &format!("refs/heads/case_{n_commits}"),
+                )?;
                 cases.push(SizeCase {
                     n_commits,
-                    head: gix_oid(head),
+                    head: head,
                 });
             }
         }
@@ -129,13 +132,11 @@ impl SubdirBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
-            let filtered_tree = repo.find_commit(git2_oid(filtered))?.tree()?.id();
-            let raw_subdir_tree = repo
-                .find_commit(git2_oid(case.head))?
-                .tree()?
-                .get_path(Path::new(SUBDIR))?
-                .id();
+            let repo = josh_test_support::bench::open_repo(transaction.path())?;
+            let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
+            let raw_subdir_tree =
+                josh_test_support::bench::commit_path(&repo, case.head, Path::new(SUBDIR))?
+                    .ok_or_else(|| anyhow::anyhow!("fixture path is missing"))?;
             anyhow::ensure!(
                 filtered_tree == raw_subdir_tree,
                 "subdir filter did not select `{SUBDIR}` -- benchmark would measure the wrong thing"
@@ -164,10 +165,8 @@ impl SubdirBench {
 }
 
 /// Number of commits reachable from `head`.
-fn count_history(repo: &git2::Repository, head: gix_hash::ObjectId) -> anyhow::Result<usize> {
-    let mut walk = repo.revwalk()?;
-    walk.push(git2_oid(head))?;
-    Ok(walk.count())
+fn count_history(repo: &gix::Repository, head: gix_hash::ObjectId) -> anyhow::Result<usize> {
+    josh_test_support::bench::count_history(repo, head)
 }
 
 fn random_string(rng: &mut StdRng, len: usize) -> String {
@@ -185,24 +184,24 @@ fn random_string(rng: &mut StdRng, len: usize) -> String {
 /// `CHURN_PER_COMMIT` files outside it, and only with probability `SUBDIR_CHANGE_PROB` also touches a
 /// `dir_00` file. The tip is tagged `refs/heads/case_<n_commits>` so the head survives the cache
 /// round-trip.
-fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
+fn build_case(repo: &gix::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
     use rand::RngExt;
 
     // Deterministic root tree: file `i` lives at `dir_{i % N_DIRS}/file_{i}`; split the paths into the
     // filtered subdir (`dir_00`) and the rest so churn can target each set independently.
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     let mut subdir_paths = vec![];
     let mut other_paths = vec![];
     for i in 0..TREE_FILES {
         let dir = i % N_DIRS;
         let path = PathBuf::from(format!("dir_{dir:02}")).join(format!("file_{i:04}"));
-        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.to_string_lossy().as_bytes())?;
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
         if dir == 0 {
             subdir_paths.push(path);
@@ -211,17 +210,18 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
         }
     }
 
-    let root_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
+    let root_tree = builder.write()?.detach();
 
-    let sig = josh_commit_signature()?;
+    let sig = josh_actor_signature()?;
     // No ref update yet -- the tip ref is set once the history is complete.
-    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+    let mut head =
+        josh_gix_ext::write_commit(&repo.objects, root_tree, &[], &sig, &sig, "content")?;
 
     let mut rng = StdRng::seed_from_u64(1);
     for i in 0..n_commits {
-        let parent = repo.find_commit(head)?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
 
         // Always churn non-dir_00 files (guarantees a real input commit, no effect on the filter).
         // Dedup indices so a path is never upserted twice in the same commit.
@@ -231,65 +231,57 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
         }
         for idx in idxs {
             let path = &other_paths[idx];
-            let blob = repo.blob(random_string(&mut rng, CHURN_CONTENT_LEN).as_bytes())?;
+            let blob = josh_gix_ext::write_blob(
+                &repo.objects,
+                random_string(&mut rng, CHURN_CONTENT_LEN).as_bytes(),
+            )?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
         // Rarely also touch dir_00, producing an output commit.
         if rng.random_bool(SUBDIR_CHANGE_PROB) {
             let path = &subdir_paths[rng.random_range(0..subdir_paths.len())];
-            let blob = repo.blob(random_string(&mut rng, CHURN_CONTENT_LEN).as_bytes())?;
+            let blob = josh_gix_ext::write_blob(
+                &repo.objects,
+                random_string(&mut rng, CHURN_CONTENT_LEN).as_bytes(),
+            )?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
 
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = repo.commit(
-            None,
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("commit {i}"),
-            &new_tree,
-            &[&parent],
         )?;
     }
 
     repo.reference(
-        &format!("refs/heads/case_{n_commits}"),
+        format!("refs/heads/case_{n_commits}"),
         head,
-        true,
+        gix::refs::transaction::PreviousValue::Any,
         "bench case tip",
     )?;
-    Ok(gix_oid(head))
+    Ok(head)
 }
 
 /// Aggregate every case tip under one index commit so its oid is a content-addressed cache stamp for
 /// the whole repo and every case stays reachable through provision_repo's `git prune`. Never filtered.
 fn build_index(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     heads: &[gix_hash::ObjectId],
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    let sig = josh_commit_signature()?;
-    let empty_tree = repo.find_tree(repo.treebuilder(None)?.write()?)?;
-    let parents = heads
-        .iter()
-        .map(|oid| repo.find_commit(git2_oid(*oid)))
-        .collect::<Result<Vec<_>, _>>()?;
-    let parent_refs = parents.iter().collect::<Vec<_>>();
-    Ok(gix_oid(repo.commit(
-        Some("refs/heads/bench-index"),
-        &sig,
-        &sig,
-        "bench index",
-        &empty_tree,
-        &parent_refs,
-    )?))
+    josh_test_support::bench::build_index(repo, &josh_actor_signature()?, heads)
 }
 
 fn deephistory_subdir_sparse(c: &mut Criterion) {

--- a/josh-core/benches/refs_filter_update.rs
+++ b/josh-core/benches/refs_filter_update.rs
@@ -1,7 +1,7 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_test_support::bench::josh_commit_signature;
-use josh_test_support::bench::{EntryKind, build_index, git2_oid, gix_oid, random_string};
+use josh_core::git::josh_actor_signature;
+use josh_test_support::bench::{EntryKind, build_index, random_string};
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -53,7 +53,7 @@ const CACHE_NAME: &str = if cfg!(debug_assertions) {
     "refs_filter_update"
 };
 
-/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME` so the built
+/// Fixed commit timestamp fed to `josh_actor_signature()` via `JOSH_COMMIT_TIME` so the built
 /// history is reproducible. Without it the signature uses the wall clock, every run produces
 /// different head oids, and `EXPECTED_HEAD` can never be stable. The value itself is arbitrary.
 const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
@@ -101,7 +101,7 @@ impl RefsBench {
                         .in_scope(|| build_case(repo, n_refs))?;
                     heads.push(head);
                 }
-                build_index(repo, &josh_commit_signature()?, &heads)
+                build_index(repo, &josh_actor_signature()?, &heads)
             },
         )?;
 
@@ -111,11 +111,11 @@ impl RefsBench {
         {
             let repo = &provisioned.repo;
             for &n_refs in REF_COUNTS {
-                let head = repo.refname_to_id(&format!("refs/heads/case_{n_refs}_tip"))?;
-                cases.push(SizeCase {
-                    n_refs,
-                    head: gix_oid(head),
-                });
+                let head = josh_test_support::bench::ref_target(
+                    repo,
+                    &format!("refs/heads/case_{n_refs}_tip"),
+                )?;
+                cases.push(SizeCase { n_refs, head: head });
             }
         }
 
@@ -138,13 +138,11 @@ impl RefsBench {
             // The gate reads the filtered result through the repository handle, which only
             // sees what is on disk.
             transaction.flush_mem_odb()?;
-            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
-            let filtered_tree = repo.find_commit(git2_oid(filtered))?.tree()?.id();
-            let raw_subdir_tree = repo
-                .find_commit(git2_oid(case.head))?
-                .tree()?
-                .get_path(Path::new(SUBDIR))?
-                .id();
+            let repo = josh_test_support::bench::open_repo(transaction.path())?;
+            let filtered_tree = repo.find_commit(filtered)?.tree()?.id();
+            let raw_subdir_tree =
+                josh_test_support::bench::commit_path(&repo, case.head, Path::new(SUBDIR))?
+                    .ok_or_else(|| anyhow::anyhow!("fixture path is missing"))?;
             anyhow::ensure!(
                 filtered_tree == raw_subdir_tree,
                 "subdir filter did not select `{SUBDIR}` -- benchmark would measure the wrong thing"
@@ -174,36 +172,36 @@ impl RefsBench {
 /// directories, then generate `n_refs` churn commits, pointing `refs/heads/case_<n>/change_<i>` at
 /// each. The tip additionally gets `refs/heads/case_<n>_tip` so the head is recoverable after
 /// the repo round-trips through the cache.
-fn build_case(repo: &git2::Repository, n_refs: usize) -> anyhow::Result<gix_hash::ObjectId> {
+fn build_case(repo: &gix::Repository, n_refs: usize) -> anyhow::Result<gix_hash::ObjectId> {
     use rand::RngExt;
 
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     let mut all_paths = vec![];
     for i in 0..TREE_FILES {
         let path = PathBuf::from(format!("dir_{:02}", i % N_DIRS)).join(format!("file_{i:04}"));
-        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.to_string_lossy().as_bytes())?;
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
         all_paths.push(path);
     }
 
-    let root_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
+    let root_tree = builder.write()?.detach();
 
-    let sig = josh_commit_signature()?;
-    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+    let sig = josh_actor_signature()?;
+    let mut head =
+        josh_gix_ext::write_commit(&repo.objects, root_tree, &[], &sig, &sig, "content")?;
 
     // Deterministic history: each commit churns a fresh random ~CHURN_FRACTION of the files and
     // gets its own change ref, so every ref resolves to a distinct commit.
     let mut rng = StdRng::seed_from_u64(1);
     for i in 0..n_refs {
-        let parent = repo.find_commit(head)?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
 
         let churned = all_paths
             .iter()
@@ -213,27 +211,27 @@ fn build_case(repo: &git2::Repository, n_refs: usize) -> anyhow::Result<gix_hash
 
         for path in &churned {
             let content = random_string(&mut rng, CHURN_CONTENT_LEN);
-            let blob = repo.blob(content.as_bytes())?;
+            let blob = josh_gix_ext::write_blob(&repo.objects, content.as_bytes())?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
 
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = repo.commit(
-            None,
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("commit {i}"),
-            &new_tree,
-            &[&parent],
         )?;
         repo.reference(
-            &format!("refs/heads/case_{n_refs}/change_{i:04}"),
+            format!("refs/heads/case_{n_refs}/change_{i:04}"),
             head,
-            true,
+            gix::refs::transaction::PreviousValue::Any,
             "bench change ref",
         )?;
     }
@@ -242,13 +240,13 @@ fn build_case(repo: &git2::Repository, n_refs: usize) -> anyhow::Result<gix_hash
     // never runs. Named `_tip` (not `case_<n>`) because `refs/heads/case_<n>/change_<i>` makes
     // `case_<n>` a ref *directory*, and a ref cannot shadow a directory.
     repo.reference(
-        &format!("refs/heads/case_{n_refs}_tip"),
+        format!("refs/heads/case_{n_refs}_tip"),
         head,
-        true,
+        gix::refs::transaction::PreviousValue::Any,
         "bench case tip",
     )?;
 
-    Ok(gix_oid(head))
+    Ok(head)
 }
 
 fn refs_filter_update(c: &mut Criterion) {

--- a/josh-core/benches/ultrawide_pin.rs
+++ b/josh-core/benches/ultrawide_pin.rs
@@ -1,6 +1,6 @@
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use josh_test_support::bench::josh_commit_signature;
-use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
+use josh_core::git::josh_actor_signature;
+use josh_test_support::bench::EntryKind;
 use rand::prelude::*;
 use std::cell::RefCell;
 use std::ops::DerefMut;
@@ -21,7 +21,7 @@ const NESTING_LEVEL: usize = 3;
 /// paste here. Filled in by running the bench once after a build change.
 const EXPECTED_HEAD: &str = "dec8381c11bbbf281cfec78d8bf9b19283971f99";
 
-/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME`
+/// Fixed commit timestamp fed to `josh_actor_signature()` via `JOSH_COMMIT_TIME`
 /// so the built history is reproducible. Without it the signature uses the wall
 /// clock, every run produces a different head oid, and `EXPECTED_HEAD` can never
 /// be stable. The value itself is arbitrary.
@@ -114,7 +114,7 @@ fn paths_to_compose(paths: &[std::path::PathBuf]) -> josh_filter::Filter {
 }
 
 fn build_initial_state(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
 ) -> anyhow::Result<(gix_hash::ObjectId, Vec<std::path::PathBuf>)> {
     const PATH_COMPONENT_LENGTH: usize = 15;
 
@@ -124,9 +124,8 @@ fn build_initial_state(
     let files_in_folder =
         rand::distr::Uniform::try_from(N_PER_SUBFOLDER_MIN..=N_PER_SUBFOLDER_MAX)?;
 
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     let mut all_paths = vec![];
     let mut total_files = 0usize;
 
@@ -146,13 +145,13 @@ fn build_initial_state(
             //
             // In subsequent commits will be rewritten anyway to
             // simulate pinned updates
-            let oid = repo.blob(file_name.as_bytes())?;
+            let oid = josh_gix_ext::write_blob(&repo.objects, file_name.as_bytes())?;
 
             all_paths.push(full_path.clone());
             builder.upsert(
                 full_path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(oid),
+                oid,
             )?;
         }
 
@@ -164,27 +163,26 @@ fn build_initial_state(
     // resolve to empty for the root commit and its descendants would have an
     // empty filtered parent.
     let workspace = josh_filter::as_file(paths_to_compose(&all_paths), 2);
-    let blob = repo.blob(workspace.as_bytes())?;
-    builder.upsert("workspace/workspace.josh", EntryKind::Blob, gix_oid(blob))?;
+    let blob = josh_gix_ext::write_blob(&repo.objects, workspace.as_bytes())?;
+    builder.upsert("workspace/workspace.josh", EntryKind::Blob, blob)?;
 
-    let new_tree = git2_oid(builder.write()?.detach());
-    let new_tree = repo.find_tree(new_tree)?;
+    let new_tree = builder.write()?.detach();
 
-    let sig = josh_commit_signature()?;
-    let head = repo.commit(
-        Some("refs/heads/main"),
-        &sig,
-        &sig,
+    let sig = josh_actor_signature()?;
+    let head =
+        josh_gix_ext::write_commit(&repo.objects, new_tree, &[], &sig, &sig, "initial commit")?;
+    repo.reference(
+        "refs/heads/main",
+        head,
+        gix::refs::transaction::PreviousValue::Any,
         "initial commit",
-        &new_tree,
-        &[],
     )?;
 
-    Ok((gix_oid(head), all_paths))
+    Ok((head, all_paths))
 }
 
 fn build_history(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     paths: &[std::path::PathBuf],
     mut head: gix_hash::ObjectId,
 ) -> anyhow::Result<gix_hash::ObjectId> {
@@ -198,7 +196,6 @@ fn build_history(
 
     // Shouldn't matter for this benchmark, we don't look into blobs
     const BLOB_CONTENT_LEN: usize = 10;
-    let gix_repo = gix::open(repo.path())?;
 
     let rng = RefCell::new(StdRng::seed_from_u64(0));
     let include_path = || rng.borrow_mut().random_bool(PROB_FILE_UPDATED);
@@ -214,9 +211,9 @@ fn build_history(
     let mut pinned = std::collections::BTreeSet::<std::path::PathBuf>::new();
 
     for i_commit in 0..N_COMMITS {
-        let parent = repo.find_commit(git2_oid(head))?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
 
         let updated_paths = paths
             .iter()
@@ -237,12 +234,12 @@ fn build_history(
             }
 
             let updated_content = random_string(rng.borrow_mut().deref_mut(), BLOB_CONTENT_LEN);
-            let blob = repo.blob(updated_content.as_bytes())?;
+            let blob = josh_gix_ext::write_blob(&repo.objects, updated_content.as_bytes())?;
 
             builder.upsert(
                 updated_path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
 
@@ -258,23 +255,28 @@ fn build_history(
         // Render the filter into `workspace/workspace.josh` and add it to the
         // tree we're preparing for this commit.
         let workspace = josh_filter::as_file(filter, 2);
-        let blob = repo.blob(workspace.as_bytes())?;
+        let blob = josh_gix_ext::write_blob(&repo.objects, workspace.as_bytes())?;
 
-        builder.upsert("workspace/workspace.josh", EntryKind::Blob, gix_oid(blob))?;
+        builder.upsert("workspace/workspace.josh", EntryKind::Blob, blob)?;
 
         // Commit the updated tree on top of the current head.
-        let new_tree = git2_oid(builder.write()?.detach());
-        let new_tree = repo.find_tree(new_tree)?;
+        let new_tree = builder.write()?.detach();
 
-        let sig = josh_commit_signature()?;
-        head = gix_oid(repo.commit(
-            Some("refs/heads/main"),
+        let sig = josh_actor_signature()?;
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("commit {i_commit}"),
-            &new_tree,
-            &[&parent],
-        )?);
+        )?;
+        repo.reference(
+            "refs/heads/main",
+            head,
+            gix::refs::transaction::PreviousValue::Any,
+            "bench commit",
+        )?;
     }
 
     Ok(head)

--- a/josh-core/benches/ultrawide_pin_hook.rs
+++ b/josh-core/benches/ultrawide_pin_hook.rs
@@ -1,6 +1,6 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use josh_test_support::bench::josh_commit_signature;
-use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
+use josh_core::git::josh_actor_signature;
+use josh_test_support::bench::EntryKind;
 use rand::prelude::*;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -62,7 +62,7 @@ const HOOK_ARG_ONE_TREE: &str = "one_tree";
 /// by running the bench once after a build change.
 const EXPECTED_HEAD: &str = "8deb73b572162ae4b4caf36ae52f3b2ef70e1485";
 
-/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME` so the built
+/// Fixed commit timestamp fed to `josh_actor_signature()` via `JOSH_COMMIT_TIME` so the built
 /// history is reproducible. Without it the signature uses the wall clock, every run produces
 /// different head oids, and `EXPECTED_HEAD` can never be stable. The value itself is arbitrary.
 const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
@@ -158,7 +158,8 @@ impl PinBench {
         {
             let repo = &provisioned.repo;
             for &size in SIZES {
-                let head = gix_oid(repo.refname_to_id(&format!("refs/heads/case_{size}"))?);
+                let head =
+                    josh_test_support::bench::ref_target(repo, &format!("refs/heads/case_{size}"))?;
                 record_case(repo, head, &mut per_path, &mut one_tree)?;
                 cases.push(SizeCase { size, head });
             }
@@ -278,18 +279,18 @@ fn pin_filter(pinned: &[PathBuf]) -> josh_filter::Filter {
 /// for the empty pinned set. The pin argument is one op no matter how many paths are pinned, so
 /// filter-engine work stays near-constant as the pinned set grows.
 fn pin_filter_tree(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     pinned: &[PathBuf],
 ) -> anyhow::Result<josh_filter::Filter> {
-    let placeholder = repo.blob(b"x")?;
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+    let placeholder = josh_gix_ext::write_blob(&repo.objects, b"x")?;
+
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     for path in pinned {
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(placeholder),
+            placeholder,
         )?;
     }
     let tree = builder.write()?.detach();
@@ -301,7 +302,7 @@ fn pin_filter_tree(
 /// per commit. The tip is tagged with `refs/heads/case_<size>` so the head is recoverable after the
 /// repo round-trips through the cache; the pinned set and per-commit pin filters are not recorded here
 /// -- they are reconstructed from tree diffs in `record_case`.
-fn build_case(repo: &git2::Repository, size: usize) -> anyhow::Result<gix_hash::ObjectId> {
+fn build_case(repo: &gix::Repository, size: usize) -> anyhow::Result<gix_hash::ObjectId> {
     use rand::RngExt;
 
     // Distribute files uniformly across nested subfolders.
@@ -309,9 +310,8 @@ fn build_case(repo: &git2::Repository, size: usize) -> anyhow::Result<gix_hash::
     let files_in_folder =
         rand::distr::Uniform::try_from(N_PER_SUBFOLDER_MIN..=N_PER_SUBFOLDER_MAX)?;
 
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     let mut all_paths = vec![];
 
     while all_paths.len() < size {
@@ -324,30 +324,31 @@ fn build_case(repo: &git2::Repository, size: usize) -> anyhow::Result<gix_hash::
         for i in 0..to_add {
             let file_name = format!("file_{}", i);
             let full_path = subpath.join(&file_name);
-            let oid = repo.blob(file_name.as_bytes())?;
+            let oid = josh_gix_ext::write_blob(&repo.objects, file_name.as_bytes())?;
             builder.upsert(
                 full_path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(oid),
+                oid,
             )?;
             all_paths.push(full_path);
         }
     }
 
-    let root_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
+    let root_tree = builder.write()?.detach();
 
-    let sig = josh_commit_signature()?;
+    let sig = josh_actor_signature()?;
     // No ref update yet -- the tip ref is set once the history is complete.
-    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+    let mut head =
+        josh_gix_ext::write_commit(&repo.objects, root_tree, &[], &sig, &sig, "content")?;
 
     // Deterministic history: each commit churns a fresh random ~CHURN_FRACTION of the files. Only the
     // content churn is written here; the churned set is what `record_case` recovers by diffing against
     // the parent, and the evolving pinned set is derived from it there.
     let mut rng = StdRng::seed_from_u64(1);
     for i in 0..N_COMMITS {
-        let parent = repo.find_commit(head)?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
 
         let churned = all_paths
             .iter()
@@ -357,60 +358,45 @@ fn build_case(repo: &git2::Repository, size: usize) -> anyhow::Result<gix_hash::
 
         for path in &churned {
             let content = random_string(&mut rng, CHURN_CONTENT_LEN);
-            let blob = repo.blob(content.as_bytes())?;
+            let blob = josh_gix_ext::write_blob(&repo.objects, content.as_bytes())?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
 
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = repo.commit(
-            None,
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("commit {i}"),
-            &new_tree,
-            &[&parent],
         )?;
     }
 
     // Tag the tip so `record_case` can find this case's head on the cache-hit path, where the
     // build callback never runs. Also keeps the whole history reachable through `git prune`.
     repo.reference(
-        &format!("refs/heads/case_{size}"),
+        format!("refs/heads/case_{size}"),
         head,
-        true,
+        gix::refs::transaction::PreviousValue::Any,
         "bench case tip",
     )?;
 
-    Ok(gix_oid(head))
+    Ok(head)
 }
 
 /// Aggregate every case tip under one index commit. Its oid changes whenever any case head changes,
 /// making it a faithful content-addressed cache stamp for the entire repo, and it keeps all cases
 /// reachable so provision_repo's `git prune` retains the full history. It is never filtered.
 fn build_index(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     heads: &[gix_hash::ObjectId],
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    let sig = josh_commit_signature()?;
-    let empty_tree = repo.find_tree(repo.treebuilder(None)?.write()?)?;
-    let parents = heads
-        .iter()
-        .map(|oid| repo.find_commit(git2_oid(*oid)))
-        .collect::<Result<Vec<_>, _>>()?;
-    let parent_refs = parents.iter().collect::<Vec<_>>();
-    let index = repo.commit(
-        Some("refs/heads/bench-index"),
-        &sig,
-        &sig,
-        "bench index",
-        &empty_tree,
-        &parent_refs,
-    )?;
-    Ok(gix_oid(index))
+    josh_test_support::bench::build_index(repo, &josh_actor_signature()?, heads)
 }
 
 /// Walk a case's linear history root-to-tip, reconstructing each commit's pinned set and recording
@@ -422,7 +408,7 @@ fn build_index(
 /// model purely from repo-derived data, so it is identical whether the repo was freshly built or
 /// copied from cache.
 fn record_case(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     head: gix_hash::ObjectId,
     per_path: &mut HashMap<gix_hash::ObjectId, josh_filter::Filter>,
     one_tree: &mut HashMap<gix_hash::ObjectId, josh_filter::Filter>,
@@ -431,23 +417,21 @@ fn record_case(
     let mut chain = vec![];
     let mut oid = head;
     loop {
-        let commit = repo.find_commit(git2_oid(oid))?;
+        let commit = josh_gix_ext::CommitData::read(&repo.objects, oid)?;
         chain.push(oid);
-        if commit.parent_count() == 0 {
+        let Some(parent) = commit.parent_ids().next() else {
             break;
-        }
-        oid = gix_oid(commit.parent_id(0)?);
+        };
+        oid = parent;
     }
     chain.reverse();
 
     let mut pinned = std::collections::BTreeSet::<PathBuf>::new();
     for (commit_index, &oid) in chain.iter().enumerate() {
-        let commit = repo.find_commit(git2_oid(oid))?;
-
         // Re-roll the hold status of every churned path; unchurned paths keep the status they carried
         // over. The root commit has no parent, so its churned set is empty and the pinned set stays
         // empty there.
-        for path in changed_paths(repo, &commit)? {
+        for path in changed_paths(repo, oid)? {
             if holds_back(&path, commit_index) {
                 pinned.insert(path);
             } else {
@@ -482,26 +466,45 @@ fn holds_back(path: &std::path::Path, commit_index: usize) -> bool {
 }
 
 /// The paths that differ between `commit` and its first parent (empty for a parentless commit).
-fn changed_paths(repo: &git2::Repository, commit: &git2::Commit) -> anyhow::Result<Vec<PathBuf>> {
-    if commit.parent_count() == 0 {
+fn changed_paths(
+    repo: &gix::Repository,
+    commit_id: gix_hash::ObjectId,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let commit = josh_gix_ext::CommitData::read(&repo.objects, commit_id)?;
+    let Some(parent_id) = commit.parent_ids().next() else {
         return Ok(vec![]);
-    }
-    let parent_tree = commit.parent(0)?.tree()?;
-    let tree = commit.tree()?;
-    let diff = repo.diff_tree_to_tree(Some(&parent_tree), Some(&tree), None)?;
-    let mut paths = vec![];
-    diff.foreach(
-        &mut |delta, _| {
-            if let Some(path) = delta.new_file().path() {
-                paths.push(path.to_path_buf());
+    };
+    let parent_tree = josh_gix_ext::CommitData::read(&repo.objects, parent_id)?.tree_id()?;
+    let tree = commit.tree_id()?;
+
+    let entries = |root| -> anyhow::Result<
+        std::collections::BTreeMap<PathBuf, (gix::objs::tree::EntryKind, gix_hash::ObjectId)>,
+    > {
+        let mut entries = std::collections::BTreeMap::new();
+        josh_gix_ext::walk_tree_preorder(&repo.objects, root, &mut |parent, entry| {
+            if !entry.mode.is_tree() {
+                let name = std::str::from_utf8(entry.filename)?;
+                let path = if parent.is_empty() {
+                    PathBuf::from(name)
+                } else {
+                    PathBuf::from(parent).join(name)
+                };
+                entries.insert(path, (entry.mode.kind(), entry.oid.to_owned()));
             }
-            true
-        },
-        None,
-        None,
-        None,
-    )?;
-    Ok(paths)
+            Ok(())
+        })?;
+        Ok(entries)
+    };
+    let parent_entries = entries(parent_tree)?;
+    let entries = entries(tree)?;
+    Ok(parent_entries
+        .keys()
+        .chain(entries.keys())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .filter(|path| parent_entries.get(*path) != entries.get(*path))
+        .cloned()
+        .collect())
 }
 
 fn ultrawide_pin_hook(c: &mut Criterion) {

--- a/josh-core/benches/unapply.rs
+++ b/josh-core/benches/unapply.rs
@@ -1,8 +1,8 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
+use josh_core::git::josh_actor_signature;
 use josh_core::history::{OrphansMode, unapply_filter};
-use josh_test_support::bench::josh_commit_signature;
-use josh_test_support::bench::{EntryKind, git2_oid, gix_oid};
+use josh_test_support::bench::EntryKind;
 use rand::prelude::*;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -101,9 +101,12 @@ impl UnapplyBench {
         let mut cases = vec![];
         {
             let transaction = context.open()?;
-            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
+            let repo = josh_test_support::bench::open_repo(transaction.path())?;
             for &n_commits in HISTORY_SIZES {
-                let head = gix_oid(repo.refname_to_id(&format!("refs/heads/case_{n_commits}"))?);
+                let head = josh_test_support::bench::ref_target(
+                    &repo,
+                    &format!("refs/heads/case_{n_commits}"),
+                )?;
                 let filtered_head = josh_core::filter_commit(&transaction, filter, head)?;
                 // The first-parent chase below reads the filtered commits through the
                 // repository handle, which only sees what is on disk.
@@ -112,11 +115,11 @@ impl UnapplyBench {
                 // First-parent chase to the middle of the filtered history.
                 let mut filtered_mid = filtered_head;
                 for _ in 0..n_commits / 2 {
-                    let commit = repo.find_commit(git2_oid(filtered_mid))?;
-                    match commit.parent_id(0) {
-                        Ok(p) => filtered_mid = gix_oid(p),
-                        Err(_) => break,
-                    }
+                    let commit = josh_gix_ext::CommitData::read(&repo.objects, filtered_mid)?;
+                    let Some(parent) = commit.parent_ids().next() else {
+                        break;
+                    };
+                    filtered_mid = parent;
                 }
 
                 cases.push(SizeCase {
@@ -149,34 +152,34 @@ fn random_string(rng: &mut StdRng, len: usize) -> String {
 
 /// deephistory-style case builder: fixed tree, `n_commits` of ~10% churn, tip tagged as
 /// `refs/heads/case_<n_commits>`.
-fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
+fn build_case(repo: &gix::Repository, n_commits: usize) -> anyhow::Result<gix_hash::ObjectId> {
     use rand::RngExt;
 
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     let mut all_paths = vec![];
     for i in 0..TREE_FILES {
         let path = PathBuf::from(format!("dir_{:02}", i % N_DIRS)).join(format!("file_{i:04}"));
-        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.to_string_lossy().as_bytes())?;
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
         all_paths.push(path);
     }
 
-    let root_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
+    let root_tree = builder.write()?.detach();
 
-    let sig = josh_commit_signature()?;
-    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+    let sig = josh_actor_signature()?;
+    let mut head =
+        josh_gix_ext::write_commit(&repo.objects, root_tree, &[], &sig, &sig, "content")?;
 
     let mut rng = StdRng::seed_from_u64(1);
     for i in 0..n_commits {
-        let parent = repo.find_commit(head)?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
 
         let churned = all_paths
             .iter()
@@ -186,83 +189,68 @@ fn build_case(repo: &git2::Repository, n_commits: usize) -> anyhow::Result<gix_h
 
         for path in &churned {
             let content = random_string(&mut rng, CHURN_CONTENT_LEN);
-            let blob = repo.blob(content.as_bytes())?;
+            let blob = josh_gix_ext::write_blob(&repo.objects, content.as_bytes())?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
 
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = repo.commit(
-            None,
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("commit {i}"),
-            &new_tree,
-            &[&parent],
         )?;
     }
 
     repo.reference(
-        &format!("refs/heads/case_{n_commits}"),
+        format!("refs/heads/case_{n_commits}"),
         head,
-        true,
+        gix::refs::transaction::PreviousValue::Any,
         "bench case tip",
     )?;
 
-    Ok(gix_oid(head))
+    Ok(head)
 }
 
 fn build_index(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     heads: &[gix_hash::ObjectId],
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    let sig = josh_commit_signature()?;
-    let empty_tree = repo.find_tree(repo.treebuilder(None)?.write()?)?;
-    let parents = heads
-        .iter()
-        .map(|oid| repo.find_commit(git2_oid(*oid)))
-        .collect::<Result<Vec<_>, _>>()?;
-    let parent_refs = parents.iter().collect::<Vec<_>>();
-    let index = repo.commit(
-        Some("refs/heads/bench-index"),
-        &sig,
-        &sig,
-        "bench index",
-        &empty_tree,
-        &parent_refs,
-    )?;
-    Ok(gix_oid(index))
+    josh_test_support::bench::build_index(repo, &josh_actor_signature()?, heads)
 }
 
 /// Build `PUSH_LEN` commits on top of `base` in FILTERED space, each touching the filtered
 /// root's `file_0000` with content salted by `salt` so every bench iteration pushes a chain
 /// of commits the caches have never seen.
 fn extend_filtered(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     base: gix_hash::ObjectId,
     salt: usize,
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    let sig = josh_commit_signature()?;
+    let sig = josh_actor_signature()?;
     let mut head = base;
-    let gix_repo = gix::open(repo.path())?;
+
     for i in 0..PUSH_LEN {
-        let parent = repo.find_commit(git2_oid(head))?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
-        let blob = repo.blob(format!("push {salt} {i}").as_bytes())?;
-        builder.upsert("file_0000", EntryKind::Blob, gix_oid(blob))?;
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = gix_oid(repo.commit(
-            None,
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
+        let blob = josh_gix_ext::write_blob(&repo.objects, format!("push {salt} {i}").as_bytes())?;
+        builder.upsert("file_0000", EntryKind::Blob, blob)?;
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("push {salt} {i}"),
-            &new_tree,
-            &[&parent],
-        )?);
+        )?;
     }
     Ok(head)
 }
@@ -281,7 +269,7 @@ fn unapply_extend(c: &mut Criterion) {
         let case = bench.cases.first().expect("at least one case");
         let transaction = bench.context.open().expect("open transaction");
         let reference_repo =
-            josh_test_support::bench::open_git2_repo(transaction.path()).expect("open repo");
+            josh_test_support::bench::open_repo(transaction.path()).expect("open repo");
         let tip = extend_filtered(&reference_repo, case.filtered_head, usize::MAX)
             .expect("extend filtered");
         let unapplied = unapply_filter(
@@ -313,8 +301,7 @@ fn unapply_extend(c: &mut Criterion) {
                 || {
                     let transaction = bench.context.open().expect("open transaction");
                     let reference_repo =
-                        josh_test_support::bench::open_git2_repo(transaction.path())
-                            .expect("open repo");
+                        josh_test_support::bench::open_repo(transaction.path()).expect("open repo");
                     let tip = extend_filtered(
                         &reference_repo,
                         case.filtered_head,

--- a/josh-core/benches/widetree_glob.rs
+++ b/josh-core/benches/widetree_glob.rs
@@ -1,9 +1,7 @@
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use josh_core::filter::Filter;
-use josh_test_support::bench::josh_commit_signature;
-use josh_test_support::bench::{
-    EntryKind, build_index, expected_tree, git2_oid, gix_oid, random_string,
-};
+use josh_core::git::josh_actor_signature;
+use josh_test_support::bench::{EntryKind, build_index, expected_tree, random_string};
 use rand::prelude::*;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -67,7 +65,7 @@ const CACHE_NAME: &str = if cfg!(debug_assertions) {
     "widetree_glob"
 };
 
-/// Fixed commit timestamp fed to `josh_commit_signature()` via `JOSH_COMMIT_TIME` so the built
+/// Fixed commit timestamp fed to `josh_actor_signature()` via `JOSH_COMMIT_TIME` so the built
 /// history is reproducible. Without it the signature uses the wall clock, every run produces
 /// different head oids, and `EXPECTED_HEAD` can never be stable. The value itself is arbitrary.
 const JOSH_BENCH_COMMIT_TIME: &str = "1700000000";
@@ -113,7 +111,7 @@ impl GlobBench {
                         .in_scope(|| build_case(repo, n_files))?;
                     heads.push(head);
                 }
-                build_index(repo, &josh_commit_signature()?, &heads)
+                build_index(repo, &josh_actor_signature()?, &heads)
             },
         )?;
 
@@ -123,10 +121,13 @@ impl GlobBench {
         {
             let repo = &provisioned.repo;
             for &n_files in TREE_SIZES {
-                let head = repo.refname_to_id(&format!("refs/heads/case_{n_files}"))?;
+                let head = josh_test_support::bench::ref_target(
+                    repo,
+                    &format!("refs/heads/case_{n_files}"),
+                )?;
                 cases.push(SizeCase {
                     n_files,
-                    head: gix_oid(head),
+                    head: head,
                 });
             }
         }
@@ -139,14 +140,14 @@ impl GlobBench {
         let context = josh_core::cache::TransactionContext::new(provisioned.path(), cache);
 
         // Correctness gates (untimed, per size case, all three patterns): confirm the filters
-        // produce exactly the trees an independent git2 walk predicts, so we never silently
+        // produce exactly the trees an independent reference walk predicts, so we never silently
         // measure a filter that drops everything or is a no-op. A pattern filter keeps matching
         // blobs at their ORIGINAL paths (it does not lift subtrees to the root like `:/subdir`).
         // Run through a throwaway transaction, then reset caches so nothing here warms the timed
         // runs.
         {
             let transaction = context.open()?;
-            let repo = josh_test_support::bench::open_git2_repo(transaction.path())?;
+            let repo = josh_test_support::bench::open_repo(transaction.path())?;
             for case in &cases {
                 // Recursive pattern: keeps exactly the `.rs` blobs everywhere (string predicate is
                 // exact -- see the no-dot-component invariant above).
@@ -154,14 +155,13 @@ impl GlobBench {
                     .pattern(PATTERN_RECURSIVE)
                     .expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
-                // The gate compares against an independent git2 reference model, which only
-                // sees what is on disk.
+                // The reference walk sees only objects already persisted to disk.
                 transaction.flush_mem_odb()?;
-                let got = repo.find_commit(git2_oid(filtered))?.tree_id();
+                let got = josh_test_support::bench::commit_tree(&repo, filtered)?;
                 let (want, kept) = expected_tree(&repo, case.head, &|p| p.ends_with(".rs"))?;
                 anyhow::ensure!(kept > 0, "recursive gate kept no blobs -- would be a no-op");
                 anyhow::ensure!(
-                    gix_oid(got) == want,
+                    got == want,
                     "`::{PATTERN_RECURSIVE}` produced {got}, expected {want} (n_files {})",
                     case.n_files
                 );
@@ -173,18 +173,21 @@ impl GlobBench {
                 let filter = Filter::new().pattern(PATTERN_PREFIX).expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
                 transaction.flush_mem_odb()?;
-                let got_tree = repo.find_commit(git2_oid(filtered))?.tree()?;
+                let got_tree = josh_test_support::bench::commit_tree(&repo, filtered)?;
+                let got_entries = josh_gix_ext::read_tree_entries(&repo.objects, got_tree)?;
                 anyhow::ensure!(
-                    got_tree.len() == 1,
+                    got_entries.len() == 1,
                     "`::{PATTERN_PREFIX}` result must have exactly one top-level entry"
                 );
-                let raw_subtree = repo
-                    .find_commit(git2_oid(case.head))?
-                    .tree()?
-                    .get_path(Path::new(PREFIX_DIR))?
-                    .id();
+                let raw_subtree =
+                    josh_test_support::bench::commit_path(&repo, case.head, Path::new(PREFIX_DIR))?
+                        .ok_or_else(|| anyhow::anyhow!("fixture path is missing"))?;
                 anyhow::ensure!(
-                    got_tree.get_name(PREFIX_DIR).map(|e| e.id()) == Some(raw_subtree),
+                    got_entries
+                        .iter()
+                        .find(|entry| entry.filename == PREFIX_DIR.as_bytes())
+                        .map(|entry| entry.oid)
+                        == Some(raw_subtree),
                     "`::{PATTERN_PREFIX}` must keep `{PREFIX_DIR}` at its original path"
                 );
 
@@ -192,14 +195,14 @@ impl GlobBench {
                 let filter = Filter::new().pattern(PATTERN_SPARSE).expect("valid glob");
                 let filtered = josh_core::filter_commit(&transaction, filter, case.head)?;
                 transaction.flush_mem_odb()?;
-                let got = repo.find_commit(git2_oid(filtered))?.tree_id();
+                let got = josh_test_support::bench::commit_tree(&repo, filtered)?;
                 let (want, kept) = expected_tree(&repo, case.head, &|p| p.ends_with(".toml"))?;
                 anyhow::ensure!(
                     kept == N_SPARSE,
                     "sparse gate kept {kept} blobs, expected exactly {N_SPARSE}"
                 );
                 anyhow::ensure!(
-                    gix_oid(got) == want,
+                    got == want,
                     "`::{PATTERN_SPARSE}` produced {got}, expected {want} (n_files {})",
                     case.n_files
                 );
@@ -232,17 +235,16 @@ fn file_path(i: usize) -> PathBuf {
 /// CHURN_PER_COMMIT files at deterministic indices. The tip is tagged with
 /// `refs/heads/case_<n_files>` so the head is recoverable after the repo round-trips through the
 /// cache.
-fn build_case(repo: &git2::Repository, n_files: usize) -> anyhow::Result<gix_hash::ObjectId> {
-    let gix_repo = gix::open(repo.path())?;
-    let baseline = repo.treebuilder(None)?.write()?;
-    let mut builder = gix_repo.edit_tree(gix_oid(baseline))?;
+fn build_case(repo: &gix::Repository, n_files: usize) -> anyhow::Result<gix_hash::ObjectId> {
+    let baseline = josh_test_support::bench::empty_tree(repo)?;
+    let mut builder = repo.edit_tree(baseline)?;
     for i in 0..n_files {
         let path = file_path(i);
-        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.to_string_lossy().as_bytes())?;
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
     }
     // Planted sparse files -- the only `.toml` blobs (see N_SPARSE above).
@@ -250,46 +252,47 @@ fn build_case(repo: &git2::Repository, n_files: usize) -> anyhow::Result<gix_has
         let path = PathBuf::from(format!("sub_{k:02}"))
             .join("dir_00")
             .join(format!("config_{k:02}.toml"));
-        let oid = repo.blob(path.to_string_lossy().as_bytes())?;
+        let oid = josh_gix_ext::write_blob(&repo.objects, path.to_string_lossy().as_bytes())?;
         builder.upsert(
             path.to_str().expect("benchmark paths are UTF-8"),
             EntryKind::Blob,
-            gix_oid(oid),
+            oid,
         )?;
     }
 
-    let root_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
+    let root_tree = builder.write()?.detach();
 
-    let sig = josh_commit_signature()?;
+    let sig = josh_actor_signature()?;
     // No ref update yet -- the tip ref is set once the history is complete.
-    let mut head = repo.commit(None, &sig, &sig, "content", &root_tree, &[])?;
+    let mut head =
+        josh_gix_ext::write_commit(&repo.objects, root_tree, &[], &sig, &sig, "content")?;
 
     // Deterministic short history: each commit churns CHURN_PER_COMMIT files at rotating indices.
     let mut rng = StdRng::seed_from_u64(1);
     for commit_idx in 0..N_COMMITS - 1 {
-        let parent = repo.find_commit(head)?;
-        let tree = parent.tree()?;
-        let mut builder = gix_repo.edit_tree(gix_oid(tree.id()))?;
+        let parent = josh_gix_ext::CommitData::read(&repo.objects, head)?;
+        let tree = parent.tree_id()?;
+        let mut builder = repo.edit_tree(tree)?;
 
         for j in 0..CHURN_PER_COMMIT {
             let path = file_path((commit_idx * 31 + j) % n_files);
             let content = random_string(&mut rng, 10);
-            let blob = repo.blob(content.as_bytes())?;
+            let blob = josh_gix_ext::write_blob(&repo.objects, content.as_bytes())?;
             builder.upsert(
                 path.to_str().expect("benchmark paths are UTF-8"),
                 EntryKind::Blob,
-                gix_oid(blob),
+                blob,
             )?;
         }
 
-        let new_tree = repo.find_tree(git2_oid(builder.write()?.detach()))?;
-        head = repo.commit(
-            None,
+        let new_tree = builder.write()?.detach();
+        head = josh_gix_ext::write_commit(
+            &repo.objects,
+            new_tree,
+            &[head],
             &sig,
             &sig,
             &format!("commit {commit_idx}"),
-            &new_tree,
-            &[&parent],
         )?;
     }
 
@@ -297,13 +300,13 @@ fn build_case(repo: &git2::Repository, n_files: usize) -> anyhow::Result<gix_has
     // callback never runs. Also keeps the whole history reachable, so provision_repo's `git prune`
     // retains it.
     repo.reference(
-        &format!("refs/heads/case_{n_files}"),
+        format!("refs/heads/case_{n_files}"),
         head,
-        true,
+        gix::refs::transaction::PreviousValue::Any,
         "bench case tip",
     )?;
 
-    Ok(gix_oid(head))
+    Ok(head)
 }
 
 fn widetree_glob(c: &mut Criterion) {


### PR DESCRIPTION
Remove josh-test-support's libgit2 dependency

Build and inspect benchmark repositories entirely through gitoxide. Shared fixture helpers now write commits, resolve refs, walk trees, and count history without libgit2, while every migrated benchmark preserves its pinned fixture object IDs and correctness gates.

Change: josh-test-support-git2

Assisted-By: openai-codex/gpt-5.6-sol