### PR TITLE
Handle nested gitlink history references

### DIFF
--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -21,6 +21,7 @@ pub use josh_filter::persist::{peel_filter, peel_op, to_filter, to_op, to_ops};
 pub use josh_filter::{Filter, InsertContent, LazyRef, Op, RevMatch};
 pub use josh_filter::{as_file, pretty, spec};
 
+mod object_deref;
 pub mod text;
 pub mod tree;
 
@@ -683,91 +684,6 @@ pub fn apply_to_commit2(
             ))
             .transpose();
         }
-        Op::ObjectDeref(path) => {
-            let referenced_commit = tree::get_path_entry(transaction, odb, commit.tree_id()?, path)
-                .ok()
-                .flatten()
-                .filter(|entry| entry.mode.is_commit())
-                .and_then(|entry| {
-                    matches!(odb.try_kind(entry.oid), Ok(Some(gix_object::Kind::Commit)))
-                        .then_some(entry.oid)
-                });
-
-            if let Some(new_oid) = referenced_commit {
-                let normal_parents = commit
-                    .parent_ids()
-                    .map(|parent| transaction.get(filter, parent))
-                    .collect::<anyhow::Result<Option<Vec<gix_hash::ObjectId>>>>()?;
-                let normal_parents = some_or!(normal_parents, { return Ok(None) });
-
-                let old_oid = if let Some(parent) = commit.first_parent_id() {
-                    let parent_tree = git::read_tree_id(odb, parent)?;
-                    tree::get_path_entry(transaction, odb, parent_tree, path)
-                        .ok()
-                        .flatten()
-                        .filter(|entry| entry.mode.is_commit())
-                        .and_then(|entry| {
-                            matches!(odb.try_kind(entry.oid), Ok(Some(gix_object::Kind::Commit)))
-                                .then_some(entry.oid)
-                        })
-                        .unwrap_or_else(|| gix_hash::ObjectId::null(gix_hash::Kind::Sha1))
-                } else {
-                    gix_hash::ObjectId::null(gix_hash::Kind::Sha1)
-                };
-
-                let original_target = normal_parents
-                    .first()
-                    .copied()
-                    .unwrap_or_else(|| gix_hash::ObjectId::null(gix_hash::Kind::Sha1));
-                let normal_parent_count = normal_parents.len();
-                let mut filtered_parents = normal_parents;
-                let path_filter = to_filter(Op::Subdir(path.clone()));
-                if original_target != gix_hash::ObjectId::null(gix_hash::Kind::Sha1)
-                    && transaction.get(path_filter, original_target)?.is_none()
-                {
-                    return Ok(None);
-                }
-
-                if old_oid != new_oid {
-                    let referenced_history = history::unapply_filter(
-                        transaction,
-                        path_filter,
-                        original_target,
-                        old_oid,
-                        new_oid,
-                        history::OrphansMode::Keep,
-                        None,
-                    )?;
-                    if referenced_history != gix_hash::ObjectId::null(gix_hash::Kind::Sha1) {
-                        filtered_parents.push(referenced_history);
-                    }
-                }
-
-                let filtered_tree =
-                    apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?;
-                let filtered_commit = if filtered_parents.len() > normal_parent_count {
-                    history::create_filtered_commit_with_forced_parents(
-                        &commit,
-                        filtered_parents,
-                        filtered_tree,
-                        transaction,
-                        filter,
-                        filter.into_meta(),
-                    )
-                } else {
-                    history::create_filtered_commit(
-                        &commit,
-                        filtered_parents,
-                        filtered_tree,
-                        transaction,
-                        filter,
-                    )
-                };
-                return Some(filtered_commit).transpose();
-            }
-
-            apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?
-        }
         Op::Workspace(ws_path) => {
             // The get_* helpers return a bare Filter and would fold an unreadable tree to
             // Op::Empty, so bad input must error here; every probe below shares the read.
@@ -896,19 +812,46 @@ pub fn apply_to_commit2(
         commit
             .parent_ids()
             .map(|x| transaction.get(filter, x))
-            .collect::<anyhow::Result<Option<_>>>()?
+            .collect::<anyhow::Result<Option<Vec<gix_hash::ObjectId>>>>()?
     };
 
-    let filtered_parent_ids = some_or!(filtered_parent_ids, { return Ok(None) });
-
-    Some(history::create_filtered_commit(
-        &commit,
-        filtered_parent_ids,
-        tree_data,
+    let mut filtered_parent_ids = some_or!(filtered_parent_ids, { return Ok(None) });
+    let normal_parent_count = filtered_parent_ids.len();
+    let original_target = filtered_parent_ids
+        .first()
+        .copied()
+        .unwrap_or_else(|| gix_hash::ObjectId::null(gix_hash::Kind::Sha1));
+    if !object_deref::append_parents(
         transaction,
+        &commit,
         filter,
-    ))
-    .transpose()
+        commit.first_parent_id().map(|_| filter),
+        tree_data.tree_id(),
+        original_target,
+        &mut filtered_parent_ids,
+    )? {
+        return Ok(None);
+    }
+
+    let filtered_commit = if filtered_parent_ids.len() > normal_parent_count {
+        history::create_filtered_commit_with_forced_parents(
+            &commit,
+            filtered_parent_ids,
+            tree_data,
+            transaction,
+            filter,
+            filter.into_meta(),
+        )
+    } else {
+        history::create_filtered_commit(
+            &commit,
+            filtered_parent_ids,
+            tree_data,
+            transaction,
+            filter,
+        )
+    };
+    Some(filtered_commit).transpose()
 }
 
 /// Filter a single tree. This does not involve walking history and is thus fast in most cases.
