### PR TITLE
Add Discord badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![Just One Single History](/splash.jpg)
 
+[![Discord](https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white)](https://discord.gg/eM4yK2tBdC)
+
 Josh – “Just One Single History” – is a collection of tools and services together composing
 a platform for scaling out distributed development and collaboration with Git.
 


### PR DESCRIPTION
Add Discord badge to README

Link the project Discord invite directly below the README banner.

Change: add-discord-badge

Assisted-By: openai-codex/gpt-5.6-sol