### PR TITLE
Store revision tips in RevMatch

### DIFF
--- a/josh-core/benches/deephistory_subdir.rs
+++ b/josh-core/benches/deephistory_subdir.rs
@@ -304,8 +304,7 @@ fn deephistory_rev(c: &mut Criterion) {
     {
         let case = bench.cases.first().expect("at least one case");
         let rev_filter = Filter::new().rev(vec![(
-            RevMatch::AncestorInclusive,
-            case.head,
+            RevMatch::AncestorInclusive(case.head),
             Filter::new().subdir(SUBDIR),
         )]);
         let transaction = bench.context.open().expect("open transaction");
@@ -332,8 +331,7 @@ fn deephistory_rev(c: &mut Criterion) {
     group.sample_size(10);
     for case in &bench.cases {
         let rev_filter = Filter::new().rev(vec![(
-            RevMatch::AncestorInclusive,
-            case.head,
+            RevMatch::AncestorInclusive(case.head),
             Filter::new().subdir(SUBDIR),
         )]);
         group.throughput(Throughput::Elements(case.n_commits as u64));

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -400,34 +400,30 @@ fn get_filter(
 fn get_rev_filter(
     transaction: &cache::Transaction,
     commit_id: gix_hash::ObjectId,
-    filters: &[(RevMatch, gix_hash::ObjectId, Filter)],
+    filters: &[(RevMatch, Filter)],
 ) -> anyhow::Result<Filter> {
     // First match wins - iterate in order
-    for (match_op, filter_tip, startfilter) in filters.iter() {
-        let filter_tip = filter_tip.to_owned();
-        if match_op != &RevMatch::Default && !transaction.odb().contains(filter_tip) {
+    for (match_op, startfilter) in filters {
+        let filter_tip = match *match_op {
+            RevMatch::AncestorStrict(oid)
+            | RevMatch::AncestorInclusive(oid)
+            | RevMatch::Equal(oid) => Some(oid),
+            RevMatch::Default => None,
+        };
+        if let Some(filter_tip) = filter_tip
+            && !transaction.odb().contains(filter_tip)
+        {
             return Err(anyhow!("`:rev(...)` with nonexistent OID: {}", filter_tip));
         }
-        let matches = match match_op {
-            RevMatch::AncestorStrict => {
-                // `<` - matches if commit is ancestor of tip AND commit != tip (strict)
-
+        let matches = match *match_op {
+            RevMatch::AncestorStrict(filter_tip) => {
                 is_ancestor_of(transaction, commit_id, filter_tip)? && commit_id != filter_tip
             }
-            RevMatch::AncestorInclusive => {
-                // `<=` - matches if commit is ancestor of tip OR commit == tip (inclusive)
-
+            RevMatch::AncestorInclusive(filter_tip) => {
                 is_ancestor_of(transaction, commit_id, filter_tip)?
             }
-            RevMatch::Equal => {
-                // `==` - matches if commit == tip
-
-                commit_id == filter_tip
-            }
-            RevMatch::Default => {
-                // `_` - always matches (makes filters after it unreachable)
-                true
-            }
+            RevMatch::Equal(filter_tip) => commit_id == filter_tip,
+            RevMatch::Default => true,
         };
 
         if matches {

--- a/josh-core/src/filter/object_deref.rs
+++ b/josh-core/src/filter/object_deref.rs
@@ -19,9 +19,7 @@ fn legalize_object_derefs(filter: Filter) -> Filter {
         Op::Rev(filters) => Op::Rev(
             filters
                 .into_iter()
-                .map(|(match_op, target, filter)| {
-                    (match_op, target, legalize_object_derefs(filter))
-                })
+                .map(|(match_op, filter)| (match_op, legalize_object_derefs(filter)))
                 .collect(),
         ),
         Op::Meta(meta, filter) => Op::Meta(meta, legalize_object_derefs(filter)),

--- a/josh-filter/src/filter.rs
+++ b/josh-filter/src/filter.rs
@@ -86,10 +86,10 @@ impl Filter {
         self.chain(to_filter(Op::Pin(other)))
     }
 
-    /// Chain a `:rev(...)` filter. Each `(match, tip, then)` arm applies `then` to a commit whose
-    /// relationship to `tip` satisfies `match` (e.g. `AncestorInclusive` is `<=tip`); the first
-    /// matching arm wins and a commit matching none passes through unchanged.
-    pub fn rev(self, arms: Vec<(RevMatch, gix_hash::ObjectId, Filter)>) -> Filter {
+    /// Chain a `:rev(...)` filter. Each `(match, then)` arm applies `then` to a commit
+    /// satisfying `match`; the first matching arm wins and a commit matching none passes
+    /// through unchanged.
+    pub fn rev(self, arms: Vec<(RevMatch, Filter)>) -> Filter {
         self.chain(to_filter(Op::Rev(arms)))
     }
 
@@ -359,15 +359,11 @@ pub fn invert(filter: Filter) -> anyhow::Result<Filter> {
 
 /// Lower squash-with-ids to a deterministic `:rev(...)` filter.
 pub fn squash_to_rev(ids: impl IntoIterator<Item = (gix_hash::ObjectId, Filter)>) -> Op {
-    let mut entries: Vec<(RevMatch, gix_hash::ObjectId, Filter)> = ids
+    let mut entries: Vec<(RevMatch, Filter)> = ids
         .into_iter()
-        .map(|(r, f)| (RevMatch::Equal, r, f))
+        .map(|(oid, filter)| (RevMatch::Equal(oid), filter))
         .collect();
-    entries.push((
-        RevMatch::Default,
-        gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
-        to_filter(Op::Squash),
-    ));
+    entries.push((RevMatch::Default, to_filter(Op::Squash)));
     Op::Rev(entries)
 }
 

--- a/josh-filter/src/flang/mod.rs
+++ b/josh-filter/src/flang/mod.rs
@@ -176,14 +176,14 @@ pub(crate) fn spec2(op: &Op) -> String {
             // No sorting - preserve order for first-match semantics
             let v = filters
                 .iter()
-                .map(|(match_op, k, v)| {
+                .map(|(match_op, filter)| {
                     let match_str = match match_op {
-                        RevMatch::AncestorStrict => format!("<{}", k),
-                        RevMatch::AncestorInclusive => format!("<={}", k),
-                        RevMatch::Equal => format!("=={}", k),
+                        RevMatch::AncestorStrict(oid) => format!("<{}", oid),
+                        RevMatch::AncestorInclusive(oid) => format!("<={}", oid),
+                        RevMatch::Equal(oid) => format!("=={}", oid),
                         RevMatch::Default => "_".to_string(),
                     };
-                    format!("{}{}", match_str, spec(*v))
+                    format!("{}{}", match_str, spec(*filter))
                 })
                 .collect::<Vec<_>>();
             format!(":rev({})", v.join(","))

--- a/josh-filter/src/flang/parse.rs
+++ b/josh-filter/src/flang/parse.rs
@@ -255,18 +255,19 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
                                     .next()
                                     .context("rev_default: missing filter")?;
                                 let filter = parse(filter_pair.as_str())?;
-                                entries.push((
-                                    RevMatch::Default,
-                                    gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
-                                    filter,
-                                ));
+                                entries.push((RevMatch::Default, filter));
                             }
                             Rule::rev_match => {
                                 // Regular match with operator, SHA, and filter
+                                let oid_pair = inner.next().context("rev_entry: missing rev")?;
+                                let filter_pair =
+                                    inner.next().context("rev_entry: missing filter")?;
+                                let oid = oid_pair.as_str().parse()?;
+                                let filter = parse(filter_pair.as_str())?;
                                 let match_op = match first.as_str() {
-                                    "<" => RevMatch::AncestorStrict,
-                                    "<=" => RevMatch::AncestorInclusive,
-                                    "==" => RevMatch::Equal,
+                                    "<" => RevMatch::AncestorStrict(oid),
+                                    "<=" => RevMatch::AncestorInclusive(oid),
+                                    "==" => RevMatch::Equal(oid),
                                     _ => {
                                         return Err(anyhow!(
                                             "invalid rev match operator: {:?}",
@@ -274,14 +275,8 @@ fn parse_item(pair: pest::iterators::Pair<Rule>) -> anyhow::Result<Filter> {
                                         ));
                                     }
                                 };
-                                let oid_pair = inner.next().context("rev_entry: missing rev")?;
-                                let filter_pair =
-                                    inner.next().context("rev_entry: missing filter")?;
 
-                                let oid = oid_pair.as_str().parse()?;
-                                let filter = parse(filter_pair.as_str())?;
-
-                                entries.push((match_op, oid, filter));
+                                entries.push((match_op, filter));
                             }
                             _ => {
                                 return Err(anyhow!(

--- a/josh-filter/src/op.rs
+++ b/josh-filter/src/op.rs
@@ -37,13 +37,13 @@ pub enum InsertContent {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum RevMatch {
-    /// `<` - matches if is_ancestor_of(commit, tip) && commit != tip (strict)
-    AncestorStrict,
-    /// `<=` - matches if is_ancestor_of(commit, tip) || commit == tip (inclusive)
-    AncestorInclusive,
-    /// `==` - matches if commit == tip
-    Equal,
-    /// `_` - default filter when no other matches (no SHA needed)
+    /// `<` - matches strict ancestors of the tip.
+    AncestorStrict(gix_hash::ObjectId),
+    /// `<=` - matches the tip and its ancestors.
+    AncestorInclusive(gix_hash::ObjectId),
+    /// `==` - matches only the tip.
+    Equal(gix_hash::ObjectId),
+    /// `_` - matches when no previous arm did.
     Default,
 }
 
@@ -62,7 +62,7 @@ pub enum Op {
     Committer(String, String),
 
     // Vec instead of BTreeMap to preserve order - first match wins
-    Rev(Vec<(RevMatch, gix_hash::ObjectId, Filter)>),
+    Rev(Vec<(RevMatch, Filter)>),
     Prune,
     RegexReplace(Vec<(Regex, String)>),
 

--- a/josh-filter/src/opt/step.rs
+++ b/josh-filter/src/opt/step.rs
@@ -97,12 +97,7 @@ pub(super) fn step(filter: Filter) -> Filter {
                 Op::File(dest_path.clone(), source_path.clone())
             }
         }
-        Op::Rev(filters) => Op::Rev(
-            filters
-                .iter()
-                .map(|(m, i, f)| (*m, i.clone(), step(*f)))
-                .collect(),
-        ),
+        Op::Rev(filters) => Op::Rev(filters.iter().map(|(m, f)| (*m, step(*f))).collect()),
         Op::Compose(filters) if filters.is_empty() => Op::Empty,
         Op::Compose(filters) if filters.len() == 1 => to_op(filters[0]),
         Op::Compose(filters) => {

--- a/josh-filter/src/persist.rs
+++ b/josh-filter/src/persist.rs
@@ -63,7 +63,7 @@ fn child_filters(op: &Op) -> Vec<Filter> {
         | Op::Unapply(_, f) => vec![*f],
         Op::Subtract(a, b) => vec![*a, *b],
         Op::Compose(v) | Op::Chain(v) => v.clone(),
-        Op::Rev(v) => v.iter().map(|(_, _, f)| *f).collect(),
+        Op::Rev(v) => v.iter().map(|(_, f)| *f).collect(),
         _ => vec![],
     }
 }
@@ -188,15 +188,15 @@ impl<'a> InMemoryBuilder<'a> {
 
     fn build_rev_params(
         &mut self,
-        params: &[(RevMatch, gix_hash::ObjectId, Filter)],
+        params: &[(RevMatch, Filter)],
     ) -> anyhow::Result<gix_hash::ObjectId> {
         let mut outer_entries = Vec::new();
-        for (i, (match_op, oid, filter)) in params.iter().enumerate() {
+        for (i, (match_op, filter)) in params.iter().enumerate() {
             // Encode match operator as prefix
             let key = match match_op {
-                RevMatch::AncestorStrict => format!("<{}", oid),
-                RevMatch::AncestorInclusive => format!("<={}", oid),
-                RevMatch::Equal => format!("=={}", oid),
+                RevMatch::AncestorStrict(oid) => format!("<{}", oid),
+                RevMatch::AncestorInclusive(oid) => format!("<={}", oid),
+                RevMatch::Equal(oid) => format!("=={}", oid),
                 RevMatch::Default => {
                     // Default filter uses "_" as key (no SHA)
                     "_".to_string()
@@ -1084,18 +1084,14 @@ fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyh
                 let key = std::str::from_utf8(key_blob.content())?;
 
                 // Parse match operator from key
-                let (match_op, oid) = if key == "_" {
-                    // Default filter uses a null OID that is ignored during matching.
-                    (
-                        RevMatch::Default,
-                        gix_hash::ObjectId::null(gix_hash::Kind::Sha1),
-                    )
+                let match_op = if key == "_" {
+                    RevMatch::Default
                 } else if let Some(ref_str) = key.strip_prefix("<=") {
-                    (RevMatch::AncestorInclusive, ref_str.parse()?)
+                    RevMatch::AncestorInclusive(ref_str.parse()?)
                 } else if let Some(ref_str) = key.strip_prefix('<') {
-                    (RevMatch::AncestorStrict, ref_str.parse()?)
+                    RevMatch::AncestorStrict(ref_str.parse()?)
                 } else if let Some(ref_str) = key.strip_prefix("==") {
-                    (RevMatch::Equal, ref_str.parse()?)
+                    RevMatch::Equal(ref_str.parse()?)
                 } else {
                     return Err(anyhow!(
                         "rev: invalid key format, must start with '<', '<=', '==', or be '_': {}",
@@ -1104,7 +1100,7 @@ fn from_tree2(src: &impl gix_object::Find, tree_oid: gix_hash::ObjectId) -> anyh
                 };
 
                 let filter = from_tree2(src, filter_tree.id())?;
-                filters.push((match_op, oid, to_filter(filter)));
+                filters.push((match_op, to_filter(filter)));
             }
             Ok(Op::Rev(filters))
         }


### PR DESCRIPTION
Store revision tips in RevMatch

Make each revision predicate self-contained and remove the meaningless object ID paired with the default arm.

Change: self-contained-revision-matches

Assisted-By: openai-codex/gpt-5.6-sol