### PR TITLE
Add Docker backend for josh compose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3330,6 +3330,8 @@ dependencies = [
  "glob",
  "josh-changes",
  "josh-compose",
+ "josh-compose-backend",
+ "josh-compose-docker",
  "josh-compose-podman",
  "josh-core",
  "josh-gerrit-changes",
@@ -3385,6 +3387,21 @@ dependencies = [
  "anyhow",
  "josh-compose-graph",
  "josh-core",
+]
+
+[[package]]
+name = "josh-compose-docker"
+version = "26.8.28"
+dependencies = [
+ "anyhow",
+ "backon",
+ "hex",
+ "josh-compose-backend",
+ "josh-compose-graph",
+ "libc",
+ "log",
+ "rand 0.10.2",
+ "tar",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "josh-compose-backend",
     "josh-compose-graph",
     "josh-compose-podman",
+    "josh-compose-docker",
 
     "forges/josh-github-changes",
     "forges/josh-github-graphql",
@@ -115,6 +116,7 @@ josh-compose = { path = "josh-compose", version = "26.8.28" }
 josh-compose-backend = { path = "josh-compose-backend", version = "26.8.28" }
 josh-compose-graph = { path = "josh-compose-graph", version = "26.8.28" }
 josh-compose-podman = { path = "josh-compose-podman", version = "26.8.28" }
+josh-compose-docker = { path = "josh-compose-docker", version = "26.8.28" }
 josh-graphql = { path = "josh-graphql", version = "26.8.28" }
 josh-link = { path = "josh-link", version = "26.8.28" }
 josh-rpc = { path = "josh-rpc", version = "26.8.28" }
@@ -213,6 +215,7 @@ josh-compose = { path = "josh-compose" }
 josh-compose-backend = { path = "josh-compose-backend" }
 josh-compose-graph = { path = "josh-compose-graph" }
 josh-compose-podman = { path = "josh-compose-podman" }
+josh-compose-docker = { path = "josh-compose-docker" }
 josh-graphql = { path = "josh-graphql" }
 josh-link = { path = "josh-link" }
 josh-rpc = { path = "josh-rpc" }

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -34,7 +34,9 @@ arboard = { version = "^3.6", default-features = false }
 josh-changes.workspace = true
 josh-core.workspace = true
 josh-compose.workspace = true
+josh-compose-backend.workspace = true
 josh-compose-podman.workspace = true
+josh-compose-docker.workspace = true
 josh-search.workspace = true
 josh-github-auth.workspace = true
 josh-github-keyring.workspace = true

--- a/josh-cli/src/commands/run.rs
+++ b/josh-cli/src/commands/run.rs
@@ -1,5 +1,22 @@
 use josh_compose::{CleanMode, RunOptions};
+use josh_compose_backend::Runtime;
+use josh_compose_docker::DockerRuntime;
 use josh_compose_podman::PodmanRuntime;
+
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub enum Backend {
+    Podman,
+    Docker,
+}
+
+impl Backend {
+    fn runtime(&self) -> Box<dyn Runtime> {
+        match self {
+            Backend::Podman => Box::new(PodmanRuntime::new()),
+            Backend::Docker => Box::new(DockerRuntime::new()),
+        }
+    }
+}
 
 #[derive(Debug, clap::Parser)]
 pub struct ComposeArgs {
@@ -45,6 +62,10 @@ pub struct RunArgs {
     #[arg(long = "clean-all")]
     pub clean_all: bool,
 
+    /// Container backend to run the workspace in
+    #[arg(long, value_enum, default_value_t = Backend::Podman, env = "JOSH_COMPOSE_BACKEND")]
+    pub backend: Backend,
+
     /// Git revision to use as input: "." (working tree), "+" (index), or any rev (e.g. "HEAD", "HEAD~1", "main")
     #[arg(default_value = ".")]
     pub reference: String,
@@ -66,7 +87,7 @@ pub fn handle_run(
         CleanMode::None
     };
 
-    let runtime = PodmanRuntime::new();
+    let runtime = args.backend.runtime();
     josh_compose::run(
         transaction,
         RunOptions {
@@ -74,7 +95,7 @@ pub fn handle_run(
             input_ref: args.reference.clone(),
             clean,
         },
-        &runtime,
+        runtime.as_ref(),
     )
 }
 
@@ -83,6 +104,10 @@ pub struct ListImagesArgs {
     /// Ignore the local job cache and list every image a fresh run would build
     #[arg(long = "all")]
     pub all: bool,
+
+    /// Container backend to check for prepared images
+    #[arg(long, value_enum, default_value_t = Backend::Podman, env = "JOSH_COMPOSE_BACKEND")]
+    pub backend: Backend,
 
     /// Git revision to use as input: "." (working tree), "+" (index), or any rev (e.g. "HEAD", "HEAD~1", "main")
     #[arg(default_value = ".")]
@@ -97,7 +122,8 @@ pub fn handle_list_images(
     args: &ListImagesArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let runtime = PodmanRuntime::new();
+    let runtime = args.backend.runtime();
+    let artifacts: &dyn josh_compose_backend::ArtifactBackend = runtime.as_ref();
     let oids = josh_compose::plan_images(
         transaction,
         RunOptions {
@@ -106,7 +132,7 @@ pub fn handle_list_images(
             clean: CleanMode::None,
         },
         args.all,
-        &runtime,
+        artifacts,
     )?;
 
     for oid in oids {
@@ -121,6 +147,10 @@ pub struct ListJobsArgs {
     #[arg(long = "all")]
     pub all: bool,
 
+    /// Container backend to check for existing outputs
+    #[arg(long, value_enum, default_value_t = Backend::Podman, env = "JOSH_COMPOSE_BACKEND")]
+    pub backend: Backend,
+
     /// Git revision to use as input: "." (working tree), "+" (index), or any rev (e.g. "HEAD", "HEAD~1", "main")
     #[arg(default_value = ".")]
     pub reference: String,
@@ -134,7 +164,8 @@ pub fn handle_list_jobs(
     args: &ListJobsArgs,
     transaction: &josh_core::cache::Transaction,
 ) -> anyhow::Result<()> {
-    let runtime = PodmanRuntime::new();
+    let runtime = args.backend.runtime();
+    let artifacts: &dyn josh_compose_backend::ArtifactBackend = runtime.as_ref();
     let oids = josh_compose::plan_jobs(
         transaction,
         RunOptions {
@@ -143,7 +174,7 @@ pub fn handle_list_jobs(
             clean: CleanMode::None,
         },
         args.all,
-        &runtime,
+        artifacts,
     )?;
 
     for oid in oids {

--- a/josh-compose-docker/Cargo.toml
+++ b/josh-compose-docker/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors = ["Josh Project authors <contact@josh-project.dev>"]
+description = "Docker execution backend for josh-compose"
+edition = "2024"
+keywords = ["git", "monorepo", "workflow", "scm"]
+license-file = "../LICENSE"
+name = "josh-compose-docker"
+readme = "../README.md"
+repository = "https://github.com/josh-project/josh"
+version = "26.8.28"
+
+[dependencies]
+anyhow.workspace = true
+backon.workspace = true
+hex.workspace = true
+josh-compose-backend.workspace = true
+josh-compose-graph.workspace = true
+libc.workspace = true
+log.workspace = true
+rand.workspace = true
+
+tar = "0.4"

--- a/josh-compose-docker/src/artifacts.rs
+++ b/josh-compose-docker/src/artifacts.rs
@@ -1,0 +1,202 @@
+use anyhow::Context;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use super::{DockerRuntime, align_artifact};
+use josh_compose_backend::ArtifactBackend;
+
+fn artifact_exists(name: &str) -> anyhow::Result<bool> {
+    let status = Command::new("docker")
+        .args(["volume", "inspect", "--format", "{{.Name}}", name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("failed to run docker volume inspect")?;
+    Ok(status.success())
+}
+
+fn create_artifact(name: &str) -> anyhow::Result<()> {
+    let output = Command::new("docker")
+        .args(["volume", "create", name])
+        .output()
+        .context("failed to run docker volume create")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("docker volume create {name} failed: {stderr}");
+    }
+    Ok(())
+}
+
+// The docker CLI has no `volume import`/`volume export` (podman-only
+// subcommands), so tar data is piped through a throwaway busybox container
+// with the volume mounted.
+fn import_artifact(name: &str, tar: &[u8]) -> anyhow::Result<()> {
+    let mut child = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "-i",
+            "--volume",
+            &format!("{name}:/mnt"),
+            "busybox",
+            "tar",
+            "-xf",
+            "-",
+            "-C",
+            "/mnt",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("failed to spawn docker import container")?;
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(tar)
+        .context("failed to write tar data to docker import container")?;
+
+    let output = child
+        .wait_with_output()
+        .context("failed to wait for docker import container")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("docker volume import {name} failed: {stderr}");
+    }
+    Ok(())
+}
+
+fn export_artifact(name: &str) -> anyhow::Result<Vec<u8>> {
+    let output = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--volume",
+            &format!("{name}:/mnt"),
+            "busybox",
+            "tar",
+            "-cf",
+            "-",
+            "-C",
+            "/mnt",
+            ".",
+        ])
+        .output()
+        .context("failed to run docker export container")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("docker volume export {name} failed: {stderr}");
+    }
+    Ok(output.stdout)
+}
+
+fn remove_artifact(name: &str, force: bool) -> anyhow::Result<()> {
+    let mut args = vec!["volume", "rm"];
+    if force {
+        args.push("--force");
+    }
+    args.push(name);
+    let output = Command::new("docker")
+        .args(&args)
+        .output()
+        .context("failed to run docker volume rm")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("docker volume rm {name} failed: {stderr}");
+    }
+    Ok(())
+}
+
+fn list_artifacts(prefix: &str) -> anyhow::Result<Vec<String>> {
+    let output = Command::new("docker")
+        .args(["volume", "ls", "--format", "{{.Name}}"])
+        .output()
+        .context("failed to run docker volume ls")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| l.starts_with(prefix))
+        .collect())
+}
+
+fn extract_artifact(name: &str, dest: &std::path::Path) -> anyhow::Result<()> {
+    let tar_data = export_artifact(name)?;
+    tar::Archive::new(std::io::Cursor::new(tar_data))
+        .unpack(dest)
+        .map_err(|e| anyhow::anyhow!("failed to extract artifact {name}: {e}"))
+}
+
+fn create_scratch_artifact(tar: &[u8]) -> anyhow::Result<String> {
+    let bytes: [u8; 4] = rand::random();
+    let name = format!("josh-scratch-{}", hex::encode(bytes));
+    create_artifact(&name)?;
+    if let Err(error) = import_artifact(&name, tar).and_then(|_| align_artifact(&name)) {
+        if let Err(cleanup_error) = remove_artifact(&name, true) {
+            return Err(error.context(format!(
+                "failed to remove scratch artifact {name} after initialization failed: \
+                 {cleanup_error}"
+            )));
+        }
+        return Err(error);
+    }
+    Ok(name)
+}
+
+/// Override of the trait's default `recreate_artifact` to also fix ownership for
+/// the invoking user (fresh docker volumes are root-owned).
+fn recreate_artifact(name: &str) -> anyhow::Result<()> {
+    if artifact_exists(name)? {
+        remove_artifact(name, true)?;
+        if artifact_exists(name)? {
+            anyhow::bail!("runtime artifact {name} still exists after removal");
+        }
+    }
+    create_artifact(name)?;
+    if !artifact_exists(name)? {
+        anyhow::bail!("runtime artifact {name} was not created");
+    }
+    align_artifact(name)?;
+    Ok(())
+}
+
+impl ArtifactBackend for DockerRuntime {
+    fn artifact_exists(&self, name: &str) -> anyhow::Result<bool> {
+        artifact_exists(name)
+    }
+
+    fn create_artifact(&self, name: &str) -> anyhow::Result<()> {
+        create_artifact(name)
+    }
+
+    fn import_artifact(&self, name: &str, tar: &[u8]) -> anyhow::Result<()> {
+        import_artifact(name, tar)
+    }
+
+    fn export_artifact(&self, name: &str) -> anyhow::Result<Vec<u8>> {
+        export_artifact(name)
+    }
+
+    fn extract_artifact(&self, name: &str, dest: &std::path::Path) -> anyhow::Result<()> {
+        extract_artifact(name, dest)
+    }
+
+    fn remove_artifact(&self, name: &str, force: bool) -> anyhow::Result<()> {
+        remove_artifact(name, force)
+    }
+
+    fn list_artifacts(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        list_artifacts(prefix)
+    }
+
+    fn create_scratch_artifact(&self, tar: &[u8]) -> anyhow::Result<String> {
+        create_scratch_artifact(tar)
+    }
+
+    fn recreate_artifact(&self, name: &str) -> anyhow::Result<()> {
+        recreate_artifact(name)
+    }
+}

--- a/josh-compose-docker/src/envs.rs
+++ b/josh-compose-docker/src/envs.rs
@@ -1,0 +1,102 @@
+use anyhow::Context;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use super::{DockerRuntime, host_uid_gid};
+use josh_compose_backend::{EnvRecipe, EnvironmentBackend};
+
+fn env_exists(key: &str) -> anyhow::Result<bool> {
+    let status = Command::new("docker")
+        .args(["image", "inspect", "--format", "{{.Id}}", key])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("failed to run docker image inspect")?;
+    Ok(status.success())
+}
+
+fn prepare_env(key: &str, recipe: EnvRecipe) -> anyhow::Result<()> {
+    // Standard build args a Containerfile expects: the target architecture
+    // (Go-style naming) and the host UID/GID so images can match the invoking
+    // user. These are container-build concerns, so the backend owns them —
+    // the scheduler only supplies the logical build args in `recipe`.
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => other,
+    };
+    let (uid, gid) = host_uid_gid();
+
+    let mut cmd = Command::new("docker");
+    cmd.arg("build");
+    cmd.args(["--build-arg", &format!("ARCH={arch}")]);
+    cmd.args(["--build-arg", &format!("USER_UID={uid}")]);
+    cmd.args(["--build-arg", &format!("USER_GID={gid}")]);
+    for (k, v) in &recipe.build_args {
+        cmd.arg(format!("--build-arg={k}={v}"));
+    }
+    cmd.args(["-t", key]);
+    cmd.arg("-"); // read build context from stdin
+    cmd.stdin(Stdio::piped());
+
+    let mut child = cmd.spawn().context("failed to spawn docker build")?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(&recipe.context)
+            .context("failed to write tar to docker build stdin")?;
+    }
+    let status = child.wait().context("failed to wait for docker build")?;
+    if !status.success() {
+        anyhow::bail!("docker build failed for environment {key}");
+    }
+    Ok(())
+}
+
+fn list_envs(prefix: &str) -> anyhow::Result<Vec<String>> {
+    let output = Command::new("docker")
+        .args([
+            "images",
+            "--format",
+            "{{.Repository}}:{{.Tag}}",
+            "--filter",
+            &format!("reference={prefix}*"),
+        ])
+        .output()
+        .context("failed to run docker images")?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect())
+}
+
+fn remove_env(key: &str) -> anyhow::Result<()> {
+    let output = Command::new("docker")
+        .args(["rmi", "--force", key])
+        .output()
+        .context("failed to run docker rmi")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::warn!("docker rmi {key} failed: {stderr}");
+    }
+    Ok(())
+}
+
+impl EnvironmentBackend for DockerRuntime {
+    fn env_exists(&self, key: &str) -> anyhow::Result<bool> {
+        env_exists(key)
+    }
+
+    fn prepare_env(&self, key: &str, recipe: EnvRecipe) -> anyhow::Result<()> {
+        prepare_env(key, recipe)
+    }
+
+    fn list_envs(&self, prefix: &str) -> anyhow::Result<Vec<String>> {
+        list_envs(prefix)
+    }
+
+    fn remove_env(&self, key: &str) -> anyhow::Result<()> {
+        remove_env(key)
+    }
+}

--- a/josh-compose-docker/src/lib.rs
+++ b/josh-compose-docker/src/lib.rs
@@ -1,0 +1,80 @@
+//! Docker implementation of the backend capability traits.
+//!
+//! Each capability delegates to the thematic submodule that owns its Docker
+//! commands: [`envs`], [`artifacts`], [`run`], or [`sidecars`].
+//!
+//! Container specifics the scheduler is unaware of live here: the internal sidecar
+//! network, the `busybox` chown used for ownership fix-ups, and the detached
+//! containers that realize sidecar workers.
+
+use anyhow::Context;
+use std::process::Command;
+
+mod artifacts;
+mod envs;
+mod run;
+mod sidecars;
+
+/// Internal network sidecar workers and their consuming steps are attached to.
+const SIDECAR_NETWORK: &str = "josh-sidecar-net";
+
+/// Docker container runtime backend.
+pub struct DockerRuntime;
+
+impl DockerRuntime {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for DockerRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Host uid/gid of the invoking user — the identity container steps run as and
+/// artifacts are chowned to. This is a container mechanic; the scheduler never
+/// needs to know it.
+#[cfg(unix)]
+fn host_uid_gid() -> (u32, u32) {
+    let uid = unsafe { libc::getuid() };
+    let gid = unsafe { libc::getgid() };
+    (uid, gid)
+}
+
+/// Unreachable: `josh compose` is refused on Windows before any container runs.
+#[cfg(windows)]
+fn host_uid_gid() -> (u32, u32) {
+    unreachable!("josh compose is not supported on Windows")
+}
+
+fn host_identity() -> String {
+    let (uid, gid) = host_uid_gid();
+    format!("{uid}:{gid}")
+}
+
+/// Chown an artifact's contents to the invoking user via a throwaway busybox
+/// container. The mount path is arbitrary — only the contents matter.
+fn align_artifact(artifact: &str) -> anyhow::Result<()> {
+    let mount = "/mnt";
+    let identity = host_identity();
+    let status = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "--volume",
+            &format!("{artifact}:{mount}"),
+            "busybox",
+            "chown",
+            "-R",
+            &identity,
+            mount,
+        ])
+        .status()
+        .context("failed to run chown container")?;
+    if !status.success() {
+        anyhow::bail!("chown failed for artifact {artifact}");
+    }
+    Ok(())
+}

--- a/josh-compose-docker/src/run.rs
+++ b/josh-compose-docker/src/run.rs
@@ -1,0 +1,142 @@
+use anyhow::Context;
+use std::process::{Command, Stdio};
+
+use super::{DockerRuntime, SIDECAR_NETWORK, align_artifact, host_identity, sidecars};
+use josh_compose_backend::{
+    ExecutionBackend, Mount, RunArgs, RunOutput, SidecarArgs, SidecarHandle,
+};
+use josh_compose_graph::NetworkPolicy;
+
+fn run(args: RunArgs) -> anyhow::Result<RunOutput> {
+    // Defensively fix ownership of read-only mounts — pre-existing artifacts such
+    // as dependency outputs, which may have been restored from a remote cache with
+    // root ownership — so the step can read them.
+    for mount in &args.mounts {
+        if mount.read_only {
+            align_artifact(&mount.artifact)?;
+        }
+    }
+
+    let mut cmd = Command::new("docker");
+    cmd.args(["run", "--rm"]);
+
+    // Run as the invoking user so files land with the right ownership.
+    let identity = host_identity();
+    cmd.args(["--user", &identity]);
+
+    // When sidecars are present, attach the step to the internal sidecar network
+    // so it can reach them; otherwise honor the requested policy.
+    let network = if !args.sidecars.is_empty() {
+        SIDECAR_NETWORK.to_string()
+    } else {
+        match args.network {
+            NetworkPolicy::Host => "host".to_string(),
+            NetworkPolicy::None => "none".to_string(),
+        }
+    };
+    cmd.args(["--network", &network]);
+
+    if let Some(workdir) = &args.working_dir {
+        cmd.args(["--workdir", workdir]);
+    }
+
+    for mount in &args.mounts {
+        let spec = mount_spec(mount);
+        cmd.args(["--volume", &spec]);
+    }
+
+    for (key, val) in &args.env_vars {
+        cmd.args(["-e", &format!("{key}={val}")]);
+    }
+
+    // Treat the argv's first element as the executable (overriding any image
+    // entrypoint) and the rest as its arguments.
+    match args.command.as_slice() {
+        [] => {
+            cmd.arg(&args.env);
+        }
+        [exe, rest @ ..] => {
+            cmd.args(["--entrypoint", exe]);
+            cmd.arg(&args.env);
+            cmd.args(rest);
+        }
+    }
+
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().context("failed to run docker container")?;
+
+    let child_stdout = child.stdout.take().expect("stdout piped");
+    let child_stderr = child.stderr.take().expect("stderr piped");
+
+    let stdout_thread = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut reader = child_stdout;
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let _ = std::io::Write::write_all(&mut std::io::stdout(), &chunk[..n]);
+                    buf.extend_from_slice(&chunk[..n]);
+                }
+                Err(_) => break,
+            }
+        }
+        buf
+    });
+
+    let stderr_thread = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut reader = child_stderr;
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 4096];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let _ = std::io::Write::write_all(&mut std::io::stderr(), &chunk[..n]);
+                    buf.extend_from_slice(&chunk[..n]);
+                }
+                Err(_) => break,
+            }
+        }
+        buf
+    });
+
+    let status = child
+        .wait()
+        .context("failed to wait for docker container")?;
+    let stdout = stdout_thread.join().unwrap_or_default();
+    let stderr = stderr_thread.join().unwrap_or_default();
+
+    Ok(RunOutput {
+        exit_code: status.code().unwrap_or(1),
+        stdout,
+        stderr,
+    })
+}
+
+fn mount_spec(mount: &Mount) -> String {
+    if mount.read_only {
+        format!("{}:{}:ro", mount.artifact, mount.path)
+    } else {
+        format!("{}:{}", mount.artifact, mount.path)
+    }
+}
+
+impl ExecutionBackend for DockerRuntime {
+    fn run(&self, args: RunArgs) -> anyhow::Result<RunOutput> {
+        run(args)
+    }
+
+    fn start_sidecar(&self, args: SidecarArgs) -> anyhow::Result<SidecarHandle> {
+        sidecars::start_sidecar(args)
+    }
+
+    fn stop_sidecar(&self, handle: &SidecarHandle) -> anyhow::Result<()> {
+        sidecars::stop_sidecar(handle)
+    }
+}

