### PR TITLE
Prepare r26.08.28 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "axum-cgi"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "axum",
  "bytes",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "axum-cgi-server"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "josh-changes"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "josh-cli"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "josh-command-middleware"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "josh-compose"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "defer",
@@ -3373,14 +3373,14 @@ dependencies = [
 
 [[package]]
 name = "josh-compose-backend"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "josh-compose-podman"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "backon",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "josh-core"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "josh-cq"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -3456,7 +3456,7 @@ dependencies = [
 
 [[package]]
 name = "josh-cq-test-components"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "josh-filter"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix-hash",
@@ -3491,7 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "josh-git-serde"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix-hash",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-auth"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3528,7 +3528,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-changes"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix-hash",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-codegen-graphql"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-graphql"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-keyring"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "apple-native-keyring-store",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-webhooks"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "josh-gix-ext"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "josh-graphql"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3650,7 +3650,7 @@ dependencies = [
 
 [[package]]
 name = "josh-link"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix-actor",
@@ -3660,7 +3660,7 @@ dependencies = [
 
 [[package]]
 name = "josh-memodb"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix",
@@ -3677,7 +3677,7 @@ dependencies = [
 
 [[package]]
 name = "josh-proxy"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "axum",
@@ -3731,7 +3731,7 @@ dependencies = [
 
 [[package]]
 name = "josh-rpc"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "libc",
  "serde",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "josh-search"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "criterion2",
@@ -3757,7 +3757,7 @@ dependencies = [
 
 [[package]]
 name = "josh-ssh-shell"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "clap",
  "josh-rpc",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "josh-starlark"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3789,7 +3789,7 @@ dependencies = [
 
 [[package]]
 name = "josh-templates"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "form_urlencoded",
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "josh-test-webhook-client"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "backon",
@@ -3837,7 +3837,7 @@ dependencies = [
 
 [[package]]
 name = "josh-test-webhook-service"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,37 +102,37 @@ prettyplease = "0.2.37"
 graphql_client = "^0.16"
 graphql_client_codegen = { version = "^0.16.0" }
 
-axum-cgi = { path = "axum-cgi", version = "26.7.28" }
-josh-filter = { path = "josh-filter", version = "26.7.28" }
-josh-gix-ext = { path = "josh-gix-ext", version = "26.7.28" }
-josh-git-serde = { path = "josh-git-serde", version = "26.7.28" }
-josh-changes = { path = "josh-changes", version = "26.7.28" }
-josh-core = { path = "josh-core", version = "26.7.28" }
-josh-memodb = { path = "josh-memodb", version = "26.7.28" }
-josh-compose = { path = "josh-compose", version = "26.7.28" }
-josh-compose-backend = { path = "josh-compose-backend", version = "26.7.28" }
-josh-compose-podman = { path = "josh-compose-podman", version = "26.7.28" }
-josh-graphql = { path = "josh-graphql", version = "26.7.28" }
-josh-link = { path = "josh-link", version = "26.7.28" }
-josh-rpc = { path = "josh-rpc", version = "26.7.28" }
-josh-search = { path = "josh-search", version = "26.7.28" }
-josh-starlark = { path = "josh-starlark", version = "26.7.28" }
-josh-templates = { path = "josh-templates", version = "26.7.28" }
+axum-cgi = { path = "axum-cgi", version = "26.8.28" }
+josh-filter = { path = "josh-filter", version = "26.8.28" }
+josh-gix-ext = { path = "josh-gix-ext", version = "26.8.28" }
+josh-git-serde = { path = "josh-git-serde", version = "26.8.28" }
+josh-changes = { path = "josh-changes", version = "26.8.28" }
+josh-core = { path = "josh-core", version = "26.8.28" }
+josh-memodb = { path = "josh-memodb", version = "26.8.28" }
+josh-compose = { path = "josh-compose", version = "26.8.28" }
+josh-compose-backend = { path = "josh-compose-backend", version = "26.8.28" }
+josh-compose-podman = { path = "josh-compose-podman", version = "26.8.28" }
+josh-graphql = { path = "josh-graphql", version = "26.8.28" }
+josh-link = { path = "josh-link", version = "26.8.28" }
+josh-rpc = { path = "josh-rpc", version = "26.8.28" }
+josh-search = { path = "josh-search", version = "26.8.28" }
+josh-starlark = { path = "josh-starlark", version = "26.8.28" }
+josh-templates = { path = "josh-templates", version = "26.8.28" }
 
 # Forges support
-josh-github-changes = { path = "forges/josh-github-changes", version = "26.7.28" }
-josh-github-graphql = { path = "forges/josh-github-graphql", version = "26.7.28" }
-josh-github-codegen-graphql = { path = "forges/josh-github-codegen-graphql", version = "26.7.28" }
-josh-github-webhooks = { path = "forges/josh-github-webhooks", version = "26.7.28" }
-josh-github-auth = { path = "forges/josh-github-auth", version = "26.7.28" }
-josh-github-keyring = { path = "forges/josh-github-keyring", version = "26.7.28" }
+josh-github-changes = { path = "forges/josh-github-changes", version = "26.8.28" }
+josh-github-graphql = { path = "forges/josh-github-graphql", version = "26.8.28" }
+josh-github-codegen-graphql = { path = "forges/josh-github-codegen-graphql", version = "26.8.28" }
+josh-github-webhooks = { path = "forges/josh-github-webhooks", version = "26.8.28" }
+josh-github-auth = { path = "forges/josh-github-auth", version = "26.8.28" }
+josh-github-keyring = { path = "forges/josh-github-keyring", version = "26.8.28" }
 
-josh-cq-test-components = { path = "cq/josh-cq-test-components", version = "26.7.28" }
+josh-cq-test-components = { path = "cq/josh-cq-test-components", version = "26.8.28" }
 
 # Deployment
-josh-test-webhook-service = { path = "deployment/josh-test-webhook-service", version = "26.7.28" }
-josh-test-webhook-client = { path = "deployment/josh-test-webhook-client", version = "26.7.28" }
-josh-command-middleware = { path = "deployment/josh-command-middleware", version = "26.7.28" }
+josh-test-webhook-service = { path = "deployment/josh-test-webhook-service", version = "26.8.28" }
+josh-test-webhook-client = { path = "deployment/josh-test-webhook-client", version = "26.8.28" }
+josh-command-middleware = { path = "deployment/josh-command-middleware", version = "26.8.28" }
 
 
 [workspace.dependencies.juniper]

--- a/axum-cgi-server/Cargo.toml
+++ b/axum-cgi-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-cgi-server"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 license-file = "../axum-cgi/LICENSE"
 repository = "https://github.com/josh-project/josh"

--- a/axum-cgi/Cargo.toml
+++ b/axum-cgi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-cgi"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 license-file = "LICENSE"
 description = "CGI handler support for the axum web framework"

--- a/cq/josh-cq-test-components/Cargo.toml
+++ b/cq/josh-cq-test-components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-cq-test-components"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 license-file = "../../LICENSE"
 

--- a/cq/josh-cq/Cargo.toml
+++ b/cq/josh-cq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-cq"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "Code quality tooling for the josh git proxy"

--- a/deployment/josh-command-middleware/Cargo.toml
+++ b/deployment/josh-command-middleware/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-command-middleware"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "Command middleware for josh"

--- a/deployment/josh-test-webhook-client/Cargo.toml
+++ b/deployment/josh-test-webhook-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-test-webhook-client"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "Test webhook client for josh integration testing"

--- a/deployment/josh-test-webhook-service/Cargo.toml
+++ b/deployment/josh-test-webhook-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-test-webhook-service"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "Test webhook service for josh integration testing"

--- a/docs/src/guide/migration.md
+++ b/docs/src/guide/migration.md
@@ -2,6 +2,40 @@
 
 This page covers breaking changes introduced in recent releases and how to adapt to them.
 
+## `josh pull` moved to `josh changes pull`
+
+*Applies when upgrading from r26.07.28 to r26.08.28.*
+
+The top-level `josh pull` command has moved under `josh changes`. The new command requires Git
+2.41 or newer, always integrates with rebase-style restacking and autostash, and no longer accepts
+`--rebase` or `--autostash`.
+
+**How to migrate:** Upgrade Git to 2.41 or newer, replace `josh pull` with
+`josh changes pull`, and remove the `--rebase` and `--autostash` flags from scripts.
+
+## Pattern-filter construction is fallible
+
+*Applies when upgrading from r26.07.28 to r26.08.28.*
+
+Invalid globs now fail when a pattern filter is constructed rather than when it is first applied.
+The Rust `Filter::pattern` API therefore returns an error result.
+
+**How to migrate:** Update Rust callers to propagate or handle the result from
+`Filter::pattern(...)`, for example with `Filter::pattern(pattern)?`. Validate user-supplied
+patterns at construction time instead of expecting application to report the error.
+
+## Malformed Git trees are preserved instead of normalized
+
+*Applies when upgrading from r26.07.28 to r26.08.28.*
+
+Filtering no longer sorts, deduplicates, or canonicalizes unchanged entries in fsck-invalid Git
+trees. Rebuilt filtered commits can consequently have different object IDs than earlier Josh
+versions when their source history contains malformed trees.
+
+**How to migrate:** Run `git fsck` on source repositories that may contain malformed trees. If
+external systems pin filtered commit IDs from such histories, regenerate those references with
+the new Josh version or replace the malformed source trees with canonical commits.
+
 ## `josh publish` renamed to `josh changes publish`
 
 *Applies when upgrading from r26.05.08 to r26.06.11.*

--- a/forges/josh-github-auth/Cargo.toml
+++ b/forges/josh-github-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-github-auth"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "GitHub authentication for Josh"

--- a/forges/josh-github-changes/Cargo.toml
+++ b/forges/josh-github-changes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-github-changes"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2021"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "GitHub change tracking for Josh"

--- a/forges/josh-github-codegen-graphql/Cargo.toml
+++ b/forges/josh-github-codegen-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-github-codegen-graphql"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2021"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "GitHub GraphQL codegen for Josh"

--- a/forges/josh-github-graphql/Cargo.toml
+++ b/forges/josh-github-graphql/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "josh-github-graphql"
-version = "26.7.28"
+version = "26.8.28"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "GitHub GraphQL client for Josh"
 license-file = "../../LICENSE"

--- a/forges/josh-github-keyring/Cargo.toml
+++ b/forges/josh-github-keyring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-github-keyring"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "Credential storage for Josh GitHub integration"

--- a/forges/josh-github-webhooks/Cargo.toml
+++ b/forges/josh-github-webhooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-github-webhooks"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "GitHub webhook handling for Josh"

--- a/josh-changes/Cargo.toml
+++ b/josh-changes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-changes"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "Josh change tracking"

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "../LICENSE"
 name = "josh-cli"
 readme = "../README.md"
 repository = "https://github.com/josh-project/josh"
-version = "26.7.28"
+version = "26.8.28"
 
 [dependencies]
 anyhow.workspace = true

--- a/josh-compose-backend/Cargo.toml
+++ b/josh-compose-backend/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "../LICENSE"
 name = "josh-compose-backend"
 readme = "../README.md"
 repository = "https://github.com/josh-project/josh"
-version = "26.7.28"
+version = "26.8.28"
 
 [dependencies]
 anyhow.workspace = true

--- a/josh-compose-podman/Cargo.toml
+++ b/josh-compose-podman/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "../LICENSE"
 name = "josh-compose-podman"
 readme = "../README.md"
 repository = "https://github.com/josh-project/josh"
-version = "26.7.28"
+version = "26.8.28"
 
 [dependencies]
 anyhow.workspace = true

--- a/josh-compose/Cargo.toml
+++ b/josh-compose/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "../LICENSE"
 name = "josh-compose"
 readme = "../README.md"
 repository = "https://github.com/josh-project/josh"
-version = "26.7.28"
+version = "26.8.28"
 
 [dependencies]
 anyhow.workspace = true

--- a/josh-core/Cargo.toml
+++ b/josh-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-core"
-version = "26.7.28"
+version = "26.8.28"
 repository = "https://ithub.com/josh-project/josh"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 license-file = "../LICENSE"

--- a/josh-filter/Cargo.toml
+++ b/josh-filter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-filter"
-version = "26.7.28"
+version = "26.8.28"
 repository = "https://github.com/josh-project/josh"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 license-file = "../LICENSE"

--- a/josh-git-serde/Cargo.toml
+++ b/josh-git-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-git-serde"
-version = "26.7.28"
+version = "26.8.28"
 repository = "https://github.com/josh-project/josh"
 license-file = "../LICENSE"
 description = "serde serialization of Rust values into git tree objects"

--- a/josh-gix-ext/Cargo.toml
+++ b/josh-gix-ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-gix-ext"
-version = "26.7.28"
+version = "26.8.28"
 repository = "https://github.com/josh-project/josh"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 license-file = "../LICENSE"

--- a/josh-graphql/Cargo.toml
+++ b/josh-graphql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-graphql"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "GraphQL support for Josh"

--- a/josh-gui/Cargo.lock
+++ b/josh-gui/Cargo.lock
@@ -4188,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "josh-changes"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "josh-command-middleware"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4211,7 +4211,7 @@ dependencies = [
 
 [[package]]
 name = "josh-core"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "josh-filter"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix-hash",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "josh-git-serde"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix-hash",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-auth"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-changes"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix-hash",
@@ -4320,7 +4320,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-codegen-graphql"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-graphql"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4355,7 +4355,7 @@ dependencies = [
 
 [[package]]
 name = "josh-github-webhooks"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "axum",
  "chrono",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "josh-gix-ext"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix-actor",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "josh-memodb"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix-features",
@@ -4423,7 +4423,7 @@ dependencies = [
 
 [[package]]
 name = "josh-search"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "anyhow",
  "gix-hash",
@@ -4433,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "josh-starlark"
-version = "26.7.28"
+version = "26.8.28"
 dependencies = [
  "allocative",
  "anyhow",

--- a/josh-link/Cargo.toml
+++ b/josh-link/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-link"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "Josh link resolution"

--- a/josh-memodb/Cargo.toml
+++ b/josh-memodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-memodb"
-version = "26.7.28"
+version = "26.8.28"
 repository = "https://ithub.com/josh-project/josh"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 license-file = "../LICENSE"

--- a/josh-proxy/Cargo.toml
+++ b/josh-proxy/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "../LICENSE"
 name = "josh-proxy"
 readme = "../README.md"
 repository = "https://github.com/josh-project/josh"
-version = "26.7.28"
+version = "26.8.28"
 
 [dependencies]
 sha2 = "0.11.0"

--- a/josh-rpc/Cargo.toml
+++ b/josh-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-rpc"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "RPC primitives for the josh git proxy"

--- a/josh-search/Cargo.toml
+++ b/josh-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-search"
-version = "26.7.28"
+version = "26.8.28"
 repository = "https://github.com/josh-project/josh"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 license-file = "../LICENSE"

--- a/josh-ssh-shell/Cargo.toml
+++ b/josh-ssh-shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-ssh-shell"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "SSH shell integration for the josh git proxy"

--- a/josh-starlark/Cargo.toml
+++ b/josh-starlark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-starlark"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 license-file = "../LICENSE"

--- a/josh-templates/Cargo.toml
+++ b/josh-templates/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "josh-templates"
-version = "26.7.28"
+version = "26.8.28"
 edition = "2024"
 authors = ["Josh Project authors <contact@josh-project.dev>"]
 description = "Josh templating support"

--- a/releases/r26.08.28.md
+++ b/releases/r26.08.28.md
@@ -1,0 +1,108 @@
+## core
+
+### New features
+
+* **Josh now builds and runs natively on Windows** (#2539)
+  `josh-proxy`, `josh`, and `josh-filter` support Windows on x86-64 and ARM64. SSH serving and
+  `josh compose` remain unavailable on Windows.
+
+### Breaking changes
+
+* **Pattern-filter construction is now fallible** (#2356)
+  Invalid globs fail when a pattern enters the system instead of during its first application.
+  Rust callers of `Filter::pattern` must now handle its error result.
+
+* **Filters preserve malformed Git trees byte-for-byte** (#2380)
+  Unchanged entries in fsck-invalid trees are no longer reordered, deduplicated, or normalized.
+  Rebuilt filtered commit IDs can therefore change for repositories containing such trees.
+
+### Bug fixes
+
+* **Absent-ref guards are checked when deferred writes are committed** (#2501)
+  Concurrent writers can no longer invalidate an `Expected::Absent` check between queueing and
+  publication.
+
+### Performance
+
+* **Josh has completed its Gitoxide migration** (#2331, #2377, #2398, #2447,
+  #2470, #2510, #2533)
+  Object reads and writes, ref transactions, tree rebuilding, caches, and history walks now share
+  a transaction-oriented in-memory object store backed by `gix`. The Rust workspace and runtime
+  container no longer depend on libgit2.
+
+* **Glob filters prune unmatched subtrees and avoid repeated compilation and allocation**
+  (#2356, #2309, #2310)
+  Prefix patterns are up to 9× faster on wide trees, with substantial gains for deep histories.
+
+* **History walks and sparse-cache lookups avoid repeated deep traversals** (#2377, #2492, #2542,
+  #2546)
+  Native generation-ordered walkers keep recent side branches near the search frontier and bound
+  cache walks for filters that drop most commits.
+
+Release benchmarks measured 54% less aggregate time for Rust subtree syncs via `josh-sync`
+(48% proxy, 64% CLI) and 68% lower mean Criterion latency.
+
+## josh-cli
+
+### New features
+
+* **Publish stacked changes from a fork** (#2357)
+  `josh remote add --push-url` and `josh clone --push-url` send branches to a fork while opening
+  pull requests against the target repository. Dependent pull requests remain drafts until their
+  predecessors merge.
+
+* **Publish stacked changes to Gerrit** (#2358)
+  `josh changes publish --forge gerrit` supports independent-root reviews or a full Gerrit
+  relation chain selected with `--gerrit-mode`.
+
+* **Focused change inspection with `changes show` and `changes deps`** (#2160)
+  `josh changes list` is now a compact summary; the new subcommands provide per-change details and
+  direct dependency output.
+
+* **Curated pull and publish output** (#2355, #2374)
+  Internal stacked-ref traffic is replaced with branch/change summaries, and interactive PR links
+  use terminal hyperlinks where supported.
+
+### Breaking changes
+
+* **`josh pull` moved to `josh changes pull`** (#2355)
+  The command now requires Git 2.41 or newer, always uses rebase-style restacking and autostash,
+  and no longer accepts `--rebase` or `--autostash`.
+
+### Bug fixes
+
+* **Pull keeps and restacks local commits without a `Change-Id`** (#2371)
+  WIP and fixup commits no longer abort integration merely because they are outside the changes
+  flow.
+
+* **Published merge changes retain their second parent** (#2361)
+  Downstacking no longer silently turns a merge carrying a change ID into a single-parent commit.
+
+## josh-proxy
+
+### Bug fixes
+
+* **Refs are published only after their target objects reach disk** (#2545)
+  A failed in-memory object-store flush can no longer leave a visible ref pointing to an object
+  that exists only in memory.
+
+### Performance
+
+* **Proxy object lookups avoid unnecessary pack-directory rescans** (#2543)
+  Primary and alternate snapshots are probed before either store refreshes its object directory.
+
+* **Synchronous proxy packs favor request latency** (#2544)
+  Transient packs now use zlib's best-speed mode; later maintenance can repack durable objects for
+  density.
+
+## josh-compose
+
+### Bug fixes
+
+* **Long archive paths and symlink targets are supported** (#2519)
+  Compose archives emit GNU long-name records instead of failing at fixed tar-header limits.
+
+* **Container runs no longer hold the repository cache lock** (#2391)
+  The sled cache is flushed and released after workspace filtering, allowing other Josh commands
+  to run during the container build.
+


### PR DESCRIPTION
Prepare the r26.08.28 release from official master.

- curate release notes for r26.07.28..r26.08.28
- document migration steps for breaking CLI, experimental index, filter API, and malformed-tree changes
- bump all 31 date-versioned workspace packages and 26 root path requirements to 26.8.28
- update only workspace package versions in Cargo.lock

Verification:
- cargo metadata --no-deps --locked
- cargo fmt
