### PR TITLE
Rebuild missing cached trees

### DIFF
--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -1177,19 +1177,21 @@ impl Transaction {
     }
 
     pub fn insert_paths(&self, tree: (gix_hash::ObjectId, String), result: gix_hash::ObjectId) {
-        PATHS_MAP.write().unwrap().entry(tree).or_insert(result);
+        PATHS_MAP.write().unwrap().insert(tree, result);
     }
 
     pub fn get_paths(&self, tree: (gix_hash::ObjectId, String)) -> Option<gix_hash::ObjectId> {
-        PATHS_MAP.read().unwrap().get(&tree).cloned()
+        let cached = PATHS_MAP.read().unwrap().get(&tree).copied()?;
+        self.odb().contains(cached).then_some(cached)
     }
 
     pub fn insert_invert(&self, tree: (gix_hash::ObjectId, String), result: gix_hash::ObjectId) {
-        INVERT_MAP.write().unwrap().entry(tree).or_insert(result);
+        INVERT_MAP.write().unwrap().insert(tree, result);
     }
 
     pub fn get_invert(&self, tree: (gix_hash::ObjectId, String)) -> Option<gix_hash::ObjectId> {
-        INVERT_MAP.read().unwrap().get(&tree).cloned()
+        let cached = INVERT_MAP.read().unwrap().get(&tree).copied()?;
+        self.odb().contains(cached).then_some(cached)
     }
 
     /// Cache indexes under the commit's history shard. A null ID means no commit context.
