### PR TITLE
Fetch tags before building the winget release binary

### DIFF
--- a/.github/workflows/rust-windows.yml
+++ b/.github/workflows/rust-windows.yml
@@ -131,15 +131,6 @@ jobs:
     # release publications and PRs gated on the build-release-winget label.
     # Label runs are validation-only; release runs additionally get their zips
     # uploaded to the release by the winget-release job below.
-    - name: Build release josh.exe
-      if: >-
-        github.event_name == 'release' ||
-        (
-          github.event_name == 'pull_request' &&
-          github.event.action == 'labeled' &&
-          contains(github.event.pull_request.labels.*.name, 'build-release-winget')
-        )
-      run: cargo build --locked --release -p josh-cli --bin josh
     - name: Fetch full history
       if: >-
         github.event_name == 'release' ||
@@ -150,12 +141,22 @@ jobs:
         )
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        # The checkout above is shallow: package.ps1 derives the version from
-        # the last release tag, which needs history and tags. Keep the default
-        # workspace cleaning off — it would wipe the untracked target/ tree
-        # the build step just produced.
+        # The checkout above is shallow: the release build bakes in
+        # `git describe --tags` output and package.ps1 derives the version
+        # from the last release tag, both of which need history and tags.
+        # Keep the default workspace cleaning off — it would wipe the
+        # untracked target/ tree the debug build and tests just produced.
         clean: false
         fetch-depth: 0
+    - name: Build release josh.exe
+      if: >-
+        github.event_name == 'release' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.action == 'labeled' &&
+          contains(github.event.pull_request.labels.*.name, 'build-release-winget')
+        )
+      run: cargo build --locked --release -p josh-cli --bin josh
     - name: Package for WinGet
       if: >-
         github.event_name == 'release' ||


### PR DESCRIPTION
Fetch tags before building the winget release binary

josh_core::VERSION is baked at build time from `git describe --tags
--always`; in label-gated winget runs the full-history fetch happened
after the release build, so describe fell back to the bare short SHA
and `josh --version` printed e.g. c1234f4 instead of r26.08.28-5-g97b0.
Move the fetch-depth: 0 checkout ahead of the release build. Release
runs were unaffected: they check out the tag itself.

Assisted-By: openrouter/z-ai/glm-5.3-flash

Change: winget-build-version-string
Change-Series: winget-packaging