--- a/josh-compose-docker/src/sidecars.rs
+++ b/josh-compose-docker/src/sidecars.rs
@@ -1,0 +1,201 @@
+use anyhow::Context;
+use backon::{BlockingRetryable, ExponentialBuilder};
+use std::net::TcpStream;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use super::SIDECAR_NETWORK;
+use josh_compose_backend::{SidecarArgs, SidecarHandle};
+
+/// Start a sidecar worker and block until it is reachable.
+///
+/// Lifecycle:
+/// 1. Ensure the internal sidecar network exists (create if missing).
+/// 2. Launch the sidecar image as a detached container with a random name on
+///    the default bridge (so the sidecar can reach the internet during
+///    startup), then attach it to the internal sidecar network.
+/// 3. Extract the container's IP on the sidecar network (fail → stop + rm).
+/// 4. Probe the published port with exponential backoff; if the sidecar
+///    never becomes reachable, stop + rm the container and return an error.
+/// 5. Return a [`SidecarHandle`] with the step-reachable address and the
+///    opaque container id.
+pub(super) fn start_sidecar(args: SidecarArgs) -> anyhow::Result<SidecarHandle> {
+    ensure_network_internal(SIDECAR_NETWORK)?;
+
+    let bytes: [u8; 4] = rand::random();
+    let container_name = format!("josh-sidecar-{}-{}", args.name, hex::encode(bytes));
+
+    run_detached(&args.env, &container_name, &args.env_vars, args.port)?;
+
+    // `docker run` accepts only one `--network`, so the internal sidecar
+    // network is attached after the container starts on the default bridge.
+    if let Err(e) = network_connect(SIDECAR_NETWORK, &container_name) {
+        stop_container(&container_name);
+        rm_container_force(&container_name);
+        return Err(e);
+    }
+
+    let step_address = match container_ip(&container_name, SIDECAR_NETWORK) {
+        Ok(ip) => ip,
+        Err(e) => {
+            stop_container(&container_name);
+            rm_container_force(&container_name);
+            return Err(e);
+        }
+    };
+
+    let probe_address =
+        container_port(&container_name, args.port).context("sidecar port not published")?;
+
+    let probe = || -> std::io::Result<()> {
+        TcpStream::connect_timeout(&probe_address, Duration::from_millis(200)).map(|_| ())
+    };
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(25))
+        .with_max_delay(Duration::from_millis(250))
+        .with_max_times(50)
+        .with_jitter();
+    if let Err(e) = probe.retry(backoff).call() {
+        stop_container(&container_name);
+        rm_container_force(&container_name);
+        anyhow::bail!(
+            "sidecar {} not reachable at {probe_address} within timeout: {e}",
+            args.name
+        );
+    }
+
+    Ok(SidecarHandle {
+        step_address,
+        id: container_name,
+    })
+}
+
+pub(super) fn stop_sidecar(handle: &SidecarHandle) -> anyhow::Result<()> {
+    stop_container(&handle.id);
+    rm_container_force(&handle.id);
+    Ok(())
+}
+
+fn ensure_network_internal(name: &str) -> anyhow::Result<()> {
+    if !network_exists(name)? {
+        network_create_internal(name)?;
+    }
+    Ok(())
+}
+
+fn network_exists(name: &str) -> anyhow::Result<bool> {
+    let status = Command::new("docker")
+        .args(["network", "inspect", "--format", "{{.Name}}", name])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("failed to run docker network inspect")?;
+    Ok(status.success())
+}
+
+fn network_create_internal(name: &str) -> anyhow::Result<()> {
+    let output = Command::new("docker")
+        .args(["network", "create", "--internal", name])
+        .output()
+        .context("failed to run docker network create")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("docker network create {name} failed: {stderr}");
+    }
+    Ok(())
+}
+
+fn network_connect(network: &str, container: &str) -> anyhow::Result<()> {
+    let output = Command::new("docker")
+        .args(["network", "connect", network, container])
+        .output()
+        .context("failed to run docker network connect")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("docker network connect {network} {container} failed: {stderr}");
+    }
+    Ok(())
+}
+
+fn run_detached(
+    image: &str,
+    name: &str,
+    env_vars: &[(String, String)],
+    port: u16,
+) -> anyhow::Result<()> {
+    let mut cmd = Command::new("docker");
+    cmd.args(["run", "--rm", "-d", "--name", name]);
+    for (key, val) in env_vars {
+        cmd.args(["-e", &format!("{key}={val}")]);
+    }
+    cmd.args(["-p", &format!("{port}")]);
+    cmd.arg(image);
+
+    let output = cmd.output().context("failed to run docker run --detach")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("docker run --detach {name} failed: {stderr}");
+    }
+    Ok(())
+}
+
+fn container_port(container: &str, port: u16) -> anyhow::Result<std::net::SocketAddr> {
+    let output = Command::new("docker")
+        .args(["port", container, &format!("{port}")])
+        .output()
+        .context("failed to run docker port")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("docker port {container} {port} failed: {stderr}");
+    }
+    let binding = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    binding
+        .parse()
+        .with_context(|| format!("docker port {container} {port}: invalid output: {binding}"))
+}
+
+fn container_ip(container: &str, network: &str) -> anyhow::Result<String> {
+    // Use `index` rather than dotted access so hyphens in `network` don't break Go-template parsing.
+    let format = format!("{{{{(index .NetworkSettings.Networks \"{network}\").IPAddress}}}}");
+    let output = Command::new("docker")
+        .args(["inspect", "--format", &format, container])
+        .output()
+        .context("failed to run docker inspect")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("docker inspect {container} failed: {stderr}");
+    }
+    let ip = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if ip.is_empty() {
+        anyhow::bail!("container {container} has no IP on network {network}");
+    }
+    Ok(ip)
+}
+
+fn stop_container(name: &str) {
+    let output = Command::new("docker").args(["stop", name]).output();
+    match output {
+        Ok(o) if !o.status.success() => {
+            log::warn!(
+                "docker stop {name} failed: {}",
+                String::from_utf8_lossy(&o.stderr)
+            );
+        }
+        Err(e) => log::warn!("failed to run docker stop: {e}"),
+        _ => {}
+    }
+}
+
+fn rm_container_force(name: &str) {
+    let output = Command::new("docker").args(["rm", "-f", name]).output();
+    match output {
+        Ok(o) if !o.status.success() => {
+            log::warn!(
+                "docker rm -f {name} failed: {}",
+                String::from_utf8_lossy(&o.stderr)
+            );
+        }
+        Err(e) => log::warn!("failed to run docker rm: {e}"),
+        _ => {}
+    }
+}


### PR DESCRIPTION
Add Docker backend for josh compose

Add a josh-compose-docker crate implementing the compose backend
capability traits by shelling out to the docker CLI, mirroring the
podman backend. Docker CLI differences are handled inside the crate:
volume import/export are emulated with throwaway busybox containers
(docker has no such subcommands), sidecars are attached to the
internal network via docker network connect after start (docker run
accepts only one --network), and podman-only flags are dropped.

Select the backend with a new --backend flag on all compose
subcommands (default podman), also settable via JOSH_COMPOSE_BACKEND.

Change: docker-compose-backend
Assisted-By: kimi-code/k3