### PR TITLE
Remove libgit2 from container images

### DIFF
--- a/images/dev/Dockerfile
+++ b/images/dev/Dockerfile
@@ -29,7 +29,6 @@ RUN apk add --no-cache \
     py3-pip \
     tree \
     autoconf \
-    libgit2-dev \
     psmisc \
     gcompat \
     libgcc

--- a/images/run/Dockerfile
+++ b/images/run/Dockerfile
@@ -12,7 +12,6 @@ RUN apk add --no-cache \
     zlib \
     openssl \
     libexpat \
-    libgit2 \
     libgcc \
     libcurl \
     ca-certificates \

--- a/images/scrut-test/Dockerfile
+++ b/images/scrut-test/Dockerfile
@@ -56,7 +56,6 @@ RUN apk add --no-cache \
     py3-pip \
     tree \
     autoconf \
-    libgit2-dev \
     psmisc \
     zlib-dev \
     openssl-dev \


### PR DESCRIPTION
Remove libgit2 from container images

The Rust workspaces no longer contain git2 or libgit2-sys, so the development, test, and runtime images no longer need Alpine libgit2 packages.

Change: container-images-git2

Assisted-By: openai-codex/gpt-5.6-sol