@@ -1265,14 +1267,15 @@ impl Transaction {
         tree: (gix_hash::ObjectId, gix_hash::ObjectId, u64),
         result: gix_hash::ObjectId,
     ) {
-        GLOB_MAP.write().unwrap().entry(tree).or_insert(result);
+        GLOB_MAP.write().unwrap().insert(tree, result);
     }
 
     pub fn get_glob(
         &self,
         tree: (gix_hash::ObjectId, gix_hash::ObjectId, u64),
     ) -> Option<gix_hash::ObjectId> {
-        GLOB_MAP.read().unwrap().get(&tree).cloned()
+        let cached = GLOB_MAP.read().unwrap().get(&tree).copied()?;
+        self.odb().contains(cached).then_some(cached)
     }
 
     pub fn insert_ref(

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -1288,6 +1288,88 @@ mod tests {
         ctx.open().unwrap()
     }
 
+    #[test]
+    fn pathstree_rebuilds_missing_cached_tree() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(td.path()).unwrap();
+        let input = make_tree(&repo, &["paths-recovery/file.txt"]);
+        let transaction = open_transaction(&td);
+        let missing = objects::hash_blob(b"missing paths tree");
+        transaction.insert_paths((input, String::new()), missing);
+        let rebuilt = pathstree("", input, &transaction).unwrap();
+        assert_ne!(rebuilt, missing);
+        assert_eq!(transaction.get_paths((input, String::new())), Some(rebuilt));
+        assert!(
+            get_path_entry(
+                &transaction,
+                transaction.odb(),
+                rebuilt,
+                Path::new("paths-recovery/file.txt")
+            )
+            .unwrap()
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn invert_paths_rebuilds_missing_cached_tree() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(td.path()).unwrap();
+        let input = make_tree(&repo, &["invert-recovery/file.txt"]);
+        let transaction = open_transaction(&td);
+        let projected = pathstree("", input, &transaction).unwrap();
+        let missing = objects::hash_blob(b"missing inverse tree");
+        transaction.insert_invert((projected, String::new()), missing);
+        let rebuilt = invert_paths(&transaction, transaction.odb(), "", projected).unwrap();
+        assert_ne!(rebuilt, missing);
+        assert_eq!(
+            transaction.get_invert((projected, String::new())),
+            Some(rebuilt)
+        );
+        assert!(
+            get_path_entry(
+                &transaction,
+                transaction.odb(),
+                rebuilt,
+                Path::new("invert-recovery/file.txt")
+            )
+            .unwrap()
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn remove_pred_rebuilds_missing_cached_tree() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(td.path()).unwrap();
+        let input = make_tree(&repo, &["pred-recovery/file.txt"]);
+        let transaction = open_transaction(&td);
+        let key = objects::hash_blob(b"predicate recovery");
+        let root_key = objects::hash_blob(format!("glob-fallback:{:?}:", key).as_bytes());
+        let missing = objects::hash_blob(b"missing predicate tree");
+        transaction.insert_glob((input, root_key, 0), missing);
+        let rebuilt =
+            remove_pred(&transaction, &mut String::new(), input, &|_, _| true, key).unwrap();
+        assert_eq!(rebuilt, input);
+        assert_eq!(transaction.get_glob((input, root_key, 0)), Some(rebuilt));
+    }
+
+    #[test]
+    fn remove_pattern_rebuilds_missing_cached_tree() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(td.path()).unwrap();
+        let input = make_tree(&repo, &["pattern-recovery/file.txt"]);
+        let transaction = open_transaction(&td);
+        let key = objects::hash_blob(b"pattern recovery");
+        let missing = objects::hash_blob(b"missing pattern tree");
+        let pattern = CompiledPattern::compile("**/*.txt").unwrap();
+        let state = pattern.closure(CompiledPattern::initial_state());
+        transaction.insert_glob((input, key, state), missing);
+        let rebuilt = remove_pattern(&transaction, input, &pattern, key, state).unwrap();
+        assert_eq!(rebuilt, input);
+        assert_eq!(transaction.get_glob((input, key, state)), Some(rebuilt));
+    }
+
     // A gitlink (submodule) entry must be dropped from the rebuilt tree -- and must therefore
     // defeat the "unchanged input" fast path -- while a symlink blob accepted by the predicate
     // keeps its 0o120000 filemode.

--- a/josh-search/src/lib.rs
+++ b/josh-search/src/lib.rs
@@ -478,7 +478,9 @@ impl Run<'_> {
         if let Some(id) = self.ix.tree_memo.get(&tree_oid) {
             return Ok(*id);
         }
-        if let Some(cached) = self.cache.get_index(tree_oid) {
+        if let Some(cached) = self.cache.get_index(tree_oid)
+            && (self.ix.pending.contains_key(&cached) || self.src.exists(&cached))
+        {
             let id = cached;
             self.ix.tree_memo.insert(tree_oid, id);
             return Ok(id);
@@ -933,6 +935,27 @@ mod tests {
                 .unwrap();
         }
         builder.write().unwrap().detach()
+    }
+
+    #[test]
+    fn trigram_index_rebuilds_missing_cached_tree() {
+        let (_tmp, repo) = test_repo();
+        let tree = commit_tree(&repo, &[("file.txt", "recover the index")]);
+        let cache = MapCache::default();
+        let missing =
+            gix_hash::ObjectId::from_hex(b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap();
+        cache.set_index(tree, missing);
+        let rebuilt = trigram_index(objects(&repo), &cache, &mut Indexer::default(), tree).unwrap();
+        let expected = trigram_index(
+            objects(&repo),
+            &MapCache::default(),
+            &mut Indexer::default(),
+            tree,
+        )
+        .unwrap();
+        assert_ne!(rebuilt, missing);
+        assert_eq!(rebuilt, expected);
+        assert_eq!(cache.get_index(tree), Some(rebuilt));
     }
 
     #[test]


### PR DESCRIPTION
Intermediate tree caches can reference Git objects that are absent from the current repository. Garbage collection or reuse across repositories can leave these entries behind. Returning a missing tree ID then causes filtering to fail.

Treat missing cached path, inverse, glob, pattern, and trigram trees as cache misses. Rebuild the trees and replace stale entries with the rebuilt results.

Validation:

- `cargo fmt --all -- --check`
- `cargo test --locked -p josh-core -p josh-search --lib`: 93 tests passed (88 core, 5 search).
- Regression tests cover each affected tree cache.

This is the tree-recovery part of #2557, based directly on `master`.

<!-- codex-thread: 01a05ec0-adc8-7a90-8e51-f6971481d90c -->