@@ -1837,6 +1780,9 @@ fn per_rev_filter(
         ));
     }
 
+    let parent_object_filter = parent_filters
+        .first()
+        .map(|(_, parent_filter)| propagate_meta(*parent_filter, &meta));
     let splice_parents = if no_splice {
         vec![]
     } else {
@@ -1877,7 +1823,12 @@ fn per_rev_filter(
         None
     };
 
-    let filtered_parent_ids: Vec<_> = normal_parents.into_iter().chain(splice_parents).collect();
+    let original_target = normal_parents
+        .first()
+        .copied()
+        .unwrap_or_else(|| gix_hash::ObjectId::null(gix_hash::Kind::Sha1));
+    let mut filtered_parent_ids: Vec<_> =
+        normal_parents.into_iter().chain(splice_parents).collect();
 
     if let Op::Squash = to_op(commit_filter.peel()) {
         // `:SQUASH` as a per-commit filter squashes the commit away, mapping it
@@ -1937,15 +1888,39 @@ fn per_rev_filter(
         tree_data = tree_data.with_tree(with_overlay);
     }
 
-    return Some(history::create_filtered_commit_with_meta(
-        commit,
-        filtered_parent_ids,
-        tree_data,
+    let parent_count_before_object_derefs = filtered_parent_ids.len();
+    if !object_deref::append_parents(
         transaction,
-        filter,
-        commit_filter.into_meta(),
-    ))
-    .transpose();
+        commit,
+        commit_filter,
+        parent_object_filter,
+        tree_data.tree_id(),
+        original_target,
+        &mut filtered_parent_ids,
+    )? {
+        return Ok(None);
+    }
+
+    let filtered_commit = if filtered_parent_ids.len() > parent_count_before_object_derefs {
+        history::create_filtered_commit_with_forced_parents(
+            commit,
+            filtered_parent_ids,
+            tree_data,
+            transaction,
+            filter,
+            commit_filter.into_meta(),
+        )
+    } else {
+        history::create_filtered_commit_with_meta(
+            commit,
+            filtered_parent_ids,
+            tree_data,
+            transaction,
+            filter,
+            commit_filter.into_meta(),
+        )
+    };
+    Some(filtered_commit).transpose()
 }
 
 /// Rebuild the stack from `base_oid` to `change_oid`, dropping intermediate commits

--- a/josh-core/src/filter/object_deref.rs
+++ b/josh-core/src/filter/object_deref.rs
@@ -1,0 +1,174 @@
+use super::{Filter, Op, Rewrite, apply, legalize_stored, to_filter, tree};
+use crate::{cache, git, history, objects};
+use std::path::Path;
+
+fn legalize_object_derefs(filter: Filter) -> Filter {
+    to_filter(match super::to_op(filter) {
+        Op::ObjectDeref(path) => Op::ObjectRef(path),
+        Op::Compose(filters) => {
+            Op::Compose(filters.into_iter().map(legalize_object_derefs).collect())
+        }
+        Op::Chain(filters) => Op::Chain(filters.into_iter().map(legalize_object_derefs).collect()),
+        Op::Subtract(a, b) => Op::Subtract(legalize_object_derefs(a), legalize_object_derefs(b)),
+        Op::Exclude(filter) => Op::Exclude(legalize_object_derefs(filter)),
+        Op::Select(filter) => Op::Select(legalize_object_derefs(filter)),
+        Op::Pin(filter) => Op::Pin(legalize_object_derefs(filter)),
+        Op::Starlark(path, filter) => Op::Starlark(path, legalize_object_derefs(filter)),
+        Op::TreeId(path, filter) => Op::TreeId(path, legalize_object_derefs(filter)),
+        Op::Unapply(target, filter) => Op::Unapply(target, legalize_object_derefs(filter)),
+        Op::Rev(filters) => Op::Rev(
+            filters
+                .into_iter()
+                .map(|(match_op, target, filter)| {
+                    (match_op, target, legalize_object_derefs(filter))
+                })
+                .collect(),
+        ),
+        Op::Meta(meta, filter) => Op::Meta(meta, legalize_object_derefs(filter)),
+        op => op,
+    })
+}
+
+/// Apply the filter with dereferences replaced by references, then retain only
+/// the resulting gitlinks. Their paths are the destinations in the filtered tree,
+/// including prefixes and duplicate target objects at different paths.
+fn object_reference_tree(
+    transaction: &cache::Transaction,
+    filter: Filter,
+    input_tree: gix_hash::ObjectId,
+) -> anyhow::Result<Option<gix_hash::ObjectId>> {
+    let odb = transaction.odb();
+    let reader = tree::read_tree(transaction, odb, input_tree)?;
+    let filter = legalize_stored(transaction, odb, filter, input_tree, &reader)?;
+    let pointer_filter = legalize_object_derefs(filter);
+    if pointer_filter == filter {
+        return Ok(None);
+    }
+
+    let pointer_tree =
+        apply(transaction, pointer_filter, Rewrite::from_tree(input_tree))?.tree_id();
+    // `remove_pred` keeps every non-gitlink; subtracting it leaves only gitlinks.
+    let without_gitlinks = tree::remove_pred(
+        transaction,
+        &mut String::new(),
+        pointer_tree,
+        &|_, _| true,
+        objects::hash_blob(b"object-reference-tree"),
+    )?;
+    Ok(Some(tree::subtract(
+        transaction,
+        pointer_tree,
+        without_gitlinks,
+    )?))
+}
+
+fn gitlink_entries(
+    odb: &josh_memodb::Odb,
+    tree: gix_hash::ObjectId,
+) -> anyhow::Result<Vec<(std::path::PathBuf, gix_hash::ObjectId)>> {
+    let mut entries = Vec::new();
+    objects::walk_tree_preorder(odb, tree, &mut |parent, entry| {
+        if entry.mode.is_commit() {
+            let name = std::str::from_utf8(entry.filename)?;
+            let path = if parent.is_empty() {
+                name.into()
+            } else {
+                Path::new(parent).join(name)
+            };
+            entries.push((path, entry.oid.to_owned()));
+        }
+        Ok(())
+    })?;
+    Ok(entries)
+}
+
+fn commit_reference_at_path(
+    transaction: &cache::Transaction,
+    odb: &josh_memodb::Odb,
+    tree: gix_hash::ObjectId,
+    path: &Path,
+) -> Option<gix_hash::ObjectId> {
+    tree::get_path_entry(transaction, odb, tree, path)
+        .ok()
+        .flatten()
+        .filter(|entry| entry.mode.is_commit())
+        .and_then(|entry| {
+            matches!(odb.try_kind(entry.oid), Ok(Some(gix_object::Kind::Commit)))
+                .then_some(entry.oid)
+        })
+}
+
+pub(super) fn append_parents(
+    transaction: &cache::Transaction,
+    commit: &objects::CommitData,
+    filter: Filter,
+    parent_filter: Option<Filter>,
+    filtered_tree: gix_hash::ObjectId,
+    original_target: gix_hash::ObjectId,
+    filtered_parents: &mut Vec<gix_hash::ObjectId>,
+) -> anyhow::Result<bool> {
+    let odb = transaction.odb();
+    let Some(references) = object_reference_tree(transaction, filter, commit.tree_id()?)? else {
+        return Ok(true);
+    };
+    let parent_references = commit
+        .first_parent_id()
+        .zip(parent_filter)
+        .map(|(parent, parent_filter)| {
+            object_reference_tree(transaction, parent_filter, git::read_tree_id(odb, parent)?)
+        })
+        .transpose()?
+        .flatten();
+    let mut pending = Vec::new();
+    let mut ready = true;
+
+    for (path, new_oid) in gitlink_entries(odb, references)? {
+        if !matches!(odb.try_kind(new_oid), Ok(Some(gix_object::Kind::Commit))) {
+            continue;
+        }
+        let referenced_tree = git::read_tree_id(odb, new_oid)?;
+        let appears_in_output = tree::get_path_entry(transaction, odb, filtered_tree, &path)
+            .ok()
+            .flatten()
+            .is_some_and(|entry| entry.mode.is_tree() && entry.oid == referenced_tree);
+        if !appears_in_output {
+            continue;
+        }
+
+        let old_oid = parent_references
+            .and_then(|tree| commit_reference_at_path(transaction, odb, tree, &path))
+            .unwrap_or_else(|| gix_hash::ObjectId::null(gix_hash::Kind::Sha1));
+        if old_oid == new_oid {
+            continue;
+        }
+
+        let path_filter = to_filter(Op::Subdir(path));
+        if original_target != gix_hash::ObjectId::null(gix_hash::Kind::Sha1)
+            && transaction.get(path_filter, original_target)?.is_none()
+        {
+            ready = false;
+        }
+        pending.push((path_filter, old_oid, new_oid));
+    }
+
+    if !ready {
+        return Ok(false);
+    }
+
+    for (path_filter, old_oid, new_oid) in pending {
+        let referenced_history = history::unapply_filter(
+            transaction,
+            path_filter,
+            original_target,
+            old_oid,
+            new_oid,
+            history::OrphansMode::Keep,
+            None,
+        )?;
+        if referenced_history != gix_hash::ObjectId::null(gix_hash::Kind::Sha1) {
+            filtered_parents.push(referenced_history);
+        }
+    }
+
+    Ok(true)
+}

--- a/tests/experimental/object_deref_submodule.t
+++ b/tests/experimental/object_deref_submodule.t
@@ -60,6 +60,11 @@ keeps the main repository content and replaces only the gitlink.
 
   $ josh-filter ':[:exclude[:#libs],:#libs]' master --update refs/josh/filter/combined 1> /dev/null
 
+The same history splice applies when the dereference is nested in a compose.
+
+  $ [ "$(git rev-list --parents -n 1 refs/josh/filter/combined | wc -w | tr -d ' ')" = 3 ] && echo "submodule history parent present"
+  submodule history parent present
+
   $ git-tree-pretty refs/josh/filter/combined
   .
   ├── .gitmodules
@@ -75,6 +80,101 @@ keeps the main repository content and replaces only the gitlink.
   │           ┆  foo content
   └── main.txt
       ┆  main content
+
+Multiple references each contribute a history parent, including duplicate
+target commits that land at different prefixed destinations deep in the AST.
+
+  $ cd ${TESTTMP}/submodule-repo
+  $ git checkout -b vendor HEAD~1 1> /dev/null 2> /dev/null
+  $ mkdir vendor
+  $ echo "vendor content" > vendor/file.txt
+  $ git add vendor/file.txt
+  $ git commit -m "add vendor content" 1> /dev/null
+  $ VENDOR_COMMIT=$(git rev-parse HEAD)
+  $ LIBS_COMMIT=$(git rev-parse master)
+  $ git checkout master 1> /dev/null 2> /dev/null
+
+  $ cd ${TESTTMP}/main-repo
+  $ git checkout -b multiple master~1 1> /dev/null 2> /dev/null
+  $ git fetch ../submodule-repo master vendor 1> /dev/null 2> /dev/null
+  $ git update-index --add --cacheinfo "160000,$LIBS_COMMIT,libs"
+  $ git update-index --add --cacheinfo "160000,$LIBS_COMMIT,libs-copy"
+  $ git update-index --add --cacheinfo "160000,$VENDOR_COMMIT,vendor"
+  $ git commit -m "add three submodule references" 1> /dev/null
+
+  $ josh-filter ':[:#libs:prefix=left,:[:#libs-copy:prefix=right,:#vendor]]' multiple --update refs/josh/filter/multiple 1> /dev/null
+  $ [ "$(git rev-list --parents -n 1 refs/josh/filter/multiple | wc -w | tr -d ' ')" = 5 ] && echo "three landing-path history parents present"
+  three landing-path history parents present
+
+  $ git ls-tree -r --name-only refs/josh/filter/multiple^2
+  left/libs/bar/file2.txt
+  left/libs/foo/file1.txt
+  $ git ls-tree -r --name-only refs/josh/filter/multiple^3
+  right/libs-copy/bar/file2.txt
+  right/libs-copy/foo/file1.txt
+  $ git ls-tree -r --name-only refs/josh/filter/multiple^4
+  vendor/foo/file1.txt
+  vendor/vendor/file.txt
+
+  $ git-tree-pretty refs/josh/filter/multiple
+  .
+  ├── left/
+  │   └── libs/
+  │       ├── bar/
+  │       │   └── file2.txt
+  │       │       ┆  bar content
+  │       └── foo/
+  │           └── file1.txt
+  │               ┆  foo content
+  ├── right/
+  │   └── libs-copy/
+  │       ├── bar/
+  │       │   └── file2.txt
+  │       │       ┆  bar content
+  │       └── foo/
+  │           └── file1.txt
+  │               ┆  foo content
+  └── vendor/
+      ├── foo/
+      │   └── file1.txt
+      │       ┆  foo content
+      └── vendor/
+          └── file.txt
+              ┆  vendor content
+
+Updating all three pointers in one superproject commit produces one merge
+parent per landing path. The two duplicate targets remain separate histories.
+
+  $ FILTERED_BASE=$(git rev-parse refs/josh/filter/multiple)
+  $ cd ${TESTTMP}/submodule-repo
+  $ git checkout -b multiple-libs "$LIBS_COMMIT" 1> /dev/null 2> /dev/null
+  $ echo "updated libs content" > bar/updated.txt
+  $ git add bar/updated.txt
+  $ git commit -m "update libs content" 1> /dev/null
+  $ UPDATED_LIBS_COMMIT=$(git rev-parse HEAD)
+  $ git checkout vendor 1> /dev/null 2> /dev/null
+  $ echo "updated vendor content" > vendor/updated.txt
+  $ git add vendor/updated.txt
+  $ git commit -m "update vendor content" 1> /dev/null
+  $ UPDATED_VENDOR_COMMIT=$(git rev-parse HEAD)
+  $ git checkout master 1> /dev/null 2> /dev/null
+
+  $ cd ${TESTTMP}/main-repo
+  $ git fetch ../submodule-repo multiple-libs vendor 1> /dev/null 2> /dev/null
+  $ git update-index --cacheinfo "160000,$UPDATED_LIBS_COMMIT,libs"
+  $ git update-index --cacheinfo "160000,$UPDATED_LIBS_COMMIT,libs-copy"
+  $ git update-index --cacheinfo "160000,$UPDATED_VENDOR_COMMIT,vendor"
+  $ git commit -m "update three submodule references" 1> /dev/null
+  $ josh-filter ':[:#libs:prefix=left,:[:#libs-copy:prefix=right,:#vendor]]' multiple --update refs/josh/filter/multiple 1> /dev/null
+
+  $ git log --graph --pretty=%s "${FILTERED_BASE}..refs/josh/filter/multiple" | sed 's/ *$//'
+  *-.   update three submodule references
+  |\ \
+  | | * update vendor content
+  | * update libs content
+  * update libs content
+
+  $ git checkout master 1> /dev/null 2> /dev/null
 
 Moving the gitlink merges only the newly referenced submodule commits.
 


### PR DESCRIPTION
Handle nested gitlink history references

Derive submodule history parents from a pointer-only filtered tree so multiple references retain their final paths, including duplicate targets and nested filters. Cover simultaneous pointer updates in the history graph.

Change: nested-gitlink-history-references
Assisted-By: openai-codex/gpt-5.6-sol