### PR TITLE
Favor latency when flushing proxy packs

### DIFF
--- a/josh-memodb/src/pack.rs
+++ b/josh-memodb/src/pack.rs
@@ -25,7 +25,7 @@ pub(crate) fn objects_dir(repo: &gix::Repository) -> std::path::PathBuf {
 /// (loose, packed, or via alternates) as a single packfile-plus-index pair in
 /// `objects_dir/pack`. A no-op if every object is already on disk.
 ///
-/// The pack is deterministic for a given snapshot: entries are compressed at a fixed level and
+/// The pack is deterministic for a given snapshot: entries use the fastest zlib level and are
 /// serialized single-threaded in snapshot order, and the file pair is named after the pack
 /// trailer checksum, so identical snapshots produce identical packs. Files are written via
 /// tempfile-and-rename, index last, so a concurrent reader never sees a torn pair.
@@ -62,9 +62,9 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow:
         to_pack.iter().map(|(oid, kind, data)| {
             output::Entry::from_data(
                 &output::Count::from_data(*oid, None),
-                // Fixed level 6, the zlib/libgit2/git `pack.compression` default.
+                // Favor request latency; maintenance repacks can optimize the durable ratio.
                 &gix_object::Data::new(data, *kind, gix_hash::Kind::Sha1),
-                gix_zlib::Compression::DEFAULT,
+                gix_zlib::Compression::BEST_SPEED,
             )
             .map(|entry| vec![entry])
         }),
@@ -94,7 +94,7 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow:
             object_hash: gix_hash::Kind::Sha1,
             alloc_limit_bytes: None,
             // Only used to complete thin packs, which this never writes.
-            compression: gix_zlib::Compression::DEFAULT,
+            compression: gix_zlib::Compression::BEST_SPEED,
         },
     )
     .context("mem-odb pack write failed")?;

--- a/tests/proxy/amend_patchset.t
+++ b/tests/proxy/amend_patchset.t
@@ -197,12 +197,12 @@
       |   |   `-- 4ad756a74e200f89b43b0d6f21b41eb284b454
       |   |-- info
       |   `-- pack
-      |       |-- pack-40095ca152b59e2e5b75f9a5ce06bcf88a3eed59.idx
-      |       |-- pack-40095ca152b59e2e5b75f9a5ce06bcf88a3eed59.pack
-      |       |-- pack-8e855a558d184842f61c9b98788ee35e6a1f2fb0.idx
-      |       |-- pack-8e855a558d184842f61c9b98788ee35e6a1f2fb0.pack
-      |       |-- pack-c9d173f1861d5fda8d1751fef4702b539ef510ef.idx
-      |       `-- pack-c9d173f1861d5fda8d1751fef4702b539ef510ef.pack
+      |       |-- pack-5ca2c094e037dc50933787ec330f4712b0dc5e79.idx
+      |       |-- pack-5ca2c094e037dc50933787ec330f4712b0dc5e79.pack
+      |       |-- pack-9273907899ba71d35045695bfe3c3caa38d01e93.idx
+      |       |-- pack-9273907899ba71d35045695bfe3c3caa38d01e93.pack
+      |       |-- pack-e60e99878bf7985839fe23abc9e5a9e9843ebb58.idx
+      |       `-- pack-e60e99878bf7985839fe23abc9e5a9e9843ebb58.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/caching.t
+++ b/tests/proxy/caching.t
@@ -100,10 +100,10 @@
       |   |   `-- c926c483c4dfa77e84105c6967e74d8ff9bf5f
       |   |-- info
       |   `-- pack
