### PR TITLE
Remove libgit2 from git-tree-viewer

### DIFF
--- a/devtools/Cargo.lock
+++ b/devtools/Cargo.lock
@@ -1402,27 +1402,12 @@ dependencies = [
  "clap",
  "eframe",
  "egui",
- "git2",
+ "gix",
  "josh-cq-test-components",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
-]
-
-[[package]]
-name = "git2"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
-dependencies = [
- "bitflags 2.13.1",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "url",
 ]
 
 [[package]]
@@ -2989,19 +2974,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.7+1.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,18 +2999,6 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.9.1",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -3600,37 +3560,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-src"
-version = "300.6.1+3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4182,7 +4114,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -5043,12 +4975,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vello_common"

--- a/devtools/git-tree-viewer/Cargo.toml
+++ b/devtools/git-tree-viewer/Cargo.toml
@@ -11,7 +11,7 @@ name = "git-tree-viewer"
 path = "src/bin/git-tree-viewer.rs"
 
 [dependencies]
-git2 = { version = "0.21", default-features = false, features = ["vendored-openssl", "https"] }
+gix = { version = "0.86", default-features = false, features = ["sha1", "revision"] }
 anyhow = { version = "1", features = ["backtrace"] }
 clap = { version = "4.6.5", features = ["derive", "env"] }
 egui = "0.35.0"

--- a/devtools/git-tree-viewer/src/git/blob.rs
+++ b/devtools/git-tree-viewer/src/git/blob.rs
@@ -1,11 +1,8 @@
-use git2::{Oid, Repository};
-
-pub fn load_blob_content(repo: &Repository, oid: Oid) -> String {
+pub fn load_blob_content(repo: &gix::Repository, oid: gix::ObjectId) -> String {
     match repo.find_blob(oid) {
-        Ok(blob) => {
-            let content = blob.content();
-            String::from_utf8(content.to_vec()).unwrap_or_else(|_| "<Binary file>".to_string())
-        }
-        Err(e) => format!("Error loading file: {}", e),
+        Ok(blob) => std::str::from_utf8(&blob.data)
+            .map(str::to_owned)
+            .unwrap_or_else(|_| "<Binary file>".to_string()),
+        Err(e) => format!("Error loading file: {e}"),
     }
 }

--- a/devtools/git-tree-viewer/src/git/mod.rs
+++ b/devtools/git-tree-viewer/src/git/mod.rs
@@ -5,3 +5,63 @@ pub mod tree;
 pub use blob::load_blob_content;
 pub use repo::{open_repo, resolve_commit};
 pub use tree::{build_tree, TreeItem};
+
+#[cfg(test)]
+mod tests {
+    use super::{build_tree, load_blob_content, open_repo, resolve_commit, TreeItem};
+
+    #[test]
+    fn opens_repository_and_loads_commit_tree() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let repo = gix::init(dir.path())?;
+        let blob_id = repo.write_blob(b"hello from gitoxide")?.detach();
+        let tree_id = repo
+            .write_object(gix::objs::Tree {
+                entries: vec![gix::objs::tree::Entry {
+                    mode: gix::objs::tree::EntryKind::Blob.into(),
+                    filename: "hello.txt".into(),
+                    oid: blob_id,
+                }],
+            })?
+            .detach();
+        let signature = gix::actor::Signature {
+            name: "Josh Test".into(),
+            email: "josh@example.com".into(),
+            time: gix::actor::date::Time {
+                seconds: 0,
+                offset: 0,
+            },
+        };
+        let mut committer_time = gix::date::parse::TimeBuf::default();
+        let mut author_time = gix::date::parse::TimeBuf::default();
+        repo.commit_as(
+            signature.to_ref(&mut committer_time),
+            signature.to_ref(&mut author_time),
+            "HEAD",
+            "initial",
+            tree_id,
+            std::iter::empty::<gix::ObjectId>(),
+        )?;
+
+        std::fs::create_dir(dir.path().join("nested"))?;
+        let discovered = open_repo(dir.path().join("nested"))?;
+        let commit_id = resolve_commit(&discovered, None)?;
+        let commit = discovered.find_commit(commit_id)?;
+        let items = build_tree(&discovered, commit.tree_id()?.detach(), "");
+
+        match items.as_slice() {
+            [TreeItem::File {
+                name,
+                full_path,
+                oid,
+            }] => {
+                assert_eq!(name, "hello.txt");
+                assert_eq!(full_path, "hello.txt");
+                assert_eq!(load_blob_content(&discovered, *oid), "hello from gitoxide");
+            }
+            _ => panic!("unexpected tree contents"),
+        }
+
+        Ok(())
+    }
+}

