### PR TITLE
Declare git dependency in winget installer manifest

### DIFF
--- a/packaging/winget/generate-manifests.ps1
+++ b/packaging/winget/generate-manifests.ps1
@@ -67,6 +67,10 @@ NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: josh.exe
 ReleaseDate: $(Get-Date -Format yyyy-MM-dd)
+# josh shells out to git (ls-remote, patch-id, ...) so it must be on PATH.
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Git.Git
 Installers:
 $installers
 ManifestType: installer


### PR DESCRIPTION
Declare git dependency in winget installer manifest

josh shells out to git (ls-remote, patch-id, and the generic runner in
josh-core), so the winget package should pull in Git.Git for users who
do not already have git on PATH.

Assisted-By: openrouter/z-ai/glm-5.3-flash

Change: winget-git-dependency
Change-Series: winget-packaging