### PR TITLE
Add compose graph D2 output

### DIFF
--- a/docs/src/contributing/josh-run.md
+++ b/docs/src/contributing/josh-run.md
@@ -60,6 +60,17 @@ josh compose run + :+ws/test
 josh compose run HEAD :+ws/test
 ```
 
+### Inspect the execution plan
+
+```sh
+josh compose graph HEAD :+ws/test
+```
+
+`josh compose graph` accepts the same reference and filter arguments as `run` and prints D2 source
+to standard output. The graph includes workspace inputs, images, image bases, and sidecars;
+dependency edges point toward the steps that consume them. Pipe the output to a `.d2` file or a D2
+renderer if rendered output is needed.
+
 ## Syntax
 
 ```

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -335,7 +335,25 @@ josh compose run . :+ws/test
 josh compose run + :+ws/test
 ```
 
+## josh compose graph
+
+> **Experimental:** requires `JOSH_EXPERIMENTAL_FEATURES=1`.
+
+Print the complete workspace plan as D2 source. The command does not run containers or render the
+diagram.
+
+```
+josh compose graph [REFERENCE] [FILTER]
+```
+
+`REFERENCE` and `FILTER` have the same meaning and defaults as `josh compose run`.
+
+```shell
+josh compose graph HEAD :+ws/test > graph.d2
+```
+
 ---
+
 
 ## josh-filter (standalone binary)
 

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -240,7 +240,9 @@ fn run_repo(cmd: &RepoCommand, distributed_cache: bool) -> anyhow::Result<()> {
     let ephemeral_compose = match cmd {
         RepoCommand::Compose(args) => match &args.command {
             ComposeCommand::Run(args) => !args.clean && !args.clean_all,
-            ComposeCommand::ListImages(_) | ComposeCommand::ListJobs(_) => true,
+            ComposeCommand::Graph(_)
+            | ComposeCommand::ListImages(_)
+            | ComposeCommand::ListJobs(_) => true,
             ComposeCommand::Pull(_) | ComposeCommand::Push(_) => false,
         },
         _ => false,

--- a/josh-cli/src/commands/run.rs
+++ b/josh-cli/src/commands/run.rs
@@ -51,6 +51,8 @@ pub struct ComposeArgs {
 pub enum ComposeCommand {
     /// Run a workspace in a container
     Run(RunArgs),
+    /// Print the workspace graph as D2 source
+    Graph(GraphArgs),
     /// List every image (as `josh_ws_image_<oid>`) a `run` with the same args would need
     ListImages(ListImagesArgs),
     /// List the job hash of every workspace a `run` with the same args would touch
@@ -74,6 +76,7 @@ pub fn handle_compose(
     #[cfg(not(windows))]
     match &args.command {
         ComposeCommand::Run(run_args) => handle_run(run_args, transaction),
+        ComposeCommand::Graph(graph_args) => handle_graph(graph_args, transaction),
         ComposeCommand::ListImages(list_args) => handle_list_images(list_args, transaction),
         ComposeCommand::ListJobs(list_args) => handle_list_jobs(list_args, transaction),
         ComposeCommand::Pull(transfer_args) => {
@@ -141,6 +144,30 @@ pub fn handle_run(
         },
         runtime.as_ref(),
     )
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct GraphArgs {
+    /// Bind a named compose argument (currently a Git revision)
+    #[arg(long = "arg", value_name = "NAME=VALUE")]
+    pub arguments: Vec<ArgumentBinding>,
+    /// Git revision to use as input: "." (working tree), "+" (index), or any rev (e.g. "HEAD", "HEAD~1", "main")
+    #[arg(default_value = ".")]
+    pub reference: String,
+
+    /// Filter spec to apply, e.g. ":+ws/test" (defaults to ":+compose")
+    #[arg(default_value = ":+compose")]
+    pub filter: String,
+}
+
+pub fn handle_graph(
+    args: &GraphArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let graph =
+        josh_compose::load_plan(transaction, &args.filter, &args.reference, &args.arguments)?;
+    println!("{}", graph.d2());
+    Ok(())
 }
 
 #[derive(Debug, clap::Parser)]

--- a/josh-compose-graph/src/graph.rs
+++ b/josh-compose-graph/src/graph.rs
@@ -21,12 +21,12 @@ use crate::meta::{self, WorkspaceMeta};
 pub struct Graph {
     /// Workspaces in dependency order (a workspace always appears after its
     /// inputs), deduplicated. The last job is the run's root.
-    jobs: Vec<Job>,
+    pub(super) jobs: Vec<Job>,
     /// Images in bases-first order (a base image always appears before any
     /// image that uses it), deduplicated.
-    images: Vec<ImageNode>,
-    job_index: HashMap<gix_hash::ObjectId, usize>,
-    image_index: HashMap<gix_hash::ObjectId, usize>,
+    pub(super) images: Vec<ImageNode>,
+    pub(super) job_index: HashMap<gix_hash::ObjectId, usize>,
+    pub(super) image_index: HashMap<gix_hash::ObjectId, usize>,
 }
 
 /// One workspace step in the build graph.

--- a/josh-compose-graph/src/lib.rs
+++ b/josh-compose-graph/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod graph;
 mod meta;
+mod visualize;
 
 pub use graph::{Graph, ImageNode, Job, load_graph};
 pub use meta::{SidecarSpec, WorkspaceMeta};

--- a/josh-compose-graph/src/visualize.rs
+++ b/josh-compose-graph/src/visualize.rs
@@ -1,0 +1,185 @@
+use std::fmt::{self, Write as _};
+
+use crate::Graph;
+
+impl Graph {
+    /// Return this plan as D2 source.
+    pub fn d2(&self) -> impl fmt::Display + '_ {
+        D2(self)
+    }
+}
+
+struct D2<'a>(&'a Graph);
+
+impl fmt::Display for D2<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("direction: down")?;
+
+        for image in self.0.images() {
+            write!(f, "\nimage_{}: \"image {}\"", image.oid, image.oid)?;
+        }
+        for job in self.0.jobs() {
+            write!(f, "\njob_{}: \"{}\"", job.ws_tree, D2Text(&job.meta.label))?;
+        }
+
+        for image in self.0.images() {
+            for (name, base_oid) in &image.bases {
+                write!(
+                    f,
+                    "\nimage_{base_oid} -> image_{}: \"{}\"",
+                    image.oid,
+                    D2Text(name)
+                )?;
+            }
+        }
+        for job in self.0.jobs() {
+            if let Some(image_oid) = job.meta.image {
+                write!(f, "\nimage_{image_oid} -> job_{}: \"image\"", job.ws_tree)?;
+            }
+            for sidecar in &job.meta.sidecars {
+                write!(
+                    f,
+                    "\nimage_{} -> job_{}: \"sidecar: {}\"",
+                    sidecar.image,
+                    job.ws_tree,
+                    D2Text(&sidecar.name)
+                )?;
+            }
+            for (name, input_oid) in &job.inputs {
+                write!(
+                    f,
+                    "\njob_{input_oid} -> job_{}: \"{}\"",
+                    job.ws_tree,
+                    D2Text(name)
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+struct D2Text<'a>(&'a str);
+
+impl fmt::Display for D2Text<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut chars = self.0.chars().peekable();
+        while let Some(ch) = chars.next() {
+            match ch {
+                '\\' => f.write_str("\\\\")?,
+                '"' => f.write_str("\\\"")?,
+                '\r' => {
+                    if chars.peek() == Some(&'\n') {
+                        chars.next();
+                    }
+                    f.write_char(' ')?;
+                }
+                ch if ch.is_control() => f.write_char(' ')?,
+                ch => f.write_char(ch)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{Graph, ImageNode, Job, NetworkPolicy, OutputMode, SidecarSpec, WorkspaceMeta};
+
+    fn oid(digit: u8) -> gix_hash::ObjectId {
+        gix_hash::ObjectId::from_hex(&[digit; 40]).unwrap()
+    }
+
+    fn meta(
+        label: &str,
+        image: Option<gix_hash::ObjectId>,
+        sidecars: Vec<SidecarSpec>,
+    ) -> WorkspaceMeta {
+        WorkspaceMeta {
+            label: label.to_string(),
+            output: OutputMode::Keep,
+            cmd: String::new(),
+            cache: None,
+            network: NetworkPolicy::None,
+            image,
+            worktree: None,
+            sidecars,
+        }
+    }
+
+    #[test]
+    fn d2_includes_all_dependency_types_and_escapes_labels() {
+        let base = oid(b'1');
+        let image = oid(b'2');
+        let sidecar = oid(b'3');
+        let dependency = oid(b'4');
+        let root = oid(b'5');
+        let graph = Graph {
+            jobs: vec![
+                Job {
+                    ws_tree: dependency,
+                    meta: meta("dependency", None, vec![]),
+                    inputs: vec![],
+                    env: vec![],
+                },
+                Job {
+                    ws_tree: root,
+                    meta: meta(
+                        "root \"<&\\path\r\njob",
+                        Some(image),
+                        vec![SidecarSpec {
+                            name: "db\"one".to_string(),
+                            image: sidecar,
+                            env: vec![],
+                            passthrough: vec![],
+                            inject: vec![],
+                            port: 5432,
+                        }],
+                    ),
+                    inputs: vec![("source|code".to_string(), dependency)],
+                    env: vec![],
+                },
+            ],
+            images: vec![
+                ImageNode {
+                    oid: base,
+                    bases: vec![],
+                    args: vec![],
+                    context: None,
+                },
+                ImageNode {
+                    oid: image,
+                    bases: vec![("BASE|IMAGE".to_string(), base)],
+                    args: vec![],
+                    context: None,
+                },
+                ImageNode {
+                    oid: sidecar,
+                    bases: vec![],
+                    args: vec![],
+                    context: None,
+                },
+            ],
+            job_index: HashMap::new(),
+            image_index: HashMap::new(),
+        };
+
+        assert_eq!(
+            graph.d2().to_string(),
+            format!(
+                "direction: down\
+                 \nimage_{base}: \"image {base}\"\
+                 \nimage_{image}: \"image {image}\"\
+                 \nimage_{sidecar}: \"image {sidecar}\"\
+                 \njob_{dependency}: \"dependency\"\
+                 \njob_{root}: \"root \\\"<&\\\\path job\"\
+                 \nimage_{base} -> image_{image}: \"BASE|IMAGE\"\
+                 \nimage_{image} -> job_{root}: \"image\"\
+                 \nimage_{sidecar} -> job_{root}: \"sidecar: db\\\"one\"\
+                 \njob_{dependency} -> job_{root}: \"source|code\""
+            )
+        );
+    }
+}

--- a/josh-compose/src/lib.rs
+++ b/josh-compose/src/lib.rs
@@ -74,6 +74,22 @@ pub fn run_with_executor(
     };
     executor.execute(transaction, &graph, runtime, &exec_opts)
 }
+
+/// Load the complete workspace and image dependency graph for a compose run.
+pub fn load_plan(
+    transaction: &josh_core::cache::Transaction,
+    filter_spec: &str,
+    input_ref: &str,
+    arguments: &[ArgumentBinding],
+) -> anyhow::Result<josh_compose_graph::Graph> {
+    josh_filter::check_experimental_features_enabled("josh compose graph")?;
+
+    let (ws_tree, _safe_name) =
+        filter::prepare_workspace(transaction, filter_spec, input_ref, arguments)?;
+
+    josh_compose_graph::load_graph(transaction, transaction.odb(), ws_tree)
+}
+
 /// Pull compose result metadata from `remote`, merging concurrent local results.
 pub fn pull(transaction: &josh_core::cache::Transaction, remote: &str) -> anyhow::Result<()> {
     josh_filter::check_experimental_features_enabled("josh compose pull")?;

--- a/tests/cli/compose.t
+++ b/tests/cli/compose.t
@@ -22,6 +22,35 @@ Pulling compose metadata must persist the ref for later CLI invocations.
   $ git cat-file -t refs/josh/compose
   commit
 
+Compose graphing must discard objects created while applying the workspace filter.
+
+  $ git init -q ${TESTTMP}/filtered
+  $ cd ${TESTTMP}/filtered
+  $ mkdir -p image-context images
+  $ echo 'FROM scratch' > image-context/Dockerfile
+  $ echo ':$label="friendly image"' > images/test.josh
+  $ echo 'context = :/image-context' >> images/test.josh
+  $ echo ':$label="ephemeral-workspace"' > compose.josh
+  $ echo ':#image[:+images/test]' >> compose.josh
+  $ echo ':$output="none"' >> compose.josh
+  $ echo 'worktree = :/image-context' >> compose.josh
+  $ git add compose.josh image-context images
+  $ git commit -q -m "add compose workspace"
+  $ workspace=$(josh compose list-jobs --all HEAD)
+
+Abbreviated commit SHAs must select the same compose input.
+
+  $ short=$(git rev-parse --short HEAD)
+  $ test "$(josh compose list-jobs --all "${short}")" = "${workspace}"
+  $ josh compose graph HEAD | sed -E 's/[0-9a-f]{40}/OID/g'
+  direction: down
+  image_OID: "image OID"
+  job_OID: "ephemeral-workspace"
+  image_OID -> job_OID: "image"
+  $ test -n "${workspace}"
+  $ git cat-file -e "${workspace}" 2>/dev/null
+  [1]
+
 Revision object expressions resolve across every compose planning command.
 
   $ git init -q ${TESTTMP}/revisions
@@ -52,6 +81,10 @@ Revision object expressions resolve across every compose planning command.
   $ test -n "${default_job}"
   $ test -n "${explicit_job}"
   $ test "${default_job}" != "${explicit_job}"
+  $ default_graph=$(josh compose graph "${current}" "${filter}")
+  $ explicit_graph=$(josh compose graph --arg baseline="${explicit}" "${current}" "${filter}")
+  $ case "${default_graph}" in *"job_${default_job}"*) true;; *) false;; esac
+  $ case "${explicit_graph}" in *"job_${explicit_job}"*) true;; *) false;; esac
   $ test -z "$(josh compose list-images --all "${current}" "${filter}")"
   $ test -z "$(josh compose list-images --all --arg baseline="${explicit}" "${current}" "${filter}")"
   $ mkdir bin


### PR DESCRIPTION
Add compose graph D2 output

Expose compose dependency graphs as D2 source through josh compose graph.

Change: compose-graph-d2
Assisted-By: openai-codex/gpt-5.6-sol