### PR TITLE
Scope filter caches to transactions

### DIFF
--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -80,31 +80,6 @@ fn previous_value(expected: Expected) -> gix::refs::transaction::PreviousValue {
     }
 }
 
-static REF_CACHE: LazyLock<
-    RwLock<HashMap<gix_hash::ObjectId, HashMap<gix_hash::ObjectId, gix_hash::ObjectId>>>,
-> = LazyLock::new(Default::default);
-
-static POPULATE_MAP: LazyLock<
-    RwLock<HashMap<(gix_hash::ObjectId, gix_hash::ObjectId), gix_hash::ObjectId>>,
-> = LazyLock::new(Default::default);
-
-// Keyed by (input tree, pattern key, NFA state mask). The state mask makes entries independent
-// of the path a subtree was reached through; the legacy full-path fallback folds its root path
-// into a synthetic pattern key and uses mask 0.
-static GLOB_MAP: LazyLock<
-    RwLock<HashMap<(gix_hash::ObjectId, gix_hash::ObjectId, u64), gix_hash::ObjectId>>,
-> = LazyLock::new(Default::default);
-
-// Path-projection memoization for `:PATHS` and its inverse, keyed by (input tree oid, root path).
-// Both are pure functions of the input tree, and workspace filters walk commits parent-first, so a
-// child commit reuses the projections its parent just computed for the subtrees they share, which
-// an in-process map captures.
-static PATHS_MAP: LazyLock<RwLock<HashMap<(gix_hash::ObjectId, String), gix_hash::ObjectId>>> =
-    LazyLock::new(Default::default);
-
-static INVERT_MAP: LazyLock<RwLock<HashMap<(gix_hash::ObjectId, String), gix_hash::ObjectId>>> =
-    LazyLock::new(Default::default);
-
 /// Placeholder hint for tree-keyed records with no commit context. Sequence 0 is
 /// eligible and lands in shard 0 of the distributed backend; the local backend
 /// ignores the hint.
@@ -114,15 +89,6 @@ const TREE_KEYED_FALLBACK_HINT: HistoryGraphHint = HistoryGraphHint {
     jump_delta: 1,
     jump_is_second: false,
 };
