### PR TITLE
Add josh link command for remote-bound views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3327,6 +3327,7 @@ dependencies = [
  "josh-graphql",
  "josh-search",
  "josh-templates",
+ "josh-view",
  "juniper",
  "log",
  "reqwest",
@@ -3880,6 +3881,18 @@ dependencies = [
  "tower-http 0.7.0",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "josh-view"
+version = "26.8.28"
+dependencies = [
+ "anyhow",
+ "gix",
+ "gix-hash",
+ "josh-core",
+ "josh-filter",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "josh-memodb",
     "josh-cli",
     "josh-filter",
+    "josh-view",
     "josh-gix-ext",
     "josh-git-serde",
     "josh-graphql",
@@ -106,6 +107,7 @@ graphql_client_codegen = { version = "^0.16.0" }
 
 axum-cgi = { path = "axum-cgi", version = "26.8.28" }
 josh-filter = { path = "josh-filter", version = "26.8.28" }
+josh-view = { path = "josh-view", version = "26.8.28" }
 josh-gix-ext = { path = "josh-gix-ext", version = "26.8.28" }
 josh-git-serde = { path = "josh-git-serde", version = "26.8.28" }
 josh-changes = { path = "josh-changes", version = "26.8.28" }

--- a/josh-cli/Cargo.toml
+++ b/josh-cli/Cargo.toml
@@ -38,6 +38,7 @@ josh-compose-backend.workspace = true
 josh-compose-podman.workspace = true
 josh-compose-docker.workspace = true
 josh-search.workspace = true
+josh-view.workspace = true
 josh-github-auth.workspace = true
 josh-github-keyring.workspace = true
 josh-github-graphql.workspace = true

--- a/josh-cli/src/bin/josh.rs
+++ b/josh-cli/src/bin/josh.rs
@@ -6,6 +6,7 @@ use josh_cli::commands::cache::CacheArgs;
 use josh_cli::commands::changes::{DepsArgs, ListArgs, ShowArgs};
 use josh_cli::commands::comment::CommentArgs;
 use josh_cli::commands::fetch::FetchArgs;
+use josh_cli::commands::link::LinkArgs;
 use josh_cli::commands::pull::PullArgs;
 use josh_cli::commands::push::{PublishArgs, PushArgs};
 use josh_cli::commands::run::ComposeArgs;
@@ -59,6 +60,9 @@ pub enum RepoCommand {
 
     /// Apply filtering to existing refs (like `josh fetch` but without fetching)
     Filter(FilterArgs),
+
+    /// Manage links: named views of the repository bound to external remotes
+    Link(LinkArgs),
 
     /// Manage the distributed filter cache
     Cache(CacheArgs),
@@ -313,6 +317,7 @@ fn run_repo(cmd: &RepoCommand, distributed_cache: bool) -> anyhow::Result<()> {
         },
         RepoCommand::Remote(args) => handle_remote(args, &transaction),
         RepoCommand::Filter(args) => handle_filter(args, &transaction),
+        RepoCommand::Link(args) => josh_cli::commands::link::handle_link(args, &transaction),
         RepoCommand::Compose(args) => josh_cli::commands::run::handle_compose(args, &transaction),
         RepoCommand::Cache(args) => josh_cli::commands::cache::handle_cache(args, &transaction),
     }

--- a/josh-cli/src/commands/link.rs
+++ b/josh-cli/src/commands/link.rs
@@ -1,0 +1,125 @@
+use anyhow::{Context, anyhow};
+
+#[derive(Debug, clap::Parser)]
+pub struct LinkArgs {
+    /// Link subcommand
+    #[command(subcommand)]
+    pub command: LinkCommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum LinkCommand {
+    /// Add a link to a view of a remote repository
+    Add(LinkAddArgs),
+    /// Remove a link
+    Rm(LinkRmArgs),
+    /// List links
+    List,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct LinkAddArgs {
+    /// Remote repository URL
+    #[arg()]
+    pub url: String,
+
+    /// Filter defining the view (e.g. :/subfolder)
+    #[arg()]
+    pub filter: String,
+
+    /// Link id (defaults to the repository name derived from the URL)
+    #[arg(long = "id")]
+    pub id: Option<String>,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct LinkRmArgs {
+    /// Link id
+    #[arg()]
+    pub id: String,
+}
+
+pub fn handle_link(
+    args: &LinkArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    josh_core::filter::check_experimental_features_enabled("josh link")?;
+    match &args.command {
+        LinkCommand::Add(add_args) => handle_link_add(add_args, transaction),
+        LinkCommand::Rm(rm_args) => handle_link_rm(rm_args, transaction),
+        LinkCommand::List => handle_link_list(transaction),
+    }
+}
+
+fn handle_link_add(
+    args: &LinkAddArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    let id = match &args.id {
+        Some(id) => id.clone(),
+        None => josh_view::derive_id_from_url(&args.url).ok_or_else(|| {
+            anyhow!(
+                "Could not derive a link id from URL '{}'; pass --id",
+                args.url
+            )
+        })?,
+    };
+    josh_view::validate_link_id(&id)?;
+
+    if transaction
+        .resolve_ref(&josh_view::link_ref_name(&id))?
+        .is_some()
+    {
+        return Err(anyhow!("Link '{id}' already exists"));
+    }
+
+    let filter = josh_core::filter::parse(&args.filter)
+        .with_context(|| format!("Failed to parse filter '{}'", args.filter))?;
+
+    let tracked_ref =
+        crate::remote_ops::get_head_branch(&args.url, &transaction.path().to_path_buf(), &id)
+            .with_context(|| format!("Failed to determine default branch of '{}'", args.url))?;
+
+    let view = josh_view::View {
+        filter,
+        link: Some(josh_view::Link {
+            url: args.url.clone(),
+            tracked_ref: tracked_ref.clone(),
+        }),
+    };
+
+    josh_view::write_view(transaction, &id, &view, &format!("josh link add {id}"))?;
+
+    println!(
+        "Added link '{id}': {} {} {}",
+        args.url,
+        tracked_ref,
+        josh_core::filter::spec(filter)
+    );
+    Ok(())
+}
+
+fn handle_link_rm(
+    args: &LinkRmArgs,
+    transaction: &josh_core::cache::Transaction,
+) -> anyhow::Result<()> {
+    josh_view::delete_view(transaction, &args.id)?;
+    println!("Removed link '{}'", args.id);
+    Ok(())
+}
+
+fn handle_link_list(transaction: &josh_core::cache::Transaction) -> anyhow::Result<()> {
+    for (id, view) in josh_view::list_views(transaction)? {
+        match &view.link {
+            Some(link) => println!(
+                "{}\t{}\t{}\t{}",
+                id,
+                link.url,
+                link.tracked_ref,
+                josh_core::filter::spec(view.filter)
+            ),
+            None => println!("{}\t{}", id, josh_core::filter::spec(view.filter)),
+        }
+    }
+    Ok(())
+}

--- a/josh-cli/src/commands/mod.rs
+++ b/josh-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod cache;
 pub mod changes;
 pub mod comment;
 pub mod fetch;
+pub mod link;
 pub mod pull;
 pub mod push;
 pub mod run;

--- a/josh-view/Cargo.toml
+++ b/josh-view/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "josh-view"
+version = "26.8.28"
+edition = "2024"
+authors = ["Josh Project authors <contact@josh-project.dev>"]
+description = "Josh views and links"
+license-file = "../LICENSE"
+repository = "https://github.com/josh-project/josh"
+keywords = ["git", "monorepo", "workflow", "scm"]
+
+[dependencies]
+anyhow.workspace = true
+gix-hash.workspace = true
+
+josh-core.workspace = true
+josh-filter.workspace = true
+
+[dev-dependencies]
+gix.workspace = true
+tempfile.workspace = true

--- a/josh-view/src/lib.rs
+++ b/josh-view/src/lib.rs
@@ -1,0 +1,350 @@
+//! Views and links: named, versioned filter objects stored as git refs.
+//!
+//! A view is a filter plus pragmas, stored as flang text in a file versioned
+//! under its own ref. A link is a view bound to an external remote: its `url`
+//! and `tracked-ref` ride along as `:~(...)` meta options on the filter.
+
+use anyhow::{Context, anyhow};
+use josh_core::cache::{Expected, Transaction};
+use josh_core::filter::tree;
+use josh_core::objects;
+use std::path::Path;
+
+/// The file inside a link ref's tree holding the view definition.
+pub const LINK_FILE: &str = "link.josh";
+
+/// Ref namespace links live in: `refs/josh/links/<id>`.
+pub const LINKS_REF_PREFIX: &str = "refs/josh/links/";
+
+const META_URL: &str = "url";
+const META_TRACKED_REF: &str = "tracked-ref";
+
+/// A view bound to an external remote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Link {
+    pub url: String,
+    /// The main ref of the remote (e.g. `main` or `master`).
+    pub tracked_ref: String,
+}
+
+/// A named, versioned binding of a filter plus optional link parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct View {
+    pub filter: josh_filter::Filter,
+    pub link: Option<Link>,
+}
+
+impl View {
+    /// The view as a filter: the body wrapped in `:~(...)` meta carrying the
+    /// link parameters when this view is a link.
+    pub fn to_filter(&self) -> josh_filter::Filter {
+        match &self.link {
+            Some(link) => self
+                .filter
+                .with_meta(META_URL, link.url.clone())
+                .with_meta(META_TRACKED_REF, link.tracked_ref.clone()),
+            None => self.filter,
+        }
+    }
+
+    /// Recover a view from a filter: link parameters come from the `url` and
+    /// `tracked-ref` meta keys, which are stripped from the body; any other
+    /// meta options stay on the filter.
+    pub fn from_filter(filter: josh_filter::Filter) -> View {
+        let link = match (filter.get_meta(META_URL), filter.get_meta(META_TRACKED_REF)) {
+            (Some(url), Some(tracked_ref)) => Some(Link { url, tracked_ref }),
+            _ => None,
+        };
+        View {
+            filter: filter.without_meta_keys(&[META_URL, META_TRACKED_REF]),
+            link,
+        }
+    }
+
+    /// The `link.josh` file content for this view.
+    pub fn to_file_string(&self) -> String {
+        josh_filter::as_file(self.to_filter(), 0)
+    }
+
+    /// Parse a view from `link.josh` file content.
+    pub fn parse(text: &str) -> anyhow::Result<View> {
+        let filter = josh_core::filter::parse(text)
+            .with_context(|| format!("failed to parse {LINK_FILE}"))?;
+        Ok(View::from_filter(filter))
+    }
+}
+
+/// The fully-qualified ref a link with `id` is versioned under.
+pub fn link_ref_name(id: &str) -> String {
+    format!("{LINKS_REF_PREFIX}{id}")
+}
+
+/// A link id becomes a git ref component, so reject anything that would make
+/// the refname invalid or escape the links namespace.
+pub fn validate_link_id(id: &str) -> anyhow::Result<()> {
+    let invalid = id.is_empty()
+        || id.starts_with('/')
+        || id.ends_with('/')
+        || id.ends_with('.')
+        || id.contains("..")
+        || id.contains("//")
+        || id
+            .chars()
+            .any(|c| c.is_ascii_control() || " ~^:?*[\\".contains(c));
+    if invalid {
+        return Err(anyhow!("invalid link id '{id}'"));
+    }
+    Ok(())
+}
+
+/// Derive a link id from a remote URL: the last path segment (which for
+/// scp-style URLs follows the host `:`), without the `.git` suffix.
+pub fn derive_id_from_url(url: &str) -> Option<String> {
+    let last = url.trim_end_matches('/').rsplit(['/', ':']).next()?;
+    let name = last.strip_suffix(".git").unwrap_or(last);
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+/// Commit `view` as `link.josh` onto the link's ref, with the previous tip as
+/// parent when the ref already exists. The ref update is compare-and-swap
+/// guarded against the tip read here, so a concurrent update is never
+/// overwritten.
+pub fn write_view(
+    transaction: &Transaction,
+    id: &str,
+    view: &View,
+    message: &str,
+) -> anyhow::Result<gix_hash::ObjectId> {
+    validate_link_id(id)?;
+    if view.link.is_some() {
+        for key in [META_URL, META_TRACKED_REF] {
+            if view.filter.get_meta(key).is_some() {
+                return Err(anyhow!(
+                    "filter must not set reserved meta key '{key}': it is owned by the link config"
+                ));
+            }
+        }
+    }
+    let refname = link_ref_name(id);
+    let odb = transaction.odb();
+
+    let blob = objects::write_blob(odb, view.to_file_string().as_bytes())?;
+
+    let (base_tree, parents, guard) = if let Some(prev) = transaction.resolve_ref(&refname)? {
+        let commit = objects::CommitData::read(odb, prev)?;
+        (commit.tree_id()?, vec![prev], Expected::At(prev))
+    } else {
+        (tree::empty_id(), vec![], Expected::Absent)
+    };
+
+    let new_tree = tree::insert_oid(odb, base_tree, Path::new(LINK_FILE), blob, 0o0100644)?;
+    let sig = josh_core::git::user_signature(transaction)?;
+    let commit = objects::write_commit(odb, new_tree, &parents, &sig, &sig, message)?;
+    transaction.update_ref(&refname, guard, commit, message)?;
+    Ok(commit)
+}
+
+/// Read the view stored under the link's ref, or `None` when the link (or its
+/// `link.josh` file) does not exist.
+pub fn read_view(transaction: &Transaction, id: &str) -> anyhow::Result<Option<View>> {
+    let Some(tip) = transaction.resolve_ref(&link_ref_name(id))? else {
+        return Ok(None);
+    };
+    let odb = transaction.odb();
+    let commit = objects::CommitData::read(odb, tip)?;
+    let Some(entry) =
+        tree::get_path_entry(transaction, odb, commit.tree_id()?, Path::new(LINK_FILE))?
+    else {
+        return Ok(None);
+    };
+    let Some(bytes) = tree::blob_bytes(odb, entry.oid) else {
+        return Err(anyhow!("{LINK_FILE} in link '{id}' is not a blob"));
+    };
+    let text = std::str::from_utf8(&bytes)
+        .with_context(|| format!("{LINK_FILE} in link '{id}' is not valid UTF-8"))?;
+    View::parse(text)
+        .with_context(|| format!("failed to load link '{id}'"))
+        .map(Some)
+}
+
+/// Delete the link's ref. Errors when the link does not exist.
+pub fn delete_view(transaction: &Transaction, id: &str) -> anyhow::Result<()> {
+    let refname = link_ref_name(id);
+    let Some(tip) = transaction.resolve_ref(&refname)? else {
+        return Err(anyhow!("link '{id}' does not exist"));
+    };
+    transaction.delete_ref(&refname, Expected::At(tip))
+}
+
+/// All links in the repo, sorted by id.
+pub fn list_views(transaction: &Transaction) -> anyhow::Result<Vec<(String, View)>> {
+    let mut views = Vec::new();
+    transaction.for_each_ref_prefixed(LINKS_REF_PREFIX, |name, _oid| {
+        let id = name
+            .strip_prefix(LINKS_REF_PREFIX)
+            .unwrap_or(name)
+            .to_string();
+        if let Some(view) = read_view(transaction, &id)? {
+            views.push((id, view));
+        }
+        Ok(())
+    })?;
+    Ok(views)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use josh_core::cache::{CacheStack, SledCacheBackend, TransactionContext};
+
+    #[test]
+    fn derive_id_from_url_cases() {
+        assert_eq!(
+            derive_id_from_url("https://example.com/repo.git"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            derive_id_from_url("https://example.com/org/sub/repo.git"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            derive_id_from_url("git@example.com:org/repo.git"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            derive_id_from_url("ssh://git@example.com/repo"),
+            Some("repo".to_string())
+        );
+        assert_eq!(
+            derive_id_from_url("https://example.com/repo/"),
+            Some("repo".to_string())
+        );
+        assert_eq!(derive_id_from_url(""), None);
+    }
+
+    #[test]
+    fn view_file_round_trip() {
+        let link_view = View {
+            filter: josh_core::filter::parse(":/subfolder").unwrap(),
+            link: Some(Link {
+                url: "https://example.com/repo.git".to_string(),
+                tracked_ref: "main".to_string(),
+            }),
+        };
+        assert_eq!(View::parse(&link_view.to_file_string()).unwrap(), link_view);
+
+        let plain_view = View {
+            filter: josh_core::filter::parse(":/subfolder").unwrap(),
+            link: None,
+        };
+        assert_eq!(
+            View::parse(&plain_view.to_file_string()).unwrap(),
+            plain_view
+        );
+    }
+
+    #[test]
+    fn parse_link_file_with_meta() {
+        let view = View::parse(
+            ":~(tracked-ref=\"main\",url=\"https://example.com/repo.git\")[:/subfolder]\n",
+        )
+        .unwrap();
+        assert_eq!(
+            view.link,
+            Some(Link {
+                url: "https://example.com/repo.git".to_string(),
+                tracked_ref: "main".to_string(),
+            })
+        );
+        assert_eq!(
+            view.filter,
+            josh_core::filter::parse(":/subfolder").unwrap()
+        );
+    }
+
+    #[test]
+    fn unrelated_meta_stays_on_filter() {
+        let view = View::parse(
+            ":~(history=\"linear\",tracked-ref=\"main\",url=\"https://example.com/repo.git\")[:/subfolder]\n",
+        )
+        .unwrap();
+        assert!(view.link.is_some());
+        assert_eq!(view.filter.get_meta("history"), Some("linear".to_string()));
+    }
+
+    fn open_transaction(td: &tempfile::TempDir) -> Transaction {
+        gix::init_bare(td.path()).unwrap();
+        // Commits need an identity; don't depend on the ambient global git
+        // config (CI containers have none).
+        use std::io::Write as _;
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(td.path().join("config"))
+            .unwrap()
+            .write_all(b"\n[user]\n\tname = test\n\temail = test@example.com\n")
+            .unwrap();
+
+        let cachestack =
+            std::sync::Arc::new(CacheStack::new().with_backend(SledCacheBackend::new(td.path())));
+        TransactionContext::new(td.path(), cachestack)
+            .open()
+            .unwrap()
+    }
+
+    #[test]
+    fn write_read_list_delete_round_trip() {
+        let td = tempfile::tempdir().unwrap();
+        let transaction = open_transaction(&td);
+
+        let view = View {
+            filter: josh_core::filter::parse(":/subfolder").unwrap(),
+            link: Some(Link {
+                url: "https://example.com/repo.git".to_string(),
+                tracked_ref: "main".to_string(),
+            }),
+        };
+
+        assert!(read_view(&transaction, "repo").unwrap().is_none());
+
+        let first = write_view(&transaction, "repo", &view, "add link repo").unwrap();
+        assert_eq!(read_view(&transaction, "repo").unwrap(), Some(view.clone()));
+
+        // A second write keeps history: the new commit's parent is the first.
+        let second = write_view(&transaction, "repo", &view, "update link repo").unwrap();
+        let commit = objects::CommitData::read(transaction.odb(), second).unwrap();
+        assert_eq!(commit.parent_ids().collect::<Vec<_>>(), vec![first]);
+
+        assert_eq!(
+            list_views(&transaction).unwrap(),
+            vec![("repo".to_string(), view)]
+        );
+
+        delete_view(&transaction, "repo").unwrap();
+        assert!(read_view(&transaction, "repo").unwrap().is_none());
+        assert!(delete_view(&transaction, "repo").is_err());
+    }
+
+    #[test]
+    fn write_rejects_reserved_meta_keys() {
+        let td = tempfile::tempdir().unwrap();
+        let transaction = open_transaction(&td);
+
+        let view = View {
+            filter: josh_core::filter::parse(
+                ":~(url=\"https://example.com/other.git\")[:/subfolder]",
+            )
+            .unwrap(),
+            link: Some(Link {
+                url: "https://example.com/repo.git".to_string(),
+                tracked_ref: "main".to_string(),
+            }),
+        };
+
+        assert!(write_view(&transaction, "repo", &view, "add link repo").is_err());
+        assert!(read_view(&transaction, "repo").unwrap().is_none());
+    }
+}

--- a/tests/cli/link.t
+++ b/tests/cli/link.t
@@ -1,0 +1,76 @@
+  $ export TESTTMP=${PWD}
+
+Set up a remote repository to link to.
+
+  $ git init -q remote
+  $ cd remote
+  $ mkdir sub1
+  $ echo contents1 > sub1/file1
+  $ git add sub1
+  $ git commit -m "add file1" 1> /dev/null
+  $ cd ${TESTTMP}
+
+  $ git init -q work
+  $ cd work
+
+The link feature is experimental.
+
+  $ josh link list
+  Error: josh link requires JOSH_EXPERIMENTAL_FEATURES=1
+  josh link requires JOSH_EXPERIMENTAL_FEATURES=1
+  [1]
+  $ export JOSH_EXPERIMENTAL_FEATURES=1
+
+Add a link; the id is derived from the URL and the tracked ref is discovered
+from the remote's HEAD symref.
+
+  $ josh link add ${TESTTMP}/remote :/sub1 | sed "s|${TESTTMP}|\${TESTTMP}|g"
+  Added link 'remote': ${TESTTMP}/remote master :/sub1
+
+  $ josh link list | sed "s|${TESTTMP}|\${TESTTMP}|g"
+  remote\t${TESTTMP}/remote\tmaster\t:/sub1 (escaped)
+
+The link is versioned in its own ref, holding only link.josh.
+
+  $ git log --format='%s' refs/josh/links/remote
+  josh link add remote
+
+  $ git show refs/josh/links/remote:link.josh | sed "s|${TESTTMP}|\${TESTTMP}|g"
+  :~(
+      tracked-ref="master"
+      url="${TESTTMP}/remote"
+  )[
+      :/sub1
+  ]
+
+Adding the same link again fails.
+
+  $ josh link add ${TESTTMP}/remote :/sub1
+  Error: Link 'remote' already exists
+  Link 'remote' already exists
+  [1]
+
+An explicit --id overrides the derived one.
+
+  $ josh link add ${TESTTMP}/remote :/sub1 --id custom | sed "s|${TESTTMP}|\${TESTTMP}|g"
+  Added link 'custom': ${TESTTMP}/remote master :/sub1
+
+  $ josh link list | sed "s|${TESTTMP}|\${TESTTMP}|g"
+  custom\t${TESTTMP}/remote\tmaster\t:/sub1 (escaped)
+  remote\t${TESTTMP}/remote\tmaster\t:/sub1 (escaped)
+
+Remove links.
+
+  $ josh link rm remote
+  Removed link 'remote'
+
+  $ josh link rm remote
+  Error: link 'remote' does not exist
+  link 'remote' does not exist
+  [1]
+
+  $ josh link list | sed "s|${TESTTMP}|\${TESTTMP}|g"
+  custom\t${TESTTMP}/remote\tmaster\t:/sub1 (escaped)
+
+  $ git rev-parse --verify -q refs/josh/links/remote
+  [1]


### PR DESCRIPTION
Add josh link command for remote-bound views

Links are named, versioned views of the repository bound to an external
remote. Each link is stored as a link.josh file -- the view filter with
the link parameters as :~(...) meta options -- versioned alone in an
orphan-history commit chain under refs/josh/links/<id>.

The new josh-view crate carries the View/Link data types and the ref
storage (write/read/delete/list, CAS-guarded ref updates, commit-per-
update history). The CLI gains "josh link add <url> <filter> [--id]",
"josh link rm <id>" and "josh link list"; the id defaults to the
repository name derived from the URL and the tracked ref is discovered
from the remote's HEAD symref.

Change: josh-link-views
Assisted-By: kimi-code/k3