### PR TITLE
Generalize transaction-local memoization

### DIFF
--- a/josh-core/src/cache/memo.rs
+++ b/josh-core/src/cache/memo.rs
@@ -1,0 +1,96 @@
+use crate::filter::{DownstackDep, Filter};
+use gix_hash::ObjectId;
+use std::cell::{Cell, RefCell};
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+
+/// Independent borrow state lets unrelated memo tables be used concurrently.
+pub(crate) struct MemoMap<K, V> {
+    entries: RefCell<HashMap<K, V>>,
+}
+
+impl<K, V> Default for MemoMap<K, V> {
+    fn default() -> Self {
+        Self {
+            entries: Default::default(),
+        }
+    }
+}
+
+impl<K: Eq + Hash, V: Clone> MemoMap<K, V> {
+    pub(crate) fn get(&self, key: &K) -> Option<V> {
+        self.entries.borrow().get(key).cloned()
+    }
+
+    pub(crate) fn get_with<R>(&self, key: &K, f: impl FnOnce(&V) -> R) -> Option<R> {
+        self.entries.borrow().get(key).map(f)
+    }
+
+    pub(crate) fn insert(&self, key: K, value: V) {
+        self.entries.borrow_mut().insert(key, value);
+    }
+
+    pub(crate) fn insert_if_absent(&self, key: K, value: V) {
+        self.entries.borrow_mut().entry(key).or_insert(value);
+    }
+}
+
+/// Partitions entries by a first key to avoid hashing composite keys and allocating unused
+/// inner maps.
+pub(crate) struct PartitionedMemoMap<P, K, V> {
+    entries: RefCell<HashMap<P, HashMap<K, V>>>,
+}
+
+impl<P, K, V> Default for PartitionedMemoMap<P, K, V> {
+    fn default() -> Self {
+        Self {
+            entries: Default::default(),
+        }
+    }
+}
+
+impl<P: Eq + Hash, K: Eq + Hash, V: Clone> PartitionedMemoMap<P, K, V> {
+    pub(crate) fn get(&self, partition: &P, key: &K) -> Option<V> {
+        self.entries
+            .borrow()
+            .get(partition)
+            .and_then(|entries| entries.get(key))
+            .cloned()
+    }
+
+    pub(crate) fn insert(&self, partition: P, key: K, value: V) {
+        self.entries
+            .borrow_mut()
+            .entry(partition)
+            .or_default()
+            .insert(key, value);
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct TransactionMemo {
+    pub(crate) apply: PartitionedMemoMap<ObjectId, ObjectId, ObjectId>,
+    pub(crate) subtract: MemoMap<(ObjectId, ObjectId), ObjectId>,
+    pub(crate) intersect: MemoMap<(ObjectId, ObjectId), ObjectId>,
+    pub(crate) overlay: MemoMap<(ObjectId, ObjectId), ObjectId>,
+    pub(crate) unapply: PartitionedMemoMap<ObjectId, ObjectId, ObjectId>,
+    pub(crate) legalize: MemoMap<(Filter, ObjectId), Filter>,
+    pub(crate) downstack_deps: MemoMap<ObjectId, HashSet<DownstackDep>>,
+    pub(crate) merge_trees: MemoMap<(ObjectId, ObjectId, ObjectId), ObjectId>,
+    pub(crate) references: PartitionedMemoMap<ObjectId, ObjectId, ObjectId>,
+    pub(crate) populate: MemoMap<(ObjectId, ObjectId), ObjectId>,
+    /// Keyed by (input tree, pattern key, NFA state mask). The state mask makes entries
+    /// independent of the path used to reach a subtree. Full-path lookups fold their root into
+    /// a synthetic pattern key and use mask 0.
+    pub(crate) glob: MemoMap<(ObjectId, ObjectId, u64), ObjectId>,
+    /// Path-projection memoization for `:PATHS` and its inverse, keyed by (input tree oid,
+    /// root path). Workspace filters walk commits parent-first, so a child commit reuses the
+    /// projections its parent computed for shared subtrees.
+    pub(crate) paths: MemoMap<(ObjectId, String), ObjectId>,
+    pub(crate) invert: MemoMap<(ObjectId, String), ObjectId>,
+    pub(crate) workspaces: MemoMap<ObjectId, Filter>,
+    pub(crate) ancestors: MemoMap<ObjectId, HashSet<ObjectId>>,
+    /// The most recent commit josh wrote as `(oid, tree_id)`. A history walk processes a commit
+    /// immediately after its parent, so one slot avoids reparsing without retaining every commit.
+    pub(crate) last_written_commit: Cell<Option<(ObjectId, ObjectId)>>,
+}

--- a/josh-core/src/cache/mod.rs
+++ b/josh-core/src/cache/mod.rs
@@ -1,6 +1,7 @@
 mod backend;
 pub mod distributed;
 mod history_graph;
+mod memo;
 pub mod sled;
 pub mod stack;
 mod transaction;

--- a/josh-core/src/cache/transaction.rs
+++ b/josh-core/src/cache/transaction.rs
@@ -1,5 +1,6 @@
 use super::backend::HistoryGraphHint;
 use super::history_graph::compute_history_hint;
+use super::memo::TransactionMemo;
 use super::stack::CacheStack;
 use super::tree_cache::{TreeBytes, TreeCache};
 use anyhow::anyhow;
@@ -199,32 +200,7 @@ impl TransactionContext {
 #[allow(unused)]
 struct Transaction2 {
     commit_map: HashMap<gix_hash::ObjectId, HashMap<gix_hash::ObjectId, gix_hash::ObjectId>>,
-    apply_map: HashMap<gix_hash::ObjectId, HashMap<gix_hash::ObjectId, gix_hash::ObjectId>>,
-    subtract_map: HashMap<(gix_hash::ObjectId, gix_hash::ObjectId), gix_hash::ObjectId>,
-    intersect_map: HashMap<(gix_hash::ObjectId, gix_hash::ObjectId), gix_hash::ObjectId>,
-    overlay_map: HashMap<(gix_hash::ObjectId, gix_hash::ObjectId), gix_hash::ObjectId>,
-    unapply_map: HashMap<gix_hash::ObjectId, HashMap<gix_hash::ObjectId, gix_hash::ObjectId>>,
-    legalize_map: HashMap<(crate::filter::Filter, gix_hash::ObjectId), crate::filter::Filter>,
-    downstack_deps_map:
-        HashMap<gix_hash::ObjectId, std::collections::HashSet<crate::filter::DownstackDep>>,
-    merge_trees_map:
-        HashMap<(gix_hash::ObjectId, gix_hash::ObjectId, gix_hash::ObjectId), gix_hash::ObjectId>,
-    ref_map: HashMap<gix_hash::ObjectId, HashMap<gix_hash::ObjectId, gix_hash::ObjectId>>,
-    populate_map: HashMap<(gix_hash::ObjectId, gix_hash::ObjectId), gix_hash::ObjectId>,
-    /// Keyed by (input tree, pattern key, NFA state mask). The state mask makes entries
-    /// independent of the path a subtree was reached through; the legacy full-path fallback
-    /// folds its root path into a synthetic pattern key and uses mask 0.
-    glob_map: HashMap<(gix_hash::ObjectId, gix_hash::ObjectId, u64), gix_hash::ObjectId>,
-    /// Path-projection memoization for `:PATHS` and its inverse, keyed by (input tree oid,
-    /// root path). Workspace filters walk commits parent-first, so a child commit reuses the
-    /// projections its parent computed for shared subtrees.
-    paths_map: HashMap<(gix_hash::ObjectId, String), gix_hash::ObjectId>,
-    invert_map: HashMap<(gix_hash::ObjectId, String), gix_hash::ObjectId>,
-    workspace_map: HashMap<gix_hash::ObjectId, crate::filter::Filter>,
-    ancestor_map: HashMap<gix_hash::ObjectId, std::collections::HashSet<gix_hash::ObjectId>>,
-    last_written_commit: Option<(gix_hash::ObjectId, gix_hash::ObjectId)>,
     tree_cache: TreeCache,
-
     cache: std::sync::Arc<CacheStack>,
     // In-transaction memoization of the trigram index (source tree -> index tree); the
     // cache backend behind it holds the durable, cross-transaction copy.
@@ -236,6 +212,7 @@ struct Transaction2 {
 
 pub struct Transaction {
     t2: std::cell::RefCell<Transaction2>,
+    memo: TransactionMemo,
     /// josh-search indexing state kept for the whole transaction, so indexing a chain of
     /// commits reuses the merge work of earlier commits. Its own cell because `trigram_index`
     /// borrows it for the entire call while also borrowing other caches through `t2`.
@@ -340,22 +317,6 @@ impl Transaction {
         Transaction {
             t2: std::cell::RefCell::new(Transaction2 {
                 commit_map: HashMap::new(),
-                apply_map: HashMap::new(),
-                subtract_map: HashMap::new(),
-                intersect_map: HashMap::new(),
-                overlay_map: HashMap::new(),
-                unapply_map: HashMap::new(),
-                legalize_map: HashMap::new(),
-                downstack_deps_map: HashMap::new(),
-                merge_trees_map: HashMap::new(),
-                ref_map: HashMap::new(),
-                populate_map: HashMap::new(),
-                glob_map: HashMap::new(),
-                paths_map: HashMap::new(),
-                invert_map: HashMap::new(),
-                workspace_map: HashMap::new(),
-                ancestor_map: HashMap::new(),
-                last_written_commit: None,
                 tree_cache: Default::default(),
                 cache,
                 index_map: HashMap::new(),
@@ -363,6 +324,7 @@ impl Transaction {
                 misses: 0,
                 nesting_level: 0,
             }),
+            memo: Default::default(),
             trigram_indexer: Default::default(),
             search_cache: Default::default(),
             gix_repo,
@@ -399,6 +361,10 @@ impl Transaction {
     /// fallback (see [`josh_memodb::Odb`]).
     pub fn odb(&self) -> &josh_memodb::Odb {
         &self.odb
+    }
+
+    pub(crate) fn memo(&self) -> &TransactionMemo {
+        &self.memo
     }
 
     /// Add `path` (an objects directory) as a runtime alternate: the facade reads through it
@@ -1015,206 +981,6 @@ impl Transaction {
         prev
     }
 
-    pub fn insert_apply(
-        &self,
-        filter: crate::filter::Filter,
-        from: gix_hash::ObjectId,
-        to: gix_hash::ObjectId,
-    ) {
-        let mut t2 = self.t2.borrow_mut();
-        t2.apply_map
-            .entry(filter.id())
-            .or_default()
-            .insert(from, to);
-    }
-
-    pub fn get_apply(
-        &self,
-        filter: crate::filter::Filter,
-        from: gix_hash::ObjectId,
-    ) -> Option<gix_hash::ObjectId> {
-        let t2 = self.t2.borrow_mut();
-        if let Some(m) = t2.apply_map.get(&filter.id()) {
-            return m.get(&from).cloned();
-        }
-        None
-    }
-
-    pub(crate) fn insert_downstack_deps(
-        &self,
-        oid: gix_hash::ObjectId,
-        deps: std::collections::HashSet<crate::filter::DownstackDep>,
-    ) {
-        let mut t2 = self.t2.borrow_mut();
-        t2.downstack_deps_map.insert(oid, deps);
-    }
-
-    pub(crate) fn get_downstack_deps(
-        &self,
-        oid: gix_hash::ObjectId,
-    ) -> Option<std::collections::HashSet<crate::filter::DownstackDep>> {
-        let t2 = self.t2.borrow_mut();
-        t2.downstack_deps_map.get(&oid).cloned()
-    }
-
-    pub(crate) fn insert_merge_trees(
-        &self,
-        key: (gix_hash::ObjectId, gix_hash::ObjectId, gix_hash::ObjectId),
-        result: gix_hash::ObjectId,
-    ) {
-        let mut t2 = self.t2.borrow_mut();
-        t2.merge_trees_map.insert(key, result);
-    }
-
-    pub(crate) fn get_merge_trees(
-        &self,
-        key: (gix_hash::ObjectId, gix_hash::ObjectId, gix_hash::ObjectId),
-    ) -> Option<gix_hash::ObjectId> {
-        let t2 = self.t2.borrow_mut();
-        t2.merge_trees_map.get(&key).copied()
-    }
-
-    pub fn insert_subtract(
-        &self,
-        from: (gix_hash::ObjectId, gix_hash::ObjectId),
-        to: gix_hash::ObjectId,
-    ) {
-        let mut t2 = self.t2.borrow_mut();
-        t2.subtract_map.insert(from, to);
-    }
-
-    pub fn get_subtract(
-        &self,
-        from: (gix_hash::ObjectId, gix_hash::ObjectId),
-    ) -> Option<gix_hash::ObjectId> {
-        let t2 = self.t2.borrow_mut();
-        t2.subtract_map.get(&from).cloned()
-    }
-
-    pub fn insert_intersect(
-        &self,
-        from: (gix_hash::ObjectId, gix_hash::ObjectId),
-        to: gix_hash::ObjectId,
-    ) {
-        let mut t2 = self.t2.borrow_mut();
-        t2.intersect_map.insert(from, to);
-    }
-
-    pub fn get_intersect(
-        &self,
-        from: (gix_hash::ObjectId, gix_hash::ObjectId),
-    ) -> Option<gix_hash::ObjectId> {
-        let t2 = self.t2.borrow_mut();
-        t2.intersect_map.get(&from).cloned()
-    }
-
-    pub fn insert_overlay(
-        &self,
-        from: (gix_hash::ObjectId, gix_hash::ObjectId),
-        to: gix_hash::ObjectId,
-    ) {
-        let mut t2 = self.t2.borrow_mut();
-        t2.overlay_map.insert(from, to);
-    }
-
-    pub fn get_overlay(
-        &self,
-        from: (gix_hash::ObjectId, gix_hash::ObjectId),
-    ) -> Option<gix_hash::ObjectId> {
-        let t2 = self.t2.borrow_mut();
-        t2.overlay_map.get(&from).cloned()
-    }
-
-    /// Remember the most recent commit josh wrote in this transaction as `(oid, tree_id)`. A history
-    /// walk processes a commit right after writing its parent, so this single slot answers the
-    /// common "what tree does my filtered parent have" lookup without re-parsing the parent from the
-    /// odb -- and without retaining every written commit the way a map would.
-    pub fn set_last_written_commit(&self, commit: gix_hash::ObjectId, tree: gix_hash::ObjectId) {
-        self.t2.borrow_mut().last_written_commit = Some((commit, tree));
-    }
-
-    pub fn last_written_commit(&self) -> Option<(gix_hash::ObjectId, gix_hash::ObjectId)> {
-        self.t2.borrow().last_written_commit
-    }
-
-    pub fn insert_legalize(
-        &self,
-        from: (crate::filter::Filter, gix_hash::ObjectId),
-        to: crate::filter::Filter,
-    ) {
-        let mut t2 = self.t2.borrow_mut();
-        t2.legalize_map.insert(from, to);
-    }
-
-    pub fn get_legalize(
-        &self,
-        from: (crate::filter::Filter, gix_hash::ObjectId),
-    ) -> Option<crate::filter::Filter> {
-        let t2 = self.t2.borrow_mut();
-        t2.legalize_map.get(&from).cloned()
-    }
-
-    pub fn insert_unapply(
-        &self,
-        filter: crate::filter::Filter,
-        from: gix_hash::ObjectId,
-        to: gix_hash::ObjectId,
-    ) {
-        let mut t2 = self.t2.borrow_mut();
-        t2.unapply_map
-            .entry(filter.id())
-            .or_default()
-            .insert(from, to);
-    }
-
-    pub fn insert_paths(&self, tree: (gix_hash::ObjectId, String), result: gix_hash::ObjectId) {
-        self.t2.borrow_mut().paths_map.entry(tree).or_insert(result);
-    }
-
-    pub fn get_paths(&self, tree: (gix_hash::ObjectId, String)) -> Option<gix_hash::ObjectId> {
-        self.t2.borrow().paths_map.get(&tree).copied()
-    }
-
-    pub fn insert_invert(&self, tree: (gix_hash::ObjectId, String), result: gix_hash::ObjectId) {
-        self.t2
-            .borrow_mut()
-            .invert_map
-            .entry(tree)
-            .or_insert(result);
-    }
-
-    pub fn get_invert(&self, tree: (gix_hash::ObjectId, String)) -> Option<gix_hash::ObjectId> {
-        self.t2.borrow().invert_map.get(&tree).copied()
-    }
-
-    pub(crate) fn get_workspace(&self, blob: gix_hash::ObjectId) -> Option<crate::filter::Filter> {
-        self.t2.borrow().workspace_map.get(&blob).copied()
-    }
-
-    pub(crate) fn insert_workspace(&self, blob: gix_hash::ObjectId, filter: crate::filter::Filter) {
-        self.t2.borrow_mut().workspace_map.insert(blob, filter);
-    }
-
-    pub(crate) fn get_ancestor(
-        &self,
-        tip: gix_hash::ObjectId,
-        commit: gix_hash::ObjectId,
-    ) -> Option<bool> {
-        self.t2
-            .borrow()
-            .ancestor_map
-            .get(&tip)
-            .map(|ancestors| ancestors.contains(&commit))
-    }
-
-    pub(crate) fn insert_ancestors(
-        &self,
-        tip: gix_hash::ObjectId,
-        ancestors: std::collections::HashSet<gix_hash::ObjectId>,
-    ) {
-        self.t2.borrow_mut().ancestor_map.insert(tip, ancestors);
-    }
-
     /// Cache indexes under the commit's history shard. A null ID means no commit context.
     pub fn trigram_index_cache(&self, commit: gix_hash::ObjectId) -> TrigramIndexCache<'_> {
         TrigramIndexCache {
@@ -1266,81 +1032,6 @@ impl Transaction {
         } else {
             None
         }
-    }
-
-    pub fn insert_populate(
-        &self,
-        tree: (gix_hash::ObjectId, gix_hash::ObjectId),
-        result: gix_hash::ObjectId,
-    ) {
-        self.t2
-            .borrow_mut()
-            .populate_map
-            .entry(tree)
-            .or_insert(result);
-    }
-
-    pub fn get_populate(
-        &self,
-        tree: (gix_hash::ObjectId, gix_hash::ObjectId),
-    ) -> Option<gix_hash::ObjectId> {
-        self.t2.borrow().populate_map.get(&tree).copied()
-    }
-
-    pub fn insert_glob(
-        &self,
-        tree: (gix_hash::ObjectId, gix_hash::ObjectId, u64),
-        result: gix_hash::ObjectId,
-    ) {
-        self.t2.borrow_mut().glob_map.entry(tree).or_insert(result);
-    }
-
-    pub fn get_glob(
-        &self,
-        tree: (gix_hash::ObjectId, gix_hash::ObjectId, u64),
-    ) -> Option<gix_hash::ObjectId> {
-        self.t2.borrow().glob_map.get(&tree).copied()
-    }
-
-    pub fn insert_ref(
-        &self,
-        filter: crate::filter::Filter,
-        from: gix_hash::ObjectId,
-        to: gix_hash::ObjectId,
-    ) {
-        self.t2
-            .borrow_mut()
-            .ref_map
-            .entry(filter.id())
-            .or_default()
-            .insert(from, to);
-    }
-
-    pub fn get_ref(
-        &self,
-        filter: crate::filter::Filter,
-        from: gix_hash::ObjectId,
-    ) -> Option<gix_hash::ObjectId> {
-        let oid = self
-            .t2
-            .borrow()
-            .ref_map
-            .get(&filter.id())
-            .and_then(|entries| entries.get(&from))
-            .copied()?;
-        self.odb().contains(oid).then_some(oid)
-    }
-
-    pub fn get_unapply(
-        &self,
-        filter: crate::filter::Filter,
-        from: gix_hash::ObjectId,
-    ) -> Option<gix_hash::ObjectId> {
-        let t2 = self.t2.borrow_mut();
-        if let Some(m) = t2.unapply_map.get(&filter.id()) {
-            return m.get(&from).cloned();
-        }
-        None
     }
 
     pub fn lookup_filter_hook(
@@ -1592,30 +1283,54 @@ mod tests {
         let oid = commit(&first, "cached");
         let filter = crate::filter::Filter::new();
 
-        first.insert_ref(filter, oid, oid);
-        first.insert_populate((oid, oid), oid);
-        first.insert_glob((oid, oid, 1), oid);
-        first.insert_paths((oid, "root".to_owned()), oid);
-        first.insert_invert((oid, "root".to_owned()), oid);
-        first.insert_workspace(oid, filter);
-        first.insert_ancestors(oid, std::collections::HashSet::from([oid]));
+        first.memo().references.insert(filter.id(), oid, oid);
+        first.memo().populate.insert_if_absent((oid, oid), oid);
+        first.memo().glob.insert_if_absent((oid, oid, 1), oid);
+        first
+            .memo()
+            .paths
+            .insert_if_absent((oid, "root".to_owned()), oid);
+        first
+            .memo()
+            .invert
+            .insert_if_absent((oid, "root".to_owned()), oid);
+        first.memo().workspaces.insert(oid, filter);
+        first
+            .memo()
+            .ancestors
+            .insert(oid, std::collections::HashSet::from([oid]));
 
-        assert_eq!(first.get_ref(filter, oid), Some(oid));
-        assert_eq!(first.get_populate((oid, oid)), Some(oid));
-        assert_eq!(first.get_glob((oid, oid, 1)), Some(oid));
-        assert_eq!(first.get_paths((oid, "root".to_owned())), Some(oid));
-        assert_eq!(first.get_invert((oid, "root".to_owned())), Some(oid));
-        assert_eq!(first.get_workspace(oid), Some(filter));
-        assert_eq!(first.get_ancestor(oid, oid), Some(true));
+        assert_eq!(first.memo().references.get(&filter.id(), &oid), Some(oid));
+        assert_eq!(first.memo().populate.get(&(oid, oid)), Some(oid));
+        assert_eq!(first.memo().glob.get(&(oid, oid, 1)), Some(oid));
+        assert_eq!(first.memo().paths.get(&(oid, "root".to_owned())), Some(oid));
+        assert_eq!(
+            first.memo().invert.get(&(oid, "root".to_owned())),
+            Some(oid)
+        );
+        assert_eq!(first.memo().workspaces.get(&oid), Some(filter));
+        assert_eq!(
+            first
+                .memo()
+                .ancestors
+                .get_with(&oid, |ancestors| ancestors.contains(&oid)),
+            Some(true)
+        );
 
         let second = context.open().unwrap();
-        assert_eq!(second.get_ref(filter, oid), None);
-        assert_eq!(second.get_populate((oid, oid)), None);
-        assert_eq!(second.get_glob((oid, oid, 1)), None);
-        assert_eq!(second.get_paths((oid, "root".to_owned())), None);
-        assert_eq!(second.get_invert((oid, "root".to_owned())), None);
-        assert_eq!(second.get_workspace(oid), None);
-        assert_eq!(second.get_ancestor(oid, oid), None);
+        assert_eq!(second.memo().references.get(&filter.id(), &oid), None);
+        assert_eq!(second.memo().populate.get(&(oid, oid)), None);
+        assert_eq!(second.memo().glob.get(&(oid, oid, 1)), None);
+        assert_eq!(second.memo().paths.get(&(oid, "root".to_owned())), None);
+        assert_eq!(second.memo().invert.get(&(oid, "root".to_owned())), None);
+        assert_eq!(second.memo().workspaces.get(&oid), None);
+        assert_eq!(
+            second
+                .memo()
+                .ancestors
+                .get_with(&oid, |ancestors| ancestors.contains(&oid)),
+            None
+        );
     }
 
     #[test]

--- a/josh-core/src/filter/mod.rs
+++ b/josh-core/src/filter/mod.rs
@@ -39,14 +39,6 @@ pub fn from_tree(
     josh_filter::persist::from_tree(transaction.odb(), tree_oid)
 }
 
-// MESSAGE_MATCH_ALL_REGEX is now in josh-filter
-
-// Filter type and builder methods are now in josh-filter
-// Note: TryFrom<String> and From<Filter> for String implementations
-// are not included here because they require parse/spec from josh-core
-// and we cannot implement external traits for external types.
-// These conversions should be done via parse() and spec() functions directly.
-
 /// A signature override for `rewrite_commit`.
 #[derive(Debug, Clone)]
 pub enum SigRewrite {
@@ -352,7 +344,6 @@ fn get_filter(
     path: &Path,
 ) -> Filter {
     let ws_path = normalize_path(path);
-    // One descent resolves the transaction cache key: the workspace.josh entry oid.
     let ws_id = match tree::get_path_entry_at(transaction, odb, reader, &ws_path) {
         Ok(Some(entry)) => entry.oid,
         _ => {
@@ -360,7 +351,7 @@ fn get_filter(
         }
     };
 
-    if let Some(f) = transaction.get_workspace(ws_id) {
+    if let Some(f) = transaction.memo().workspaces.get(&ws_id) {
         f
     } else {
         let ws_blob = tree::blob_text(odb, ws_id);
@@ -373,7 +364,7 @@ fn get_filter(
         } else {
             to_filter(Op::Empty)
         };
-        transaction.insert_workspace(ws_id, f);
+        transaction.memo().workspaces.insert(ws_id, f);
         f
     }
 }
@@ -1695,9 +1686,8 @@ fn compute_warnings2(
     warnings
 }
 
-/// Check if `commit` is an ancestor of `tip`.
-///
-/// Creates a cache for a given `tip` so repeated queries with the same `tip` are more efficient.
+/// Check whether `commit` is an ancestor of `tip`, memoizing the ancestor set because callers
+/// commonly test many commits against the same tip.
 pub fn is_ancestor_of(
     transaction: &cache::Transaction,
     commit: gix_hash::ObjectId,
@@ -1709,25 +1699,26 @@ pub fn is_ancestor_of(
         }
     }
 
-    if let Some(is_ancestor) = transaction.get_ancestor(tip, commit) {
+    if let Some(is_ancestor) = transaction
+        .memo()
+        .ancestors
+        .get_with(&tip, |ancestors| ancestors.contains(&commit))
+    {
         return Ok(is_ancestor);
     }
 
     tracing::trace!("is_ancestor_of tip={tip}");
-    // Recursively compute all ancestors of `tip`.
-    // Invariant: Everything in `todo` is also in `ancestors`.
     let mut todo = vec![tip];
     let mut ancestors = std::collections::HashSet::from_iter(todo.iter().copied());
     while let Some(commit) = todo.pop() {
         for parent in crate::git::read_parent_ids(transaction.odb(), commit)? {
             if ancestors.insert(parent) {
-                // Newly inserted! Also handle its parents.
                 todo.push(parent);
             }
         }
     }
     let is_ancestor = ancestors.contains(&commit);
-    transaction.insert_ancestors(tip, ancestors);
+    transaction.memo().ancestors.insert(tip, ancestors);
     Ok(is_ancestor)
 }
 
@@ -1774,14 +1765,12 @@ fn legalize_stored(
         return Ok(f);
     }
 
-    if let Some(f) = t.get_legalize((f, tree)) {
+    if let Some(f) = t.memo().legalize.get(&(f, tree)) {
         return Ok(f);
     }
 
-    // Put an entry into the hashtable to prevent infinite recursion.
-    // If we get called with the same arguments again before we return,
-    // Above check breaks the recursion.
-    t.insert_legalize((f, tree), Filter::new().empty());
+    // Break cycles while repository-backed filters recursively legalize one another.
+    t.memo().legalize.insert((f, tree), Filter::new().empty());
 
     let r = match to_op(f) {
         Op::Compose(f) => {
@@ -1839,7 +1828,7 @@ fn legalize_stored(
         _ => f,
     };
 
-    t.insert_legalize((f, tree), r);
+    t.memo().legalize.insert((f, tree), r);
 
     Ok(r)
 }
@@ -2207,11 +2196,11 @@ fn cached_merge_trees(
     }
 
     let key = (a, b, c);
-    if let Some(hit) = transaction.get_merge_trees(key) {
+    if let Some(hit) = transaction.memo().merge_trees.get(&key) {
         return Ok(hit);
     }
     let oid = objects::merge_trees(transaction.odb(), a, b, c)?;
-    transaction.insert_merge_trees(key, oid);
+    transaction.memo().merge_trees.insert(key, oid);
     Ok(oid)
 }
 
@@ -2237,7 +2226,7 @@ fn downstack_commit_deps(
     commit: &objects::CommitData,
 ) -> anyhow::Result<std::collections::HashSet<DownstackDep>> {
     let oid = commit.id();
-    if let Some(hit) = transaction.get_downstack_deps(oid) {
+    if let Some(hit) = transaction.memo().downstack_deps.get(&oid) {
         return Ok(hit);
     }
 
@@ -2269,7 +2258,7 @@ fn downstack_commit_deps(
         deps.insert(DownstackDep::Series(s));
     }
 
-    transaction.insert_downstack_deps(oid, deps.clone());
+    transaction.memo().downstack_deps.insert(oid, deps.clone());
     Ok(deps)
 }
 
@@ -2902,7 +2891,7 @@ mod tests {
         .unwrap()
         .unwrap()
         .oid;
-        assert!(transaction.get_workspace(blob).is_none());
+        assert!(transaction.memo().workspaces.get(&blob).is_none());
 
         let resolver = FixedResolver(build_tree(&repo, &[("selected", "baseline")]));
         let parser = |spec: &str| josh_filter::parse_with_resolver(spec, &resolver);
@@ -2916,7 +2905,7 @@ mod tests {
         let error = format!("{error:#}");
         assert!(error.contains("defs/context-only.josh"));
         assert!(error.contains("undefined revision variable `missing`"));
-        assert!(transaction.get_workspace(blob).is_none());
+        assert!(transaction.memo().workspaces.get(&blob).is_none());
     }
 
     #[test]

--- a/josh-core/src/filter/tree.rs
+++ b/josh-core/src/filter/tree.rs
@@ -18,7 +18,7 @@ fn pathstree_inner(
     transaction: &cache::Transaction,
     odb: &josh_memodb::Odb,
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    if let Some(cached) = transaction.get_paths((input, root.to_string())) {
+    if let Some(cached) = transaction.memo().paths.get(&(input, root.to_string())) {
         return Ok(cached);
     }
 
@@ -62,7 +62,10 @@ fn pathstree_inner(
         }
     }
     let result = objects::write_tree_now(odb, rebuild.out)?;
-    transaction.insert_paths((input, root.to_string()), result);
+    transaction
+        .memo()
+        .paths
+        .insert_if_absent((input, root.to_string()), result);
     Ok(result)
 }
 
@@ -406,8 +409,8 @@ fn insert_in_order(out: &mut Vec<gix_object::tree::Entry>, entry: gix_object::tr
 /// incoming length before returning. Gitlink (submodule) entries are always dropped.
 ///
 /// The predicate sees full paths, so the result of a subtree depends on where it sits, not only
-/// on its oid. The cache key therefore folds the current root path into a synthetic oid (the
-/// insert_invert idiom): identical subtrees at different paths get distinct entries.
+/// on its oid. The cache key therefore folds the current root path into a synthetic oid, so
+/// identical subtrees at different paths get distinct entries.
 pub fn remove_pred(
     transaction: &cache::Transaction,
     path: &mut String,
@@ -430,7 +433,7 @@ fn remove_pred_inner(
     key: gix_hash::ObjectId,
 ) -> anyhow::Result<gix_hash::ObjectId> {
     let root_key = objects::hash_blob(format!("glob-fallback:{:?}:{}", key, path).as_bytes());
-    if let Some(cached) = transaction.get_glob((input, root_key, 0)) {
+    if let Some(cached) = transaction.memo().glob.get(&(input, root_key, 0)) {
         return Ok(cached);
     }
 
@@ -478,7 +481,10 @@ fn remove_pred_inner(
     }
 
     let result = rebuild.finish(odb, input)?;
-    transaction.insert_glob((input, root_key, 0), result);
+    transaction
+        .memo()
+        .glob
+        .insert_if_absent((input, root_key, 0), result);
     Ok(result)
 }
 
@@ -516,7 +522,7 @@ fn remove_pattern_inner(
     state: u64,
 ) -> anyhow::Result<gix_hash::ObjectId> {
     let state = cp.closure(state);
-    if let Some(cached) = transaction.get_glob((input, key, state)) {
+    if let Some(cached) = transaction.memo().glob.get(&(input, key, state)) {
         return Ok(cached);
     }
 
@@ -615,7 +621,10 @@ fn remove_pattern_inner(
 
     // See remove_pred: an untouched entry set reproduces `input` bit-identically.
     let result = rebuild.finish(odb, input)?;
-    transaction.insert_glob((input, key, state), result);
+    transaction
+        .memo()
+        .glob
+        .insert_if_absent((input, key, state), result);
     Ok(result)
 }
 
@@ -642,7 +651,7 @@ fn subtract_inner(
         return Ok(empty_id());
     }
 
-    if let Some(cached) = transaction.get_subtract((input1, input2)) {
+    if let Some(cached) = transaction.memo().subtract.get(&(input1, input2)) {
         return Ok(cached);
     }
 
@@ -682,12 +691,15 @@ fn subtract_inner(
         }
         let result = objects::write_tree_now(odb, out)?;
 
-        transaction.insert_subtract((input1, input2), result);
+        transaction.memo().subtract.insert((input1, input2), result);
 
         return Ok(result);
     }
 
-    transaction.insert_subtract((input1, input2), empty_id());
+    transaction
+        .memo()
+        .subtract
+        .insert((input1, input2), empty_id());
 
     Ok(empty_id())
 }
@@ -723,7 +735,7 @@ fn intersect_inner(
         return Ok(empty_id());
     }
 
-    if let Some(cached) = transaction.get_intersect((input1, input2)) {
+    if let Some(cached) = transaction.memo().intersect.get(&(input1, input2)) {
         return Ok(cached);
     }
 
@@ -758,7 +770,10 @@ fn intersect_inner(
         input1
     };
 
-    transaction.insert_intersect((input1, input2), result);
+    transaction
+        .memo()
+        .intersect
+        .insert((input1, input2), result);
 
     Ok(result)
 }
@@ -996,7 +1011,7 @@ fn overlay_inner(
     input1: gix_hash::ObjectId,
     input2: gix_hash::ObjectId,
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    if let Some(cached) = transaction.get_overlay((input1, input2)) {
+    if let Some(cached) = transaction.memo().overlay.get(&(input1, input2)) {
         return Ok(cached);
     }
     if input1 == input2 {
@@ -1043,7 +1058,7 @@ fn overlay_inner(
 
         let rid = objects::write_tree_now(odb, out)?;
 
-        transaction.insert_overlay((input1, input2), rid);
+        transaction.memo().overlay.insert((input1, input2), rid);
         return Ok(rid);
     }
 
@@ -1067,7 +1082,7 @@ pub fn invert_paths(
     root: &str,
     tree: gix_hash::ObjectId,
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    if let Some(cached) = transaction.get_invert((tree, root.to_string())) {
+    if let Some(cached) = transaction.memo().invert.get(&(tree, root.to_string())) {
         return Ok(cached);
     }
 
@@ -1114,7 +1129,10 @@ pub fn invert_paths(
         }
     }
 
-    transaction.insert_invert((tree, root.to_string()), result);
+    transaction
+        .memo()
+        .invert
+        .insert_if_absent((tree, root.to_string()), result);
 
     Ok(result)
 }
@@ -1157,7 +1175,7 @@ pub fn populate(
     paths: gix_hash::ObjectId,
     content: gix_hash::ObjectId,
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    if let Some(cached) = transaction.get_populate((paths, content)) {
+    if let Some(cached) = transaction.memo().populate.get(&(paths, content)) {
         return Ok(cached);
     }
 
@@ -1191,7 +1209,10 @@ pub fn populate(
         }
     }
 
-    transaction.insert_populate((paths, content), result_tree);
+    transaction
+        .memo()
+        .populate
+        .insert_if_absent((paths, content), result_tree);
 
     Ok(result_tree)
 }
@@ -1212,22 +1233,22 @@ pub fn compose(
         // since the original filter was already applied by the caller and passed via the "trees"
         // parameter.
         let f = invert(invert(*f)?)?;
-        let taken_applied = if let Some(cached) = transaction.get_apply(f, tid) {
+        let taken_applied = if let Some(cached) = transaction.memo().apply.get(&f.id(), &tid) {
             cached
         } else {
             apply(transaction, f, Rewrite::from_tree(taken))?.tree_id()
         };
-        transaction.insert_apply(f, tid, taken_applied);
+        transaction.memo().apply.insert(f.id(), tid, taken_applied);
 
         let subtracted = subtract(transaction, applied, taken_applied)?;
 
         let aid = applied;
-        let unapplied = if let Some(cached) = transaction.get_unapply(f, aid) {
+        let unapplied = if let Some(cached) = transaction.memo().unapply.get(&f.id(), &aid) {
             cached
         } else {
             apply(transaction, invert(f)?, Rewrite::from_tree(applied))?.tree_id()
         };
-        transaction.insert_unapply(f, aid, unapplied);
+        transaction.memo().unapply.insert(f.id(), aid, unapplied);
         taken = overlay(transaction, taken, unapplied)?;
         result = overlay(transaction, subtracted, result)?;
     }
@@ -1765,8 +1786,7 @@ mod tests {
         );
     }
 
-    // The remove_pred fallback keys its cache by (subtree, pattern, root path), so identical
-    // subtrees at different paths must not alias even in the legacy walk.
+    // The root path is part of the memo key so identical subtrees cannot alias here.
     #[test]
     fn remove_pred_does_not_alias_identical_subtrees() {
         let td = tempfile::tempdir().unwrap();

--- a/josh-core/src/history.rs
+++ b/josh-core/src/history.rs
@@ -918,7 +918,10 @@ fn create_filtered_commit2(
     )?;
     // Record the freshly written commit's tree so the next commit in this walk (usually its child)
     // reads its parent's tree from the slot instead of re-parsing the commit from the odb.
-    transaction.set_last_written_commit(new_oid, new_tree_id);
+    transaction
+        .memo()
+        .last_written_commit
+        .set(Some((new_oid, new_tree_id)));
     Ok((new_oid, true))
 }
 
@@ -930,7 +933,7 @@ pub(crate) fn filtered_parent_tree_id(
     transaction: &cache::Transaction,
     oid: gix_hash::ObjectId,
 ) -> anyhow::Result<gix_hash::ObjectId> {
-    if let Some((last, tree_id)) = transaction.last_written_commit() {
+    if let Some((last, tree_id)) = transaction.memo().last_written_commit.get() {
         if last == oid {
             return Ok(tree_id);
         }

--- a/josh-core/src/lib.rs
+++ b/josh-core/src/lib.rs
@@ -107,14 +107,11 @@ impl $name {
     }
 }
 
-/// Reset josh's on-disk cache to a cold state.
+/// Clear the disposable on-disk cache used by benchmarks and tests.
 ///
-/// Per-transaction in-memory caches are not cleared here: callers reset them by dropping and
-/// reopening the transaction. Filter interning and optimizer memoization are structural and
-/// independent of repository data.
-///
-/// Nuking the on-disk sled cache is safe: it is ephemeral and, when configured, backed by a
-/// remote cache. Intended for benchmarks and tests that need a cold cache between runs.
+/// Transaction-local memoization expires with its owner. Filter interning and optimizer
+/// memoization are structural and remain valid independently of repository data.
+/// A configured remote backend can repopulate the sled cache.
 pub fn reset_caches() -> anyhow::Result<()> {
     cache::sled_clear()?;
     Ok(())
@@ -130,7 +127,12 @@ pub fn filter_commit(
     // has to see the transaction's buffered objects.
     let original_commit = objects::peel_to_commit(transaction.odb(), oid)?;
 
-    let filter_commit = if let Some(s) = transaction.get_ref(filterobj, oid) {
+    let filter_commit = if let Some(s) = transaction
+        .memo()
+        .references
+        .get(&filterobj.id(), &oid)
+        .filter(|oid| transaction.odb().contains(*oid))
+    {
         s
     } else {
         tracing::trace!("apply_to_commit");
@@ -138,7 +140,10 @@ pub fn filter_commit(
         filter::apply_to_commit(filterobj, original_commit, transaction)?
     };
 
-    transaction.insert_ref(filterobj, oid, filter_commit);
+    transaction
+        .memo()
+        .references
+        .insert(filterobj.id(), oid, filter_commit);
 
     Ok(filter_commit)
 }


### PR DESCRIPTION
Generalize transaction-local memoization

Replace cache-specific Transaction getters and setters with typed memo tables while preserving the specialized persistent cache paths.

Change: generalize-transaction-memos
Assisted-By: openai-codex/gpt-5.6-sol