### PR TITLE
Add optional caching of requested commit endpoints

### DIFF
--- a/josh-core/src/cache/backend.rs
+++ b/josh-core/src/cache/backend.rs
@@ -27,6 +27,18 @@ pub trait CacheBackend: Send + Sync {
         tree_keyed: bool,
     ) -> anyhow::Result<()>;
 
+    /// Persist a requested commit even when sparse sampling would skip it.
+    fn write_forced(
+        &self,
+        filter: crate::filter::Filter,
+        from: gix_hash::ObjectId,
+        to: gix_hash::ObjectId,
+        hint: HistoryGraphHint,
+        tree_keyed: bool,
+    ) -> anyhow::Result<()> {
+        self.write(filter, from, to, hint, tree_keyed)
+    }
+
     /// Register the start of a transaction against this backend. The default is a no-op; backends
     /// whose underlying store holds a process-exclusive lock (the sled backend) use this to open
     /// lazily and reference-count active transactions.

--- a/josh-core/src/cache/distributed.rs
+++ b/josh-core/src/cache/distributed.rs
@@ -207,8 +207,9 @@ impl DistributedCacheBackend {
 // is used in addition to the sparse cache.
 // The sparse cache is mostly only used for initial "cold starts" or longer "catch up".
 // For incremental filtering it's fine re-filter commits and rely on the local "dense" cache.
-// Only the sample points are persisted; see `HistoryGraphHint::is_sample_point` for the
+// Ordinary writes persist only sample points; see `HistoryGraphHint::is_sample_point` for the
 // invariant that bounds how far a walk runs before it hits one.
+// Explicitly requested endpoints can also be persisted and reused during history traversal.
 //
 // To additionally limit the size of the trees the cache is also sharded by sequence
 // number in groups of 10000. Note that this does not limit the number of entries per bucket
@@ -236,17 +237,12 @@ impl CacheBackend for DistributedCacheBackend {
         filter: Filter,
         from: gix_hash::ObjectId,
         hint: HistoryGraphHint,
-        tree_keyed: bool,
+        _tree_keyed: bool,
     ) -> anyhow::Result<Option<gix_hash::ObjectId>> {
         if filter == filter::sequence_number() || filter == filter::reachable_roots() {
             return Ok(None);
         }
-        // Tree-keyed records were written by whichever indexing commit was eligible,
-        // so gating reads on the reader's eligibility would hide them from the
-        // (usually non-sampled) commits that reuse them.
-        if !tree_keyed && !hint.is_sample_point() {
-            return Ok(None);
-        }
+        // Reads also honor forced endpoints and tree-keyed records from sampled commits.
         let repo = self.repo.to_thread_local();
 
         let guard = self.new_entries.lock().unwrap();
@@ -308,6 +304,20 @@ impl CacheBackend for DistributedCacheBackend {
         hint: HistoryGraphHint,
         // Writes stay eligibility-gated for tree-keyed records too: subtrees recur
         // across commits, so a stable subtree is still caught at some sampled commit.
+        tree_keyed: bool,
+    ) -> anyhow::Result<()> {
+        if !hint.is_sample_point() {
+            return Ok(());
+        }
+        self.write_forced(filter, from, to, hint, tree_keyed)
+    }
+
+    fn write_forced(
+        &self,
+        filter: Filter,
+        from: gix_hash::ObjectId,
+        to: gix_hash::ObjectId,
+        hint: HistoryGraphHint,
         _tree_keyed: bool,
     ) -> anyhow::Result<()> {
         if !self.writable {
@@ -316,10 +326,6 @@ impl CacheBackend for DistributedCacheBackend {
         if filter == filter::sequence_number() || filter == filter::reachable_roots() {
             return Ok(());
         }
-        if !hint.is_sample_point() {
-            return Ok(());
-        }
-
         let shard = hint.sequence_number / 10000;
 
         let mut guard = self.new_entries.lock().unwrap();
@@ -337,5 +343,62 @@ impl CacheBackend for DistributedCacheBackend {
         self.flush(false)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unsampled_hint() -> HistoryGraphHint {
+        HistoryGraphHint {
+            sequence_number: 1,
+            parent_count: 1,
+            jump_delta: 1,
+            jump_is_second: false,
+        }
+    }
+
+    #[test]
+    fn forced_entries_bypass_sparse_eligibility() {
+        for to in [
+            objects::hash_blob(b"filtered"),
+            gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
+        ] {
+            let directory = tempfile::tempdir().unwrap();
+            gix::init_bare(directory.path()).unwrap();
+            let filter = Filter::new().subdir("selected");
+            let from = objects::hash_blob(b"source");
+            let hint = unsampled_hint();
+            let backend = DistributedCacheBackend::writable(directory.path()).unwrap();
+
+            backend.write(filter, from, to, hint, false).unwrap();
+            assert_eq!(backend.read(filter, from, hint, false).unwrap(), None);
+            backend.write_forced(filter, from, to, hint, false).unwrap();
+            assert_eq!(backend.read(filter, from, hint, false).unwrap(), Some(to));
+            backend.flush(true).unwrap();
+
+            let reader = DistributedCacheBackend::new(directory.path()).unwrap();
+            assert_eq!(reader.read(filter, from, hint, false).unwrap(), Some(to));
+        }
+    }
+
+    #[test]
+    fn forced_writes_preserve_read_only_mode_and_internal_filters() {
+        let directory = tempfile::tempdir().unwrap();
+        gix::init_bare(directory.path()).unwrap();
+        let from = objects::hash_blob(b"source");
+        let to = objects::hash_blob(b"filtered");
+        let hint = unsampled_hint();
+        let reader = DistributedCacheBackend::new(directory.path()).unwrap();
+        let filter = Filter::new().subdir("selected");
+        reader.write_forced(filter, from, to, hint, false).unwrap();
+        assert!(reader.new_entries.lock().unwrap().is_empty());
+
+        let writer = DistributedCacheBackend::writable(directory.path()).unwrap();
+        for filter in [filter::sequence_number(), filter::reachable_roots()] {
+            writer.write_forced(filter, from, to, hint, false).unwrap();
+        }
+        assert!(writer.new_entries.lock().unwrap().is_empty());
     }
 }

--- a/josh-core/src/cache/stack.rs
+++ b/josh-core/src/cache/stack.rs
@@ -43,6 +43,21 @@ impl CacheStack {
         Ok(())
     }
 
+    /// Persist a requested commit in every cache backend.
+    pub fn write_forced_all(
+        &self,
+        filter: filter::Filter,
+        from: gix_hash::ObjectId,
+        to: gix_hash::ObjectId,
+        hint: HistoryGraphHint,
+        tree_keyed: bool,
+    ) -> anyhow::Result<()> {
+        for backend in &self.backends {
+            backend.write_forced(filter, from, to, hint, tree_keyed)?;
+        }
+        Ok(())
+    }
+
     /// Register the start of a transaction across all backends (see [`CacheBackend::begin`]).
     pub fn begin(&self) {
         for backend in &self.backends {

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -1367,6 +1367,22 @@ impl Transaction {
         Ok(())
     }
 
+    /// Persist a requested commit in sparse and dense cache backends.
+    pub(crate) fn insert_forced(
+        &self,
+        filter: crate::filter::Filter,
+        from: gix_hash::ObjectId,
+        to: gix_hash::ObjectId,
+    ) -> anyhow::Result<()> {
+        let hint = compute_history_hint(self, from)?;
+        let mut t2 = self.t2.borrow_mut();
+        t2.commit_map
+            .entry(filter.id())
+            .or_default()
+            .insert(from, to);
+        t2.cache.write_forced_all(filter, from, to, hint, false)
+    }
+
     pub fn get_missing(
         &self,
     ) -> anyhow::Result<Vec<(usize, crate::filter::Filter, gix_hash::ObjectId)>> {

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -375,11 +375,33 @@ pub fn apply_to_commit(
     commit: gix_hash::ObjectId,
     transaction: &cache::Transaction,
 ) -> anyhow::Result<gix_hash::ObjectId> {
+    apply_to_commit_with_options(filter, commit, transaction, ApplyToCommitOptions::default())
+}
+
+/// Options for filtering one commit.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ApplyToCommitOptions {
+    /// Store the requested commit even when sparse cache sampling would skip it.
+    pub force_cache: bool,
+}
+
+/// Calculate the filtered commit with explicit cache options.
+pub fn apply_to_commit_with_options(
+    filter: Filter,
+    commit: gix_hash::ObjectId,
+    transaction: &cache::Transaction,
+    options: ApplyToCommitOptions,
+) -> anyhow::Result<gix_hash::ObjectId> {
     let filter = opt::optimize(filter);
+    let force_cache =
+        options.force_cache && filter != sequence_number() && filter != reachable_roots();
     loop {
         let filtered = apply_to_commit2(filter, commit, transaction)?;
 
         if let Some(id) = filtered {
+            if force_cache {
+                transaction.insert_forced(filter, commit, id)?;
+            }
             return Ok(id);
         }
 
@@ -2682,6 +2704,174 @@ mod tests {
             message,
         )
         .unwrap()
+    }
+
+    fn unsampled_endpoint(
+        force_cache: bool,
+    ) -> (
+        tempfile::TempDir,
+        Filter,
+        gix_hash::ObjectId,
+        gix_hash::ObjectId,
+    ) {
+        let directory = tempfile::tempdir().unwrap();
+        let repo = gix::init_bare(directory.path()).unwrap();
+        let root = write_commit(
+            &repo,
+            build_tree(&repo, &[("selected/file.txt", "root")]),
+            &[],
+            "root",
+        );
+        let tip = write_commit(
+            &repo,
+            build_tree(&repo, &[("selected/file.txt", "tip")]),
+            &[root],
+            "tip",
+        );
+        let filter = Filter::new().subdir("selected");
+        let filtered = {
+            let stack = cache::CacheStack::new()
+                .with_backend(cache::DistributedCacheBackend::writable(directory.path()).unwrap());
+            let context = cache::TransactionContext::new(directory.path(), stack.into());
+            let transaction = context.open().unwrap();
+            let filtered = if force_cache {
+                apply_to_commit_with_options(
+                    filter,
+                    tip,
+                    &transaction,
+                    ApplyToCommitOptions { force_cache: true },
+                )
+                .unwrap()
+            } else {
+                apply_to_commit(filter, tip, &transaction).unwrap()
+            };
+            transaction.flush_mem_odb().unwrap();
+            filtered
+        };
+        (directory, filter, tip, filtered)
+    }
+
+    fn endpoint_hint() -> cache::HistoryGraphHint {
+        cache::HistoryGraphHint {
+            sequence_number: 1,
+            parent_count: 1,
+            jump_delta: 1,
+            jump_is_second: false,
+        }
+    }
+
+    #[test]
+    fn apply_to_commit_preserves_sparse_cache_by_default() {
+        use crate::cache::CacheBackend;
+        let (directory, filter, tip, _) = unsampled_endpoint(false);
+        let reader = cache::DistributedCacheBackend::new(directory.path()).unwrap();
+        assert_eq!(
+            reader.read(filter, tip, endpoint_hint(), false).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn apply_to_commit_persists_unsampled_endpoint_when_requested() {
+        use crate::cache::CacheBackend;
+        let (directory, filter, tip, filtered) = unsampled_endpoint(true);
+        let reader = cache::DistributedCacheBackend::new(directory.path()).unwrap();
+        assert_eq!(
+            reader.read(filter, tip, endpoint_hint(), false).unwrap(),
+            Some(filtered)
+        );
+    }
+
+    #[test]
+    fn apply_to_commit_reuses_forced_unsampled_parent_from_cold_cache() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct TrackingCache {
+            backend: cache::DistributedCacheBackend,
+            expected_parent: gix_hash::ObjectId,
+            parent_hits: Arc<AtomicUsize>,
+        }
+        impl cache::CacheBackend for TrackingCache {
+            fn read(
+                &self,
+                filter: Filter,
+                from: gix_hash::ObjectId,
+                hint: cache::HistoryGraphHint,
+                tree_keyed: bool,
+            ) -> anyhow::Result<Option<gix_hash::ObjectId>> {
+                let result = self.backend.read(filter, from, hint, tree_keyed)?;
+                if from == self.expected_parent && result.is_some() {
+                    self.parent_hits.fetch_add(1, Ordering::Relaxed);
+                }
+                Ok(result)
+            }
+            fn write(
+                &self,
+                filter: Filter,
+                from: gix_hash::ObjectId,
+                to: gix_hash::ObjectId,
+                hint: cache::HistoryGraphHint,
+                tree_keyed: bool,
+            ) -> anyhow::Result<()> {
+                self.backend.write(filter, from, to, hint, tree_keyed)
+            }
+        }
+
+        let (directory, filter, parent, filtered_parent) = unsampled_endpoint(true);
+        let repo = gix::open(directory.path()).unwrap();
+        let child = write_commit(
+            &repo,
+            build_tree(&repo, &[("selected/file.txt", "child")]),
+            &[parent],
+            "child",
+        );
+        let parent_hits = Arc::new(AtomicUsize::new(0));
+        let stack = cache::CacheStack::new().with_backend(TrackingCache {
+            backend: cache::DistributedCacheBackend::new(directory.path()).unwrap(),
+            expected_parent: parent,
+            parent_hits: Arc::clone(&parent_hits),
+        });
+        let context = cache::TransactionContext::new(directory.path(), stack.into());
+        let transaction = context.open().unwrap();
+        let filtered_child = apply_to_commit(filter, child, &transaction).unwrap();
+        assert!(
+            parent_hits.load(Ordering::Relaxed) > 0,
+            "history traversal did not reuse the forced parent"
+        );
+        let output = objects::CommitData::read(transaction.odb(), filtered_child).unwrap();
+        assert_eq!(
+            output.parent_ids().collect::<Vec<_>>(),
+            vec![filtered_parent]
+        );
+    }
+
+    #[test]
+    fn apply_to_commit_promotes_an_existing_local_cache_hit() {
+        use crate::cache::CacheBackend;
+        let (directory, filter, tip, filtered) = unsampled_endpoint(false);
+        {
+            let stack = cache::CacheStack::new()
+                .with_backend(cache::DistributedCacheBackend::writable(directory.path()).unwrap());
+            let context = cache::TransactionContext::new(directory.path(), stack.into());
+            let transaction = context.open().unwrap();
+            transaction.insert(filter, tip, filtered, false).unwrap();
+            assert_eq!(
+                apply_to_commit_with_options(
+                    filter,
+                    tip,
+                    &transaction,
+                    ApplyToCommitOptions { force_cache: true }
+                )
+                .unwrap(),
+                filtered
+            );
+        }
+        let reader = cache::DistributedCacheBackend::new(directory.path()).unwrap();
+        assert_eq!(
+            reader.read(filter, tip, endpoint_hint(), false).unwrap(),
+            Some(filtered)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Sparse distributed-cache sampling can skip the last commit requested by a caller. A fresh process must then walk past that endpoint when filtering later commits.

Add `apply_to_commit_with_options` with `ApplyToCommitOptions { force_cache: true }`. Writable backends store the requested input-to-output commit mapping even when sampling would skip it. Ordinary history traversal reads those entries, so filtering a later commit can reuse its cached parent. Existing `apply_to_commit` calls keep default sampling. Read-only backends still ignore writes.

Validation:

- `cargo fmt --all -- --check`
- `cargo test --locked -p josh-core --lib`: 90 tests passed.
- Regression tests cover endpoint persistence, cold-cache parent reuse, local-cache promotion, null outputs, read-only backends, and internal filters.

This is the endpoint-caching part of #2557, based directly on `master`.

<!-- codex-thread: 01a05ec0-adc8-7a90-8e51-f6971481d90c -->