-      |       |-- pack-17bda029e2f8a7cae69293dbd5cfd54be1783480.idx
-      |       |-- pack-17bda029e2f8a7cae69293dbd5cfd54be1783480.pack
-      |       |-- pack-42e8065677055f029442f4dfb1f8b930ba3a29a9.idx
-      |       `-- pack-42e8065677055f029442f4dfb1f8b930ba3a29a9.pack
+      |       |-- pack-b684f57de8a00356f3d5344adcc404a1394d4dd5.idx
+      |       |-- pack-b684f57de8a00356f3d5344adcc404a1394d4dd5.pack
+      |       |-- pack-bfb66447f35f6e09480807916bf683892d148b9e.idx
+      |       `-- pack-bfb66447f35f6e09480807916bf683892d148b9e.pack
       `-- refs
           |-- heads
           |-- namespaces
@@ -218,12 +218,12 @@
       |   |   `-- c926c483c4dfa77e84105c6967e74d8ff9bf5f
       |   |-- info
       |   `-- pack
-      |       |-- pack-17bda029e2f8a7cae69293dbd5cfd54be1783480.idx
-      |       |-- pack-17bda029e2f8a7cae69293dbd5cfd54be1783480.pack
-      |       |-- pack-320458e5ec491f521fae67b51436d535dc9ecb49.idx
-      |       |-- pack-320458e5ec491f521fae67b51436d535dc9ecb49.pack
-      |       |-- pack-42e8065677055f029442f4dfb1f8b930ba3a29a9.idx
-      |       `-- pack-42e8065677055f029442f4dfb1f8b930ba3a29a9.pack
+      |       |-- pack-b684f57de8a00356f3d5344adcc404a1394d4dd5.idx
+      |       |-- pack-b684f57de8a00356f3d5344adcc404a1394d4dd5.pack
+      |       |-- pack-bfb66447f35f6e09480807916bf683892d148b9e.idx
+      |       |-- pack-bfb66447f35f6e09480807916bf683892d148b9e.pack
+      |       |-- pack-e1e28266bed6b79eac944fd0ba67783845af0caa.idx
+      |       `-- pack-e1e28266bed6b79eac944fd0ba67783845af0caa.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/clone_prefix.t
+++ b/tests/proxy/clone_prefix.t
@@ -123,8 +123,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-5a34d6972372a5df1225da7b3458665b96be8d30.idx
-      |       `-- pack-5a34d6972372a5df1225da7b3458665b96be8d30.pack
+      |       |-- pack-c021d8fe7e2f1db18f64d7bbf8bce4d0ce467b35.idx
+      |       `-- pack-c021d8fe7e2f1db18f64d7bbf8bce4d0ce467b35.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/clone_subsubtree.t
+++ b/tests/proxy/clone_subsubtree.t
@@ -136,10 +136,10 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-5c8a6b6168fe8012756c4278585b1852f9a0cbcb.idx
-      |       |-- pack-5c8a6b6168fe8012756c4278585b1852f9a0cbcb.pack
-      |       |-- pack-f2883c7d8701eb14a51b3a87f0f25c77ac3669db.idx
-      |       `-- pack-f2883c7d8701eb14a51b3a87f0f25c77ac3669db.pack
+      |       |-- pack-00201d8d8f6a10dd5489e1079008c9cfcb778bfb.idx
+      |       |-- pack-00201d8d8f6a10dd5489e1079008c9cfcb778bfb.pack
+      |       |-- pack-00b9d9dd91b795a717b7ca29faaa1f2362a4849e.idx
+      |       `-- pack-00b9d9dd91b795a717b7ca29faaa1f2362a4849e.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/clone_subtree.t
+++ b/tests/proxy/clone_subtree.t
@@ -133,8 +133,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
-      |       `-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.idx
+      |       `-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/clone_subtree_no_master.t
+++ b/tests/proxy/clone_subtree_no_master.t
@@ -125,8 +125,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
-      |       `-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.idx
+      |       `-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.pack
       `-- refs
           |-- heads
           `-- tags

--- a/tests/proxy/clone_subtree_tags.t
+++ b/tests/proxy/clone_subtree_tags.t
@@ -175,8 +175,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-17827226c5c0c01f693d535b0ee03ce6b1279d8f.idx
-      |       `-- pack-17827226c5c0c01f693d535b0ee03ce6b1279d8f.pack
+      |       |-- pack-0182f3edcc62f45628446146ccea2858cd6d9002.idx
+      |       `-- pack-0182f3edcc62f45628446146ccea2858cd6d9002.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/import_export.t
+++ b/tests/proxy/import_export.t
@@ -381,20 +381,20 @@ Flushed credential cache
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-275baec11277b940c391c584112a244532b28efb.idx
-      |       |-- pack-275baec11277b940c391c584112a244532b28efb.pack
-      |       |-- pack-375d25e0c6596d9401a4d7eb7e2871d759b08277.idx
-      |       |-- pack-375d25e0c6596d9401a4d7eb7e2871d759b08277.pack
-      |       |-- pack-38e63719299466e26e7897867e7c75b859bd172c.idx
-      |       |-- pack-38e63719299466e26e7897867e7c75b859bd172c.pack
-      |       |-- pack-8810340c36e5ff2458af0bc5d9cc189e5a1192db.idx
-      |       |-- pack-8810340c36e5ff2458af0bc5d9cc189e5a1192db.pack
-      |       |-- pack-ba7b17bd156a8fc4d784351b007214e40bcd4978.idx
-      |       |-- pack-ba7b17bd156a8fc4d784351b007214e40bcd4978.pack
-      |       |-- pack-da1db865c308ca71393595171805d9ca66b37bfa.idx
-      |       |-- pack-da1db865c308ca71393595171805d9ca66b37bfa.pack
-      |       |-- pack-edbcd821de41e8484ccca7b9007453a147e16b08.idx
-      |       `-- pack-edbcd821de41e8484ccca7b9007453a147e16b08.pack
+      |       |-- pack-08793ed704fe9a993725409b62d565f58d64d846.idx
+      |       |-- pack-08793ed704fe9a993725409b62d565f58d64d846.pack
+      |       |-- pack-1c0640f5103d0a4838c76295953847657818b4f9.idx
+      |       |-- pack-1c0640f5103d0a4838c76295953847657818b4f9.pack
+      |       |-- pack-519d106b6739e29fb36d3ec315eaba7d53b394f9.idx
+      |       |-- pack-519d106b6739e29fb36d3ec315eaba7d53b394f9.pack
+      |       |-- pack-a696c9fa310d07fe0ef809c599cf5b0be6ee917c.idx
+      |       |-- pack-a696c9fa310d07fe0ef809c599cf5b0be6ee917c.pack
+      |       |-- pack-dafe0947ed8d381a0b6096346067b1f3b9a3c566.idx
+      |       |-- pack-dafe0947ed8d381a0b6096346067b1f3b9a3c566.pack
+      |       |-- pack-f67bb9d54c58effe355cd1cb93837dc3851e0e96.idx
+      |       |-- pack-f67bb9d54c58effe355cd1cb93837dc3851e0e96.pack
+      |       |-- pack-fc4bcc839bed32590186cd136aab7bfb011d8b0e.idx
+      |       `-- pack-fc4bcc839bed32590186cd136aab7bfb011d8b0e.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/join_with_merge.t
+++ b/tests/proxy/join_with_merge.t
@@ -110,8 +110,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-22a5f4914ed052ea4eea2873846d2591ddf38cfa.idx
-      |       `-- pack-22a5f4914ed052ea4eea2873846d2591ddf38cfa.pack
+      |       |-- pack-bbe192a6af4bf27018370feb936ef18eddba83cc.idx
+      |       `-- pack-bbe192a6af4bf27018370feb936ef18eddba83cc.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/markers.t
+++ b/tests/proxy/markers.t
@@ -462,14 +462,14 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-46be1f3792f935f94f7d7180cae3a269e0a41a05.idx
-      |       |-- pack-46be1f3792f935f94f7d7180cae3a269e0a41a05.pack
-      |       |-- pack-8c2f206b69cd9e00d53669fdb645f62ad8786ffa.idx
-      |       |-- pack-8c2f206b69cd9e00d53669fdb645f62ad8786ffa.pack
-      |       |-- pack-f54dc3f7d049d03172f1a116b7ec24c8daf36394.idx
-      |       |-- pack-f54dc3f7d049d03172f1a116b7ec24c8daf36394.pack
-      |       |-- pack-fe9df806f2b505fce1b94000b21fcdfb8ef27f17.idx
-      |       `-- pack-fe9df806f2b505fce1b94000b21fcdfb8ef27f17.pack
+      |       |-- pack-0368f2f2e5bb8e49b5abde3b2a721942ddc583ba.idx
+      |       |-- pack-0368f2f2e5bb8e49b5abde3b2a721942ddc583ba.pack
+      |       |-- pack-5d347d72f7ff9a075ce929550553478af1082c67.idx
+      |       |-- pack-5d347d72f7ff9a075ce929550553478af1082c67.pack
+      |       |-- pack-d40c224781d735ed5536e577e54d874c371775bf.idx
+      |       |-- pack-d40c224781d735ed5536e577e54d874c371775bf.pack
+      |       |-- pack-dc29f2af19afbbf8a49903fa6b5bc1d23b805f62.idx
+      |       `-- pack-dc29f2af19afbbf8a49903fa6b5bc1d23b805f62.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_graphql.t
+++ b/tests/proxy/push_graphql.t
@@ -113,8 +113,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-5af10d5b0a5c3a1f5ec6910ec2d1c430496a79cd.idx
-      |       `-- pack-5af10d5b0a5c3a1f5ec6910ec2d1c430496a79cd.pack
+      |       |-- pack-92ad3c27042f318b86fa2e24abe101e17dfe6e35.idx
+      |       `-- pack-92ad3c27042f318b86fa2e24abe101e17dfe6e35.pack
       `-- refs
           |-- heads
           `-- tags

--- a/tests/proxy/push_new_branch.t
+++ b/tests/proxy/push_new_branch.t
@@ -184,12 +184,12 @@ Check the branch again
       |   |   `-- 35f3fecaba02ae9cc9d462b1bd0d396fdf352f
       |   |-- info
       |   `-- pack
-      |       |-- pack-2893a00b7ba37075bd59cbf84d3e300ca17afecd.idx
-      |       |-- pack-2893a00b7ba37075bd59cbf84d3e300ca17afecd.pack
-      |       |-- pack-ca72748ef4386cec74f87862434f7c982edd66fa.idx
-      |       |-- pack-ca72748ef4386cec74f87862434f7c982edd66fa.pack
-      |       |-- pack-e54bf06bfc3b3596e93261dc699bccb21d0f5adb.idx
-      |       `-- pack-e54bf06bfc3b3596e93261dc699bccb21d0f5adb.pack
+      |       |-- pack-4720043092f3af5a4fcb245c8d93c5e1bd33e5c8.idx
+      |       |-- pack-4720043092f3af5a4fcb245c8d93c5e1bd33e5c8.pack
+      |       |-- pack-5a6c8f8c4731edda90ce7ee05a147b8b529ef15e.idx
+      |       |-- pack-5a6c8f8c4731edda90ce7ee05a147b8b529ef15e.pack
+      |       |-- pack-cfc95e43f9955d8a565f21df3d8b244815750d38.idx
+      |       `-- pack-cfc95e43f9955d8a565f21df3d8b244815750d38.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_new_orphan_branch.t
+++ b/tests/proxy/push_new_orphan_branch.t
@@ -200,12 +200,12 @@ Make sure all temporary namespace got removed
       |   |   `-- b06d7748772bdd407c5911c0ba02b0f5fb31a4
       |   |-- info
       |   `-- pack
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
-      |       |-- pack-ed1b2e1285c87d628ed4fedf2e84338a0fa698e1.idx
-      |       |-- pack-ed1b2e1285c87d628ed4fedf2e84338a0fa698e1.pack
-      |       |-- pack-f77bd2bf44561fe0f2030d424730624a36a8feea.idx
-      |       `-- pack-f77bd2bf44561fe0f2030d424730624a36a8feea.pack
+      |       |-- pack-b8333165d952a58210770b761c7bb4b121e90b09.idx
+      |       |-- pack-b8333165d952a58210770b761c7bb4b121e90b09.pack
+      |       |-- pack-c35137d50abf628e0cc7d7471c98afdd9f8939f3.idx
+      |       |-- pack-c35137d50abf628e0cc7d7471c98afdd9f8939f3.pack
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.idx
+      |       `-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_prefix.t
+++ b/tests/proxy/push_prefix.t
@@ -107,10 +107,10 @@
       |   |   `-- 9a2dde698e6d3fc31cbeedea6d0204399f90ce
       |   |-- info
       |   `-- pack
-      |       |-- pack-4bdf7423c6b0c22e388bf62ed53c1a12ca3d0d0d.idx
-      |       |-- pack-4bdf7423c6b0c22e388bf62ed53c1a12ca3d0d0d.pack
-      |       |-- pack-5776a40aaa25ae1ea80b5e471fca2e11c985c47d.idx
-      |       `-- pack-5776a40aaa25ae1ea80b5e471fca2e11c985c47d.pack
+      |       |-- pack-e7200da1ba0a1ad8fee281686be0a1484f189ed4.idx
+      |       |-- pack-e7200da1ba0a1ad8fee281686be0a1484f189ed4.pack
+      |       |-- pack-e7d92dcb46f31b5706a2bff7d09eb3180662fc7a.idx
+      |       `-- pack-e7d92dcb46f31b5706a2bff7d09eb3180662fc7a.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_review.t
+++ b/tests/proxy/push_review.t
@@ -132,10 +132,10 @@ Make sure all temporary namespace got removed
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
-      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.idx
-      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.pack
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
-      |       `-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.idx
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.pack
+      |       |-- pack-f3546ce56eb9276c964f94e9868b52b351242100.idx
+      |       `-- pack-f3546ce56eb9276c964f94e9868b52b351242100.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_review_nop_behind.t
+++ b/tests/proxy/push_review_nop_behind.t
@@ -104,8 +104,8 @@ This is a regression test for that problem.
       |   |   `-- 01f09caa6b247b64793a9d8cf1db76a9e92442
       |   |-- info
       |   `-- pack
-      |       |-- pack-e8ae6eb17251286fc38f6b55dea83f85265ac92b.idx
-      |       `-- pack-e8ae6eb17251286fc38f6b55dea83f85265ac92b.pack
+      |       |-- pack-651a3186fea7a27d814a721537434b38782f7780.idx
+      |       `-- pack-651a3186fea7a27d814a721537434b38782f7780.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_review_old.t
+++ b/tests/proxy/push_review_old.t
@@ -143,12 +143,12 @@ Flushed credential cache
       |   |   `-- 6a812a71a431e71d30949f25013ca63f8493c3
       |   |-- info
       |   `-- pack
-      |       |-- pack-4bd58ee63975a927d6f412d722859a6d5aebbbe2.idx
-      |       |-- pack-4bd58ee63975a927d6f412d722859a6d5aebbbe2.pack
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
-      |       |-- pack-84bf2195a0e00629f813ae535a24bb7fca071fa2.idx
-      |       `-- pack-84bf2195a0e00629f813ae535a24bb7fca071fa2.pack
+      |       |-- pack-683f27aadd9074c55f61bc4efb200f014889512b.idx
+      |       |-- pack-683f27aadd9074c55f61bc4efb200f014889512b.pack
+      |       |-- pack-a82ba63e2c52a87f02b9536cdfe0930635c11ee4.idx
+      |       |-- pack-a82ba63e2c52a87f02b9536cdfe0930635c11ee4.pack
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.idx
+      |       `-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_review_topic.t
+++ b/tests/proxy/push_review_topic.t
@@ -91,10 +91,10 @@ Make sure all temporary namespace got removed
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
-      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.idx
-      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.pack
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
-      |       `-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.idx
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.pack
+      |       |-- pack-f3546ce56eb9276c964f94e9868b52b351242100.idx
+      |       `-- pack-f3546ce56eb9276c964f94e9868b52b351242100.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_stacked.t
+++ b/tests/proxy/push_stacked.t
@@ -258,10 +258,10 @@ Make sure all temporary namespace got removed
       |   |   `-- b2a5b9c65fae1d20c1b1fb777d1ea025456faa
       |   |-- info
       |   `-- pack
-      |       |-- pack-73ff0b391af4bb8dff50f6070f8e6bd258d3d562.idx
-      |       |-- pack-73ff0b391af4bb8dff50f6070f8e6bd258d3d562.pack
-      |       |-- pack-d678c97bc806ec389cf8d05321e018083799eab5.idx
-      |       `-- pack-d678c97bc806ec389cf8d05321e018083799eab5.pack
+      |       |-- pack-881aaeaf00d87a487b7cb95a51b5e456bdda5cec.idx
+      |       |-- pack-881aaeaf00d87a487b7cb95a51b5e456bdda5cec.pack
+      |       |-- pack-c960cf25fa9e9c1ee238c628a9f2a6bd2e216e79.idx
+      |       `-- pack-c960cf25fa9e9c1ee238c628a9f2a6bd2e216e79.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_stacked_split.t
+++ b/tests/proxy/push_stacked_split.t
@@ -185,8 +185,8 @@ Make sure all temporary namespace got removed
       |   |   `-- b2a5b9c65fae1d20c1b1fb777d1ea025456faa
       |   |-- info
       |   `-- pack
-      |       |-- pack-7a3bcd23cf0d9c3f433e71e7885b8ff12c31d912.idx
-      |       `-- pack-7a3bcd23cf0d9c3f433e71e7885b8ff12c31d912.pack
+      |       |-- pack-f7d427dbb737d63f9e9bd1df5638b97131e5ab71.idx
+      |       `-- pack-f7d427dbb737d63f9e9bd1df5638b97131e5ab71.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_stacked_sub.t
+++ b/tests/proxy/push_stacked_sub.t
@@ -254,14 +254,14 @@ Make sure all temporary namespace got removed
       |   |   `-- 27a2e3a6bfbb7307f522ad94fdfc8c20b92967
       |   |-- info
       |   `-- pack
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
-      |       |-- pack-85062c8051be8d1cc8c3f2bb59d2c43955b713b5.idx
-      |       |-- pack-85062c8051be8d1cc8c3f2bb59d2c43955b713b5.pack
-      |       |-- pack-8e3400a243c06eadce222b7e3fc003f3ec51d8e7.idx
-      |       |-- pack-8e3400a243c06eadce222b7e3fc003f3ec51d8e7.pack
-      |       |-- pack-a19b84c20a0ea82ae2c5184e6056e9a9a8f628ad.idx
-      |       `-- pack-a19b84c20a0ea82ae2c5184e6056e9a9a8f628ad.pack
+      |       |-- pack-5d60df3d469f4500d87d2c7d17308e25aa5c70ea.idx
+      |       |-- pack-5d60df3d469f4500d87d2c7d17308e25aa5c70ea.pack
+      |       |-- pack-7ea6ef7ed8d70dcb374d5e68765568c51127e9fb.idx
+      |       |-- pack-7ea6ef7ed8d70dcb374d5e68765568c51127e9fb.pack
+      |       |-- pack-a4049c54ca69279660194039a42f3045fd90a57b.idx
+      |       |-- pack-a4049c54ca69279660194039a42f3045fd90a57b.pack
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.idx
+      |       `-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_subdir_prefix.t
+++ b/tests/proxy/push_subdir_prefix.t
@@ -99,12 +99,12 @@
       |   |   `-- 2cc0b3d612792395dd9ac2ca649da0e6e54620
       |   |-- info
       |   `-- pack
-      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.idx
-      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.pack
-      |       |-- pack-84bf2195a0e00629f813ae535a24bb7fca071fa2.idx
-      |       |-- pack-84bf2195a0e00629f813ae535a24bb7fca071fa2.pack
-      |       |-- pack-92ff53f1be3ade3375cb4bc4382ab90aa392c290.idx
-      |       `-- pack-92ff53f1be3ade3375cb4bc4382ab90aa392c290.pack
+      |       |-- pack-4658096dc6c2a469e11bdb27f1fe57164eddcff2.idx
+      |       |-- pack-4658096dc6c2a469e11bdb27f1fe57164eddcff2.pack
+      |       |-- pack-683f27aadd9074c55f61bc4efb200f014889512b.idx
+      |       |-- pack-683f27aadd9074c55f61bc4efb200f014889512b.pack
+      |       |-- pack-f3546ce56eb9276c964f94e9868b52b351242100.idx
+      |       `-- pack-f3546ce56eb9276c964f94e9868b52b351242100.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_subtree.t
+++ b/tests/proxy/push_subtree.t
@@ -146,10 +146,10 @@ Make sure all temporary namespace got removed
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
-      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.idx
-      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.pack
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
-      |       `-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.idx
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.pack
+      |       |-- pack-f3546ce56eb9276c964f94e9868b52b351242100.idx
+      |       `-- pack-f3546ce56eb9276c964f94e9868b52b351242100.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/push_subtree_two_repos.t
+++ b/tests/proxy/push_subtree_two_repos.t
@@ -182,14 +182,14 @@ Put a double slash in the URL to see that it also works
       |   |   `-- 388f5880393d255b371f1ed9b801d35620017e
       |   |-- info
       |   `-- pack
-      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.idx
-      |       |-- pack-0fbca5effb29d44fa34e315b8a34934a3d96e6a3.pack
-      |       |-- pack-3870f7c23e56f421fca42ddb98af629a74027df3.idx
-      |       |-- pack-3870f7c23e56f421fca42ddb98af629a74027df3.pack
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.idx
-      |       |-- pack-62708cde9dd54e2a4d2ba90b263314de9b886870.pack
-      |       |-- pack-cb303098d881b2cc9c72fe2d5958c4108e1dfc5f.idx
-      |       `-- pack-cb303098d881b2cc9c72fe2d5958c4108e1dfc5f.pack
+      |       |-- pack-abfdcb422e937a3ef1fd83d4935a604a7079abf0.idx
+      |       |-- pack-abfdcb422e937a3ef1fd83d4935a604a7079abf0.pack
+      |       |-- pack-c42629c132811d0a45f5e0b08c1e5d54612b7c1a.idx
+      |       |-- pack-c42629c132811d0a45f5e0b08c1e5d54612b7c1a.pack
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.idx
+      |       |-- pack-f08aac36fc50d329a77be1edb7b803cc51d9edcc.pack
+      |       |-- pack-f3546ce56eb9276c964f94e9868b52b351242100.idx
+      |       `-- pack-f3546ce56eb9276c964f94e9868b52b351242100.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/unrelated_leak.t
+++ b/tests/proxy/unrelated_leak.t
@@ -216,12 +216,12 @@ Flushed credential cache
       |   |   `-- 184bf11ece7fbeb99395ab7676b80e7d98631a
       |   |-- info
       |   `-- pack
-      |       |-- pack-3580c0a0c9c7beb59e4498be2a8e11209cf88985.idx
-      |       |-- pack-3580c0a0c9c7beb59e4498be2a8e11209cf88985.pack
-      |       |-- pack-5181289169f3bdc2ccab261ef101d1e3ba47a6c6.idx
-      |       |-- pack-5181289169f3bdc2ccab261ef101d1e3ba47a6c6.pack
-      |       |-- pack-84987279b748d1e02ab5af4ec82c39812b3bf9d9.idx
-      |       `-- pack-84987279b748d1e02ab5af4ec82c39812b3bf9d9.pack
+      |       |-- pack-6304ca7e74edfbde9b3d1c2ad7a6cd291472a77a.idx
+      |       |-- pack-6304ca7e74edfbde9b3d1c2ad7a6cd291472a77a.pack
+      |       |-- pack-7971b730d9e0cb6547920cb4202f80387877ff61.idx
+      |       |-- pack-7971b730d9e0cb6547920cb4202f80387877ff61.pack
+      |       |-- pack-fbf0047549007acd6c53299359fc5282e65e6a88.idx
+      |       `-- pack-fbf0047549007acd6c53299359fc5282e65e6a88.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace.t
+++ b/tests/proxy/workspace.t
@@ -341,12 +341,12 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-0618668c300df49932c864a4be615ce1411207b2.idx
-      |       |-- pack-0618668c300df49932c864a4be615ce1411207b2.pack
-      |       |-- pack-34c90511b5a8b771ac547f9b72395fdc5036cd52.idx
-      |       |-- pack-34c90511b5a8b771ac547f9b72395fdc5036cd52.pack
-      |       |-- pack-a7c1da3ed4de712808b5b180ebdd5f4fedec0e0f.idx
-      |       `-- pack-a7c1da3ed4de712808b5b180ebdd5f4fedec0e0f.pack
+      |       |-- pack-6086cb87158998d87ad95aa5c35cff4ddfa17f8c.idx
+      |       |-- pack-6086cb87158998d87ad95aa5c35cff4ddfa17f8c.pack
+      |       |-- pack-892322a5e5a17789f4267d43a824f2d56907a77d.idx
+      |       |-- pack-892322a5e5a17789f4267d43a824f2d56907a77d.pack
+      |       |-- pack-ce8061d6f145b7bf3f5e5e6155e4f44e477ba473.idx
+      |       `-- pack-ce8061d6f145b7bf3f5e5e6155e4f44e477ba473.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_create.t
+++ b/tests/proxy/workspace_create.t
@@ -612,22 +612,22 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
       |   |-- info
       |   `-- pack
