### PR TITLE
Publish refs only after MemOdb flush succeeds

### DIFF
--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -40,8 +40,8 @@ pub struct DistributedCacheBackend {
 
 impl Drop for DistributedCacheBackend {
     fn drop(&mut self) {
-        if !self.flush(true).is_ok() {
-            log::warn!("DistributedCacheBackend: flush failed");
+        if let Err(error) = self.flush(true) {
+            log::warn!("DistributedCacheBackend: flush failed: {error}");
         }
     }
 }

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -299,8 +299,8 @@ impl Drop for Transaction {
         }
 
         // Objects first, refs second: a ref that reaches disk must never point at an object
-        // only memory holds. A flush error is logged and the refs written anyway -- the same
-        // end state as before, where refs were already on disk by the time the flush ran.
+        // only memory holds. Repository maintenance preserves unreachable objects during the
+        // publication gap; see `josh_memodb::pack::write_snapshot`.
         let publishes_object = self.pending_refs.borrow().iter().any(|edit| {
             matches!(
                 &edit.change,
@@ -310,11 +310,19 @@ impl Drop for Transaction {
                 }
             )
         });
-        if publishes_object && let Err(e) = self.mem_odb.flush() {
-            log::error!("failed to flush in-memory object store: {e}");
-        }
-        if let Err(e) = self.apply_pending_refs() {
-            log::error!("failed to write pending ref updates: {e}");
+        let objects_are_durable = if publishes_object {
+            match self.mem_odb.flush() {
+                Ok(()) => true,
+                Err(error) => {
+                    log::error!("failed to flush in-memory object store: {error}");
+                    false
+                }
+            }
+        } else {
+            true
+        };
+        if objects_are_durable && let Err(error) = self.apply_pending_refs() {
+            log::error!("failed to write pending ref updates: {error}");
         }
     }
 }
@@ -2280,6 +2288,25 @@ mod tests {
             disk_blob(dir.path(), oid).as_deref(),
             Some(b"published".as_slice())
         );
+    }
+
+    #[test]
+    fn failed_object_flush_does_not_publish_ref() {
+        let (dir, context) = test_context();
+        {
+            let transaction = context.open().unwrap();
+            let oid = transaction
+                .odb()
+                .write(gix_object::Kind::Blob, b"cannot publish");
+            transaction
+                .update_ref("refs/josh/blob", Expected::Absent, oid, "test")
+                .unwrap();
+            let pack_dir = dir.path().join("objects").join("pack");
+            std::fs::remove_dir(&pack_dir).unwrap();
+            std::fs::write(pack_dir, b"not a directory").unwrap();
+        }
+
+        assert!(!dir.path().join("refs/josh/blob").exists());
     }
 
     /// An explicit disk-reader boundary has the same ordering as drop: object first, ref second.

--- a/josh-memodb/src/pack.rs
+++ b/josh-memodb/src/pack.rs
@@ -27,9 +27,8 @@ pub(crate) fn objects_dir(repo: &gix::Repository) -> std::path::PathBuf {
 ///
 /// The pack is deterministic for a given snapshot: entries are compressed at a fixed level and
 /// serialized single-threaded in snapshot order, and the file pair is named after the pack
-/// trailer checksum (the same rule libgit2 and modern git use), so identical snapshots produce
-/// identical packs. Files are written via tempfile-and-rename, index last, so a concurrent
-/// reader scanning for `.idx` files never sees a torn pair.
+/// trailer checksum, so identical snapshots produce identical packs. Files are written via
+/// tempfile-and-rename, index last, so a concurrent reader never sees a torn pair.
 pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow::Result<()> {
     // A fresh store handle per flush observes every pack written by previous flushes. Misses are
     // the expected case below, and the default refresh mode re-lists the pack directory on every
@@ -99,19 +98,21 @@ pub(crate) fn write_snapshot(objects_dir: &Path, snapshot: &Snapshot) -> anyhow:
         },
     )
     .context("mem-odb pack write failed")?;
-    // gix marks the freshly-landed pack with a `.keep` file for the caller to remove once its
-    // referencing refs exist. josh's flushes carry no such handshake (libgit2's packbuilder wrote
-    // no `.keep` either), and a leftover one would exempt the pack from `git repack -d` forever.
-    // Derived from `data_path` rather than taking `outcome.keep_path`: when an earlier attempt
-    // persisted the pack but failed before completing (missing idx, crash), the retry finds the
-    // pack already present and gets `keep_path: None` — deriving the name still heals the marker
-    // the earlier attempt left behind (missing-ok, since that branch usually has none to remove).
-    if let Some(data_path) = &outcome.data_path {
-        if let Err(e) = std::fs::remove_file(data_path.with_extension("keep")) {
-            if e.kind() != std::io::ErrorKind::NotFound {
-                return Err(e).context("mem-odb pack write failed");
-            }
-        }
+    // gix marks the freshly-landed pack with a `.keep` file. Josh currently assumes that its
+    // object directories are maintained only by the commands in `josh-proxy::housekeeping`:
+    // mirror repacks use `--keep-unreachable`, and overlay repacks use `--cruft`, so both preserve
+    // objects from a shared-store flush whose refs are not published yet. If arbitrary concurrent
+    // pruning becomes supported, retain this marker until every transaction sharing the MemOdb
+    // has published its refs, or give each transaction its own buffer.
+    //
+    // Derive the marker from `data_path` instead of taking `outcome.keep_path`. If an earlier
+    // attempt persisted the pack but failed before completing, a retry can find the pack already
+    // present and return no keep path; deriving the name also heals that leftover marker.
+    if let Some(data_path) = &outcome.data_path
+        && let Err(error) = std::fs::remove_file(data_path.with_extension("keep"))
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(error).context("mem-odb pack write failed");
     }
     Ok(())
 }


### PR DESCRIPTION
Publish refs only after MemOdb flush succeeds

Leave pending refs unpublished when flushing their target objects fails, so a disk-visible ref never points at an object held only in memory.

Josh maintenance preserves unreachable objects during the gap between a shared-store flush and ref publication. Document that arbitrary concurrent pruning would require retained pack markers or transaction-local buffers.

Change: safe-memodb-ref-publication
Assisted-By: openai-codex/gpt-5.6-sol