### PR TITLE
Extract Gerrit publishing into josh-gerrit-changes crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,6 +3330,7 @@ dependencies = [
  "josh-compose",
  "josh-compose-podman",
  "josh-core",
+ "josh-gerrit-changes",
  "josh-github-auth",
  "josh-github-changes",
  "josh-github-graphql",
@@ -3490,6 +3491,16 @@ dependencies = [
  "regex",
  "serde_json",
  "smallvec",
+]
+
+[[package]]
+name = "josh-gerrit-changes"
+version = "26.8.28"
+dependencies = [
+ "anyhow",
+ "gix-hash",
+ "josh-changes",
+ "josh-core",
 ]
 
 [[package]]
@@ -3702,6 +3713,7 @@ dependencies = [
  "indoc",
  "josh-changes",
  "josh-core",
+ "josh-gerrit-changes",
  "josh-graphql",
  "josh-rpc",
  "josh-templates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "forges/josh-github-webhooks",
     "forges/josh-github-auth",
     "forges/josh-github-keyring",
+    "forges/josh-gerrit-changes",
 
     "deployment/josh-test-webhook-client",
     "deployment/josh-test-webhook-service",
@@ -126,6 +127,7 @@ josh-github-codegen-graphql = { path = "forges/josh-github-codegen-graphql", ver
 josh-github-webhooks = { path = "forges/josh-github-webhooks", version = "26.8.28" }
 josh-github-auth = { path = "forges/josh-github-auth", version = "26.8.28" }
 josh-github-keyring = { path = "forges/josh-github-keyring", version = "26.8.28" }
+josh-gerrit-changes = { path = "forges/josh-gerrit-changes", version = "26.8.28" }
 
 josh-cq-test-components = { path = "cq/josh-cq-test-components", version = "26.8.28" }
 
@@ -219,6 +221,7 @@ josh-github-codegen-graphql = { path = "forges/josh-github-codegen-graphql" }
 josh-github-webhooks = { path = "forges/josh-github-webhooks" }
 josh-github-auth = { path = "forges/josh-github-auth" }
 josh-github-keyring = { path = "forges/josh-github-keyring" }
+josh-gerrit-changes = { path = "forges/josh-gerrit-changes" }
 josh-cq-test-components = { path = "cq/josh-cq-test-components" }
 josh-test-webhook-service = { path = "deployment/josh-test-webhook-service" }
 josh-test-webhook-client = { path = "deployment/josh-test-webhook-client" }

--- a/forges/josh-gerrit-changes/Cargo.toml
+++ b/forges/josh-gerrit-changes/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "josh-gerrit-changes"
+version = "26.8.28"
+edition = "2024"
+authors = ["Josh Project authors <contact@josh-project.dev>"]
+description = "Gerrit change tracking for Josh"
+license-file = "../../LICENSE"
+repository = "https://github.com/josh-project/josh"
+keywords = ["git", "gerrit", "monorepo", "workflow", "scm"]
+
+[dependencies]
+anyhow.workspace = true
+gix-hash.workspace = true
+
+josh-changes.workspace = true
+josh-core.workspace = true

--- a/forges/josh-gerrit-changes/src/lib.rs
+++ b/forges/josh-gerrit-changes/src/lib.rs
@@ -1,0 +1,7 @@
+//! Gerrit publishing support for Josh
+
+mod publish;
+mod refs;
+
+pub use publish::*;
+pub use refs::*;

--- a/forges/josh-gerrit-changes/src/publish.rs
+++ b/forges/josh-gerrit-changes/src/publish.rs
@@ -1,10 +1,12 @@
-use crate::change::{Change, get_changes, split_changes};
-use crate::stacked::PushRef;
+use josh_changes::{Change, PushRef, get_changes, split_changes};
 
 /// A valid Gerrit Change-Id is the letter `I` followed by 40 hex digits.
 fn is_gerrit_change_id(id: &str) -> bool {
     let bytes = id.as_bytes();
-    bytes.len() == 41 && bytes[0] == b'I' && bytes[1..].iter().all(u8::is_ascii_hexdigit)
+    let Some((prefix, rest)) = bytes.split_first() else {
+        return false;
+    };
+    *prefix == b'I' && rest.len() == 40 && rest.iter().all(u8::is_ascii_hexdigit)
 }
 
 /// Map a josh change id to a Gerrit-format Change-Id (`I` + 40 hex).
@@ -172,18 +174,18 @@ pub fn build_gerrit_independent_push(
 
     // `get_changes` collects into a HashMap, so sort for a deterministic push order.
     let mut changes: Vec<Change> = changes.into_iter().collect();
-    changes.sort_by_key(|c| c.commit);
+    changes.sort_by_key(|c| c.commit());
 
     let ref_name = format!("refs/for/{}", branch);
     let mut refs = Vec::new();
     for change in changes {
-        let Some(josh_id) = change.id.clone() else {
+        let Some(josh_id) = change.id().map(|s| s.to_string()) else {
             continue;
         };
 
         // A change has no dependencies when its split commit sits directly on
         // the target base (nothing else was pulled in below it by `downstack`).
-        let parent = josh_core::objects::CommitData::read(odb, change.commit)?
+        let parent = josh_core::objects::CommitData::read(odb, change.commit())?
             .parent_ids()
             .next();
         let has_no_deps = if base == gix_hash::ObjectId::null(gix_hash::Kind::Sha1) {
@@ -196,7 +198,7 @@ pub fn build_gerrit_independent_push(
         }
 
         let gerrit_id = gerrit_change_id(&josh_id)?;
-        let new_tip = rewrite_chain_with_gerrit_ids(transaction, change.commit, base)?;
+        let new_tip = rewrite_chain_with_gerrit_ids(transaction, change.commit(), base)?;
         refs.push(PushRef {
             ref_name: ref_name.clone(),
             oid: new_tip,

--- a/forges/josh-gerrit-changes/src/refs.rs
+++ b/forges/josh-gerrit-changes/src/refs.rs
@@ -1,0 +1,37 @@
+//! Parsing of Gerrit-style push refnames for josh's git transports: splitting
+//! `%` push options and translating the Gerrit magic refs (`refs/for`,
+//! `refs/drafts`, `refs/publish/for`) onto real branches, deciding which josh
+//! `PushMode` a push triggers.
+
+use anyhow::anyhow;
+
+use josh_changes::PushMode;
+
+pub fn baseref_and_options(
+    refname: &str,
+    author: &str,
+) -> anyhow::Result<(String, String, Vec<String>, PushMode)> {
+    let mut split = refname.splitn(2, '%');
+    let push_to = split.next().ok_or(anyhow!("no next"))?.to_owned();
+
+    let options = if let Some(options) = split.next() {
+        options.split(',').map(|x| x.to_string()).collect()
+    } else {
+        vec![]
+    };
+
+    let mut baseref = push_to.to_owned();
+    let mut push_mode = PushMode::Normal;
+
+    if baseref.starts_with("refs/for") {
+        baseref = baseref.replacen("refs/for", "refs/heads", 1)
+    }
+    if baseref.starts_with("refs/drafts") {
+        baseref = baseref.replacen("refs/drafts", "refs/heads", 1)
+    }
+    if baseref.starts_with("refs/publish/for") {
+        push_mode = PushMode::Publish(author.to_string());
+        baseref = baseref.replacen("refs/publish/for", "refs/heads", 1)
+    }
+    Ok((baseref, push_to, options, push_mode))
+}

--- a/josh-changes/src/change.rs
+++ b/josh-changes/src/change.rs
@@ -116,7 +116,7 @@ pub fn create_synthetic_merge_commit(
     )
 }
 
-pub(crate) fn split_changes(
+pub fn split_changes(
     transaction: &josh_core::cache::Transaction,
     changes: std::collections::HashMap<gix_hash::ObjectId, Change>,
 ) -> anyhow::Result<Vec<Change>> {
@@ -138,7 +138,7 @@ pub(crate) fn split_changes(
         .collect()
 }
 
-pub(crate) fn get_changes(
+pub fn get_changes(
     transaction: &josh_core::cache::Transaction,
     tip: gix_hash::ObjectId,
     base: gix_hash::ObjectId,

--- a/josh-changes/src/forges/mod.rs
+++ b/josh-changes/src/forges/mod.rs
@@ -1,3 +1,0 @@
-pub mod gerrit;
-
-pub use gerrit::*;

--- a/josh-changes/src/lib.rs
+++ b/josh-changes/src/lib.rs
@@ -1,6 +1,6 @@
 //! Stacked-changes metadata store for josh: change identity, comments, votes,
-//! revisions, and stacked-changes push machinery (including Gerrit-style
-//! publishing), persisted in `refs/josh/...` refs.
+//! revisions, and stacked-changes push machinery, persisted in `refs/josh/...`
+//! refs.
 //!
 //! The public API is flat: everything is re-exported at the crate root.
 
@@ -8,7 +8,6 @@ pub use josh_core::trailers::{commit_change_meta, parse_change_meta};
 
 mod change;
 mod comments;
-mod forges;
 pub mod layout;
 mod refs;
 mod revisions;
@@ -18,7 +17,6 @@ mod votes;
 
 pub use change::*;
 pub use comments::*;
-pub use forges::*;
 pub use refs::*;
 pub use revisions::*;
 pub use stacked::*;

--- a/josh-changes/src/stacked.rs
+++ b/josh-changes/src/stacked.rs
@@ -1,6 +1,5 @@
 //! Stacked-changes push machinery: deciding which refs a push must create or
-//! update. Handles `refs/for`/`refs/drafts`/`refs/publish/for` ref syntax and
-//! is used by both the GitHub-style stacked-refs flow and the Gerrit flow.
+//! update.
 
 use crate::change::{Change, get_changes, split_changes};
 use crate::refs::{StackedChangeRef, StackedRef};
@@ -18,35 +17,6 @@ pub struct PushRef {
     pub ref_name: String,
     pub oid: gix_hash::ObjectId,
     pub change_id: String,
-}
-
-pub fn baseref_and_options(
-    refname: &str,
-    author: &str,
-) -> anyhow::Result<(String, String, Vec<String>, PushMode)> {
-    let mut split = refname.splitn(2, '%');
-    let push_to = split.next().ok_or(anyhow!("no next"))?.to_owned();
-
-    let options = if let Some(options) = split.next() {
-        options.split(',').map(|x| x.to_string()).collect()
-    } else {
-        vec![]
-    };
-
-    let mut baseref = push_to.to_owned();
-    let mut push_mode = PushMode::Normal;
-
-    if baseref.starts_with("refs/for") {
-        baseref = baseref.replacen("refs/for", "refs/heads", 1)
-    }
-    if baseref.starts_with("refs/drafts") {
-        baseref = baseref.replacen("refs/drafts", "refs/heads", 1)
-    }
-    if baseref.starts_with("refs/publish/for") {
-        push_mode = PushMode::Publish(author.to_string());
-        baseref = baseref.replacen("refs/publish/for", "refs/heads", 1)
-    }
-    Ok((baseref, push_to, options, push_mode))
 }
 
 pub(crate) fn changes_to_refs(

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -40,6 +40,7 @@ josh-github-auth.workspace = true
 josh-github-keyring.workspace = true
 josh-github-graphql.workspace = true
 josh-github-changes.workspace = true
+josh-gerrit-changes.workspace = true
 josh-graphql.workspace = true
 josh-link.workspace = true
 josh-templates.workspace = true

--- a/josh-cli/src/commands/push.rs
+++ b/josh-cli/src/commands/push.rs
@@ -213,14 +213,14 @@ fn prepare_push(
     // relation chain.
     let to_push = match (forge, push_mode) {
         (Some(Forge::Gerrit), PushMode::Publish(_)) => match gerrit_mode {
-            GerritMode::Independent => josh_changes::build_gerrit_independent_push(
+            GerritMode::Independent => josh_gerrit_changes::build_gerrit_independent_push(
                 transaction,
                 remote_ref,
                 unfiltered_oid,
                 original_target,
             )
             .context("Failed to build Gerrit push")?,
-            GerritMode::Stack => josh_changes::build_gerrit_push(
+            GerritMode::Stack => josh_gerrit_changes::build_gerrit_push(
                 transaction,
                 remote_ref,
                 unfiltered_oid,

--- a/josh-proxy/Cargo.toml
+++ b/josh-proxy/Cargo.toml
@@ -56,6 +56,7 @@ gix-hash.workspace = true
 url.workspace = true
 
 josh-changes.workspace = true
+josh-gerrit-changes.workspace = true
 josh-rpc.workspace = true
 josh-core.workspace = true
 josh-templates.workspace = true

--- a/josh-proxy/src/upstream.rs
+++ b/josh-proxy/src/upstream.rs
@@ -5,8 +5,9 @@ use anyhow::{Context, anyhow};
 use backon::BackoffBuilder;
 use std::str::FromStr;
 
-use josh_changes::{PushMode, baseref_and_options, build_to_push};
+use josh_changes::{PushMode, build_to_push};
 use josh_core::cache::{CacheStack, TransactionContext};
+use josh_gerrit_changes::baseref_and_options;
 
 use std::path::PathBuf;
 use std::sync::Arc;


### PR DESCRIPTION
Extract Gerrit publishing into josh-gerrit-changes crate

Move the Gerrit-specific code out of josh-changes so the crate is
forge-agnostic: forges/gerrit.rs becomes publish.rs in the new
forges/josh-gerrit-changes crate, and baseref_and_options (Gerrit
magic-ref push grammar) moves there too. josh-changes widens
get_changes/split_changes to pub; josh-cli and josh-proxy are
re-pointed to the new crate. Sentinel change_id strings
(JOSH_GERRIT_PUSH, JOSH_PUSH) are unchanged.

Assisted-By: openrouter/z-ai/glm-5.3-flash

Change: gerrit-changes-crate