-      |       |-- pack-54fef233f76a8e6e43153db0cfb036c950efabb0.idx
-      |       |-- pack-54fef233f76a8e6e43153db0cfb036c950efabb0.pack
-      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
-      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
-      |       |-- pack-8739d0708434a80a1f35dea255c7fa677209221b.idx
-      |       |-- pack-8739d0708434a80a1f35dea255c7fa677209221b.pack
-      |       |-- pack-97f12e7b2b70cbd63c3daf19e953b1ab655cf1d9.idx
-      |       |-- pack-97f12e7b2b70cbd63c3daf19e953b1ab655cf1d9.pack
-      |       |-- pack-9d2d72a65a2c561c6e5f082b16dfd953a1e4da84.idx
-      |       |-- pack-9d2d72a65a2c561c6e5f082b16dfd953a1e4da84.pack
-      |       |-- pack-bb1014a1ce8fc26d5d310e021152caa61aba740d.idx
-      |       |-- pack-bb1014a1ce8fc26d5d310e021152caa61aba740d.pack
-      |       |-- pack-c15bd674d709da5f3e68e7147f93bfcffc88215a.idx
-      |       |-- pack-c15bd674d709da5f3e68e7147f93bfcffc88215a.pack
-      |       |-- pack-c803d5f49a80510bd56b22fcf31e45238f5c8778.idx
-      |       `-- pack-c803d5f49a80510bd56b22fcf31e45238f5c8778.pack
+      |       |-- pack-187cbb5182989ed48e27386077f8ceebbb45ca8e.idx
+      |       |-- pack-187cbb5182989ed48e27386077f8ceebbb45ca8e.pack
+      |       |-- pack-1d8f7b0a46339395d5f097b75f02ab6b1450a386.idx
+      |       |-- pack-1d8f7b0a46339395d5f097b75f02ab6b1450a386.pack
+      |       |-- pack-2302ca9b0ce6c35e391f3982aeb8b9f5523c31fc.idx
+      |       |-- pack-2302ca9b0ce6c35e391f3982aeb8b9f5523c31fc.pack
+      |       |-- pack-51ff195039a311d6a45c27e2dadab05b96834a4d.idx
+      |       |-- pack-51ff195039a311d6a45c27e2dadab05b96834a4d.pack
+      |       |-- pack-596605acd42f30037d5fc4ed26bfc303df3af657.idx
+      |       |-- pack-596605acd42f30037d5fc4ed26bfc303df3af657.pack
+      |       |-- pack-9d72ab9edc8ed54f7d7d2051e71e0a095512d20c.idx
+      |       |-- pack-9d72ab9edc8ed54f7d7d2051e71e0a095512d20c.pack
+      |       |-- pack-af6e71bb2e2b7bbaac06109c433f0daceeeb3c33.idx
+      |       |-- pack-af6e71bb2e2b7bbaac06109c433f0daceeeb3c33.pack
+      |       |-- pack-d77b079ce835b4c68291a745994ad61e4d1a96df.idx
+      |       `-- pack-d77b079ce835b4c68291a745994ad61e4d1a96df.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_discover.t
+++ b/tests/proxy/workspace_discover.t
@@ -187,8 +187,8 @@
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-344f101b5d72f5ef8bb927db14289ba3c44692aa.idx
-      |       `-- pack-344f101b5d72f5ef8bb927db14289ba3c44692aa.pack
+      |       |-- pack-adab3e613334749904a7ad16d41d1a1ccddeb958.idx
+      |       `-- pack-adab3e613334749904a7ad16d41d1a1ccddeb958.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_edit_commit.t
+++ b/tests/proxy/workspace_edit_commit.t
@@ -313,18 +313,18 @@
       |   |   `-- 3efb2615e1c17f0d0b6e610da85da09438cd29
       |   |-- info
       |   `-- pack
