### PR TITLE
Remove libgit2 from git-tree-trace

### DIFF
--- a/devtools/Cargo.lock
+++ b/devtools/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
 name = "git-tree-trace"
 version = "0.1.0"
 dependencies = [
- "git2",
+ "gix",
  "reqwest",
  "serde",
 ]
@@ -1771,7 +1771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
 dependencies = [
  "bstr",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1810,6 +1810,32 @@ checksum = "d4c69157820343bf1c6e4b88b9808e920900de02e18aaf5862b30ada43814848"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7b2e202fa474a3dd0bbd551be35adf199be0bf5c925fd7707fff2fdb520f651"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "nonempty",
  "thiserror 2.0.19",
 ]
 
@@ -2174,6 +2200,7 @@ checksum = "31eb8e675122e83585e461fe28f68ff8c5ed55b49017b697e7e76423ff973424"
 dependencies = [
  "bstr",
  "gix-attributes",
+ "gix-features",
  "gix-fs",
  "gix-glob",
  "gix-hash",
@@ -2869,7 +2896,7 @@ dependencies = [
  "axum",
  "axum-cgi",
  "futures",
- "git2",
+ "gix",
  "headers",
  "tempfile",
  "tokio",
@@ -2878,12 +2905,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "josh-gix-ext"
+version = "26.7.28"
+dependencies = [
+ "anyhow",
+ "gix-actor",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-glob",
+ "gix-hash",
+ "gix-merge",
+ "gix-object",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-worktree",
+]
+
+[[package]]
 name = "josh-test-support"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "dirs",
- "git2",
+ "gix",
+ "josh-gix-ext",
  "rand",
  "tempfile",
  "tracing",

--- a/devtools/git-tree-trace/Cargo.toml
+++ b/devtools/git-tree-trace/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-git2 = { version = "0.21", default-features = false }
+gix = { version = "0.86", default-features = false, features = ["sha1"] }
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"] }
 serde = { version = "1", features = ["derive"] }

--- a/devtools/git-tree-trace/src/lib.rs
+++ b/devtools/git-tree-trace/src/lib.rs
@@ -1,7 +1,6 @@
 use std::sync::OnceLock;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use git2::Oid;
 use serde::Serialize;
 
 /// Base URL of the `git-tree-viewer` HTTP server.
@@ -85,14 +84,14 @@ fn client() -> &'static reqwest::blocking::Client {
     CLIENT.get_or_init(reqwest::blocking::Client::new)
 }
 
-pub fn trace_commit(repo: &git2::Repository, oid: Oid, name: &str) {
+pub fn trace_commit(repo: &gix::Repository, oid: gix::ObjectId, name: &str) {
     // No viewer listening → nothing to push or report.
     let TraceState::Started { session_name } = state() else {
         return;
     };
 
     let refspec = format!("{}:refs/heads/_{}", oid, oid);
-    let workdir = repo.workdir().unwrap_or_else(|| repo.path());
+    let workdir = repo.workdir().unwrap_or_else(|| repo.git_dir());
 
     let mut command = std::process::Command::new("git");
     command.arg("-C");


### PR DESCRIPTION
Remove libgit2 from git-tree-trace

Use gitoxide repository paths and object IDs for trace pushes. Refresh the devtools lockfile so the trace crate no longer pulls libgit2.

Change: gix-trace-tool

Assisted-By: openai-codex/gpt-5.6-sol