### PR TITLE
Preserve requested cache endpoints and rebuild missing trees

### DIFF
--- a/josh-core/src/cache/backend.rs
+++ b/josh-core/src/cache/backend.rs
@@ -27,6 +27,18 @@ pub trait CacheBackend: Send + Sync {
         tree_keyed: bool,
     ) -> anyhow::Result<()>;
 
+    /// Persist a requested commit even when sparse sampling would skip it.
+    fn write_forced(
+        &self,
+        filter: crate::filter::Filter,
+        from: gix_hash::ObjectId,
+        to: gix_hash::ObjectId,
+        hint: HistoryGraphHint,
+        tree_keyed: bool,
+    ) -> anyhow::Result<()> {
+        self.write(filter, from, to, hint, tree_keyed)
+    }
+
     /// Register the start of a transaction against this backend. The default is a no-op; backends
     /// whose underlying store holds a process-exclusive lock (the sled backend) use this to open
     /// lazily and reference-count active transactions.

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -207,8 +207,9 @@ impl DistributedCacheBackend {
 // is used in addition to the sparse cache.
 // The sparse cache is mostly only used for initial "cold starts" or longer "catch up".
 // For incremental filtering it's fine re-filter commits and rely on the local "dense" cache.
-// Only the sample points are persisted; see `HistoryGraphHint::is_sample_point` for the
+// Ordinary writes persist only sample points; see `HistoryGraphHint::is_sample_point` for the
 // invariant that bounds how far a walk runs before it hits one.
+// Explicitly requested endpoints can also be persisted and reused during history traversal.
 //
 // To additionally limit the size of the trees the cache is also sharded by sequence
 // number in groups of 10000. Note that this does not limit the number of entries per bucket
@@ -236,17 +237,12 @@ impl CacheBackend for DistributedCacheBackend {
         filter: Filter,
         from: gix_hash::ObjectId,
         hint: HistoryGraphHint,
-        tree_keyed: bool,
+        _tree_keyed: bool,
     ) -> anyhow::Result<Option<gix_hash::ObjectId>> {
         if filter == filter::sequence_number() || filter == filter::reachable_roots() {
             return Ok(None);
         }
-        // Tree-keyed records were written by whichever indexing commit was eligible,
-        // so gating reads on the reader's eligibility would hide them from the
-        // (usually non-sampled) commits that reuse them.
-        if !tree_keyed && !hint.is_sample_point() {
-            return Ok(None);
-        }
+        // Reads also honor forced endpoints and tree-keyed records from sampled commits.
         let repo = self.repo.to_thread_local();
 
         let guard = self.new_entries.lock().unwrap();
@@ -308,6 +304,20 @@ impl CacheBackend for DistributedCacheBackend {
         hint: HistoryGraphHint,
         // Writes stay eligibility-gated for tree-keyed records too: subtrees recur
         // across commits, so a stable subtree is still caught at some sampled commit.
+        tree_keyed: bool,
+    ) -> anyhow::Result<()> {
+        if !hint.is_sample_point() {
+            return Ok(());
+        }
+        self.write_forced(filter, from, to, hint, tree_keyed)
+    }
+
+    fn write_forced(
+        &self,
+        filter: Filter,
+        from: gix_hash::ObjectId,
+        to: gix_hash::ObjectId,
+        hint: HistoryGraphHint,
         _tree_keyed: bool,
     ) -> anyhow::Result<()> {
         if !self.writable {
@@ -316,10 +326,6 @@ impl CacheBackend for DistributedCacheBackend {
         if filter == filter::sequence_number() || filter == filter::reachable_roots() {
             return Ok(());
         }
-        if !hint.is_sample_point() {
-            return Ok(());
-        }
-
         let shard = hint.sequence_number / 10000;
 
         let mut guard = self.new_entries.lock().unwrap();
@@ -337,5 +343,62 @@ impl CacheBackend for DistributedCacheBackend {
         self.flush(false)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unsampled_hint() -> HistoryGraphHint {
+        HistoryGraphHint {
+            sequence_number: 1,
+            parent_count: 1,
+            jump_delta: 1,
+            jump_is_second: false,
+        }
+    }
+
+    #[test]
+    fn forced_entries_bypass_sparse_eligibility() {
+        for to in [
+            objects::hash_blob(b"filtered"),
+            gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
+        ] {
+            let directory = tempfile::tempdir().unwrap();
+            gix::init_bare(directory.path()).unwrap();
+            let filter = Filter::new().subdir("selected");
+            let from = objects::hash_blob(b"source");
+            let hint = unsampled_hint();
+            let backend = DistributedCacheBackend::writable(directory.path()).unwrap();
+
+            backend.write(filter, from, to, hint, false).unwrap();
+            assert_eq!(backend.read(filter, from, hint, false).unwrap(), None);
+            backend.write_forced(filter, from, to, hint, false).unwrap();
+            assert_eq!(backend.read(filter, from, hint, false).unwrap(), Some(to));
+            backend.flush(true).unwrap();
+
+            let reader = DistributedCacheBackend::new(directory.path()).unwrap();
+            assert_eq!(reader.read(filter, from, hint, false).unwrap(), Some(to));
+        }
+    }
+
+    #[test]
+    fn forced_writes_preserve_read_only_mode_and_internal_filters() {
+        let directory = tempfile::tempdir().unwrap();
+        gix::init_bare(directory.path()).unwrap();
+        let from = objects::hash_blob(b"source");
+        let to = objects::hash_blob(b"filtered");
+        let hint = unsampled_hint();
+        let reader = DistributedCacheBackend::new(directory.path()).unwrap();
+        let filter = Filter::new().subdir("selected");
+        reader.write_forced(filter, from, to, hint, false).unwrap();
+        assert!(reader.new_entries.lock().unwrap().is_empty());
+
+        let writer = DistributedCacheBackend::writable(directory.path()).unwrap();
+        for filter in [filter::sequence_number(), filter::reachable_roots()] {
+            writer.write_forced(filter, from, to, hint, false).unwrap();
+        }
+        assert!(writer.new_entries.lock().unwrap().is_empty());
     }
 }

--- a/josh-core/src/cache/stack.rs
+++ b/josh-core/src/cache/stack.rs
@@ -43,6 +43,21 @@ impl CacheStack {
         Ok(())
     }
 
+    /// Persist a requested commit in every cache backend.
+    pub fn write_forced_all(
+        &self,
+        filter: filter::Filter,
+        from: gix_hash::ObjectId,
+        to: gix_hash::ObjectId,
+        hint: HistoryGraphHint,
+        tree_keyed: bool,
+    ) -> anyhow::Result<()> {
+        for backend in &self.backends {
+            backend.write_forced(filter, from, to, hint, tree_keyed)?;
+        }
+        Ok(())
+    }
+
     /// Register the start of a transaction across all backends (see [`CacheBackend::begin`]).
     pub fn begin(&self) {
         for backend in &self.backends {

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -1177,19 +1177,21 @@ impl Transaction {
     }
 
     pub fn insert_paths(&self, tree: (gix_hash::ObjectId, String), result: gix_hash::ObjectId) {
-        PATHS_MAP.write().unwrap().entry(tree).or_insert(result);
+        PATHS_MAP.write().unwrap().insert(tree, result);
     }
 
     pub fn get_paths(&self, tree: (gix_hash::ObjectId, String)) -> Option<gix_hash::ObjectId> {
-        PATHS_MAP.read().unwrap().get(&tree).cloned()
+        let cached = PATHS_MAP.read().unwrap().get(&tree).copied()?;
+        self.odb().contains(cached).then_some(cached)
     }
 
     pub fn insert_invert(&self, tree: (gix_hash::ObjectId, String), result: gix_hash::ObjectId) {
-        INVERT_MAP.write().unwrap().entry(tree).or_insert(result);
+        INVERT_MAP.write().unwrap().insert(tree, result);
     }
 
     pub fn get_invert(&self, tree: (gix_hash::ObjectId, String)) -> Option<gix_hash::ObjectId> {
-        INVERT_MAP.read().unwrap().get(&tree).cloned()
+        let cached = INVERT_MAP.read().unwrap().get(&tree).copied()?;
+        self.odb().contains(cached).then_some(cached)
     }
 
     /// Cache indexes under the commit's history shard. A null ID means no commit context.
@@ -1265,14 +1267,15 @@ impl Transaction {
         tree: (gix_hash::ObjectId, gix_hash::ObjectId, u64),
         result: gix_hash::ObjectId,
     ) {
-        GLOB_MAP.write().unwrap().entry(tree).or_insert(result);
+        GLOB_MAP.write().unwrap().insert(tree, result);
     }
 
     pub fn get_glob(
         &self,
         tree: (gix_hash::ObjectId, gix_hash::ObjectId, u64),
     ) -> Option<gix_hash::ObjectId> {
-        GLOB_MAP.read().unwrap().get(&tree).cloned()
+        let cached = GLOB_MAP.read().unwrap().get(&tree).copied()?;
+        self.odb().contains(cached).then_some(cached)
     }
 
     pub fn insert_ref(
@@ -1365,6 +1368,22 @@ impl Transaction {
             t2.cache.write_all(filter, from, to, hint, false)?;
         }
         Ok(())
+    }
+
+    /// Persist a requested commit in sparse and dense cache backends.
+    pub(crate) fn insert_forced(
+        &self,
+        filter: crate::filter::Filter,
+        from: gix_hash::ObjectId,
+        to: gix_hash::ObjectId,
+    ) -> anyhow::Result<()> {
+        let hint = compute_history_hint(self, from)?;
+        let mut t2 = self.t2.borrow_mut();
+        t2.commit_map
+            .entry(filter.id())
+            .or_default()
+            .insert(from, to);
+        t2.cache.write_forced_all(filter, from, to, hint, false)
     }
 
     pub fn get_missing(

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -375,11 +375,33 @@ pub fn apply_to_commit(
     commit: gix_hash::ObjectId,
     transaction: &cache::Transaction,
 ) -> anyhow::Result<gix_hash::ObjectId> {
+    apply_to_commit_with_options(filter, commit, transaction, ApplyToCommitOptions::default())
+}
+
+/// Options for filtering one commit.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ApplyToCommitOptions {
+    /// Store the requested commit even when sparse cache sampling would skip it.
+    pub force_cache: bool,
+}
+
+/// Calculate the filtered commit with explicit cache options.
+pub fn apply_to_commit_with_options(
+    filter: Filter,
+    commit: gix_hash::ObjectId,
+    transaction: &cache::Transaction,
+    options: ApplyToCommitOptions,
+) -> anyhow::Result<gix_hash::ObjectId> {
     let filter = opt::optimize(filter);
+    let force_cache =
+        options.force_cache && filter != sequence_number() && filter != reachable_roots();
     loop {
         let filtered = apply_to_commit2(filter, commit, transaction)?;
 
         if let Some(id) = filtered {
+            if force_cache {
+                transaction.insert_forced(filter, commit, id)?;
+            }
             return Ok(id);
         }
 
@@ -2682,6 +2704,174 @@ mod tests {
             message,
         )
         .unwrap()
+    }
+
+    fn unsampled_endpoint(
+        force_cache: bool,
+    ) -> (
+        tempfile::TempDir,
+        Filter,
+        gix_hash::ObjectId,
+        gix_hash::ObjectId,
+    ) {
+        let directory = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(directory.path()).unwrap();
+        let root = write_commit(
+            &repo,
+            build_tree(&repo, &[("selected/file.txt", "root")]),
+            &[],
+            "root",
+        );
+        let tip = write_commit(
+            &repo,
+            build_tree(&repo, &[("selected/file.txt", "tip")]),
+            &[root],
+            "tip",
+        );
+        let filter = Filter::new().subdir("selected");
+        let filtered = {
+            let stack = cache::CacheStack::new()
+                .with_backend(cache::DistributedCacheBackend::writable(directory.path()).unwrap());
+            let context = cache::TransactionContext::new(directory.path(), stack.into());
+            let transaction = context.open().unwrap();
+            let filtered = if force_cache {
+                apply_to_commit_with_options(
+                    filter,
+                    tip,
+                    &transaction,
+                    ApplyToCommitOptions { force_cache: true },
+                )
+                .unwrap()
+            } else {
+                apply_to_commit(filter, tip, &transaction).unwrap()
+            };
+            transaction.flush_mem_odb().unwrap();
+            filtered
+        };
+        (directory, filter, tip, filtered)
+    }
+
+    fn endpoint_hint() -> cache::HistoryGraphHint {
+        cache::HistoryGraphHint {
+            sequence_number: 1,
+            parent_count: 1,
+            jump_delta: 1,
+            jump_is_second: false,
+        }
+    }
+
+    #[test]
+    fn apply_to_commit_preserves_sparse_cache_by_default() {
+        use crate::cache::CacheBackend;
+        let (directory, filter, tip, _) = unsampled_endpoint(false);
+        let reader = cache::DistributedCacheBackend::new(directory.path()).unwrap();
+        assert_eq!(
+            reader.read(filter, tip, endpoint_hint(), false).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn apply_to_commit_persists_unsampled_endpoint_when_requested() {
+        use crate::cache::CacheBackend;
+        let (directory, filter, tip, filtered) = unsampled_endpoint(true);
+        let reader = cache::DistributedCacheBackend::new(directory.path()).unwrap();
+        assert_eq!(
+            reader.read(filter, tip, endpoint_hint(), false).unwrap(),
+            Some(filtered)
+        );
+    }
+
+    #[test]
+    fn apply_to_commit_reuses_forced_unsampled_parent_from_cold_cache() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct TrackingCache {
+            backend: cache::DistributedCacheBackend,
+            expected_parent: gix_hash::ObjectId,
+            parent_hits: Arc<AtomicUsize>,
+        }
+        impl cache::CacheBackend for TrackingCache {
+            fn read(
+                &self,
+                filter: Filter,
+                from: gix_hash::ObjectId,
+                hint: cache::HistoryGraphHint,
+                tree_keyed: bool,
+            ) -> anyhow::Result<Option<gix_hash::ObjectId>> {
+                let result = self.backend.read(filter, from, hint, tree_keyed)?;
+                if from == self.expected_parent && result.is_some() {
+                    self.parent_hits.fetch_add(1, Ordering::Relaxed);
+                }
+                Ok(result)
+            }
+            fn write(
+                &self,
+                filter: Filter,
+                from: gix_hash::ObjectId,
+                to: gix_hash::ObjectId,
+                hint: cache::HistoryGraphHint,
+                tree_keyed: bool,
+            ) -> anyhow::Result<()> {
+                self.backend.write(filter, from, to, hint, tree_keyed)
+            }
+        }
+
+        let (directory, filter, parent, filtered_parent) = unsampled_endpoint(true);
+        let repo = gix::open(directory.path()).unwrap();
+        let child = write_commit(
+            &repo,
+            build_tree(&repo, &[("selected/file.txt", "child")]),
+            &[parent],
+            "child",
+        );
+        let parent_hits = Arc::new(AtomicUsize::new(0));
+        let stack = cache::CacheStack::new().with_backend(TrackingCache {
+            backend: cache::DistributedCacheBackend::new(directory.path()).unwrap(),
+            expected_parent: parent,
+            parent_hits: Arc::clone(&parent_hits),
+        });
+        let context = cache::TransactionContext::new(directory.path(), stack.into());
+        let transaction = context.open().unwrap();
+        let filtered_child = apply_to_commit(filter, child, &transaction).unwrap();
+        assert!(
+            parent_hits.load(Ordering::Relaxed) > 0,
+            "history traversal did not reuse the forced parent"
+        );
+        let output = objects::CommitData::read(transaction.odb(), filtered_child).unwrap();
+        assert_eq!(
+            output.parent_ids().collect::<Vec<_>>(),
+            vec![filtered_parent]
+        );
+    }
+
+    #[test]
+    fn apply_to_commit_promotes_an_existing_local_cache_hit() {
+        use crate::cache::CacheBackend;
+        let (directory, filter, tip, filtered) = unsampled_endpoint(false);
+        {
+            let stack = cache::CacheStack::new()
+                .with_backend(cache::DistributedCacheBackend::writable(directory.path()).unwrap());
+            let context = cache::TransactionContext::new(directory.path(), stack.into());
+            let transaction = context.open().unwrap();
+            transaction.insert(filter, tip, filtered, false).unwrap();
+            assert_eq!(
+                apply_to_commit_with_options(
+                    filter,
+                    tip,
+                    &transaction,
+                    ApplyToCommitOptions { force_cache: true }
+                )
+                .unwrap(),
+                filtered
+            );
+        }
+        let reader = cache::DistributedCacheBackend::new(directory.path()).unwrap();
+        assert_eq!(
+            reader.read(filter, tip, endpoint_hint(), false).unwrap(),
+            Some(filtered)
+        );
     }
 
     #[test]

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -1288,6 +1288,88 @@ mod tests {
         ctx.open().unwrap()
     }
 
+    #[test]
+    fn pathstree_rebuilds_missing_cached_tree() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(td.path()).unwrap();
+        let input = make_tree(&repo, &["paths-recovery/file.txt"]);
+        let transaction = open_transaction(&td);
+        let missing = objects::hash_blob(b"missing paths tree");
+        transaction.insert_paths((input, String::new()), missing);
+        let rebuilt = pathstree("", input, &transaction).unwrap();
+        assert_ne!(rebuilt, missing);
+        assert_eq!(transaction.get_paths((input, String::new())), Some(rebuilt));
+        assert!(
+            get_path_entry(
+                &transaction,
+                transaction.odb(),
+                rebuilt,
+                Path::new("paths-recovery/file.txt")
+            )
+            .unwrap()
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn invert_paths_rebuilds_missing_cached_tree() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(td.path()).unwrap();
+        let input = make_tree(&repo, &["invert-recovery/file.txt"]);
+        let transaction = open_transaction(&td);
+        let projected = pathstree("", input, &transaction).unwrap();
+        let missing = objects::hash_blob(b"missing inverse tree");
+        transaction.insert_invert((projected, String::new()), missing);
+        let rebuilt = invert_paths(&transaction, transaction.odb(), "", projected).unwrap();
+        assert_ne!(rebuilt, missing);
+        assert_eq!(
+            transaction.get_invert((projected, String::new())),
+            Some(rebuilt)
+        );
+        assert!(
+            get_path_entry(
+                &transaction,
+                transaction.odb(),
+                rebuilt,
+                Path::new("invert-recovery/file.txt")
+            )
+            .unwrap()
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn remove_pred_rebuilds_missing_cached_tree() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(td.path()).unwrap();
+        let input = make_tree(&repo, &["pred-recovery/file.txt"]);
+        let transaction = open_transaction(&td);
+        let key = objects::hash_blob(b"predicate recovery");
+        let root_key = objects::hash_blob(format!("glob-fallback:{:?}:", key).as_bytes());
+        let missing = objects::hash_blob(b"missing predicate tree");
+        transaction.insert_glob((input, root_key, 0), missing);
+        let rebuilt =
+            remove_pred(&transaction, &mut String::new(), input, &|_, _| true, key).unwrap();
+        assert_eq!(rebuilt, input);
+        assert_eq!(transaction.get_glob((input, root_key, 0)), Some(rebuilt));
+    }
+
+    #[test]
+    fn remove_pattern_rebuilds_missing_cached_tree() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(td.path()).unwrap();
+        let input = make_tree(&repo, &["pattern-recovery/file.txt"]);
+        let transaction = open_transaction(&td);
+        let key = objects::hash_blob(b"pattern recovery");
+        let missing = objects::hash_blob(b"missing pattern tree");
+        let pattern = CompiledPattern::compile("**/*.txt").unwrap();
+        let state = pattern.closure(CompiledPattern::initial_state());
+        transaction.insert_glob((input, key, state), missing);
+        let rebuilt = remove_pattern(&transaction, input, &pattern, key, state).unwrap();
+        assert_eq!(rebuilt, input);
+        assert_eq!(transaction.get_glob((input, key, state)), Some(rebuilt));
+    }
+
     // A gitlink (submodule) entry must be dropped from the rebuilt tree -- and must therefore
     // defeat the "unchanged input" fast path -- while a symlink blob accepted by the predicate
     // keeps its 0o120000 filemode.

--- a/josh-search/src/lib.rs
+++ b/josh-search/src/lib.rs
@@ -478,7 +478,9 @@ impl Run<'_> {
         if let Some(id) = self.ix.tree_memo.get(&tree_oid) {
             return Ok(*id);
         }
-        if let Some(cached) = self.cache.get_index(tree_oid) {
+        if let Some(cached) = self.cache.get_index(tree_oid)
+            && (self.ix.pending.contains_key(&cached) || self.src.exists(&cached))
+        {
             let id = cached;
             self.ix.tree_memo.insert(tree_oid, id);
             return Ok(id);
@@ -933,6 +935,27 @@ mod tests {
                 .unwrap();
         }
         builder.write().unwrap().detach()
+    }
+
+    #[test]
+    fn trigram_index_rebuilds_missing_cached_tree() {
+        let (_tmp, repo) = test_repo();
+        let tree = commit_tree(&repo, &[("file.txt", "recover the index")]);
+        let cache = MapCache::default();
+        let missing =
+            gix_hash::ObjectId::from_hex(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+        cache.set_index(tree, missing);
+        let rebuilt = trigram_index(objects(&repo), &cache, &mut Indexer::default(), tree).unwrap();
+        let expected = trigram_index(
+            objects(&repo),
+            &MapCache::default(),
+            &mut Indexer::default(),
+            tree,
+        )
+        .unwrap();
+        assert_ne!(rebuilt, missing);
+        assert_eq!(rebuilt, expected);
+        assert_eq!(cache.get_index(tree), Some(rebuilt));
     }
 
     #[test]


### PR DESCRIPTION
Sparse cache sampling can skip the last commit requested by a caller. A fresh process must then walk past that endpoint. Intermediate tree caches can also reference objects absent from the current repository after garbage collection or use in another repository.

This adds `apply_to_commit_with_options` with `ApplyToCommitOptions { force_cache: true }`. Writable backends store the requested input-to-output commit mapping even when sampling would skip it. Ordinary history traversal reads those entries, so filtering a later commit can reuse its cached parent. Existing `apply_to_commit` calls keep the default sampling behavior. Read-only backends still ignore writes.

Missing cached path, inverse, glob, pattern, and trigram trees are treated as cache misses. Filtering rebuilds those trees and replaces stale entries. The changes use the current `gix` APIs.

Validation:

- `cargo fmt --all -- --check`
- `cargo test --locked -p josh-core -p josh-search --lib`: 99 tests passed (94 core, 5 search).

Regression coverage includes forced endpoint persistence, cold-cache parent reuse, promotion of a local cache hit, null outputs, read-only backends, internal filters, and missing cached trees.

<!-- codex-thread: 01a05ec0-adc8-7a90-8e51-f6971481d90c -->