-      |       |-- pack-1045e0215955d0d17455f662d87e9e9e9f525f61.idx
-      |       |-- pack-1045e0215955d0d17455f662d87e9e9e9f525f61.pack
-      |       |-- pack-424d13ce1705b756e4096bc480ccf751cc269fdf.idx
-      |       |-- pack-424d13ce1705b756e4096bc480ccf751cc269fdf.pack
-      |       |-- pack-7c542c70d0d9425967b64d48abb92c8437cd3e12.idx
-      |       |-- pack-7c542c70d0d9425967b64d48abb92c8437cd3e12.pack
-      |       |-- pack-8faf89e68dac787f61976cda504ca21ac1b452b3.idx
-      |       |-- pack-8faf89e68dac787f61976cda504ca21ac1b452b3.pack
-      |       |-- pack-9c4b2c03aaf94e1c174c7c5853d105a952d83199.idx
-      |       |-- pack-9c4b2c03aaf94e1c174c7c5853d105a952d83199.pack
-      |       |-- pack-a9d3e9f7de4bdd92d422c446d9d5c491beff94f6.idx
-      |       `-- pack-a9d3e9f7de4bdd92d422c446d9d5c491beff94f6.pack
+      |       |-- pack-3709195fe7fa5850facea335c0c3da3f1b025870.idx
+      |       |-- pack-3709195fe7fa5850facea335c0c3da3f1b025870.pack
+      |       |-- pack-52da4448028b15eec64962f9defaed0a6a99362b.idx
+      |       |-- pack-52da4448028b15eec64962f9defaed0a6a99362b.pack
+      |       |-- pack-5b0f5cd1ec07111a67e8e3bd12e38b90a2e88902.idx
+      |       |-- pack-5b0f5cd1ec07111a67e8e3bd12e38b90a2e88902.pack
+      |       |-- pack-7edf912d12b715d87b3e6723963fe1b95443515d.idx
+      |       |-- pack-7edf912d12b715d87b3e6723963fe1b95443515d.pack
+      |       |-- pack-a39a3922f6b4d544a96c31099ec682dd5b1fc182.idx
+      |       |-- pack-a39a3922f6b4d544a96c31099ec682dd5b1fc182.pack
+      |       |-- pack-cdb445cb0267716cd5ef5ee2db2967a38a0fea19.idx
+      |       `-- pack-cdb445cb0267716cd5ef5ee2db2967a38a0fea19.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_in_workspace.t
+++ b/tests/proxy/workspace_in_workspace.t
@@ -382,16 +382,16 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-8ff00f1e1d6cae0d9a353341bcabe039c2695bcf.idx
-      |       |-- pack-8ff00f1e1d6cae0d9a353341bcabe039c2695bcf.pack
-      |       |-- pack-98fe2fcc1ca8d493770a9fe52ae4d50e96793a27.idx
-      |       |-- pack-98fe2fcc1ca8d493770a9fe52ae4d50e96793a27.pack
-      |       |-- pack-c105a3cf9958469daa4b7c9bcb22c21025fdc83b.idx
-      |       |-- pack-c105a3cf9958469daa4b7c9bcb22c21025fdc83b.pack
-      |       |-- pack-d2f1121a06a53dbc7c35b23f77a1edf526503745.idx
-      |       |-- pack-d2f1121a06a53dbc7c35b23f77a1edf526503745.pack
-      |       |-- pack-f7abe9eb33a28f534dd36b4772fec65a411fc901.idx
-      |       `-- pack-f7abe9eb33a28f534dd36b4772fec65a411fc901.pack
+      |       |-- pack-27bd9620b76cd632fac0caebebcdf4d0dc7fb835.idx
+      |       |-- pack-27bd9620b76cd632fac0caebebcdf4d0dc7fb835.pack
+      |       |-- pack-347edecd2be22ee5b0b2696ae2c6ef33fd8bf49d.idx
+      |       |-- pack-347edecd2be22ee5b0b2696ae2c6ef33fd8bf49d.pack
+      |       |-- pack-49bb7d7fd3fb7fb97ac306bb971a4f5af797c3a8.idx
+      |       |-- pack-49bb7d7fd3fb7fb97ac306bb971a4f5af797c3a8.pack
+      |       |-- pack-be0b3e8fd31cd30fd25da9dc16f84eec828281aa.idx
+      |       |-- pack-be0b3e8fd31cd30fd25da9dc16f84eec828281aa.pack
+      |       |-- pack-cca0f80d7d8de45df0c1d26acbd52bd2db47f42e.idx
+      |       `-- pack-cca0f80d7d8de45df0c1d26acbd52bd2db47f42e.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_invalid_trailing_slash.t
+++ b/tests/proxy/workspace_invalid_trailing_slash.t
@@ -264,12 +264,12 @@ Flushed credential cache
       |   |   `-- 8eb888451be077531b50794384c2faec025765
       |   |-- info
       |   `-- pack
