### PR TITLE
Split josh-compose build-graph loading from execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,6 +3369,7 @@ dependencies = [
  "gix",
  "gix-hash",
  "josh-compose-backend",
+ "josh-compose-graph",
  "josh-core",
  "josh-filter",
  "tar",
@@ -3380,6 +3381,19 @@ name = "josh-compose-backend"
 version = "26.8.28"
 dependencies = [
  "anyhow",
+ "josh-compose-graph",
+ "josh-core",
+]
+
+[[package]]
+name = "josh-compose-graph"
+version = "26.8.28"
+dependencies = [
+ "anyhow",
+ "gix",
+ "gix-hash",
+ "josh-core",
+ "tempfile",
 ]
 
 [[package]]
@@ -3390,6 +3404,7 @@ dependencies = [
  "backon",
  "hex",
  "josh-compose-backend",
+ "josh-compose-graph",
  "libc",
  "log",
  "rand 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "josh-changes",
     "josh-compose",
     "josh-compose-backend",
+    "josh-compose-graph",
     "josh-compose-podman",
 
     "forges/josh-github-changes",
@@ -112,6 +113,7 @@ josh-core = { path = "josh-core", version = "26.8.28" }
 josh-memodb = { path = "josh-memodb", version = "26.8.28" }
 josh-compose = { path = "josh-compose", version = "26.8.28" }
 josh-compose-backend = { path = "josh-compose-backend", version = "26.8.28" }
+josh-compose-graph = { path = "josh-compose-graph", version = "26.8.28" }
 josh-compose-podman = { path = "josh-compose-podman", version = "26.8.28" }
 josh-graphql = { path = "josh-graphql", version = "26.8.28" }
 josh-link = { path = "josh-link", version = "26.8.28" }
@@ -209,6 +211,7 @@ josh-core = { path = "josh-core" }
 josh-memodb = { path = "josh-memodb" }
 josh-compose = { path = "josh-compose" }
 josh-compose-backend = { path = "josh-compose-backend" }
+josh-compose-graph = { path = "josh-compose-graph" }
 josh-compose-podman = { path = "josh-compose-podman" }
 josh-graphql = { path = "josh-graphql" }
 josh-link = { path = "josh-link" }

--- a/josh-compose-backend/Cargo.toml
+++ b/josh-compose-backend/Cargo.toml
@@ -11,3 +11,5 @@ version = "26.8.28"
 
 [dependencies]
 anyhow.workspace = true
+josh-compose-graph.workspace = true
+josh-core.workspace = true

--- a/josh-compose-backend/src/lib.rs
+++ b/josh-compose-backend/src/lib.rs
@@ -1,23 +1,18 @@
 //! Execution backend contracts for `josh-compose`.
 //!
-//! The scheduler needs three capabilities from a backend: prepared environments, named
-//! tar-addressable artifacts, and execution of steps and their sidecar workers. These traits
-//! describe those capabilities without coupling orchestration to a specific backend.
+//! Two families of contracts live here:
+//!
+//! - Backend capabilities: prepared environments, named tar-addressable artifacts,
+//!   and execution of steps and their sidecar workers ([`EnvironmentBackend`],
+//!   [`ArtifactBackend`], [`ExecutionBackend`], aggregated as [`Runtime`]). These
+//!   describe capabilities without coupling orchestration to a specific backend.
+//! - The [`Executor`] strategy contract: how a loaded build graph
+//!   ([`josh_compose_graph::Graph`]) is scheduled against a [`Runtime`].
 //!
 //! Backend-specific details the scheduler does not care about, such as networks, published ports,
 //! container addresses, detached processes, and UID fix-ups, remain private to each implementation.
 
-/// Network reachability the step itself requests (independent of sidecars).
-///
-/// When a step has sidecar workers, the backend connects the step to them regardless of this
-/// policy.
-#[derive(Debug, Clone, PartialEq)]
-pub enum NetworkPolicy {
-    /// No network access.
-    None,
-    /// Full host network access.
-    Host,
-}
+use josh_compose_graph::{Graph, NetworkPolicy};
 
 /// Recipe for preparing an environment: a tar build context plus build arguments.
 #[derive(Debug, Clone)]
@@ -92,7 +87,10 @@ pub struct SidecarHandle {
 }
 
 /// Prepared environment management for `josh-compose`.
-pub trait EnvironmentBackend {
+///
+/// Backends must be `Send + Sync`: parallel executors drive a shared runtime
+/// from multiple threads.
+pub trait EnvironmentBackend: Send + Sync {
     /// Whether the environment for `key` is already prepared.
     fn env_exists(&self, key: &str) -> anyhow::Result<bool>;
     /// Prepare the environment for `key` from `recipe` (build it). Idempotent
@@ -105,7 +103,9 @@ pub trait EnvironmentBackend {
 }
 
 /// Named, tar-addressable artifact management for `josh-compose`.
-pub trait ArtifactBackend {
+///
+/// `Send + Sync` for the same reason as [`EnvironmentBackend`].
+pub trait ArtifactBackend: Send + Sync {
     fn artifact_exists(&self, name: &str) -> anyhow::Result<bool>;
     fn create_artifact(&self, name: &str) -> anyhow::Result<()>;
     /// Seed artifact `name` with the contents of `tar`.
@@ -153,7 +153,9 @@ pub trait ArtifactBackend {
 }
 
 /// Step and sidecar execution for `josh-compose`.
-pub trait ExecutionBackend {
+///
+/// `Send + Sync` for the same reason as [`EnvironmentBackend`].
+pub trait ExecutionBackend: Send + Sync {
     /// Run a step, streaming stdout/stderr to the terminal while capturing them.
     fn run(&self, args: RunArgs) -> anyhow::Result<RunOutput>;
     /// Start a sidecar worker and block until it is reachable; return its handle.
@@ -169,3 +171,26 @@ pub trait ExecutionBackend {
 pub trait Runtime: EnvironmentBackend + ArtifactBackend + ExecutionBackend {}
 
 impl<T> Runtime for T where T: EnvironmentBackend + ArtifactBackend + ExecutionBackend {}
+
+/// Options shared by executors.
+pub struct ExecOpts {
+    /// Extract `OutputMode::Workdir` artifacts into the host working directory.
+    pub extract_to_workdir: bool,
+}
+
+/// An execution strategy for a loaded build [`Graph`].
+///
+/// Graph loading ([`josh_compose_graph::load_graph`]) is separate from execution: an
+/// executor receives the fully-resolved graph and owns scheduling decisions — cache
+/// checks, sidecar lifecycle, artifact handling — for each job it runs.
+/// `transaction` provides git access for lazy materialization of byte payloads
+/// (build contexts, worktree tars).
+pub trait Executor {
+    fn execute(
+        &self,
+        transaction: &josh_core::cache::Transaction,
+        graph: &Graph,
+        runtime: &dyn Runtime,
+        opts: &ExecOpts,
+    ) -> anyhow::Result<()>;
+}

--- a/josh-compose-graph/Cargo.toml
+++ b/josh-compose-graph/Cargo.toml
@@ -1,24 +1,18 @@
 [package]
 authors = ["Josh Project authors <contact@josh-project.dev>"]
-description = "Josh container workspace runner"
+description = "Build-graph data structures and loading for josh-compose"
 edition = "2024"
 keywords = ["git", "monorepo", "workflow", "scm"]
 license-file = "../LICENSE"
-name = "josh-compose"
+name = "josh-compose-graph"
 readme = "../README.md"
 repository = "https://github.com/josh-project/josh"
 version = "26.8.28"
 
 [dependencies]
 anyhow.workspace = true
-defer.workspace = true
 gix-hash.workspace = true
 josh-core.workspace = true
-josh-filter.workspace = true
-josh-compose-backend.workspace = true
-josh-compose-graph.workspace = true
-
-tar = "0.4"
 
 [dev-dependencies]
 gix.workspace = true

--- a/josh-compose-graph/src/graph.rs
+++ b/josh-compose-graph/src/graph.rs
@@ -1,0 +1,209 @@
+//! Build-graph loading: resolve the full workspace and image dependency closure
+//! from git trees into an in-memory [`Graph`], before any execution starts.
+//!
+//! Every edge in the graph is a gitlink — a commit-mode tree entry holding the
+//! target OID (`inputs/<name>` for workspace dependencies, `bases/<name>` for
+//! image bases) — so the closure is static and fully determined by the root
+//! workspace tree. Executors consume the loaded graph and never walk git trees
+//! themselves; only heavy byte payloads (build-context and worktree tars) stay
+//! lazy, addressed by tree OID.
+
+use std::collections::HashMap;
+
+use josh_core::cache;
+use josh_core::filter::tree;
+use josh_core::memodb;
+
+use crate::meta::{self, WorkspaceMeta};
+
+/// A fully-resolved build graph: every workspace a run would touch and every
+/// image it would build.
+pub struct Graph {
+    /// Workspaces in dependency order (a workspace always appears after its
+    /// inputs), deduplicated. The last job is the run's root.
+    jobs: Vec<Job>,
+    /// Images in bases-first order (a base image always appears before any
+    /// image that uses it), deduplicated.
+    images: Vec<ImageNode>,
+    job_index: HashMap<gix_hash::ObjectId, usize>,
+    image_index: HashMap<gix_hash::ObjectId, usize>,
+}
+
+/// One workspace step in the build graph.
+pub struct Job {
+    /// Workspace tree OID; also the job's cache key.
+    pub ws_tree: gix_hash::ObjectId,
+    pub meta: WorkspaceMeta,
+    /// Dependencies as (input name, dependency workspace tree OID), in the
+    /// order they are declared in the workspace tree.
+    pub inputs: Vec<(String, gix_hash::ObjectId)>,
+    /// Environment variables from the workspace tree's `env/` subtree.
+    pub env: Vec<(String, String)>,
+}
+
+/// One image build in the graph. The build context is kept as a tree OID and
+/// materialized to a tar lazily by the executor.
+pub struct ImageNode {
+    pub oid: gix_hash::ObjectId,
+    /// Base images as (build-arg name, base image tree OID).
+    pub bases: Vec<(String, gix_hash::ObjectId)>,
+    /// Additional build args from the image tree's `args/` subtree.
+    pub args: Vec<(String, String)>,
+    /// OID of the `context` subtree; `None` if the image tree has none. The
+    /// executor errors only when the image actually needs building.
+    pub context: Option<gix_hash::ObjectId>,
+}
+
+impl Graph {
+    pub fn jobs(&self) -> &[Job] {
+        &self.jobs
+    }
+
+    pub fn images(&self) -> &[ImageNode] {
+        &self.images
+    }
+
+    pub fn job(&self, ws_tree: gix_hash::ObjectId) -> Option<&Job> {
+        self.job_index.get(&ws_tree).map(|&i| &self.jobs[i])
+    }
+
+    pub fn image(&self, oid: gix_hash::ObjectId) -> Option<&ImageNode> {
+        self.image_index.get(&oid).map(|&i| &self.images[i])
+    }
+
+    /// The workspace the run was invoked on: the last job in dependency order.
+    pub fn root(&self) -> &Job {
+        self.jobs
+            .last()
+            .expect("graph contains at least the root job")
+    }
+}
+
+/// Load the build graph reachable from the workspace tree `ws_tree`.
+///
+/// The whole closure is validated here: malformed references (a non-gitlink
+/// entry where an object reference is expected) and dependency cycles are
+/// load-time errors, even for workspaces whose run would later be
+/// short-circuited by the output cache.
+pub fn load_graph(
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
+    ws_tree: gix_hash::ObjectId,
+) -> anyhow::Result<Graph> {
+    let mut graph = Graph {
+        jobs: vec![],
+        images: vec![],
+        job_index: HashMap::new(),
+        image_index: HashMap::new(),
+    };
+    let mut job_stack: Vec<gix_hash::ObjectId> = vec![];
+    let mut image_stack: Vec<gix_hash::ObjectId> = vec![];
+    load_job(
+        transaction,
+        odb,
+        ws_tree,
+        &mut graph,
+        &mut job_stack,
+        &mut image_stack,
+    )?;
+    Ok(graph)
+}
+
+fn push_job(graph: &mut Graph, job: Job) {
+    graph.job_index.insert(job.ws_tree, graph.jobs.len());
+    graph.jobs.push(job);
+}
+
+fn push_image(graph: &mut Graph, image: ImageNode) {
+    graph.image_index.insert(image.oid, graph.images.len());
+    graph.images.push(image);
+}
+
+fn load_job(
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
+    ws_tree: gix_hash::ObjectId,
+    graph: &mut Graph,
+    job_stack: &mut Vec<gix_hash::ObjectId>,
+    image_stack: &mut Vec<gix_hash::ObjectId>,
+) -> anyhow::Result<()> {
+    if graph.job_index.contains_key(&ws_tree) {
+        return Ok(());
+    }
+    if job_stack.contains(&ws_tree) {
+        anyhow::bail!("dependency cycle detected involving workspace {ws_tree}");
+    }
+    job_stack.push(ws_tree);
+
+    let meta = meta::read_meta(transaction, odb, ws_tree)?;
+    let mut inputs = vec![];
+    for (dep_name, dep_tree) in meta::read_gitlink_entries(transaction, odb, ws_tree, "inputs")? {
+        load_job(transaction, odb, dep_tree, graph, job_stack, image_stack)?;
+        inputs.push((dep_name, dep_tree));
+    }
+    job_stack.pop();
+
+    if let Some(image_oid) = meta.image {
+        load_image(transaction, odb, image_oid, graph, image_stack)?;
+    }
+    for spec in &meta.sidecars {
+        load_image(transaction, odb, spec.image, graph, image_stack)?;
+    }
+
+    let env = meta::read_blob_entries(transaction, odb, ws_tree, "env");
+
+    push_job(
+        graph,
+        Job {
+            ws_tree,
+            meta,
+            inputs,
+            env,
+        },
+    );
+    Ok(())
+}
+
+/// Record an image and all its transitive base images, bases-first.
+///
+/// The recursive call for each base happens *before* the current image is
+/// pushed (post-order traversal), so a base image always appears before any
+/// image that uses it as a base — the order images must be pulled/built in.
+fn load_image(
+    transaction: &cache::Transaction,
+    odb: &memodb::Odb,
+    image_oid: gix_hash::ObjectId,
+    graph: &mut Graph,
+    image_stack: &mut Vec<gix_hash::ObjectId>,
+) -> anyhow::Result<()> {
+    if graph.image_index.contains_key(&image_oid) {
+        return Ok(());
+    }
+    if image_stack.contains(&image_oid) {
+        anyhow::bail!("base image cycle detected involving image {image_oid}");
+    }
+    image_stack.push(image_oid);
+
+    let mut bases = vec![];
+    for (base_name, base_oid) in meta::read_gitlink_entries(transaction, odb, image_oid, "bases")? {
+        load_image(transaction, odb, base_oid, graph, image_stack)?;
+        bases.push((base_name, base_oid));
+    }
+    image_stack.pop();
+
+    let args = meta::read_blob_entries(transaction, odb, image_oid, "args");
+    let context = tree::read_tree(transaction, odb, image_oid)?
+        .entry(b"context")
+        .map(|e| e.oid.to_owned());
+
+    push_image(
+        graph,
+        ImageNode {
+            oid: image_oid,
+            bases,
+            args,
+            context,
+        },
+    );
+    Ok(())
+}

--- a/josh-compose-graph/src/lib.rs
+++ b/josh-compose-graph/src/lib.rs
@@ -1,0 +1,37 @@
+//! Build-graph data structures and loading for `josh-compose`.
+//!
+//! [`load_graph`] resolves the full workspace and image dependency closure from
+//! git trees into an in-memory [`Graph`], before any execution starts. Executors
+//! (see the `Executor` trait in `josh-compose-backend`) consume the loaded graph
+//! and never walk git trees themselves; only heavy byte payloads (build-context
+//! and worktree tars) stay lazy, addressed by tree OID.
+
+mod graph;
+mod meta;
+
+pub use graph::{Graph, ImageNode, Job, load_graph};
+pub use meta::{SidecarSpec, WorkspaceMeta};
+
+/// Whether a job produces an output artifact and whether it is extracted.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OutputMode {
+    /// No output artifact is created; only success/failure is recorded.
+    None,
+    /// Output artifact is created and its contents are extracted to the host working directory.
+    Workdir,
+    /// Output artifact is created and kept (e.g. for use as a dependency input), but not
+    /// extracted.
+    Keep,
+}
+
+/// Network reachability a step requests (independent of sidecars).
+///
+/// When a step has sidecar workers, the backend connects the step to them
+/// regardless of this policy.
+#[derive(Debug, Clone, PartialEq)]
+pub enum NetworkPolicy {
+    /// No network access.
+    None,
+    /// Full host network access.
+    Host,
+}

--- a/josh-compose-graph/src/meta.rs
+++ b/josh-compose-graph/src/meta.rs
@@ -3,8 +3,7 @@
 
 use std::path::Path;
 
-use crate::OutputMode;
-use josh_compose_backend::NetworkPolicy;
+use crate::{NetworkPolicy, OutputMode};
 use josh_core::cache;
 use josh_core::filter::tree;
 use josh_core::memodb;

--- a/josh-compose-podman/Cargo.toml
+++ b/josh-compose-podman/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 backon.workspace = true
 hex.workspace = true
 josh-compose-backend.workspace = true
+josh-compose-graph.workspace = true
 libc.workspace = true
 log.workspace = true
 rand.workspace = true

--- a/josh-compose-podman/src/run.rs
+++ b/josh-compose-podman/src/run.rs
@@ -3,8 +3,9 @@ use std::process::{Command, Stdio};
 
 use super::{PodmanRuntime, SIDECAR_NETWORK, align_artifact, host_identity, sidecars};
 use josh_compose_backend::{
-    ExecutionBackend, Mount, NetworkPolicy, RunArgs, RunOutput, SidecarArgs, SidecarHandle,
+    ExecutionBackend, Mount, RunArgs, RunOutput, SidecarArgs, SidecarHandle,
 };
+use josh_compose_graph::NetworkPolicy;
 
 fn run(args: RunArgs) -> anyhow::Result<RunOutput> {
     // Defensively fix ownership of read-only mounts — pre-existing artifacts such

--- a/josh-compose/src/executor.rs
+++ b/josh-compose/src/executor.rs
@@ -1,18 +1,53 @@
-use std::collections::HashSet;
+//! The sequential executor: runs a loaded build [`Graph`] against a runtime
+//! backend one job at a time, in dependency order. The [`Executor`] strategy
+//! contract itself lives in `josh-compose-backend`.
+
+use std::collections::HashMap;
 use std::path::Path;
 
+use josh_compose_backend::{
+    ExecOpts, Executor, Mount, RunArgs, Runtime, SidecarArgs, SidecarHandle,
+};
+use josh_compose_graph::{Graph, Job, OutputMode, SidecarSpec};
 use josh_core::cache;
 use josh_core::memodb;
 
-use josh_compose_backend::{Mount, RunArgs, Runtime, SidecarArgs, SidecarHandle};
-
-use crate::OutputMode;
 use crate::image;
 use crate::job_cache;
-use crate::meta::{self, SidecarSpec};
 use crate::naming;
 
 const SIDECAR_IP_PLACEHOLDER: &str = "{SIDECAR_IP}";
+
+/// Depth-first, one-job-at-a-time executor — the default strategy.
+///
+/// Jobs run in the graph's dependency order. A job whose dependencies failed is
+/// skipped, but independent branches still run; the run fails if the root job
+/// (or any job it transitively depends on) failed.
+pub struct SequentialExecutor;
+
+impl Executor for SequentialExecutor {
+    fn execute(
+        &self,
+        transaction: &cache::Transaction,
+        graph: &Graph,
+        runtime: &dyn Runtime,
+        opts: &ExecOpts,
+    ) -> anyhow::Result<()> {
+        let odb = transaction.odb();
+        let mut failed: HashMap<gix_hash::ObjectId, String> = HashMap::new();
+        for job in graph.jobs() {
+            if let Err(e) = run_job(transaction, odb, graph, job, &failed, runtime, opts) {
+                failed.insert(job.ws_tree, e.to_string());
+            }
+        }
+
+        let root = graph.root();
+        if let Some(e) = failed.get(&root.ws_tree) {
+            anyhow::bail!("{e}");
+        }
+        Ok(())
+    }
+}
 
 /// Resolve passthrough env names by looking each up in the outer process environment.
 /// Errors listing every missing variable when any are absent or empty, so that the
@@ -47,10 +82,11 @@ fn resolve_passthrough(
 fn start_sidecar(
     transaction: &cache::Transaction,
     odb: &memodb::Odb,
+    graph: &Graph,
     spec: &SidecarSpec,
     runtime: &dyn Runtime,
 ) -> anyhow::Result<SidecarHandle> {
-    let env_key = image::ensure_image(transaction, odb, spec.image, runtime)?;
+    let env_key = image::ensure_image(transaction, odb, graph, spec.image, runtime)?;
 
     let passthrough_env = resolve_passthrough(&spec.name, &spec.passthrough)?;
 
@@ -65,70 +101,56 @@ fn start_sidecar(
     })
 }
 
-/// Run a workspace identified by `ws_tree`, recursively running all dependencies
-/// depth-first. Failures in sibling dependencies are collected so all are attempted
-/// before bailing.
+/// Run a single job whose dependencies have already been attempted. Failures in
+/// sibling dependencies are collected so all are reported before the job bails.
 ///
-/// Sidecars declared in the workspace metadata are started before the main step and
-/// torn down when this function returns (including on error paths), via [`defer::defer`].
-/// A scratch artifact seeded from the worktree is created and cleaned up the same way.
-///
-/// `attempted` tracks ws_trees already visited in this invocation to avoid redundant
-/// re-runs; the output cache may also short-circuit re-runs across invocations.
-pub fn run_container(
+/// Sidecars declared in the job's metadata are started before the main step and
+/// torn down when this function returns (including on error paths), via
+/// [`defer::defer`]. A scratch artifact seeded from the worktree is created and
+/// cleaned up the same way.
+fn run_job(
     transaction: &cache::Transaction,
     odb: &memodb::Odb,
-    ws_tree: gix_hash::ObjectId,
-    attempted: &mut HashSet<gix_hash::ObjectId>,
-    extract_to_workdir: bool,
+    graph: &Graph,
+    job: &Job,
+    failed: &HashMap<gix_hash::ObjectId, String>,
     runtime: &dyn Runtime,
+    opts: &ExecOpts,
 ) -> anyhow::Result<()> {
-    let workspace_meta = meta::read_meta(transaction, odb, ws_tree)?;
+    let workspace_meta = &job.meta;
 
     // Cache check: skip only if a previous successful run is recorded AND its
-    // output volume is still present (when one is expected). Mirrors
-    // `plan::workspace_is_skippable` so a stale marker without its volume —
-    // reachable when an R2 volume pull fails after the marker pull succeeded —
-    // self-heals by re-running rather than failing downstream dep-mounts.
-    let hash = ws_tree.to_string();
-    let out_vol = naming::output(ws_tree);
+    // output volume is still present (when one is expected). A stale marker
+    // without its volume — reachable when an R2 volume pull fails after the
+    // marker pull succeeded — self-heals by re-running rather than failing
+    // downstream dep-mounts.
+    let hash = job.ws_tree.to_string();
+    let out_vol = naming::output(job.ws_tree);
     if job_cache::is_cached_success(&hash)
         && (workspace_meta.output == OutputMode::None || runtime.artifact_exists(&out_vol)?)
     {
         eprintln!(
             "[{}] Using cached output ({})",
-            workspace_meta.label, ws_tree
+            workspace_meta.label, job.ws_tree
         );
         return Ok(());
     }
 
-    if !attempted.insert(ws_tree) {
-        anyhow::bail!(
-            "[{}] Already attempted in this run ({})",
-            workspace_meta.label,
-            ws_tree
-        );
-    }
+    eprintln!("[{}] Running ({})", workspace_meta.label, job.ws_tree);
 
-    eprintln!("[{}] Running ({})", workspace_meta.label, ws_tree);
-
-    // Run all dependencies, collecting failures so sibling jobs still get a chance to run.
-    let input_entries = meta::read_gitlink_entries(transaction, odb, ws_tree, "inputs")?;
+    // Dependencies completed earlier in graph order. Collect the output volumes
+    // to mount; a failed dependency is fatal to this job but not to siblings.
     let mut dep_volumes: Vec<(String, String, bool)> = vec![];
     let mut dep_errors: Vec<String> = vec![];
-    for (dep_name, dep_tree) in &input_entries {
-        if let Err(e) = run_container(
-            transaction,
-            odb,
-            *dep_tree,
-            attempted,
-            extract_to_workdir,
-            runtime,
-        ) {
+    for (dep_name, dep_tree) in &job.inputs {
+        if let Some(e) = failed.get(dep_tree) {
             dep_errors.push(format!("dependency {dep_name} failed: {e}"));
             continue;
         }
-        let dep_meta = meta::read_meta(transaction, odb, *dep_tree)?;
+        let dep_meta = &graph
+            .job(*dep_tree)
+            .expect("job inputs reference jobs in the graph")
+            .meta;
         if dep_meta.output == OutputMode::None {
             continue;
         }
@@ -156,7 +178,7 @@ pub fn run_container(
     };
 
     // Resolve the environment (cache-or-build).
-    let image_name = image::ensure_image(transaction, odb, image_oid, runtime)?;
+    let image_name = image::ensure_image(transaction, odb, graph, image_oid, runtime)?;
 
     let mut cache_volume: Option<String> = None;
     if let Some(cache_name) = &workspace_meta.cache {
@@ -165,8 +187,7 @@ pub fn run_container(
         cache_volume = Some(vol_name);
     }
 
-    // Read env vars from env/ subtree
-    let mut env_vars = meta::read_blob_entries(transaction, odb, ws_tree, "env");
+    let mut env_vars = job.env.clone();
 
     // Start any declared sidecars and inject their addresses into the main container's env.
     // Any sidecar failure (missing creds, start error, readiness timeout) is fatal: tear
@@ -175,7 +196,7 @@ pub fn run_container(
     let mut started_sidecars: Vec<SidecarHandle> = vec![];
     if !workspace_meta.sidecars.is_empty() {
         for spec in &workspace_meta.sidecars {
-            match start_sidecar(transaction, odb, spec, runtime) {
+            match start_sidecar(transaction, odb, graph, spec, runtime) {
                 Ok(handle) => {
                     for (k, v) in &spec.inject {
                         env_vars.push((
@@ -265,7 +286,7 @@ pub fn run_container(
     let success = output.exit_code == 0;
     job_cache::write_result(&hash, success, &output.stdout, &output.stderr);
 
-    if workspace_meta.output == OutputMode::Workdir && extract_to_workdir {
+    if workspace_meta.output == OutputMode::Workdir && opts.extract_to_workdir {
         runtime.extract_artifact(&out_vol, Path::new("."))?;
     }
 

--- a/josh-compose/src/image.rs
+++ b/josh-compose/src/image.rs
@@ -1,22 +1,24 @@
 use anyhow::Context;
 
+use crate::naming;
 use josh_compose_backend::{EnvRecipe, EnvironmentBackend};
+use josh_compose_graph::Graph;
 use josh_core::cache;
-use josh_core::filter::tree;
 use josh_core::memodb;
 
-use crate::meta;
-use crate::naming;
-
-/// Ensure the environment for the given build tree exists, building it if needed.
+/// Ensure the environment for the given image exists, building it if needed.
 /// Returns the environment key (image name).
+///
+/// Base images are ensured first, recursively, and passed to the build as args
+/// so the Containerfile can reference them (e.g. `ARG my_base; FROM $my_base`).
 pub fn ensure_image(
     transaction: &cache::Transaction,
     odb: &memodb::Odb,
-    build_tree: gix_hash::ObjectId,
+    graph: &Graph,
+    image_oid: gix_hash::ObjectId,
     runtime: &dyn EnvironmentBackend,
 ) -> anyhow::Result<String> {
-    let image_name = naming::env(build_tree);
+    let image_name = naming::env(image_oid);
 
     if runtime.env_exists(&image_name)? {
         eprintln!("[image:{image_name}] Already built");
@@ -25,26 +27,21 @@ pub fn ensure_image(
 
     eprintln!("[image:{image_name}] Building...");
 
+    let node = graph
+        .image(image_oid)
+        .with_context(|| format!("image {image_oid} is not in the build graph"))?;
+
     let mut build_args: Vec<(String, String)> = vec![];
-
-    // Build each base environment and pass its key as a build arg so the
-    // Containerfile can reference it (e.g. ARG my_base; FROM $my_base).
-    for (base_name, base_oid) in meta::read_gitlink_entries(transaction, odb, build_tree, "bases")?
-    {
-        let base_env = ensure_image(transaction, odb, base_oid, runtime)?;
-        build_args.push((base_name, base_env));
+    for (base_name, base_oid) in &node.bases {
+        let base_env = ensure_image(transaction, odb, graph, *base_oid, runtime)?;
+        build_args.push((base_name.clone(), base_env));
     }
+    build_args.extend(node.args.iter().cloned());
 
-    for (k, v) in meta::read_blob_entries(transaction, odb, build_tree, "args") {
-        build_args.push((k, v));
-    }
-
-    let context_entry = tree::read_tree(transaction, odb, build_tree)?
-        .entry(b"context")
-        .map(|e| e.oid.to_owned())
+    let context_oid = node
+        .context
         .context("workspace image tree missing 'context' subtree")?;
-
-    let context = crate::archive::tree_to_tar(transaction, odb, context_entry)?;
+    let context = crate::archive::tree_to_tar(transaction, odb, context_oid)?;
 
     runtime.prepare_env(
         &image_name,

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -1,25 +1,13 @@
-use josh_compose_backend::{ArtifactBackend, Runtime};
+use josh_compose_backend::{ArtifactBackend, ExecOpts, Executor, Runtime};
 
 pub mod archive;
 pub mod clean;
-pub mod container;
+pub mod executor;
 pub mod filter;
 pub mod image;
 pub mod job_cache;
-pub mod meta;
 pub mod naming;
 pub mod plan;
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum OutputMode {
-    /// No output artifact is created; only success/failure is recorded.
-    None,
-    /// Output artifact is created and its contents are extracted to the host working directory.
-    Workdir,
-    /// Output artifact is created and kept (e.g. for use as a dependency input), but not
-    /// extracted.
-    Keep,
-}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CleanMode {
@@ -39,11 +27,24 @@ pub struct RunOptions {
     pub clean: CleanMode,
 }
 
-/// Main entry point for `josh run`.
+/// Main entry point for `josh run`, using the default sequential executor.
 pub fn run(
     transaction: &josh_core::cache::Transaction,
     opts: RunOptions,
     runtime: &dyn Runtime,
+) -> anyhow::Result<()> {
+    run_with_executor(transaction, opts, runtime, &executor::SequentialExecutor)
+}
+
+/// Load the build graph for the given options and hand it to `executor`.
+///
+/// Graph loading (resolving the workspace and image dependency closure from git
+/// trees) happens here, once, before the executor makes any scheduling decision.
+pub fn run_with_executor(
+    transaction: &josh_core::cache::Transaction,
+    opts: RunOptions,
+    runtime: &dyn Runtime,
+    executor: &dyn Executor,
 ) -> anyhow::Result<()> {
     josh_filter::check_experimental_features_enabled("josh run")?;
 
@@ -56,31 +57,24 @@ pub fn run(
 
     let (ws_tree, _safe_name) = filter::compute_ws_tree(transaction, &filter_spec, source_commit)?;
 
-    let mut attempted = std::collections::HashSet::new();
+    let graph = josh_compose_graph::load_graph(transaction, transaction.odb(), ws_tree)?;
+
     // Only extract output artifacts into the working tree when running against
     // uncommitted changes (input_ref == "."). For committed refs there is no
     // working tree to write back to.
-    let extract_to_workdir = opts.input_ref == ".";
-    let odb = transaction.odb();
-    container::run_container(
-        transaction,
-        odb,
-        ws_tree,
-        &mut attempted,
-        extract_to_workdir,
-        runtime,
-    )?;
-
-    Ok(())
+    let exec_opts = ExecOpts {
+        extract_to_workdir: opts.input_ref == ".",
+    };
+    executor.execute(transaction, &graph, runtime, &exec_opts)
 }
 
 /// Enumerate every image build-tree OID that a `run` with the same options would
 /// require, bases-first and deduplicated.
 ///
 /// When `ignore_cache` is false, workspaces whose run is already cached successful and
-/// whose output volume still exists are pruned from the walk (mirroring
-/// `container::run_container`'s early-return). When `ignore_cache` is true, the full
-/// set is reported regardless of cache state.
+/// whose output volume still exists are pruned from the graph (mirroring the
+/// executor's cache check). When `ignore_cache` is true, the full set is reported
+/// regardless of cache state.
 pub fn plan_images(
     transaction: &josh_core::cache::Transaction,
     opts: RunOptions,
@@ -102,9 +96,9 @@ pub fn plan_images(
 /// would touch, in dependency order (dependencies first).
 ///
 /// When `ignore_cache` is false, workspaces whose run is already cached successful and
-/// whose output volume still exists are pruned from the walk (mirroring
-/// `container::run_container`'s early-return). When `ignore_cache` is true, the full
-/// set is reported regardless of cache state.
+/// whose output volume still exists are pruned from the graph (mirroring the
+/// executor's cache check). When `ignore_cache` is true, the full set is reported
+/// regardless of cache state.
 pub fn plan_jobs(
     transaction: &josh_core::cache::Transaction,
     opts: RunOptions,

--- a/josh-compose/src/plan.rs
+++ b/josh-compose/src/plan.rs
@@ -1,25 +1,30 @@
+//! Plan listings computed over the loaded build [`Graph`].
+//! The graph loader ([`josh_compose_graph::load_graph`]) resolves the full
+//! dependency closure; the functions here only filter it by cache state. A
+//! workspace is skipped when its run is already cached successful AND its output
+//! volume is still present — mirroring the executor's cache check in
+//! `executor::run_job`, so a stale marker without its volume self-heals by being
+//! planned (and later run) again.
+
 use std::collections::HashSet;
 
+use josh_compose_backend::ArtifactBackend;
+use josh_compose_graph::{Graph, Job, OutputMode, load_graph};
 use josh_core::cache;
 use josh_core::memodb;
 
-use josh_compose_backend::ArtifactBackend;
-
-use crate::OutputMode;
 use crate::job_cache;
-use crate::meta::{self, WorkspaceMeta};
 use crate::naming;
 
-/// Walk the workspace tree and collect every image build-tree OID a run would touch.
+/// Collect every image build-tree OID a run would touch: the images of all
+/// runnable jobs (including sidecar images) and their transitive bases,
+/// ordered bases-first and deduplicated. This is the order in which images
+/// would need to be pulled/built for a run to succeed.
 ///
-/// The returned vector is deduplicated and ordered bases-first (a base image's OID
-/// always appears before any image that uses it as a base). This is the order in which
-/// images would need to be pulled/built for a run to succeed.
-///
-/// When `ignore_cache` is false (the default), workspaces whose run is already cached
-/// successful AND whose output volume is still present are skipped — matching the
-/// early-return path in `container::run_container`. When `ignore_cache` is true, every
-/// image a fresh-cache run would build is reported.
+/// When `ignore_cache` is false (the default), workspaces whose run is already
+/// cached successful are pruned — along with their dependency subtrees — so
+/// only images a run would actually build are reported. When `ignore_cache` is
+/// true, every image a fresh-cache run would build is reported.
 pub fn collect_image_oids(
     transaction: &cache::Transaction,
     odb: &memodb::Odb,
@@ -27,30 +32,39 @@ pub fn collect_image_oids(
     ignore_cache: bool,
     runtime: &dyn ArtifactBackend,
 ) -> anyhow::Result<Vec<gix_hash::ObjectId>> {
-    let mut out: Vec<gix_hash::ObjectId> = vec![];
-    let mut image_seen: HashSet<gix_hash::ObjectId> = HashSet::new();
-    let mut ws_seen: HashSet<gix_hash::ObjectId> = HashSet::new();
-    walk_workspace(
-        transaction,
-        odb,
-        ws_tree,
-        ignore_cache,
-        runtime,
-        &mut out,
-        &mut image_seen,
-        &mut ws_seen,
-    )?;
-    Ok(out)
+    let graph = load_graph(transaction, odb, ws_tree)?;
+    let runnable = runnable_jobs(&graph, ignore_cache, runtime, true)?;
+
+    let mut wanted: HashSet<gix_hash::ObjectId> = HashSet::new();
+    for job in graph.jobs() {
+        if !runnable.contains(&job.ws_tree) {
+            continue;
+        }
+        if let Some(image_oid) = job.meta.image {
+            collect_with_bases(&graph, image_oid, &mut wanted);
+        }
+        for spec in &job.meta.sidecars {
+            collect_with_bases(&graph, spec.image, &mut wanted);
+        }
+    }
+
+    // The graph's image list is already bases-first and deduplicated; filtering
+    // it preserves both properties.
+    Ok(graph
+        .images()
+        .iter()
+        .filter(|image| wanted.contains(&image.oid))
+        .map(|image| image.oid)
+        .collect())
 }
 
-/// Walk the workspace tree and collect the job hash (ws_tree OID) of every workspace
-/// a run would touch, including orchestrator workspaces that don't build an image —
-/// those still write a `job_cache` entry, so they belong in the listing.
+/// Collect the job hash (ws_tree OID) of every workspace a run would touch, in
+/// dependency order (dependencies first) — including orchestrator workspaces
+/// that don't build an image, since those still write a `job_cache` entry.
 ///
-/// Cache semantics mirror `collect_image_oids`: when `ignore_cache` is false, a
-/// workspace whose run is already cached successful AND whose output volume is still
-/// present is pruned from the walk. When true, every job a fresh-cache run would
-/// touch is reported.
+/// Cache semantics mirror `collect_image_oids`: when `ignore_cache` is false,
+/// cached-successful workspaces are pruned with their dependency subtrees; when
+/// true, every job a fresh-cache run would touch is reported.
 pub fn collect_job_hashes(
     transaction: &cache::Transaction,
     odb: &memodb::Odb,
@@ -58,143 +72,76 @@ pub fn collect_job_hashes(
     ignore_cache: bool,
     runtime: &dyn ArtifactBackend,
 ) -> anyhow::Result<Vec<gix_hash::ObjectId>> {
-    let mut out: Vec<gix_hash::ObjectId> = vec![];
-    let mut ws_seen: HashSet<gix_hash::ObjectId> = HashSet::new();
-    walk_workspace_jobs(
-        transaction,
-        odb,
-        ws_tree,
-        ignore_cache,
-        runtime,
-        &mut out,
-        &mut ws_seen,
-    )?;
-    Ok(out)
+    let graph = load_graph(transaction, odb, ws_tree)?;
+    let runnable = runnable_jobs(&graph, ignore_cache, runtime, false)?;
+
+    Ok(graph
+        .jobs()
+        .iter()
+        .filter(|job| runnable.contains(&job.ws_tree))
+        .map(|job| job.ws_tree)
+        .collect())
 }
 
-fn walk_workspace(
-    transaction: &cache::Transaction,
-    odb: &memodb::Odb,
-    ws_tree: gix_hash::ObjectId,
+/// Compute the set of jobs a run would execute: everything reachable from the
+/// root without descending into cache-skippable workspaces (a skippable
+/// workspace's dependencies are not run either).
+fn runnable_jobs(
+    graph: &Graph,
     ignore_cache: bool,
     runtime: &dyn ArtifactBackend,
-    out: &mut Vec<gix_hash::ObjectId>,
-    image_seen: &mut HashSet<gix_hash::ObjectId>,
-    ws_seen: &mut HashSet<gix_hash::ObjectId>,
-) -> anyhow::Result<()> {
-    if !ws_seen.insert(ws_tree) {
-        return Ok(());
+    log_skips: bool,
+) -> anyhow::Result<HashSet<gix_hash::ObjectId>> {
+    let mut visited: HashSet<gix_hash::ObjectId> = HashSet::new();
+    let mut runnable: HashSet<gix_hash::ObjectId> = HashSet::new();
+    let mut stack = vec![graph.root().ws_tree];
+    while let Some(ws_tree) = stack.pop() {
+        if !visited.insert(ws_tree) {
+            continue;
+        }
+        let job = graph
+            .job(ws_tree)
+            .expect("job inputs reference jobs in the graph");
+        if !ignore_cache && workspace_is_skippable(job, runtime)? {
+            if log_skips {
+                eprintln!("[{}] Using cached output ({})", job.meta.label, ws_tree);
+            }
+            continue;
+        }
+        runnable.insert(ws_tree);
+        stack.extend(job.inputs.iter().map(|(_, dep_tree)| *dep_tree));
     }
-
-    let workspace_meta = meta::read_meta(transaction, odb, ws_tree)?;
-
-    if !ignore_cache && workspace_is_skippable(ws_tree, &workspace_meta, runtime)? {
-        eprintln!(
-            "[{}] Using cached output ({})",
-            workspace_meta.label, ws_tree
-        );
-        return Ok(());
-    }
-
-    for (_, dep_tree) in meta::read_gitlink_entries(transaction, odb, ws_tree, "inputs")? {
-        walk_workspace(
-            transaction,
-            odb,
-            dep_tree,
-            ignore_cache,
-            runtime,
-            out,
-            image_seen,
-            ws_seen,
-        )?;
-    }
-
-    if let Some(image_oid) = workspace_meta.image {
-        collect_image_with_bases(transaction, odb, image_oid, out, image_seen)?;
-    }
-    for spec in &workspace_meta.sidecars {
-        collect_image_with_bases(transaction, odb, spec.image, out, image_seen)?;
-    }
-
-    Ok(())
+    Ok(runnable)
 }
 
-fn walk_workspace_jobs(
-    transaction: &cache::Transaction,
-    odb: &memodb::Odb,
-    ws_tree: gix_hash::ObjectId,
-    ignore_cache: bool,
-    runtime: &dyn ArtifactBackend,
-    out: &mut Vec<gix_hash::ObjectId>,
-    ws_seen: &mut HashSet<gix_hash::ObjectId>,
-) -> anyhow::Result<()> {
-    if !ws_seen.insert(ws_tree) {
-        return Ok(());
-    }
-
-    let workspace_meta = meta::read_meta(transaction, odb, ws_tree)?;
-
-    if !ignore_cache && workspace_is_skippable(ws_tree, &workspace_meta, runtime)? {
-        return Ok(());
-    }
-
-    for (_, dep_tree) in meta::read_gitlink_entries(transaction, odb, ws_tree, "inputs")? {
-        walk_workspace_jobs(
-            transaction,
-            odb,
-            dep_tree,
-            ignore_cache,
-            runtime,
-            out,
-            ws_seen,
-        )?;
-    }
-
-    out.push(ws_tree);
-    Ok(())
-}
-
-/// Mirror `container::run_container`'s early-return condition, tightened to also
-/// require the output volume when the workspace produces one. A skippable workspace
-/// won't be executed by a run, so its image and sidecar images are not needed.
-fn workspace_is_skippable(
-    ws_tree: gix_hash::ObjectId,
-    meta: &WorkspaceMeta,
-    runtime: &dyn ArtifactBackend,
-) -> anyhow::Result<bool> {
-    let hash = ws_tree.to_string();
+/// Mirror the executor's cache check: a job is skippable when a previous
+/// successful run is recorded AND its output volume still exists (when one is
+/// expected).
+fn workspace_is_skippable(job: &Job, runtime: &dyn ArtifactBackend) -> anyhow::Result<bool> {
+    let hash = job.ws_tree.to_string();
     if !job_cache::is_cached_success(&hash) {
         return Ok(false);
     }
-    if meta.output == OutputMode::None {
+    if job.meta.output == OutputMode::None {
         return Ok(true);
     }
-    let out_vol = naming::output(ws_tree);
-    runtime.artifact_exists(&out_vol)
+    runtime.artifact_exists(&naming::output(job.ws_tree))
 }
 
-/// Collect an image and all its transitive base images, bases-first.
-///
-/// The recursive call for each base happens *before* the current image is inserted
-/// (post-order traversal). This ensures a base image's OID always appears before any
-/// image that uses it as a base — the ordering `collect_image_oids` guarantees.
-fn collect_image_with_bases(
-    transaction: &cache::Transaction,
-    odb: &memodb::Odb,
+/// Collect an image and all its transitive base images into `wanted`.
+fn collect_with_bases(
+    graph: &Graph,
     image_oid: gix_hash::ObjectId,
-    out: &mut Vec<gix_hash::ObjectId>,
-    image_seen: &mut HashSet<gix_hash::ObjectId>,
-) -> anyhow::Result<()> {
-    if image_seen.contains(&image_oid) {
-        return Ok(());
+    wanted: &mut HashSet<gix_hash::ObjectId>,
+) {
+    if wanted.contains(&image_oid) {
+        return;
     }
-
-    for (_, base_oid) in meta::read_gitlink_entries(transaction, odb, image_oid, "bases")? {
-        collect_image_with_bases(transaction, odb, base_oid, out, image_seen)?;
+    let node = graph
+        .image(image_oid)
+        .expect("job images reference images in the graph");
+    for (_, base_oid) in &node.bases {
+        collect_with_bases(graph, *base_oid, wanted);
     }
-
-    if image_seen.insert(image_oid) {
-        out.push(image_oid);
-    }
-    Ok(())
+    wanted.insert(image_oid);
 }


### PR DESCRIPTION
Split josh-compose build-graph loading from execution

Separate the compose stack into layers with explicit contracts:

- josh-compose-graph (new crate): build-graph data structures
  (Graph, Job, ImageNode, WorkspaceMeta, SidecarSpec, OutputMode,
  NetworkPolicy) and load_graph, which resolves the full workspace
  and image dependency closure from git trees before any execution
  starts. Only heavy byte payloads stay lazy, addressed by tree OID.
- josh-compose-backend: capability traits plus the new Executor
  strategy contract (with ExecOpts). The capability traits now
  require Send + Sync so a shared runtime can be driven from
  multiple threads by future parallel executors.
- josh-compose: keeps scheduler policy (naming, job_cache, plan
  listings as graph filters) and the default SequentialExecutor;
  run() delegates to run_with_executor.

This replaces the recursive run_container, which fused graph
traversal with execution and duplicated the dependency walk three
times across container.rs and plan.rs.

Two accepted behavioral shifts: the full dependency closure is
validated at load time (a malformed reference errors even when a
cache hit would previously have hidden it), and diamond
dependencies are deduplicated structurally instead of relying on the
job-cache marker side effect.

Assisted-By: kimi-code/k3
Change: split-compose-graph-executor