### PR TITLE
Remove lazy filter references

### DIFF
--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -22,7 +22,7 @@ fn resolve_input_ref(
 }
 
 fn squash_ids_filter(
-    ids: &[(josh_core::filter::LazyRef, josh_core::filter::Filter)],
+    ids: &[(gix_hash::ObjectId, josh_core::filter::Filter)],
 ) -> josh_core::filter::Filter {
     josh_core::filter::to_filter(josh_core::filter::squash_to_rev(ids.iter().cloned()))
 }
@@ -236,10 +236,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
                 return Ok(());
             }
             let target = josh_core::objects::peel_to_commit(transaction.odb(), oid)?;
-            ids.push((
-                josh_core::filter::LazyRef::Resolved(target),
-                josh_core::filter::Filter::new().message(name),
-            ));
+            ids.push((target, josh_core::filter::Filter::new().message(name)));
             refs.push((name.to_string(), target));
             Ok(())
         })?;
@@ -254,10 +251,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             if let [sha, name] = split.as_slice() {
                 let target = gix_hash::ObjectId::from_str(sha)?;
                 let target = josh_core::objects::peel_to_commit(transaction.odb(), target)?;
-                ids.push((
-                    josh_core::filter::LazyRef::Resolved(target),
-                    josh_core::filter::Filter::new().message(name),
-                ));
+                ids.push((target, josh_core::filter::Filter::new().message(name)));
                 refs.push((name.to_string(), target));
             } else if !split.is_empty() {
                 eprintln!("Warning: malformed line: {:?}", line);

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -18,7 +18,7 @@ pub use josh_filter::flang::parse::{get_comments, parse};
 pub use josh_filter::opt;
 pub use josh_filter::opt::invert;
 pub use josh_filter::persist::{peel_filter, peel_op, to_filter, to_op, to_ops};
-pub use josh_filter::{Filter, InsertContent, LazyRef, Op, RevMatch};
+pub use josh_filter::{Filter, InsertContent, Op, RevMatch};
 pub use josh_filter::{as_file, pretty, spec};
 
 mod object_deref;
@@ -161,104 +161,6 @@ impl Rewrite {
 }
 
 pub use josh_filter::compose;
-
-pub fn lazy_refs(filter: Filter) -> Vec<String> {
-    lazy_refs2(&peel_op(filter))
-}
-
-fn lazy_refs2(op: &Op) -> Vec<String> {
-    let mut lr = match op {
-        Op::Compose(filters) => {
-            filters
-                .iter()
-                .map(|f| lazy_refs(*f))
-                .fold(vec![], |mut acc, mut v| {
-                    acc.append(&mut v);
-                    acc
-                })
-        }
-        Op::Exclude(filter) | Op::Select(filter) | Op::Pin(filter) => lazy_refs(*filter),
-        Op::Chain(filters) => {
-            let mut av = vec![];
-            for filter in filters {
-                av.append(&mut lazy_refs(*filter));
-            }
-            av
-        }
-        Op::Subtract(a, b) => {
-            let mut av = lazy_refs(*a);
-            av.append(&mut lazy_refs(*b));
-            av
-        }
-        Op::Rev(filters) => {
-            let mut lr = lazy_refs2(&Op::Compose(filters.iter().map(|(_, _, f)| *f).collect()));
-            lr.extend(filters.iter().filter_map(|(_, nested, _)| {
-                if let LazyRef::Lazy(s) = nested {
-                    Some(s.to_owned())
-                } else {
-                    None
-                }
-            }));
-            lr.sort();
-            lr.dedup();
-            lr
-        }
-        Op::Downstack(LazyRef::Lazy(s)) => vec![s.to_owned()],
-        Op::Downstack(_) => vec![],
-        _ => vec![],
-    };
-    lr.sort();
-    lr.dedup();
-    lr
-}
-
-pub fn resolve_refs(
-    refs: &std::collections::HashMap<String, gix_hash::ObjectId>,
-    filter: Filter,
-) -> Filter {
-    to_filter(resolve_refs2(refs, &to_op(filter)))
-}
-
-fn resolve_refs2(refs: &std::collections::HashMap<String, gix_hash::ObjectId>, op: &Op) -> Op {
-    match op {
-        Op::Compose(filters) => {
-            Op::Compose(filters.iter().map(|f| resolve_refs(refs, *f)).collect())
-        }
-        Op::Exclude(filter) => Op::Exclude(resolve_refs(refs, *filter)),
-        Op::Select(filter) => Op::Select(resolve_refs(refs, *filter)),
-        Op::Pin(filter) => Op::Pin(resolve_refs(refs, *filter)),
-        Op::Chain(filters) => Op::Chain(filters.iter().map(|f| resolve_refs(refs, *f)).collect()),
-        Op::Subtract(a, b) => Op::Subtract(resolve_refs(refs, *a), resolve_refs(refs, *b)),
-        Op::Rev(filters) => {
-            let lr = filters
-                .iter()
-                .map(|(match_op, r, f)| {
-                    let f = resolve_refs(refs, *f);
-                    let resolved_r = if let LazyRef::Lazy(s) = r {
-                        if let Some(res) = refs.get(s) {
-                            LazyRef::Resolved(*res)
-                        } else {
-                            r.clone()
-                        }
-                    } else {
-                        r.clone()
-                    };
-                    (*match_op, resolved_r, f)
-                })
-                .collect();
-            Op::Rev(lr)
-        }
-
-        Op::Downstack(LazyRef::Lazy(s)) => {
-            if let Some(res) = refs.get(s) {
-                Op::Downstack(LazyRef::Resolved(*res))
-            } else {
-                op.clone()
-            }
-        }
-        _ => op.clone(),
-    }
-}
 
 pub fn src_path(filter: Filter) -> std::path::PathBuf {
     src_path2(&peel_op(filter))
@@ -498,15 +400,11 @@ fn get_filter(
 fn get_rev_filter(
     transaction: &cache::Transaction,
     commit_id: gix_hash::ObjectId,
-    filters: &[(RevMatch, LazyRef, Filter)],
+    filters: &[(RevMatch, gix_hash::ObjectId, Filter)],
 ) -> anyhow::Result<Filter> {
     // First match wins - iterate in order
-    for (match_op, filter_tip_ref, startfilter) in filters.iter() {
-        let filter_tip = if let LazyRef::Resolved(filter_tip) = filter_tip_ref {
-            filter_tip.to_owned()
-        } else {
-            return Err(anyhow!("unresolved lazy ref"));
-        };
+    for (match_op, filter_tip, startfilter) in filters.iter() {
+        let filter_tip = filter_tip.to_owned();
         if match_op != &RevMatch::Default && !transaction.odb().contains(filter_tip) {
             return Err(anyhow!("`:rev(...)` with nonexistent OID: {}", filter_tip));
         }
@@ -583,16 +481,13 @@ pub fn apply_to_commit2(
             ))
             .transpose();
         }
-        Op::Downstack(LazyRef::Resolved(base)) => {
+        Op::Downstack(base) => {
             if let Some(oid) = transaction.get(filter, commit_id)? {
                 return Ok(Some(oid));
             }
             let new_oid = downstack(transaction, commit_id, base.to_owned())?;
             transaction.insert(filter, commit_id, new_oid, false)?;
             return Ok(Some(new_oid));
-        }
-        Op::Downstack(LazyRef::Lazy(_)) => {
-            return Err(anyhow!("`:_=...` with unresolved base ref"));
         }
         _ => {
             if let Some(oid) = transaction.get(filter, commit_id)? {
@@ -797,9 +692,6 @@ pub fn apply_to_commit2(
                 .collect::<anyhow::Result<Vec<_>>>()?;
 
             return per_rev_filter(transaction, &commit, filter, commit_filter, parent_filters);
-        }
-        Op::Unapply(LazyRef::Lazy(_), _) => {
-            return Err(anyhow!("unresolved lazy ref"));
         }
         Op::Unapply(..) => apply(transaction, filter, Rewrite::from_commit_data(&commit)?)?,
 
@@ -1195,23 +1087,19 @@ fn apply_impl(
 
         Op::Unapply(target, uf) => {
             check_experimental_features_enabled("unapply filter")?;
-            if let LazyRef::Resolved(target) = target {
-                let target = objects::CommitData::read(odb, target.to_owned())?;
-                // The message must parse as an oid, so non-UTF-8 is an error.
-                let target_msg = target.message()?;
-                let target = gix_hash::ObjectId::from_str(std::str::from_utf8(target_msg)?)?;
-                let target_tree = git::read_tree_id(odb, target)?;
-                /* dbg!(&uf); */
-                Ok(Rewrite::from_tree(filter::unapply(
-                    transaction,
-                    *uf,
-                    x.tree_id(),
-                    target_tree,
-                    None,
-                )?))
-            } else {
-                return Err(anyhow!("unresolved lazy ref"));
-            }
+            let target = objects::CommitData::read(odb, target.to_owned())?;
+            // The message must parse as an oid, so non-UTF-8 is an error.
+            let target_msg = target.message()?;
+            let target = gix_hash::ObjectId::from_str(std::str::from_utf8(target_msg)?)?;
+            let target_tree = git::read_tree_id(odb, target)?;
+            /* dbg!(&uf); */
+            Ok(Rewrite::from_tree(filter::unapply(
+                transaction,
+                *uf,
+                x.tree_id(),
+                target_tree,
+                None,
+            )?))
         }
         Op::Pin(_) => Ok(x),
         Op::Downstack(_) => Err(anyhow!("not applicable to tree: downstack")),

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -1,5 +1,5 @@
 use crate::check_experimental_features_enabled;
-use crate::op::{InsertContent, LazyRef, Op, Regex, RevMatch};
+use crate::op::{InsertContent, Op, Regex, RevMatch};
 use crate::opt;
 use crate::persist::{self, Node, to_filter, to_op};
 use std::sync::LazyLock;
@@ -88,14 +88,9 @@ impl Filter {
 
     /// Chain a `:rev(...)` filter. Each `(match, tip, then)` arm applies `then` to a commit whose
     /// relationship to `tip` satisfies `match` (e.g. `AncestorInclusive` is `<=tip`); the first
-    /// matching arm wins and a commit matching none passes through unchanged. Tips are resolved
-    /// oids (`RevMatch::Default` ignores its tip); construct `Op::Rev` directly for lazy refs.
+    /// matching arm wins and a commit matching none passes through unchanged.
     pub fn rev(self, arms: Vec<(RevMatch, gix_hash::ObjectId, Filter)>) -> Filter {
-        self.chain(to_filter(Op::Rev(
-            arms.into_iter()
-                .map(|(m, tip, then)| (m, LazyRef::Resolved(tip), then))
-                .collect(),
-        )))
+        self.chain(to_filter(Op::Rev(arms)))
     }
 
     /// Create a no-op filter that passes everything through unchanged
@@ -249,7 +244,7 @@ impl Filter {
     /// Chain a downstack filter that rebuilds the stack from `base` to the input commit,
     /// dropping intermediate commits whose paths are disjoint from the tip's changes.
     pub fn downstack(self, base: gix_hash::ObjectId) -> Filter {
-        self.chain(to_filter(Op::Downstack(LazyRef::Resolved(base))))
+        self.chain(to_filter(Op::Downstack(base)))
     }
 
     /// Chain a message filter that transforms commit messages
@@ -363,14 +358,14 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
 }
 
 /// Lower squash-with-ids to a deterministic `:rev(...)` filter.
-pub fn squash_to_rev(ids: impl IntoIterator<Item = (LazyRef, Filter)>) -> Op {
-    let mut entries: Vec<(RevMatch, LazyRef, Filter)> = ids
+pub fn squash_to_rev(ids: impl IntoIterator<Item = (gix_hash::ObjectId, Filter)>) -> Op {
+    let mut entries: Vec<(RevMatch, gix_hash::ObjectId, Filter)> = ids
         .into_iter()
         .map(|(r, f)| (RevMatch::Equal, r, f))
         .collect();
     entries.push((
         RevMatch::Default,
-        LazyRef::Resolved(gix_hash::ObjectId::null(gix_hash::Kind::Sha1)),
+        gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
         to_filter(Op::Squash),
     ));
     Op::Rev(entries)

--- a/josh-filter/src/flang/grammar.pest
+++ b/josh-filter/src/flang/grammar.pest
@@ -9,7 +9,7 @@ GROUP_END = _{ "]" }
 PATH = _{ (ALNUM | "/")+ }
 filter_path = { PATH }
 argument = { string | PATH }
-rev = { string | ALNUM+ }
+rev = { object_oid }
 
 sstring = _{"\'" ~ inner ~ "\'"}
 dstring = _{"\"" ~ inner ~ "\""}

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -3,7 +3,7 @@ use crate::filter::Filter;
 use crate::opt;
 use crate::opt::invert;
 use crate::persist::to_filter;
-use crate::{InsertContent, LazyRef, Op, Regex, RevMatch};
+use crate::{InsertContent, Op, Regex, RevMatch};
 
 use anyhow::{Context, anyhow};
 use indoc::{formatdoc, indoc};
@@ -79,7 +79,7 @@ fn make_filter(args: &[&str]) -> anyhow::Result<Filter> {
         ["hook", arg] => Ok(f.hook(arg)),
         ["_", sha] => {
             check_experimental_features_enabled("downstack filter")?;
-            Ok(to_filter(Op::Downstack(LazyRef::parse(sha)?)))
+            Ok(to_filter(Op::Downstack(sha.parse()?)))
         }
         ["_"] => Err(anyhow!(indoc!(
             r#"
@@ -257,9 +257,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
                                 let filter = parse(filter_pair.as_str())?;
                                 entries.push((
                                     RevMatch::Default,
-                                    LazyRef::Resolved(gix_hash::ObjectId::null(
-                                        gix_hash::Kind::Sha1,
-                                    )),
+                                    gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
                                     filter,
                                 ));
                             }
@@ -280,7 +278,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
                                 let filter_pair =
                                     inner.next().context("rev_entry: missing filter")?;
 
-                                let oid = LazyRef::parse(oid_pair.as_str())?;
+                                let oid = oid_pair.as_str().parse()?;
                                 let filter = parse(filter_pair.as_str())?;
 
                                 entries.push((match_op, oid, filter));
@@ -309,7 +307,7 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
             let v: Vec<_> = pair.into_inner().map(|x| x.as_str()).collect();
 
             if v.len() == 2 {
-                let oid = LazyRef::parse(v[0])?;
+                let oid = v[0].parse()?;
                 let filter = parse(v[1])?;
                 Ok(to_filter(Op::Unapply(oid, filter)))
             } else {
@@ -332,12 +330,14 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
         }
         Rule::filter_squash => {
             // BTreeMap deduplicates IDs and makes the expansion deterministic.
-            let ids: std::collections::BTreeMap<LazyRef, Filter> = pair
+            let ids: std::collections::BTreeMap<gix_hash::ObjectId, Filter> = pair
                 .into_inner()
                 .tuples()
-                .map(|(oid, filter)| -> anyhow::Result<(LazyRef, Filter)> {
-                    Ok((LazyRef::parse(oid.as_str())?, parse(filter.as_str())?))
-                })
+                .map(
+                    |(oid, filter)| -> anyhow::Result<(gix_hash::ObjectId, Filter)> {
+                        Ok((oid.as_str().parse()?, parse(filter.as_str())?))
+                    },
+                )
                 .collect::<Result<Vec<_>, _>>()?
                 .into_iter()
                 .collect();
@@ -540,3 +540,13 @@ pub fn get_comments(filter_spec: &str) -> Result<String, String> {
 #[derive(pest_derive::Parser)]
 #[grammar = "flang/grammar.pest"]
 struct Grammar;
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+
+    #[test]
+    fn revision_references_require_object_ids() {
+        assert!(parse(r#":rev(=="/repo.git@refs/heads/main":/)"#).is_err());
+    }
+}

--- a/josh-filter/src/lib.rs
+++ b/josh-filter/src/lib.rs
@@ -8,7 +8,7 @@ pub mod persist;
 pub use filter::{Filter, compose};
 pub use flang::parse;
 pub use flang::{as_file, pretty, spec};
-pub use op::{InsertContent, LazyRef, Op, Regex, RevMatch};
+pub use op::{InsertContent, Op, Regex, RevMatch};
 
 static EXPERIMENTAL_FEATURES: std::sync::LazyLock<bool> =
     std::sync::LazyLock::new(|| std::env::var("JOSH_EXPERIMENTAL_FEATURES").as_deref() == Ok("1"));

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -1,5 +1,4 @@
 use crate::filter::Filter;
-use anyhow::anyhow;
 
 /// Newtype around `regex::Regex` adding structural `PartialEq`/`Eq`/`Hash` (by pattern
 /// string) so `Op` can derive them for use as an interning key. Derefs to the inner regex.
@@ -27,12 +26,6 @@ impl std::hash::Hash for Regex {
     }
 }
 
-#[derive(Hash, Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
-pub enum LazyRef {
-    Resolved(gix_hash::ObjectId),
-    Lazy(String),
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum InsertContent {
     Inline(String),
@@ -54,30 +47,6 @@ pub enum RevMatch {
     Default,
 }
 
-impl std::fmt::Display for LazyRef {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LazyRef::Resolved(id) => write!(f, "{}", id),
-            LazyRef::Lazy(lazy) => write!(f, "\"{}\"", lazy),
-        }
-    }
-}
-
-impl LazyRef {
-    pub fn parse(s: &str) -> anyhow::Result<LazyRef> {
-        let s = s.replace("'", "\"");
-        if let Ok(serde_json::Value::String(s)) = serde_json::from_str(&s) {
-            return Ok(LazyRef::Lazy(s));
-        }
-
-        if let Ok(oid) = s.parse() {
-            Ok(LazyRef::Resolved(oid))
-        } else {
-            Err(anyhow!("invalid ref: {:?}", s))
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Op {
     Meta(std::collections::BTreeMap<String, String>, Filter),
@@ -93,7 +62,7 @@ pub enum Op {
     Committer(String, String),
 
     // Vec instead of BTreeMap to preserve order - first match wins
-    Rev(Vec<(RevMatch, LazyRef, Filter)>),
+    Rev(Vec<(RevMatch, gix_hash::ObjectId, Filter)>),
     Prune,
     RegexReplace(Vec<(Regex, String)>),
 
@@ -118,7 +87,7 @@ pub enum Op {
     Pattern(std::sync::Arc<crate::pattern::CompiledPattern>),
     Message(String, Regex),
 
-    Unapply(LazyRef, Filter),
+    Unapply(gix_hash::ObjectId, Filter),
 
     Compose(Vec<Filter>),
     Chain(Vec<Filter>),
@@ -127,7 +96,7 @@ pub enum Op {
     Select(Filter),
     Pin(Filter),
 
-    Downstack(LazyRef),
+    Downstack(gix_hash::ObjectId),
 }
 
 impl Op {

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::{LazyLock, OnceLock};
 
 use crate::filter::Filter;
-use crate::op::{InsertContent, LazyRef, Op, Regex, RevMatch};
+use crate::op::{InsertContent, Op, Regex, RevMatch};
 
 /// An interned, immutable `Op` together with its lazily-computed content OID.
 /// Nodes are leaked (`&'static`) and live for the process lifetime. A `Filter` is just a
@@ -188,15 +188,15 @@ impl<'a> InMemoryBuilder<'a> {
 
     fn build_rev_params(
         &mut self,
-        params: &[(RevMatch, LazyRef, Filter)],
+        params: &[(RevMatch, gix_hash::ObjectId, Filter)],
     ) -> anyhow::Result<gix_hash::ObjectId> {
         let mut outer_entries = Vec::new();
-        for (i, (match_op, lazy_ref, filter)) in params.iter().enumerate() {
+        for (i, (match_op, oid, filter)) in params.iter().enumerate() {
             // Encode match operator as prefix
             let key = match match_op {
-                RevMatch::AncestorStrict => format!("<{}", lazy_ref),
-                RevMatch::AncestorInclusive => format!("<={}", lazy_ref),
-                RevMatch::Equal => format!("=={}", lazy_ref),
+                RevMatch::AncestorStrict => format!("<{}", oid),
+                RevMatch::AncestorInclusive => format!("<={}", oid),
+                RevMatch::Equal => format!("=={}", oid),
                 RevMatch::Default => {
                     // Default filter uses "_" as key (no SHA)
                     "_".to_string()
@@ -234,12 +234,12 @@ impl<'a> InMemoryBuilder<'a> {
         Ok(self.write_tree(outer_tree))
     }
 
-    fn build_lazyref_filter_params(
+    fn build_oid_filter_params(
         &mut self,
-        lazy_ref: &LazyRef,
+        oid: &gix_hash::ObjectId,
         filter: Filter,
     ) -> anyhow::Result<gix_hash::ObjectId> {
-        let key_blob = self.write_blob(lazy_ref.to_string().as_bytes());
+        let key_blob = self.write_blob(oid.to_string().as_bytes());
         let filter_tree = self.node_oid(filter);
 
         let inner_entries = vec![
@@ -475,8 +475,8 @@ impl<'a> InMemoryBuilder<'a> {
                 let params_tree = self.build_rev_params(filters)?;
                 push_tree_entries(&mut entries, [("rev", params_tree)]);
             }
-            Op::Unapply(lr, f) => {
-                let params_tree = self.build_lazyref_filter_params(lr, *f)?;
+            Op::Unapply(oid, f) => {
+                let params_tree = self.build_oid_filter_params(oid, *f)?;
                 push_tree_entries(&mut entries, [("unapply", params_tree)]);
             }
             Op::RegexReplace(replacements) => {
@@ -487,8 +487,8 @@ impl<'a> InMemoryBuilder<'a> {
                 let params_tree = self.build_str_params(&[hook.as_ref()]);
                 push_tree_entries(&mut entries, [("hook", params_tree)]);
             }
-            Op::Downstack(lazy_ref) => {
-                let params_tree = self.build_str_params(&[lazy_ref.to_string().as_str()]);
+            Op::Downstack(base) => {
+                let params_tree = self.build_str_params(&[base.to_string().as_str()]);
                 push_tree_entries(&mut entries, [("downstack", params_tree)]);
             }
             Op::Meta(meta, filter) => {
@@ -1084,18 +1084,18 @@ fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyh
                 let key = std::str::from_utf8(key_blob.content())?;
 
                 // Parse match operator from key
-                let (match_op, lazy_ref) = if key == "_" {
-                    // Default filter - no SHA needed
+                let (match_op, oid) = if key == "_" {
+                    // Default filter uses a null OID that is ignored during matching.
                     (
                         RevMatch::Default,
-                        LazyRef::Resolved(gix_hash::ObjectId::null(gix_hash::Kind::Sha1)),
+                        gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
                     )
                 } else if let Some(ref_str) = key.strip_prefix("<=") {
-                    (RevMatch::AncestorInclusive, LazyRef::parse(ref_str)?)
+                    (RevMatch::AncestorInclusive, ref_str.parse()?)
                 } else if let Some(ref_str) = key.strip_prefix('<') {
-                    (RevMatch::AncestorStrict, LazyRef::parse(ref_str)?)
+                    (RevMatch::AncestorStrict, ref_str.parse()?)
                 } else if let Some(ref_str) = key.strip_prefix("==") {
-                    (RevMatch::Equal, LazyRef::parse(ref_str)?)
+                    (RevMatch::Equal, ref_str.parse()?)
                 } else {
                     return Err(anyhow!(
                         "rev: invalid key format, must start with '<', '<=', '==', or be '_': {}",
@@ -1104,7 +1104,7 @@ fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyh
                 };
 
                 let filter = from_tree2(src, filter_tree.id())?;
-                filters.push((match_op, lazy_ref, to_filter(filter)));
+                filters.push((match_op, oid, to_filter(filter)));
             }
             Ok(Op::Rev(filters))
         }
@@ -1128,7 +1128,7 @@ fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyh
             )?;
             let key = std::str::from_utf8(key_blob.content())?;
             let filter = from_tree2(src, filter_tree.id())?;
-            Ok(Op::Unapply(LazyRef::parse(&key)?, to_filter(filter)))
+            Ok(Op::Unapply(key.parse()?, to_filter(filter)))
         }
         "squash" => {
             let _ = Blob::read(src, entry.id())?;
@@ -1173,7 +1173,7 @@ fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyh
                     .id(),
             )?;
             let key = std::str::from_utf8(key_blob.content())?;
-            Ok(Op::Downstack(LazyRef::parse(key)?))
+            Ok(Op::Downstack(key.parse()?))
         }
         "meta" => {
             let meta_tree = PersistedTree::read(src, entry.id())?;

--- a/josh-proxy/src/service.rs
+++ b/josh-proxy/src/service.rs
@@ -602,28 +602,6 @@ async fn filter_to_namespace(
             &josh_core::to_ns(&repo)
         )))?;
 
-        // Resolve all refs mentioned in the filter to concrete OIDs,
-        // and apply this information to the filter
-        let filter = {
-            let lazy_refs: Vec<_> = josh_core::filter::lazy_refs(filter)
-                .iter()
-                .map(|x| x.split_once("@").unwrap())
-                .map(|(x, y)| (x.to_string(), y.to_string()))
-                .collect();
-
-            let resolved_refs = lazy_refs
-                .iter()
-                .map(|(rp, rf)| {
-                    (
-                        format!("{}@{}", rp, rf),
-                        resolve_upstream_ref(&transaction, rp, rf).unwrap(),
-                    )
-                })
-                .collect();
-
-            josh_core::filter::resolve_refs(&resolved_refs, filter)
-        };
-
         let head_symref_target = match &head_ref {
             HeadRef::ExplicitHead | HeadRef::Implicit => head_symref_map
                 .read()
@@ -1167,16 +1145,6 @@ async fn upstream_fetch_middleware(
         serv.filter_prefix.chain(filter)
     };
 
-    let mut fetch_repos = vec![upstream_repo.clone()];
-
-    let lazy_refs: Vec<_> = josh_core::filter::lazy_refs(filter)
-        .iter()
-        .map(|x| x.split_once("@").unwrap())
-        .map(|(x, y)| (x.trim_start_matches('/').to_string(), y.to_string()))
-        .collect();
-
-    fetch_repos.extend(lazy_refs.iter().map(|(x, _y)| x.clone()));
-
     let remote_url = format!("{}/{}", upstream, upstream_repo);
 
     let headref = match HeadRef::from_str(&parsed_url.headref) {
@@ -1188,55 +1156,48 @@ async fn upstream_fetch_middleware(
 
     let http_auth_required = serv.require_auth && parsed_url.pathinfo == "/git-receive-pack";
 
-    for fetch_repo in fetch_repos.iter() {
-        let fetch_url = format!("{}/{}", upstream, fetch_repo);
+    match crate::auth::check_http_auth(&remote_url, &auth, http_auth_required, serv.http_retry)
+        .await
+    {
+        Ok(false) => {
+            tracing::trace!("require-auth");
 
-        match crate::auth::check_http_auth(&fetch_url, &auth, http_auth_required, serv.http_retry)
-            .await
-        {
-            Ok(false) => {
-                tracing::trace!("require-auth");
-
-                return Ok((
-                    StatusCode::UNAUTHORIZED,
-                    [(
-                        header::WWW_AUTHENTICATE,
-                        r#"Basic realm="User Visible Realm""#,
-                    )],
-                )
-                    .into_response());
-            }
-            Err(e) => {
-                return Ok((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response());
-            }
-            Ok(true) => {}
+            return Ok((
+                StatusCode::UNAUTHORIZED,
+                [(
+                    header::WWW_AUTHENTICATE,
+                    r#"Basic realm="User Visible Realm""#,
+                )],
+            )
+                .into_response());
         }
+        Err(e) => {
+            return Ok((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response());
+        }
+        Ok(true) => {}
     }
 
-    for fetch_repo in fetch_repos.iter() {
-        let fetch_url = format!("{}/{}", upstream, fetch_repo);
-        match crate::upstream::fetch_upstream(
-            serv.clone(),
-            &fetch_repo,
-            &remote_auth,
-            fetch_url.to_owned(),
-            Some(headref.get()),
-            None,
-            false,
-        )
-        .await
-        {
-            Ok(_) => {}
-            Err(FetchError::AuthRequired) => {
-                return Ok(Response::builder()
-                    .header(header::WWW_AUTHENTICATE, "Basic realm=User Visible Realm")
-                    .status(StatusCode::UNAUTHORIZED)
-                    .body(Body::default())
-                    .expect("Failed to build response"));
-            }
-            Err(FetchError::Other(e)) => {
-                return Ok((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response());
-            }
+    match crate::upstream::fetch_upstream(
+        serv.clone(),
+        &upstream_repo,
+        &remote_auth,
+        remote_url.clone(),
+        Some(headref.get()),
+        None,
+        false,
+    )
+    .await
+    {
+        Ok(_) => {}
+        Err(FetchError::AuthRequired) => {
+            return Ok(Response::builder()
+                .header(header::WWW_AUTHENTICATE, "Basic realm=User Visible Realm")
+                .status(StatusCode::UNAUTHORIZED)
+                .body(Body::default())
+                .expect("Failed to build response"));
+        }
+        Err(FetchError::Other(e)) => {
+            return Ok((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response());
         }
     }
 

--- a/rfcs/views.md
+++ b/rfcs/views.md
@@ -123,8 +123,7 @@ A view *denotes* a filter; it is not an op in the filter language. Two structura
 1. **Referential transparency.** A filter is a pure function of its input — `:/sub` means the
    same thing forever, which is what makes interning, caching, and the optimizer sound. A view
    resolves against a mutable ref. Making view lookup a first-class op would put external mutable
-   state inside the algebra. (`LazyRef` in `:squash` flirts with this, but those are resolved once
-   at invocation and frozen.)
+   state inside the algebra.
 2. **Policy placement.** A view carries evaluation pragmas — `:~(...)` history flags, migration
    points — that only make sense governing a whole filtering run. An op can appear nested anywhere
    in a composition; "what does `history=linear` mean three levels deep inside a compose" is a


### PR DESCRIPTION
Remove lazy filter references

Require concrete object IDs throughout the filter algebra and remove proxy-side cross-repository reference resolution.

Change: remove-lazy-filter-references

Assisted-By: openai-codex/gpt-5.6-sol