-      |       |-- pack-4aa0c3b06b81194f2e588db5ae323c7fb4550048.idx
-      |       |-- pack-4aa0c3b06b81194f2e588db5ae323c7fb4550048.pack
-      |       |-- pack-4c30edff00d7b5dff411c9bccd544e4068345179.idx
-      |       |-- pack-4c30edff00d7b5dff411c9bccd544e4068345179.pack
-      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
-      |       `-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
+      |       |-- pack-2302ca9b0ce6c35e391f3982aeb8b9f5523c31fc.idx
+      |       |-- pack-2302ca9b0ce6c35e391f3982aeb8b9f5523c31fc.pack
+      |       |-- pack-ce74dd83b99a7457a87150df6b5c3333afc2234f.idx
+      |       |-- pack-ce74dd83b99a7457a87150df6b5c3333afc2234f.pack
+      |       |-- pack-e231f17fe8a8638401e08a928fcf9c496574f964.idx
+      |       `-- pack-e231f17fe8a8638401e08a928fcf9c496574f964.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_modify.t
+++ b/tests/proxy/workspace_modify.t
@@ -614,22 +614,22 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 5eaa207c7aba64f4deb19a9acd060c254fb239
       |   |-- info
       |   `-- pack
-      |       |-- pack-18f5e8369b2efc356f458df3e0d3e986a815dca1.idx
-      |       |-- pack-18f5e8369b2efc356f458df3e0d3e986a815dca1.pack
-      |       |-- pack-25dfa147247bd2b0466fed0bed32246eaf9fe4dc.idx
-      |       |-- pack-25dfa147247bd2b0466fed0bed32246eaf9fe4dc.pack
-      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.idx
-      |       |-- pack-721a5e2fcf4ed965e49124b30f161a6faead2313.pack
-      |       |-- pack-7d659947da11a0cbcf3b3ac6861fa1f134b9fca7.idx
-      |       |-- pack-7d659947da11a0cbcf3b3ac6861fa1f134b9fca7.pack
-      |       |-- pack-7e5b73fe75cdbeabdb46528f04e4398efebfcc03.idx
-      |       |-- pack-7e5b73fe75cdbeabdb46528f04e4398efebfcc03.pack
-      |       |-- pack-b0cbd25fb82a58313bf6d9dd8713985699bbc9f7.idx
-      |       |-- pack-b0cbd25fb82a58313bf6d9dd8713985699bbc9f7.pack
-      |       |-- pack-c97be2528535257dcd484df2a6ab4f652d8c6970.idx
-      |       |-- pack-c97be2528535257dcd484df2a6ab4f652d8c6970.pack
-      |       |-- pack-e4f530d8d5281ae2ca99953a0a81293c83ba2d08.idx
-      |       `-- pack-e4f530d8d5281ae2ca99953a0a81293c83ba2d08.pack
+      |       |-- pack-2302ca9b0ce6c35e391f3982aeb8b9f5523c31fc.idx
+      |       |-- pack-2302ca9b0ce6c35e391f3982aeb8b9f5523c31fc.pack
+      |       |-- pack-28249654a552da0da5716fb8f0aa18e8cbd14c3d.idx
+      |       |-- pack-28249654a552da0da5716fb8f0aa18e8cbd14c3d.pack
+      |       |-- pack-32f4eb8b44455a69a2654ca83ae6694c9967178d.idx
+      |       |-- pack-32f4eb8b44455a69a2654ca83ae6694c9967178d.pack
+      |       |-- pack-48a02c50c8c136d677904cd61c22669b7213135e.idx
+      |       |-- pack-48a02c50c8c136d677904cd61c22669b7213135e.pack
+      |       |-- pack-53e416d5a638f7f1d8eedecb1c8ac8494abd09f8.idx
+      |       |-- pack-53e416d5a638f7f1d8eedecb1c8ac8494abd09f8.pack
+      |       |-- pack-86c3886f3812b98e48bf1270fd0a9f13a0215160.idx
+      |       |-- pack-86c3886f3812b98e48bf1270fd0a9f13a0215160.pack
+      |       |-- pack-9c661dcd7e11e6ec01c18318c83047934ebe3d1d.idx
+      |       |-- pack-9c661dcd7e11e6ec01c18318c83047934ebe3d1d.pack
+      |       |-- pack-c921430e71cc5aabb61e2145eb409c7f06fe8011.idx
+      |       `-- pack-c921430e71cc5aabb61e2145eb409c7f06fe8011.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_modify_chain.t
+++ b/tests/proxy/workspace_modify_chain.t
@@ -372,12 +372,12 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-2009882855c8f675680efa7d980ff158d20ca33a.idx
-      |       |-- pack-2009882855c8f675680efa7d980ff158d20ca33a.pack
-      |       |-- pack-c70df139d67bfa71319bc00c4453aaef1065577f.idx
-      |       |-- pack-c70df139d67bfa71319bc00c4453aaef1065577f.pack
-      |       |-- pack-f89fa289619bb520bbd2b67c6049b117211e3da0.idx
-      |       `-- pack-f89fa289619bb520bbd2b67c6049b117211e3da0.pack
+      |       |-- pack-883060dc96604b179b3de6a1d199b74cc3ea9789.idx
+      |       |-- pack-883060dc96604b179b3de6a1d199b74cc3ea9789.pack
+      |       |-- pack-cdff38b1e417a1748736ee403b2506996c2ac0a5.idx
+      |       |-- pack-cdff38b1e417a1748736ee403b2506996c2ac0a5.pack
+      |       |-- pack-daca06f66935274752749c4a419280e065a5dd18.idx
+      |       `-- pack-daca06f66935274752749c4a419280e065a5dd18.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_modify_chain_prefix_subtree.t
+++ b/tests/proxy/workspace_modify_chain_prefix_subtree.t
@@ -473,16 +473,16 @@ Note that ws/d/ is now present in the ws
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-293c54220e20d5b4c343777de6ec1fcf469a246a.idx
-      |       |-- pack-293c54220e20d5b4c343777de6ec1fcf469a246a.pack
-      |       |-- pack-5db946bd0dcde544bac50ab27795a4775dfc0f00.idx
-      |       |-- pack-5db946bd0dcde544bac50ab27795a4775dfc0f00.pack
-      |       |-- pack-94f23201f51cbf11abc7fce7cfe7359da6844dc7.idx
-      |       |-- pack-94f23201f51cbf11abc7fce7cfe7359da6844dc7.pack
-      |       |-- pack-bd5becad2b550884155f2442b49b91a062e8eeeb.idx
-      |       |-- pack-bd5becad2b550884155f2442b49b91a062e8eeeb.pack
-      |       |-- pack-cbe98a48db32c69560001f112d79637fc2019ccd.idx
-      |       `-- pack-cbe98a48db32c69560001f112d79637fc2019ccd.pack
+      |       |-- pack-1034684bd8a3fb0e1a7e462140434c12415dd637.idx
+      |       |-- pack-1034684bd8a3fb0e1a7e462140434c12415dd637.pack
+      |       |-- pack-13c39a7f381aa9309b304232663fb0372a9da805.idx
+      |       |-- pack-13c39a7f381aa9309b304232663fb0372a9da805.pack
+      |       |-- pack-529c12f552cbaf9b559c216d653bd2588449b1f6.idx
+      |       |-- pack-529c12f552cbaf9b559c216d653bd2588449b1f6.pack
+      |       |-- pack-a246e821e5746809afba9ee81e92851ebc0c349e.idx
+      |       |-- pack-a246e821e5746809afba9ee81e92851ebc0c349e.pack
+      |       |-- pack-c5d6e5ebc8b3c66f707eb5f3deedcf6f11acd5dd.idx
+      |       `-- pack-c5d6e5ebc8b3c66f707eb5f3deedcf6f11acd5dd.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_pre_history.t
+++ b/tests/proxy/workspace_pre_history.t
@@ -150,8 +150,8 @@ file was created
       |-- objects
       |   |-- info
       |   `-- pack
