### PR TITLE
Use cram-preserving Scrut fork

### DIFF
--- a/docs/src/contributing/testing.md
+++ b/docs/src/contributing/testing.md
@@ -14,7 +14,7 @@ cargo test --all
 
 ### 1. Setup the test environment
 Due to the fact that the integration tests need additional tools and a more complex
-environment and due to the fact that the integration test are done using [scrut](https://github.com/facebookincubator/scrut)
+environment and due to the fact that the integration test are done using [scrut](https://github.com/vlad-ivanov-name/scrut/tree/fix-cram-compat-update)
 (with cram-style `.t` test files), you will need to crate an extra environment to run these tests. To simplify the
 setup of the integration testing we have set up a [Nix Shell](https://nixos.org/manual/nix/stable/#chap-installation) environment which
 you can start by using the following command if you have installed the [Nix Shell](https://nixos.org/manual/nix/stable/#chap-installation).

--- a/images/dev/Dockerfile
+++ b/images/dev/Dockerfile
@@ -55,30 +55,13 @@ git config -f /opt/git-install/etc/gitconfig --add safe.directory "*"
 git config -f /opt/git-install/etc/gitconfig protocol.file.allow "always"
 EOF
 
-# Update check: https://github.com/facebookincubator/scrut/releases
-ARG SCRUT_VERSION=0.4.3
-# sha1 of scrut-v${SCRUT_VERSION}-linux-x86_64.tar.gz from the GitHub release
-ARG SCRUT_SHA1=e3048b47f9bc4a6ec2d14ff9b5b05befe679521c
-ARG TARGETARCH
-RUN <<EOF
-set -eux
-
-if [ "$TARGETARCH" = amd64 ]; then
-    # The prebuilt binary is glibc-linked and needs the gcompat + libgcc
-    # packages (installed above) to run on musl-based Alpine.
-    tarball=scrut-v${SCRUT_VERSION}-linux-x86_64.tar.gz
-    curl -fsSL -o /tmp/${tarball} \
-        https://github.com/facebookincubator/scrut/releases/download/v${SCRUT_VERSION}/${tarball}
-    echo "${SCRUT_SHA1}  /tmp/${tarball}" | sha1sum -c -
-    tar -xzf /tmp/${tarball} -C /tmp
-    install -m 0755 /tmp/scrut-linux-x86_64/scrut /usr/local/bin/scrut
-    rm -rf /tmp/${tarball} /tmp/scrut-linux-x86_64
-else
-    # The upstream aarch64 release tarball is mis-packaged (it contains
-    # an x86-64 binary), so build from source on other architectures.
-    cargo install --verbose --version ${SCRUT_VERSION} scrut
-fi
-EOF
+# Update check: https://github.com/vlad-ivanov-name/scrut/tree/fix-cram-compat-update
+ARG SCRUT_REPOSITORY=https://github.com/vlad-ivanov-name/scrut
+ARG SCRUT_BRANCH=fix-cram-compat-update
+RUN cargo install --verbose \
+    --git ${SCRUT_REPOSITORY} \
+    --branch ${SCRUT_BRANCH} \
+    scrut
 
 RUN apk add --no-cache go openssh-client patch
 

--- a/images/scrut-test/Dockerfile
+++ b/images/scrut-test/Dockerfile
@@ -15,30 +15,13 @@ RUN apk add --no-cache \
 
 RUN cargo install --verbose --version 0.14.0 graphql_client_cli
 
-# Update check: https://github.com/facebookincubator/scrut/releases
-ARG SCRUT_VERSION=0.4.3
-# sha1 of scrut-v${SCRUT_VERSION}-linux-x86_64.tar.gz from the GitHub release
-ARG SCRUT_SHA1=e3048b47f9bc4a6ec2d14ff9b5b05befe679521c
-ARG TARGETARCH
-RUN <<EOF
-set -eux
-
-# Install to /usr/local/cargo/bin so the "COPY --from=graphql-builder" in the
-# final stage below works unchanged.
-if [ "$TARGETARCH" = amd64 ]; then
-    tarball=scrut-v${SCRUT_VERSION}-linux-x86_64.tar.gz
-    curl -fsSL -o /tmp/${tarball} \
-        https://github.com/facebookincubator/scrut/releases/download/v${SCRUT_VERSION}/${tarball}
-    echo "${SCRUT_SHA1}  /tmp/${tarball}" | sha1sum -c -
-    tar -xzf /tmp/${tarball} -C /tmp
-    install -m 0755 /tmp/scrut-linux-x86_64/scrut /usr/local/cargo/bin/scrut
-    rm -rf /tmp/${tarball} /tmp/scrut-linux-x86_64
-else
-    # The upstream aarch64 release tarball is mis-packaged (it contains
-    # an x86-64 binary), so build from source on other architectures.
-    cargo install --verbose --version ${SCRUT_VERSION} scrut
-fi
-EOF
+# Update check: https://github.com/vlad-ivanov-name/scrut/tree/fix-cram-compat-update
+ARG SCRUT_REPOSITORY=https://github.com/vlad-ivanov-name/scrut
+ARG SCRUT_BRANCH=fix-cram-compat-update
+RUN cargo install --verbose \
+    --git ${SCRUT_REPOSITORY} \
+    --branch ${SCRUT_BRANCH} \
+    scrut
 
 FROM alpine:${ALPINE_VERSION}
 

--- a/shell.nix
+++ b/shell.nix
@@ -35,10 +35,10 @@ in
       echo "Rust version: $(rustc --version)"
       echo "Cargo version: $(cargo --version)"
 
-      # Install scrut using cargo with specific version
+      # Install scrut from the fork that preserves cram files during updates
       if ! command -v scrut &> /dev/null; then
         echo "Installing scrut..."
-        cargo install --version 0.4.3 scrut
+        cargo install --git https://github.com/vlad-ivanov-name/scrut --branch fix-cram-compat-update scrut
       fi
 
       echo "Scrut version: $(scrut --version 2>/dev/null || echo 'Installing...')"


### PR DESCRIPTION
Use cram-preserving Scrut fork

Install Scrut from the fix-cram-compat-update branch in local and container environments. Build the fork from source on every architecture and update the contributor link.

Change: scrut-cram-update-fork

Assisted-By: openai-codex/gpt-5.6-sol