### PR TITLE
Show change commit SHA in changes list

### DIFF
--- a/josh-cli/src/commands/changes.rs
+++ b/josh-cli/src/commands/changes.rs
@@ -53,6 +53,7 @@ pub fn handle_list(
 
     struct Row {
         id: String,
+        commit_sha: String,
         subject: String,
         deps_count: usize,
         comments_count: usize,
@@ -62,6 +63,7 @@ pub fn handle_list(
     let mut rows: Vec<Row> = Vec::with_capacity(changes.len());
     for change in &changes {
         let id = change.id().unwrap_or("<no-change-id>").to_string();
+        let commit_sha = change.commit().to_string();
         let commit = josh_core::objects::CommitData::read(odb, change.commit())?;
         let subject = commit.summary().unwrap_or_default();
 
@@ -91,6 +93,7 @@ pub fn handle_list(
 
         rows.push(Row {
             id,
+            commit_sha,
             subject,
             deps_count,
             comments_count,
@@ -111,7 +114,8 @@ pub fn handle_list(
     println!("Changes on {}:\n", scope_label);
     for r in &rows {
         println!(
-            "{:<id_w$}  D={:>3}  C={:>3}  V={:<vote_w$}  {}",
+            "{:<7}  {:<id_w$}  D={:>3}  C={:>3}  V={:<vote_w$}  {}",
+            &r.commit_sha[..7],
             r.id,
             r.deps_count,
             r.comments_count,

--- a/tests/cli/changes_cli.t
+++ b/tests/cli/changes_cli.t
@@ -57,9 +57,9 @@ the subject as the tiebreaker.
   $ josh changes list
   Changes on Local [master]:
   
-  c2  D=  1  C=  0  V=      B change
-  c1  D=  0  C=  0  V=      A change
-  c3  D=  0  C=  0  V=      C change
+  5ecf7d2  c2  D=  1  C=  0  V=      B change
+  28e4ce5  c1  D=  0  C=  0  V=      A change
+  b28ecba  c3  D=  0  C=  0  V=      C change
 
 Add two private comments to c1. The C= column for c1 should pick them up.
 
@@ -71,9 +71,9 @@ Add two private comments to c1. The C= column for c1 should pick them up.
   $ josh changes list
   Changes on Local [master]:
   
-  c2  D=  1  C=  0  V=      B change
-  c1  D=  0  C=  2  V=      A change
-  c3  D=  0  C=  0  V=      C change
+  5ecf7d2  c2  D=  1  C=  0  V=      B change
+  28e4ce5  c1  D=  0  C=  2  V=      A change
+  b28ecba  c3  D=  0  C=  0  V=      C change
 
 deps: c2 depends on c1; c1 and c3 depend on nothing on the ref.
 
@@ -135,9 +135,9 @@ directly:
   $ josh changes list
   Changes on Local [master]:
   
-  c2  D=  1  C=  0  V=         B change
-  c1  D=  0  C=  2  V=approve  A change
-  c3  D=  0  C=  0  V=         C change
+  5ecf7d2  c2  D=  1  C=  0  V=         B change
+  28e4ce5  c1  D=  0  C=  2  V=approve  A change
+  b28ecba  c3  D=  0  C=  0  V=         C change
 
   $ josh changes show c1
   Change-Id: c1


### PR DESCRIPTION
Show change commit SHA in changes list

Prefix each summary row with the change commit's seven-character SHA and update the CLI output expectations.

Change: changes-list-sha
Assisted-By: openai-codex/gpt-5.6-sol