-      |       |-- pack-faaf01d2dc0909611cdf7c3d1bdbbfe3ce2a9449.idx
-      |       `-- pack-faaf01d2dc0909611cdf7c3d1bdbbfe3ce2a9449.pack
+      |       |-- pack-a561d3e5f644bb99f24c18ab816b999321a6c143.idx
+      |       `-- pack-a561d3e5f644bb99f24c18ab816b999321a6c143.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_publish.t
+++ b/tests/proxy/workspace_publish.t
@@ -201,12 +201,12 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-1e3b2eb669f6830fb7caf1293ce0be84bc7dcd74.idx
-      |       |-- pack-1e3b2eb669f6830fb7caf1293ce0be84bc7dcd74.pack
-      |       |-- pack-b37b9b480fa587ae3abac4d9d69d9739c245f727.idx
-      |       |-- pack-b37b9b480fa587ae3abac4d9d69d9739c245f727.pack
-      |       |-- pack-b64c0193b9599a21219248e0ac7583470c37b5cf.idx
-      |       `-- pack-b64c0193b9599a21219248e0ac7583470c37b5cf.pack
+      |       |-- pack-6b4a19cf8560a1f630c286966ee50507c70e4f02.idx
+      |       |-- pack-6b4a19cf8560a1f630c286966ee50507c70e4f02.pack
+      |       |-- pack-87aaf7973b6e96ba2ec6c6e2b1039453e7a37641.idx
+      |       |-- pack-87aaf7973b6e96ba2ec6c6e2b1039453e7a37641.pack
+      |       |-- pack-8bac1772adffe745cbe0b9fc1e42bbe7f40c1bb3.idx
+      |       `-- pack-8bac1772adffe745cbe0b9fc1e42bbe7f40c1bb3.pack
       `-- refs
           |-- heads
           |-- namespaces

--- a/tests/proxy/workspace_tags.t
+++ b/tests/proxy/workspace_tags.t
@@ -347,12 +347,12 @@
       |   |   `-- 3dd93419493d22aeaf6bcb5c0bec4c2701b049
       |   |-- info
       |   `-- pack
-      |       |-- pack-98fe2fcc1ca8d493770a9fe52ae4d50e96793a27.idx
-      |       |-- pack-98fe2fcc1ca8d493770a9fe52ae4d50e96793a27.pack
-      |       |-- pack-d2f1121a06a53dbc7c35b23f77a1edf526503745.idx
-      |       |-- pack-d2f1121a06a53dbc7c35b23f77a1edf526503745.pack
-      |       |-- pack-f7abe9eb33a28f534dd36b4772fec65a411fc901.idx
-      |       `-- pack-f7abe9eb33a28f534dd36b4772fec65a411fc901.pack
+      |       |-- pack-27bd9620b76cd632fac0caebebcdf4d0dc7fb835.idx
+      |       |-- pack-27bd9620b76cd632fac0caebebcdf4d0dc7fb835.pack
+      |       |-- pack-be0b3e8fd31cd30fd25da9dc16f84eec828281aa.idx
+      |       |-- pack-be0b3e8fd31cd30fd25da9dc16f84eec828281aa.pack
+      |       |-- pack-cca0f80d7d8de45df0c1d26acbd52bd2db47f42e.idx
+      |       `-- pack-cca0f80d7d8de45df0c1d26acbd52bd2db47f42e.pack
       `-- refs
           |-- heads
           |-- namespaces


### PR DESCRIPTION
Favor latency when flushing proxy packs

Write transient memory-store packs with zlib best-speed compression. Proxy namespace publication is a synchronous request boundary, while later maintenance can repack durable objects for a better ratio.

Change: fast-memodb-packs
Assisted-By: openai-codex/gpt-5.6-sol