--- a/devtools/git-tree-viewer/src/git/repo.rs
+++ b/devtools/git-tree-viewer/src/git/repo.rs
@@ -1,14 +1,10 @@
-use git2::Repository;
 use std::path::Path;
 
-pub fn open_repo(path: impl AsRef<Path>) -> Result<Repository, git2::Error> {
-    Repository::discover(path)
+pub fn open_repo(path: impl AsRef<Path>) -> anyhow::Result<gix::Repository> {
+    Ok(gix::discover(path)?)
 }
 
-pub fn resolve_commit(repo: &Repository, spec: Option<&str>) -> Result<git2::Oid, git2::Error> {
-    if let Some(spec) = spec {
-        repo.revparse_single(spec)?.peel_to_commit().map(|c| c.id())
-    } else {
-        repo.head()?.resolve()?.peel_to_commit().map(|c| c.id())
-    }
+pub fn resolve_commit(repo: &gix::Repository, spec: Option<&str>) -> anyhow::Result<gix::ObjectId> {
+    let spec = spec.unwrap_or("HEAD");
+    Ok(repo.rev_parse_single(spec)?.object()?.peel_to_commit()?.id)
 }

--- a/devtools/git-tree-viewer/src/git/tree.rs
+++ b/devtools/git-tree-viewer/src/git/tree.rs
@@ -1,24 +1,26 @@
-use git2::{ObjectType, Oid, Repository};
-
 #[derive(Clone)]
 pub enum TreeItem {
     Directory {
         name: String,
-        oid: Oid,
+        oid: gix::ObjectId,
         children: Vec<TreeItem>,
     },
     File {
         name: String,
         full_path: String,
-        oid: Oid,
+        oid: gix::ObjectId,
     },
     Other {
         name: String,
-        oid: Oid,
+        oid: gix::ObjectId,
     },
 }
 
-pub fn build_tree(repo: &Repository, tree_oid: Oid, path_prefix: &str) -> Vec<TreeItem> {
+pub fn build_tree(
+    repo: &gix::Repository,
+    tree_oid: gix::ObjectId,
+    path_prefix: &str,
+) -> Vec<TreeItem> {
     let mut items = Vec::new();
 
     let tree = match repo.find_tree(tree_oid) {
@@ -26,35 +28,37 @@ pub fn build_tree(repo: &Repository, tree_oid: Oid, path_prefix: &str) -> Vec<Tr
         Err(_) => return items,
     };
 
-    let mut entries = tree.iter().collect::<Vec<_>>();
+    let mut entries = match tree.iter().collect::<Result<Vec<_>, _>>() {
+        Ok(entries) => entries,
+        Err(_) => return items,
+    };
     entries.sort_by(|a, b| {
-        let a_type = a.kind().unwrap_or(ObjectType::Any);
-        let b_type = b.kind().unwrap_or(ObjectType::Any);
-
-        let a_is_tree = a_type == ObjectType::Tree;
-        let b_is_tree = b_type == ObjectType::Tree;
+        let a_is_tree = a.kind() == gix::object::tree::EntryKind::Tree;
+        let b_is_tree = b.kind() == gix::object::tree::EntryKind::Tree;
 
         if a_is_tree != b_is_tree {
             return b_is_tree.cmp(&a_is_tree);
         }
 
-        let a_name = a.name().unwrap_or("");
-        let b_name = b.name().unwrap_or("");
-        a_name.cmp(b_name)
+        std::str::from_utf8(a.filename())
+            .unwrap_or("")
+            .cmp(std::str::from_utf8(b.filename()).unwrap_or(""))
     });
 
     for entry in entries {
-        let entry_type = entry.kind().unwrap_or(ObjectType::Any);
-        let entry_name = entry.name().unwrap_or("<invalid>").to_string();
-        let oid = entry.id();
+        let entry_type = entry.kind();
+        let entry_name = std::str::from_utf8(entry.filename())
+            .unwrap_or("<invalid>")
+            .to_string();
+        let oid = entry.id().detach();
         let full_path = if path_prefix.is_empty() {
             entry_name.clone()
         } else {
-            format!("{}/{}", path_prefix, entry_name)
+            format!("{path_prefix}/{entry_name}")
         };
 
         match entry_type {
-            ObjectType::Tree => {
+            gix::object::tree::EntryKind::Tree => {
                 let children = build_tree(repo, oid, &full_path);
                 items.push(TreeItem::Directory {
                     name: entry_name,
@@ -62,7 +66,7 @@ pub fn build_tree(repo: &Repository, tree_oid: Oid, path_prefix: &str) -> Vec<Tr
                     children,
                 });
             }
-            ObjectType::Blob => {
+            gix::object::tree::EntryKind::Blob | gix::object::tree::EntryKind::BlobExecutable => {
                 items.push(TreeItem::File {
                     name: entry_name,
                     full_path,

--- a/devtools/git-tree-viewer/src/lib.rs
+++ b/devtools/git-tree-viewer/src/lib.rs
@@ -25,12 +25,19 @@ pub enum RepoSource {
 
 impl RepoSource {
     pub fn new_temp() -> anyhow::Result<Self> {
+        use std::io::Write;
+
         let dir = tempfile::Builder::new()
             .prefix("git-tree-viewer")
             .tempdir()?;
 
-        let repo = git2::Repository::init_bare(dir.path())?;
-        repo.config()?.set_str("http.receivepack", "true")?;
+        let repo = gix::init_bare(dir.path())?;
+        writeln!(
+            std::fs::OpenOptions::new()
+                .append(true)
+                .open(repo.git_dir().join("config"))?,
+            "\n[http]\n\treceivepack = true"
+        )?;
 
         Ok(Self::TempDir(dir))
     }
@@ -53,9 +60,9 @@ pub struct Trace {
 }
 
 pub struct UiState {
-    history_start: Option<git2::Oid>,
-    selected_commit: Option<git2::Oid>,
-    selected_file: Option<(String, git2::Oid)>,
+    history_start: Option<gix::ObjectId>,
+    selected_commit: Option<gix::ObjectId>,
+    selected_file: Option<(String, gix::ObjectId)>,
     file_content: Option<String>,
     selected_session: Option<String>,
     error: Option<String>,
@@ -63,13 +70,13 @@ pub struct UiState {
 
 pub struct GitDebugApp {
     mode: AppMode,
-    repo: git2::Repository,
+    repo: gix::Repository,
     ui_state: UiState,
     _repo_source: RepoSource,
 }
 
 impl GitDebugApp {
-    pub fn new(mode: AppMode, repo_source: RepoSource) -> Result<Self, git2::Error> {
+    pub fn new(mode: AppMode, repo_source: RepoSource) -> anyhow::Result<Self> {
         let repo = git::open_repo(repo_source.as_ref())?;
 
         let resolved_commit = match &mode {

--- a/devtools/git-tree-viewer/src/ui/commit_list.rs
+++ b/devtools/git-tree-viewer/src/ui/commit_list.rs
@@ -2,7 +2,8 @@ use crate::constants::{
     BUBBLE_CORNER_RADIUS, BUBBLE_HORIZONTAL_PADDING, COMMIT_BUBBLE_HEIGHT, FONT_SIZE,
     REVWALK_LIMIT, SHA_SHORT_LEN,
 };
-use git2::{Oid, Repository};
+use gix::prelude::ObjectIdExt;
+use gix::{ObjectId, Repository};
 
 pub fn show_commit_bubble(
     ui: &mut egui::Ui,
@@ -57,9 +58,9 @@ pub fn show_commit_bubble(
 pub fn show_commits(
     ui: &mut egui::Ui,
     repo: &Repository,
-    history_start: Option<Oid>,
-    selected_commit: &mut Option<Oid>,
-    selected_file: &mut Option<(String, Oid)>,
+    history_start: Option<ObjectId>,
+    selected_commit: &mut Option<ObjectId>,
+    selected_file: &mut Option<(String, ObjectId)>,
     file_content: &mut Option<String>,
 ) {
     let history_start = match history_start {
@@ -67,28 +68,27 @@ pub fn show_commits(
         Some(oid) => oid,
     };
 
-    let mut revwalk = repo.revwalk().expect("Failed to get revwalk");
-    revwalk
-        .push(history_start)
-        .expect("Failed to push history start");
-    revwalk
-        .set_sorting(git2::Sort::NONE)
-        .expect("Failed to set sorting");
-
-    let commits: Vec<_> = revwalk
+    let commits: Vec<_> = history_start
+        .attach(repo)
+        .ancestors()
+        .all()
+        .expect("Failed to get revision walk")
         .take(REVWALK_LIMIT)
-        .filter_map(|oid| oid.ok())
-        .filter_map(|oid| repo.find_commit(oid).ok())
+        .filter_map(Result::ok)
+        .filter_map(|info| repo.find_commit(info.id).ok())
         .map(|commit| {
             let message = commit
-                .message()
+                .message_raw()
+                .ok()
+                .and_then(|message| std::str::from_utf8(message).ok())
                 .unwrap_or("<no message>")
                 .lines()
                 .next()
                 .unwrap_or("")
                 .to_string();
-            let short_id = commit.id().to_string()[..SHA_SHORT_LEN].to_string();
-            let commit_id = commit.id();
+            let commit_id = commit.id().detach();
+            let full_id = commit_id.to_string();
+            let short_id = full_id[..SHA_SHORT_LEN.min(full_id.len())].to_string();
             (commit_id, short_id, message)
         })
         .collect();

--- a/devtools/git-tree-viewer/src/ui/file_preview.rs
+++ b/devtools/git-tree-viewer/src/ui/file_preview.rs
@@ -1,6 +1,6 @@
 pub fn show_file_preview(
     ui: &mut egui::Ui,
-    selected_file: &Option<(String, git2::Oid)>,
+    selected_file: &Option<(String, gix::ObjectId)>,
     file_content: &Option<String>,
 ) {
     ui.heading("File Preview");

--- a/devtools/git-tree-viewer/src/ui/panels.rs
+++ b/devtools/git-tree-viewer/src/ui/panels.rs
@@ -75,7 +75,7 @@ fn show_sessions_section(ui: &mut egui::Ui, app: &mut GitDebugApp) {
         .max_height(100.0)
         .show(ui, |ui| {
             for trace in &filtered {
-                if let Ok(oid) = git2::Oid::from_str(&trace.commit) {
+                if let Ok(oid) = gix::ObjectId::from_hex(trace.commit.as_bytes()) {
                     let short_id = &trace.commit[..SHA_SHORT_LEN.min(trace.commit.len())];
                     let selected = app.ui_state.selected_commit == Some(oid);
                     if show_commit_bubble(ui, selected, short_id, &trace.label).clicked() {
@@ -120,9 +120,9 @@ fn show_central_panel(ui: &mut egui::Ui, app: &mut GitDebugApp) {
         .repo
         .find_commit(selected_commit)
         .expect("Failed to find commit")
-        .tree()
+        .tree_id()
         .expect("Failed to get tree")
-        .id();
+        .detach();
 
     let tree_items = git::build_tree(&app.repo, tree_id, "");
 

--- a/devtools/git-tree-viewer/src/ui/tree_view.rs
+++ b/devtools/git-tree-viewer/src/ui/tree_view.rs
@@ -5,7 +5,7 @@ use egui::Color32;
 pub fn tree_entry_label(
     icon: &str,
     name: &str,
-    oid: git2::Oid,
+    oid: gix::ObjectId,
     text_color: Color32,
     sha_color: Color32,
 ) -> egui::text::LayoutJob {
@@ -33,8 +33,8 @@ pub fn tree_entry_label(
 pub fn show_tree_item(
     ui: &mut egui::Ui,
     item: &TreeItem,
-    selected_oid: Option<git2::Oid>,
-    on_file_clicked: &mut dyn FnMut(String, git2::Oid),
+    selected_oid: Option<gix::ObjectId>,
+    on_file_clicked: &mut dyn FnMut(String, gix::ObjectId),
 ) {
     let text_color = ui.visuals().text_color();
     let sha_color = ui.visuals().strong_text_color();


### PR DESCRIPTION
Remove libgit2 from git-tree-viewer

Port repository discovery, revision parsing, history walking, tree traversal, blob loading, and temporary bare repository setup to gitoxide. Cover the browse path with a repository fixture that resolves HEAD and reads its tree and blob.

Change: git-tree-viewer-git2

Assisted-By: openai-codex/gpt-5.6-sol