-
-/// Clear the process-global in-memory caches shared across all transactions.
-pub fn clear_global_caches() {
-    REF_CACHE.write().unwrap().clear();
-    POPULATE_MAP.write().unwrap().clear();
-    GLOB_MAP.write().unwrap().clear();
-    PATHS_MAP.write().unwrap().clear();
-    INVERT_MAP.write().unwrap().clear();
-}
 
 pub struct TransactionContext {
     path: std::path::PathBuf,
@@ -141,7 +107,7 @@ pub struct TransactionContext {
 /// see the loose and packed files as they are. Entries live for the process; the proxy has a
 /// fixed pair of repositories and other processes see few paths each.
 static GIX_REPOS: LazyLock<
-    std::sync::RwLock<HashMap<std::path::PathBuf, std::sync::Arc<gix::ThreadSafeRepository>>>,
+    RwLock<HashMap<std::path::PathBuf, std::sync::Arc<gix::ThreadSafeRepository>>>,
 > = LazyLock::new(Default::default);
 
 fn shared_gix_repo(
@@ -243,6 +209,19 @@ struct Transaction2 {
         HashMap<gix_hash::ObjectId, std::collections::HashSet<crate::filter::DownstackDep>>,
     merge_trees_map:
         HashMap<(gix_hash::ObjectId, gix_hash::ObjectId, gix_hash::ObjectId), gix_hash::ObjectId>,
+    ref_map: HashMap<gix_hash::ObjectId, HashMap<gix_hash::ObjectId, gix_hash::ObjectId>>,
+    populate_map: HashMap<(gix_hash::ObjectId, gix_hash::ObjectId), gix_hash::ObjectId>,
+    /// Keyed by (input tree, pattern key, NFA state mask). The state mask makes entries
+    /// independent of the path a subtree was reached through; the legacy full-path fallback
+    /// folds its root path into a synthetic pattern key and uses mask 0.
+    glob_map: HashMap<(gix_hash::ObjectId, gix_hash::ObjectId, u64), gix_hash::ObjectId>,
+    /// Path-projection memoization for `:PATHS` and its inverse, keyed by (input tree oid,
+    /// root path). Workspace filters walk commits parent-first, so a child commit reuses the
+    /// projections its parent computed for shared subtrees.
+    paths_map: HashMap<(gix_hash::ObjectId, String), gix_hash::ObjectId>,
+    invert_map: HashMap<(gix_hash::ObjectId, String), gix_hash::ObjectId>,
+    workspace_map: HashMap<gix_hash::ObjectId, crate::filter::Filter>,
+    ancestor_map: HashMap<gix_hash::ObjectId, std::collections::HashSet<gix_hash::ObjectId>>,
     last_written_commit: Option<(gix_hash::ObjectId, gix_hash::ObjectId)>,
     tree_cache: TreeCache,
 
@@ -369,6 +348,13 @@ impl Transaction {
                 legalize_map: HashMap::new(),
                 downstack_deps_map: HashMap::new(),
                 merge_trees_map: HashMap::new(),
+                ref_map: HashMap::new(),
+                populate_map: HashMap::new(),
+                glob_map: HashMap::new(),
+                paths_map: HashMap::new(),
+                invert_map: HashMap::new(),
+                workspace_map: HashMap::new(),
+                ancestor_map: HashMap::new(),
                 last_written_commit: None,
                 tree_cache: Default::default(),
                 cache,
@@ -1182,19 +1168,51 @@ impl Transaction {
     }
 
     pub fn insert_paths(&self, tree: (gix_hash::ObjectId, String), result: gix_hash::ObjectId) {
-        PATHS_MAP.write().unwrap().entry(tree).or_insert(result);
+        self.t2.borrow_mut().paths_map.entry(tree).or_insert(result);
     }
 
     pub fn get_paths(&self, tree: (gix_hash::ObjectId, String)) -> Option<gix_hash::ObjectId> {
-        PATHS_MAP.read().unwrap().get(&tree).cloned()
+        self.t2.borrow().paths_map.get(&tree).copied()
     }
 
     pub fn insert_invert(&self, tree: (gix_hash::ObjectId, String), result: gix_hash::ObjectId) {
-        INVERT_MAP.write().unwrap().entry(tree).or_insert(result);
+        self.t2
+            .borrow_mut()
+            .invert_map
+            .entry(tree)
+            .or_insert(result);
     }
 
     pub fn get_invert(&self, tree: (gix_hash::ObjectId, String)) -> Option<gix_hash::ObjectId> {
-        INVERT_MAP.read().unwrap().get(&tree).cloned()
+        self.t2.borrow().invert_map.get(&tree).copied()
+    }
+
+    pub(crate) fn get_workspace(&self, blob: gix_hash::ObjectId) -> Option<crate::filter::Filter> {
+        self.t2.borrow().workspace_map.get(&blob).copied()
+    }
+
+    pub(crate) fn insert_workspace(&self, blob: gix_hash::ObjectId, filter: crate::filter::Filter) {
+        self.t2.borrow_mut().workspace_map.insert(blob, filter);
+    }
+
+    pub(crate) fn get_ancestor(
+        &self,
+        tip: gix_hash::ObjectId,
+        commit: gix_hash::ObjectId,
+    ) -> Option<bool> {
+        self.t2
+            .borrow()
+            .ancestor_map
+            .get(&tip)
+            .map(|ancestors| ancestors.contains(&commit))
+    }
+
+    pub(crate) fn insert_ancestors(
+        &self,
+        tip: gix_hash::ObjectId,
+        ancestors: std::collections::HashSet<gix_hash::ObjectId>,
+    ) {
+        self.t2.borrow_mut().ancestor_map.insert(tip, ancestors);
     }
 
     /// Cache indexes under the commit's history shard. A null ID means no commit context.
@@ -1255,14 +1273,18 @@ impl Transaction {
         tree: (gix_hash::ObjectId, gix_hash::ObjectId),
         result: gix_hash::ObjectId,
     ) {
-        POPULATE_MAP.write().unwrap().entry(tree).or_insert(result);
+        self.t2
+            .borrow_mut()
+            .populate_map
+            .entry(tree)
+            .or_insert(result);
     }
 
     pub fn get_populate(
         &self,
         tree: (gix_hash::ObjectId, gix_hash::ObjectId),
     ) -> Option<gix_hash::ObjectId> {
-        POPULATE_MAP.read().unwrap().get(&tree).cloned()
+        self.t2.borrow().populate_map.get(&tree).copied()
     }
 
     pub fn insert_glob(
@@ -1270,14 +1292,14 @@ impl Transaction {
         tree: (gix_hash::ObjectId, gix_hash::ObjectId, u64),
         result: gix_hash::ObjectId,
     ) {
-        GLOB_MAP.write().unwrap().entry(tree).or_insert(result);
+        self.t2.borrow_mut().glob_map.entry(tree).or_insert(result);
     }
 
     pub fn get_glob(
         &self,
         tree: (gix_hash::ObjectId, gix_hash::ObjectId, u64),
     ) -> Option<gix_hash::ObjectId> {
-        GLOB_MAP.read().unwrap().get(&tree).cloned()
+        self.t2.borrow().glob_map.get(&tree).copied()
     }
 
     pub fn insert_ref(
@@ -1286,9 +1308,9 @@ impl Transaction {
         from: gix_hash::ObjectId,
         to: gix_hash::ObjectId,
     ) {
-        REF_CACHE
-            .write()
-            .unwrap()
+        self.t2
+            .borrow_mut()
+            .ref_map
             .entry(filter.id())
             .or_default()
             .insert(from, to);
@@ -1299,13 +1321,14 @@ impl Transaction {
         filter: crate::filter::Filter,
         from: gix_hash::ObjectId,
     ) -> Option<gix_hash::ObjectId> {
-        if let Some(m) = REF_CACHE.read().unwrap().get(&filter.id())
-            && let Some(oid) = m.get(&from)
-            && self.odb().contains(*oid)
-        {
-            return Some(*oid);
-        }
-        None
+        let oid = self
+            .t2
+            .borrow()
+            .ref_map
+            .get(&filter.id())
+            .and_then(|entries| entries.get(&from))
+            .copied()?;
+        self.odb().contains(oid).then_some(oid)
     }
 
     pub fn get_unapply(
@@ -1555,6 +1578,44 @@ mod tests {
             .ok()
             .filter(|object| object.kind == gix_object::Kind::Blob)
             .map(|object| object.data.clone())
+    }
+
+    #[test]
+    fn caches_are_transaction_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+        gix::init_bare(dir.path()).unwrap();
+        let context = TransactionContext::new(
+            dir.path(),
+            std::sync::Arc::new(crate::cache::CacheStack::new()),
+        );
+        let first = context.open().unwrap();
+        let oid = commit(&first, "cached");
+        let filter = crate::filter::Filter::new();
+
+        first.insert_ref(filter, oid, oid);
+        first.insert_populate((oid, oid), oid);
+        first.insert_glob((oid, oid, 1), oid);
+        first.insert_paths((oid, "root".to_owned()), oid);
+        first.insert_invert((oid, "root".to_owned()), oid);
+        first.insert_workspace(oid, filter);
+        first.insert_ancestors(oid, std::collections::HashSet::from([oid]));
+
+        assert_eq!(first.get_ref(filter, oid), Some(oid));
+        assert_eq!(first.get_populate((oid, oid)), Some(oid));
+        assert_eq!(first.get_glob((oid, oid, 1)), Some(oid));
+        assert_eq!(first.get_paths((oid, "root".to_owned())), Some(oid));
+        assert_eq!(first.get_invert((oid, "root".to_owned())), Some(oid));
+        assert_eq!(first.get_workspace(oid), Some(filter));
+        assert_eq!(first.get_ancestor(oid, oid), Some(true));
+
+        let second = context.open().unwrap();
+        assert_eq!(second.get_ref(filter, oid), None);
+        assert_eq!(second.get_populate((oid, oid)), None);
+        assert_eq!(second.get_glob((oid, oid, 1)), None);
+        assert_eq!(second.get_paths((oid, "root".to_owned())), None);
+        assert_eq!(second.get_invert((oid, "root".to_owned())), None);
+        assert_eq!(second.get_workspace(oid), None);
+        assert_eq!(second.get_ancestor(oid, oid), None);
     }
 
     #[test]

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -7,7 +7,6 @@ pub use josh_filter::experimental_features_enabled;
 use std::collections::HashMap;
 use std::path::Path;
 use std::str::FromStr;
-use std::sync::LazyLock;
 
 // Re-export from josh-filter
 pub use josh_filter::filter::MESSAGE_MATCH_ALL_REGEX;
@@ -38,24 +37,6 @@ pub fn from_tree(
     tree_oid: gix_hash::ObjectId,
 ) -> anyhow::Result<Filter> {
     josh_filter::persist::from_tree(transaction.odb(), tree_oid)
-}
-
-static WORKSPACES: LazyLock<
-    std::sync::Mutex<std::collections::HashMap<gix_hash::ObjectId, Filter>>,
-> = LazyLock::new(Default::default);
-static ANCESTORS: LazyLock<
-    std::sync::Mutex<
-        std::collections::HashMap<
-            gix_hash::ObjectId,
-            std::collections::HashSet<gix_hash::ObjectId>,
-        >,
-    >,
-> = LazyLock::new(Default::default);
-
-/// Clear the process-global workspace and ancestor caches.
-pub fn clear_caches() {
-    WORKSPACES.lock().unwrap().clear();
-    ANCESTORS.lock().unwrap().clear();
 }
 
 // MESSAGE_MATCH_ALL_REGEX is now in josh-filter
@@ -371,19 +352,18 @@ fn get_filter(
     path: &Path,
 ) -> Filter {
     let ws_path = normalize_path(path);
-    // One descent resolves both the WORKSPACES cache key (the workspace.josh entry oid)
-    // and the blob to parse.
+    // One descent resolves the transaction cache key: the workspace.josh entry oid.
     let ws_id = match tree::get_path_entry_at(transaction, odb, reader, &ws_path) {
         Ok(Some(entry)) => entry.oid,
         _ => {
             return to_filter(Op::Empty);
         }
     };
-    let ws_blob = tree::blob_text(odb, ws_id);
 
-    if let Some(f) = WORKSPACES.lock().unwrap().get(&ws_id) {
-        *f
+    if let Some(f) = transaction.get_workspace(ws_id) {
+        f
     } else {
+        let ws_blob = tree::blob_text(odb, ws_id);
         let f = parse(&ws_blob).unwrap_or_else(|_| to_filter(Op::Empty));
         let f = legalize_stored(transaction, odb, f, tree, reader)
             .unwrap_or_else(|_| to_filter(Op::Empty));
@@ -393,7 +373,7 @@ fn get_filter(
         } else {
             to_filter(Op::Empty)
         };
-        WORKSPACES.lock().unwrap().insert(ws_id, f);
+        transaction.insert_workspace(ws_id, f);
         f
     }
 }
@@ -1729,27 +1709,26 @@ pub fn is_ancestor_of(
         }
     }
 
-    let mut ancestor_cache = ANCESTORS.lock().unwrap();
-    let ancestors = match ancestor_cache.entry(tip) {
-        std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
-        std::collections::hash_map::Entry::Vacant(entry) => {
-            tracing::trace!("is_ancestor_of tip={tip}");
-            // Recursively compute all ancestors of `tip`.
-            // Invariant: Everything in `todo` is also in `ancestors`.
-            let mut todo = vec![tip];
-            let mut ancestors = std::collections::HashSet::from_iter(todo.iter().copied());
-            while let Some(commit) = todo.pop() {
-                for parent in crate::git::read_parent_ids(transaction.odb(), commit)? {
-                    if ancestors.insert(parent) {
-                        // Newly inserted! Also handle its parents.
-                        todo.push(parent);
-                    }
-                }
+    if let Some(is_ancestor) = transaction.get_ancestor(tip, commit) {
+        return Ok(is_ancestor);
+    }
+
+    tracing::trace!("is_ancestor_of tip={tip}");
+    // Recursively compute all ancestors of `tip`.
+    // Invariant: Everything in `todo` is also in `ancestors`.
+    let mut todo = vec![tip];
+    let mut ancestors = std::collections::HashSet::from_iter(todo.iter().copied());
+    while let Some(commit) = todo.pop() {
+        for parent in crate::git::read_parent_ids(transaction.odb(), commit)? {
+            if ancestors.insert(parent) {
+                // Newly inserted! Also handle its parents.
+                todo.push(parent);
             }
-            entry.insert(ancestors)
         }
-    };
-    Ok(ancestors.contains(&commit))
+    }
+    let is_ancestor = ancestors.contains(&commit);
+    transaction.insert_ancestors(tip, ancestors);
+    Ok(is_ancestor)
 }
 
 fn legalize_pin<F>(f: Filter, c: &F) -> Filter
@@ -2923,7 +2902,7 @@ mod tests {
         .unwrap()
         .unwrap()
         .oid;
-        assert!(!WORKSPACES.lock().unwrap().contains_key(&blob));
+        assert!(transaction.get_workspace(blob).is_none());
 
         let resolver = FixedResolver(build_tree(&repo, &[("selected", "baseline")]));
         let parser = |spec: &str| josh_filter::parse_with_resolver(spec, &resolver);
@@ -2937,7 +2916,7 @@ mod tests {
         let error = format!("{error:#}");
         assert!(error.contains("defs/context-only.josh"));
         assert!(error.contains("undefined revision variable `missing`"));
-        assert!(!WORKSPACES.lock().unwrap().contains_key(&blob));
+        assert!(transaction.get_workspace(blob).is_none());
     }
 
     #[test]

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -1685,7 +1685,6 @@ mod tests {
             "a/x and c/x must be identical subtrees for the aliasing case to be exercised"
         );
 
-        let t = open_transaction(&td);
         for pattern in [
             "**/*.rs",
             "*.rs",
@@ -1707,8 +1706,7 @@ mod tests {
             "dir_0[!/]/**",
             "a/**/**/x*.rs",
         ] {
-            // Isolate the cases from each other (and from other tests in this process).
-            cache::clear_global_caches();
+            let t = open_transaction(&td);
 
             let key = objects::hash_blob(pattern.as_bytes());
             let cp = CompiledPattern::compile(pattern).unwrap();

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -107,23 +107,15 @@ impl $name {
     }
 }
 
-/// Reset all of josh's caches to a cold state.
+/// Reset josh's on-disk cache to a cold state.
 ///
-/// This clears the process-global in-memory caches shared across transactions,
-/// the workspace/ancestor caches, and the on-disk sled cache. It does not touch
-/// the filter interning tables or the filter optimizer memoization, which are
-/// structural and independent of repository data.
+/// Per-transaction in-memory caches are not cleared here: callers reset them by dropping and
+/// reopening the transaction. Filter interning and optimizer memoization are structural and
+/// independent of repository data.
 ///
-/// Per-transaction in-memory caches are not cleared here: transactions are
-/// ephemeral, so callers reset them simply by dropping and reopening the
-/// transaction.
-///
-/// Nuking the on-disk sled cache is safe: it is ephemeral and, when configured,
-/// backed by a remote cache. Intended for benchmarks and tests that need a cold
-/// cache between runs.
+/// Nuking the on-disk sled cache is safe: it is ephemeral and, when configured, backed by a
+/// remote cache. Intended for benchmarks and tests that need a cold cache between runs.
 pub fn reset_caches() -> anyhow::Result<()> {
-    cache::clear_global_caches();
-    filter::clear_caches();
     cache::sled_clear()?;
     Ok(())
 }


### PR DESCRIPTION
Scope filter caches to transactions

Keep repository-derived memoization within the transaction that uses it, while retaining the shared gitoxide repository handles. Reopening a transaction now starts these maps cold without process-global reset hooks.

Change: transaction-cache-scope
Assisted-By: openai-codex/gpt-5.6-sol