### PR TITLE
Extract ObjectDeref history with Export

### DIFF
--- a/docs/src/reference/experimental.md
+++ b/docs/src/reference/experimental.md
@@ -21,6 +21,9 @@ Reads the object ID stored directly in the gitlink at `path` and replaces the gi
 object it identifies. Blob and tree IDs restore the corresponding file or directory written by
 `:&path`. A commit ID is treated as a submodule reference: the commit's tree is restored at
 `path`, and pointer updates merge the referenced commit history into the filtered history.
+Changes made after a `:#path` submodule was inlined can be extracted with
+`:/path:export`. The exported history is a fast-forward of the referenced
+submodule commit and can be pushed upstream. Updating the superproject gitlink is a separate change.
 
 If `path` does not exist the filter is a no-op. If the entry is not a gitlink or the referenced
 object is not present in the repository, an error is returned.

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -673,51 +673,43 @@ pub fn apply_to_commit2(
                     .collect::<anyhow::Result<Option<_>>>()?
             };
 
-            let mut filtered_parent_ids: Vec<gix_hash::ObjectId> =
+            let filtered_parent_ids: Vec<gix_hash::ObjectId> =
                 some_or!(filtered_parent_ids, { return Ok(None) });
 
-            // TODO: remove all parents that don't have a .link.josh
-
-            //     let mut ok = true;
-            //     filtered_parent_ids.retain(|c| {
-            //         if let Ok(c) = repo.find_commit(*c) {
-            //             c.tree_id() != new_tree.id()
-            //         } else {
-            //             ok = false;
-            //             false
-            //         }
-            //     });
-
-            //     if !ok {
-            //         return Err(anyhow!("missing commit"));
-            //     }
-
-            let tree = commit.tree_id()?;
-            // The link probe below folds every failure into "no link", so an unreadable
-            // or unparseable commit tree must error here.
-            let tree_reader = tree::read_tree(transaction, odb, tree)?;
-            if let Some(link_file) = read_josh_link(
-                transaction,
-                odb,
-                &tree_reader,
-                &std::path::PathBuf::new(),
-                ".link.josh",
-            ) {
-                if let Some(commit_str) = link_file.get_meta("commit") {
-                    if let Ok(commit_oid) = gix_hash::ObjectId::from_str(&commit_str) {
-                        if filtered_parent_ids.contains(&commit_oid) {
-                            while filtered_parent_ids[0] != commit_oid {
-                                filtered_parent_ids.rotate_right(1);
-                            }
-                        }
+            let rewrite_data = apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?;
+            // A pointer-update splice has a referenced-history parent with the
+            // exported tree that descends from the normal first parent. Drop
+            // that splice here instead of pruning every trivial merge.
+            let inferred_parent = if let Some(first_parent) = filtered_parent_ids.first() {
+                let mut inferred_parent = None;
+                for parent in filtered_parent_ids.iter().skip(1) {
+                    if history::filtered_parent_tree_id(transaction, *parent)?
+                        == rewrite_data.tree_id()
+                        && objects::is_descendant_of(transaction.odb(), *parent, *first_parent)?
+                    {
+                        inferred_parent = Some(*parent);
+                        break;
                     }
                 }
+                inferred_parent
+            } else {
+                None
+            };
+
+            if let Some(parent) = inferred_parent {
+                return Some(history::drop_commit(
+                    commit.id(),
+                    vec![parent],
+                    transaction,
+                    filter,
+                ))
+                .transpose();
             }
 
             return Some(history::create_filtered_commit(
                 &commit,
                 filtered_parent_ids,
-                apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?,
+                rewrite_data,
                 transaction,
                 filter,
             ))
@@ -899,6 +891,7 @@ pub fn apply_to_commit2(
                     .first()
                     .copied()
                     .unwrap_or_else(|| gix_hash::ObjectId::null(gix_hash::Kind::Sha1));
+                let normal_parent_count = normal_parents.len();
                 let mut filtered_parents = normal_parents;
                 let path_filter = to_filter(Op::Subdir(path.clone()));
                 if original_target != gix_hash::ObjectId::null(gix_hash::Kind::Sha1)
@@ -924,14 +917,25 @@ pub fn apply_to_commit2(
 
                 let filtered_tree =
                     apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?;
-                return Some(history::create_filtered_commit(
-                    &commit,
-                    filtered_parents,
-                    filtered_tree,
-                    transaction,
-                    filter,
-                ))
-                .transpose();
+                let filtered_commit = if filtered_parents.len() > normal_parent_count {
+                    history::create_filtered_commit_with_forced_parents(
+                        &commit,
+                        filtered_parents,
+                        filtered_tree,
+                        transaction,
+                        filter,
+                        filter.into_meta(),
+                    )
+                } else {
+                    history::create_filtered_commit(
+                        &commit,
+                        filtered_parents,
+                        filtered_tree,
+                        transaction,
+                        filter,
+                    )
+                };
+                return Some(filtered_commit).transpose();
             }
 
             apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -737,12 +737,52 @@ pub fn create_filtered_commit_with_meta(
     filter: filter::Filter,
     meta: std::collections::BTreeMap<String, String>,
 ) -> anyhow::Result<gix_hash::ObjectId> {
+    create_filtered_commit_with_meta2(
+        original_commit,
+        filtered_parent_ids,
+        rewrite_data,
+        transaction,
+        filter,
+        meta,
+        false,
+    )
+}
+
+pub(crate) fn create_filtered_commit_with_forced_parents(
+    original_commit: &objects::CommitData,
+    filtered_parent_ids: Vec<gix_hash::ObjectId>,
+    rewrite_data: filter::Rewrite,
+    transaction: &cache::Transaction,
+    filter: filter::Filter,
+    meta: std::collections::BTreeMap<String, String>,
+) -> anyhow::Result<gix_hash::ObjectId> {
+    create_filtered_commit_with_meta2(
+        original_commit,
+        filtered_parent_ids,
+        rewrite_data,
+        transaction,
+        filter,
+        meta,
+        true,
+    )
+}
+
+fn create_filtered_commit_with_meta2(
+    original_commit: &objects::CommitData,
+    filtered_parent_ids: Vec<gix_hash::ObjectId>,
+    rewrite_data: filter::Rewrite,
+    transaction: &cache::Transaction,
+    filter: filter::Filter,
+    meta: std::collections::BTreeMap<String, String>,
+    force_parents: bool,
+) -> anyhow::Result<gix_hash::ObjectId> {
     let (r, is_new) = create_filtered_commit2(
         transaction,
         original_commit,
         filtered_parent_ids,
         rewrite_data,
         meta,
+        force_parents,
     )?;
 
     let store = is_new || original_commit.parent_count() != 1;
@@ -775,6 +815,7 @@ fn create_filtered_commit2(
     filtered_parent_ids: Vec<gix_hash::ObjectId>,
     rewrite_data: filter::Rewrite,
     options: BTreeMap<String, String>,
+    force_parents: bool,
 ) -> anyhow::Result<(gix_hash::ObjectId, bool)> {
     let odb = transaction.odb();
     let mut filtered_parents: Vec<(gix_hash::ObjectId, gix_hash::ObjectId)> = filtered_parent_ids
@@ -815,10 +856,12 @@ fn create_filtered_commit2(
         filtered_parents.truncate(1);
     }
 
-    if !history_flag(
-        options.get("history").map(String::as_str),
-        "keep-trivial-merges",
-    ) {
+    if !force_parents
+        && !history_flag(
+            options.get("history").map(String::as_str),
+            "keep-trivial-merges",
+        )
+    {
         if filtered_parents.len() > 1 {
             let is_trivial_merge = filtered_parents[0].1 == rewrite_data.tree_id();
             // No first parent is not a trivial merge; a present first parent
@@ -835,12 +878,16 @@ fn create_filtered_commit2(
         }
     }
 
-    let selected_filtered_parent_ids: Vec<gix_hash::ObjectId> = select_parent_commits(
-        odb,
-        original_commit,
-        rewrite_data.tree_id(),
-        &filtered_parents,
-    )?;
+    let selected_filtered_parent_ids: Vec<gix_hash::ObjectId> = if force_parents {
+        filtered_parents.iter().map(|(oid, _)| *oid).collect()
+    } else {
+        select_parent_commits(
+            odb,
+            original_commit,
+            rewrite_data.tree_id(),
+            &filtered_parents,
+        )?
+    };
 
     if selected_filtered_parent_ids.is_empty()
         && !(original_commit.parent_count() == 0

--- a/tests/experimental/link-submodules.t
+++ b/tests/experimental/link-submodules.t
@@ -388,10 +388,10 @@ Test Adapt with submodule changes - add commits to submodule and update
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] :prefix=libs
   [4] ::.link.josh
+  [4] :export
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
-  [5] :export
   [5] :link=embedded
   [6] :prune=trivial-merge
   [12] :/libs
@@ -414,10 +414,10 @@ Test Adapt with submodule changes - add commits to submodule and update
   [2] :unapply(e1d45e29c75aca63c80d13d82216ccfad39af822:/libs)
   [3] :prefix=libs
   [4] ::.link.josh
+  [4] :export
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
-  [5] :export
   [5] :link=embedded
   [6] :prune=trivial-merge
   [12] :/libs
@@ -439,10 +439,10 @@ Test Adapt with submodule changes - add commits to submodule and update
   [3] :prefix=libs
   [4] :/another
   [4] ::.link.josh
+  [4] :export
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
-  [5] :export
   [5] :link=embedded
   [6] :prune=trivial-merge
   [9] :/modules
@@ -464,10 +464,10 @@ Test Adapt with submodule changes - add commits to submodule and update
   [3] :prefix=libs
   [4] :/another
   [4] ::.link.josh
+  [4] :export
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
-  [5] :export
   [5] :link=embedded
   [6] :prune=trivial-merge
   [9] :/modules
@@ -511,8 +511,8 @@ Test Adapt with submodule changes - add commits to submodule and update
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
+  [5] :export
   [5] :link=embedded
-  [6] :export
   [7] :prune=trivial-merge
   [9] :/modules
   [13] :/libs
@@ -551,8 +551,8 @@ Test Adapt with submodule changes - add commits to submodule and update
   [4] :unapply(ded577ab7e4ed784dfd17e7c2d184fe667e24eae:/libs)
   [5] :"{@}"
   [5] :adapt=submodules
+  [5] :export
   [5] :link=embedded
-  [6] :export
   [7] :prefix=libs
   [7] :prune=trivial-merge
   [9] :/modules

--- a/tests/experimental/object_deref_submodule.t
+++ b/tests/experimental/object_deref_submodule.t
@@ -122,3 +122,54 @@ Moving the gitlink merges only the newly referenced submodule commits.
           │   ┆  foo content
           └── file3.txt
               ┆  new content
+
+Changes made after the submodule was inlined are exported as a new submodule
+history. Export leaves the superproject unchanged; updating its gitlink is a
+separate change.
+
+The original submodule tip is a trivial merge. Export must retain it while
+removing only the superproject pointer-update merges introduced by ObjectDeref.
+
+  $ cd ${TESTTMP}/submodule-repo
+  $ git checkout -b trivial-side 1> /dev/null 2> /dev/null
+  $ git commit --allow-empty -m "trivial side" 1> /dev/null
+  $ git checkout master 1> /dev/null 2> /dev/null
+  $ git commit --allow-empty -m "trivial main" 1> /dev/null
+  $ git merge --no-ff trivial-side -m "preserved trivial merge" 1> /dev/null
+  $ PRESERVED_MERGE=$(git rev-parse HEAD)
+  $ [ "$(git rev-list --parents -n 1 HEAD | wc -w | tr -d ' ')" = 3 ] && [ "$(git rev-parse HEAD^{tree})" = "$(git rev-parse HEAD^1^{tree})" ] && echo "trivial merge created"
+  trivial merge created
+
+  $ cd ${TESTTMP}/main-repo
+  $ git submodule update --remote libs 1> /dev/null 2> /dev/null
+  $ git add libs
+  $ git commit -m "update libs to trivial merge" 1> /dev/null
+  $ git fetch ../submodule-repo 1> /dev/null 2> /dev/null
+  $ josh-filter ':#libs' master --update refs/josh/filter/master 1> /dev/null
+
+  $ ORIGINAL_SUBMODULE_TIP=$(git rev-parse master:libs)
+  $ git worktree add -b inlined ../inlined refs/josh/filter/master 1> /dev/null 2> /dev/null
+  $ cd ../inlined
+  $ echo "edited after inline" >> libs/foo/file1.txt
+  $ git add libs/foo/file1.txt
+  $ git commit -m "edit inlined submodule" 1> /dev/null
+
+  $ josh-filter ':/libs:export' inlined --update refs/heads/exported 1> /dev/null
+  $ EXTRACTED_TIP=$(git rev-parse exported)
+  $ git merge-base --is-ancestor "${ORIGINAL_SUBMODULE_TIP}" "${EXTRACTED_TIP}" && echo "fast-forward"
+  fast-forward
+  $ [ "$(git rev-parse exported^)" = "${ORIGINAL_SUBMODULE_TIP}" ] && echo "direct child"
+  direct child
+
+  $ cd ../main-repo
+  $ [ "$(git rev-parse master:libs)" = "${ORIGINAL_SUBMODULE_TIP}" ] && echo "superproject unchanged"
+  superproject unchanged
+  $ git --git-dir=../submodule-repo/.git update-ref refs/heads/extracted "${ORIGINAL_SUBMODULE_TIP}"
+  $ git push ../submodule-repo "${EXTRACTED_TIP}:refs/heads/extracted" 1> /dev/null 2> /dev/null
+  $ git --git-dir=../submodule-repo/.git log --pretty=%s "${ORIGINAL_SUBMODULE_TIP}..extracted"
+  edit inlined submodule
+  $ git --git-dir=../submodule-repo/.git show -s --pretty=%s "${PRESERVED_MERGE}"
+  preserved trivial merge
+  $ git --git-dir=../submodule-repo/.git show extracted:foo/file1.txt
+  foo content
+  edited after inline


### PR DESCRIPTION
Extract ObjectDeref history with Export

Teach Export to remove ObjectDeref pointer-update splices without pruning legitimate trivial merges from the referenced submodule history.

Change: object-deref-export

Assisted-By: openai-codex/gpt-5.6-sol