### PR TITLE
Filter multiple refs with revspec mappings

### DIFF
--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -343,16 +343,20 @@ josh compose run + :+ws/test
 It is intended for scripting and one-off history rewriting tasks rather than day-to-day
 development workflows.
 
-**Input:** the second positional argument selects what to filter. It defaults to `HEAD`
-but can be any of:
+**Input:** by default, the second positional argument selects one revision to filter and
+`--update` names its destination. The input defaults to `HEAD` but can be any of:
 
 - `.` - the working tree (including uncommitted changes)
 - `+` - the index (staged changes only)
 - A full or abbreviated commit SHA
 - A ref name (e.g. `main`, `refs/heads/feature`)
 
-**Output:** the filtered commit SHA is printed to stdout. The filtered history is also
-written to the ref given by `--update` (default: `FILTERED_HEAD`).
+With `--revspec <source>:<destination>`, `josh-filter` instead filters every ref matched by
+the Git-style refspec and writes each result to its mapped destination. Wildcard refspecs
+and repeated `--revspec` options are supported.
+
+**Output:** single-revision mode prints the filtered commit SHA. Refspec mode prints one
+`<SHA> <destination-ref>` line per updated ref.
 
 **Basic usage:**
 
@@ -365,6 +369,9 @@ josh-filter :/docs .
 
 # Filter a specific commit SHA
 josh-filter :/docs abc1234 --update refs/my/filtered
+
+# Filter every local branch into refs/filtered/heads/
+josh-filter :/docs --revspec 'refs/heads/*:refs/filtered/heads/*'
 ```
 
 **Options:**
@@ -372,6 +379,7 @@ josh-filter :/docs abc1234 --update refs/my/filtered
 | Flag | Description |
 |------|-------------|
 | `--update <ref>` | Ref to update with the filtered result (default: `FILTERED_HEAD`) |
+| `--revspec <source>:<destination>` | Filter all matching refs into mapped destination refs; may be repeated |
 | `--file <path>` | Read filter spec from a file |
 | `--squash-pattern <pattern>` | Squash commits matching the pattern |
 | `--squash-file <path>` | Read squash patterns from a file |

--- a/josh-cli/src/bin/josh-filter.rs
+++ b/josh-cli/src/bin/josh-filter.rs
@@ -1,5 +1,8 @@
 #![warn(unused_extern_crates)]
 
+#[path = "josh-filter/revspec.rs"]
+mod revspec;
+
 use anyhow::{Context, anyhow};
 use std::fs::read_to_string;
 use std::str::FromStr;
@@ -66,6 +69,31 @@ fn make_app() -> clap::Command {
             clap::Arg::new("input")
                 .help("Ref or SHA to apply filter to, '.' for the working tree, or '+' for the index (staged changes)")
                 .default_value("HEAD"),
+        )
+        .arg(
+            clap::Arg::new("revspec")
+                .long("revspec")
+                .value_name("SOURCE:DESTINATION")
+                .action(clap::ArgAction::Append)
+                .conflicts_with_all([
+                    "input",
+                    "update",
+                    "squash-pattern",
+                    "squash-file",
+                    "discover",
+                    "search",
+                    "search-history",
+                    "search-changes",
+                    "graphql",
+                    "query",
+                    "reverse",
+                    "check-roundtrip",
+                    "force",
+                ])
+                .help(
+                    "Filter every ref selected by a Git-style refspec into its mapped destination; \
+                     may be repeated",
+                ),
         )
         .arg(
             clap::Arg::new("file")
@@ -276,13 +304,17 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         josh_core::filter::from_tree(&transaction, tree_oid)?
     };
 
-    let input_ref = args.get_one::<String>("input").unwrap();
-
-    let mut refs = vec![];
+    let revspecs = args
+        .get_many::<String>("revspec")
+        .map(|values| values.cloned().collect::<Vec<_>>());
+    let (input_ref, mut refs) = if let Some(revspecs) = revspecs.as_deref() {
+        (None, revspec::resolve(&transaction, revspecs)?)
+    } else {
+        let input_ref = args.get_one::<String>("input").unwrap();
+        let (input_ref, oid) = resolve_input_ref(&transaction, input_ref)?;
+        (Some(input_ref.clone()), vec![(input_ref, oid)])
+    };
     let mut ids = vec![];
-
-    let (input_ref, oid) = resolve_input_ref(&transaction, input_ref)?;
-    refs.push((input_ref.clone(), oid));
 
     if args.get_flag("single") {
         filterobj = josh_core::filter::Filter::new().squash().chain(filterobj);
@@ -353,8 +385,11 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
 
     if args.get_flag("discover") {
         let odb = transaction.odb();
+        let input_ref = input_ref
+            .as_deref()
+            .ok_or_else(|| anyhow!("discovery requires a single input ref"))?;
         let head = transaction
-            .rev_parse(&input_ref)?
+            .rev_parse(input_ref)?
             .ok_or_else(|| anyhow!("no such revision: {}", input_ref))?;
         let tree = josh_core::objects::CommitData::read(odb, head)?.tree_id()?;
         let hs = josh_core::housekeeping::find_all_workspaces_and_subdirectories(odb, tree)?;
@@ -369,41 +404,59 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         }
     }
 
+    let revspec_mode = revspecs.is_some();
     let update_target = args.get_one::<String>("update").unwrap();
-
     let target = update_target;
-
     let reverse = args.get_flag("reverse");
 
-    let old_oid = transaction
-        .resolve_ref(target)?
-        .unwrap_or(gix_hash::ObjectId::null(gix_hash::Kind::Sha1));
+    let old_oid = if revspec_mode {
+        gix_hash::ObjectId::null(gix_hash::Kind::Sha1)
+    } else {
+        transaction
+            .resolve_ref(target)?
+            .unwrap_or(gix_hash::ObjectId::null(gix_hash::Kind::Sha1))
+    };
 
     let (mut updated_refs, errors) = josh_core::filter_refs(&transaction, filterobj, &refs);
 
     if let Some(error) = errors.into_iter().next() {
         return Err(error.1);
     }
-    for item in &mut updated_refs {
-        if item.0 == input_ref {
-            if reverse {
-                item.0 = "refs/JOSH_TMP".to_string();
+    if !revspec_mode {
+        let input_ref = input_ref.as_deref().expect("single-ref mode has an input");
+        for item in &mut updated_refs {
+            if item.0 == input_ref {
+                if reverse {
+                    item.0 = "refs/JOSH_TMP".to_string();
+                } else {
+                    item.0 = target.to_string();
+                }
             } else {
-                item.0 = target.to_string();
+                item.0 = item.0.replacen("refs/heads/", "refs/heads/filtered/", 1);
+                item.0 = item.0.replacen("refs/tags/", "refs/tags/filtered/", 1);
             }
-        } else {
-            item.0 = item.0.replacen("refs/heads/", "refs/heads/filtered/", 1);
-            item.0 = item.0.replacen("refs/tags/", "refs/tags/filtered/", 1);
         }
     }
     josh_core::update_refs(&transaction, updated_refs.clone());
+    if revspec_mode {
+        transaction.flush_mem_odb()?;
+        for (name, oid) in updated_refs {
+            println!("{oid} {name}");
+        }
+        return Ok(0);
+    }
 
     if let Some(pattern) = args.get_one::<String>("search") {
         if args.get_flag("search-changes") {
             if !josh_core::filter::experimental_features_enabled() {
                 anyhow::bail!("--search-changes requires JOSH_EXPERIMENTAL_FEATURES=1");
             }
-            search_changes(&transaction, filterobj, &input_ref, pattern)?;
+            search_changes(
+                &transaction,
+                filterobj,
+                input_ref.as_deref().expect("single-ref mode has an input"),
+                pattern,
+            )?;
             return Ok(0);
         }
         if args.get_flag("search-history") {
@@ -414,8 +467,9 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             // whole graph, not just first-parent). Walking the filtered graph directly gives
             // exactly the trees being searched — no mapping back and forth between original
             // and filtered commits.
+            let input_ref = input_ref.as_deref().expect("single-ref mode has an input");
             let commit = transaction
-                .rev_parse(&input_ref)?
+                .rev_parse(input_ref)?
                 .ok_or_else(|| anyhow!("no such revision: {}", input_ref))?;
             let filtered_id = josh_core::filter_commit(&transaction, filterobj, commit)?;
             let ifilterobj = josh_core::filter::parse(":INDEX")?;
@@ -452,8 +506,9 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
             }
             return Ok(0);
         }
+        let input_ref = input_ref.as_deref().expect("single-ref mode has an input");
         let commit = transaction
-            .rev_parse(&input_ref)?
+            .rev_parse(input_ref)?
             .ok_or_else(|| anyhow!("no such revision: {}", input_ref))?;
 
         let odb = transaction.odb();
@@ -525,7 +580,8 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
         };
         let new = rev(target)?;
         let old = rev("JOSH_TMP")?;
-        let unfiltered_old = rev(&input_ref)?;
+        let input_ref = input_ref.as_deref().expect("single-ref mode has an input");
+        let unfiltered_old = rev(input_ref)?;
 
         let ret = match josh_core::history::unapply_filter(
             &transaction,
@@ -556,7 +612,7 @@ fn run_filter(args: Vec<String>) -> anyhow::Result<i32> {
                     ));
                 }
                 transaction.update_ref(
-                    &input_ref,
+                    input_ref,
                     josh_core::cache::Expected::At(unfiltered_old),
                     rewritten,
                     "unapply_filter",

--- a/josh-cli/src/bin/josh-filter/revspec.rs
+++ b/josh-cli/src/bin/josh-filter/revspec.rs
@@ -1,0 +1,65 @@
+use anyhow::{Context, anyhow};
+
+pub(super) fn resolve(
+    transaction: &josh_core::cache::Transaction,
+    revspecs: &[String],
+) -> anyhow::Result<Vec<(String, gix_hash::ObjectId)>> {
+    let specs = revspecs
+        .iter()
+        .map(|spec| {
+            let parsed =
+                gix::refspec::parse(spec.as_str().into(), gix::refspec::parse::Operation::Fetch)
+                    .with_context(|| format!("invalid revspec: {spec}"))?
+                    .to_owned();
+            if parsed.to_ref().source().is_none() || parsed.to_ref().destination().is_none() {
+                anyhow::bail!("revspec must map a source to a destination: {spec}");
+            }
+            Ok(parsed)
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    let mut available = Vec::new();
+    transaction.for_each_ref_prefixed("", |name, oid| {
+        available.push((name.to_owned(), oid));
+        Ok(())
+    })?;
+
+    let matches =
+        gix::refspec::MatchGroup::from_fetch_specs(specs.iter().map(gix::refspec::RefSpec::to_ref))
+            .match_lhs(
+                available
+                    .iter()
+                    .map(|(name, oid)| gix::refspec::match_group::Item {
+                        full_ref_name: name.as_str().into(),
+                        target: oid,
+                        object: None,
+                    }),
+            )
+            .mappings;
+
+    if matches.is_empty() {
+        anyhow::bail!("revspec did not match any refs");
+    }
+
+    let mut destinations = std::collections::BTreeSet::new();
+    matches
+        .into_iter()
+        .map(|mapping| {
+            let source_index = mapping
+                .item_index
+                .ok_or_else(|| anyhow!("revspec sources must name refs"))?;
+            let destination = mapping
+                .rhs
+                .ok_or_else(|| anyhow!("revspec must map every source to a destination"))?;
+            let destination = std::str::from_utf8(destination.as_ref())?.to_owned();
+            gix::refs::FullName::try_from(destination.as_str())
+                .with_context(|| format!("invalid destination ref: {destination}"))?;
+            if !destinations.insert(destination.clone()) {
+                anyhow::bail!("multiple revspecs map to destination ref: {destination}");
+            }
+            let oid =
+                josh_core::objects::peel_to_commit(transaction.odb(), available[source_index].1)?;
+            Ok((destination, oid))
+        })
+        .collect()
+}

--- a/tests/filter/cmdline.t
+++ b/tests/filter/cmdline.t
@@ -54,6 +54,26 @@
   $ git log --graph --pretty=%s josh/filter/libs/foo
   * add file3
 
+Bulk filtering maps every matching source ref through a Git-style refspec.
+
+  $ josh-filter c=:/sub1 --revspec 'refs/remotes/libs/*:refs/josh/bulk/*'
+  [0-9a-f]{40} refs/josh/bulk/foo (re)
+  [0-9a-f]{40} refs/josh/bulk/master (re)
+  $ git log --pretty=%s refs/josh/bulk/foo
+  add file2
+  add file1
+  $ git log --pretty=%s refs/josh/bulk/master
+  add file2
+  add file1
+
+An unmatched refspec fails without creating its destination.
+
+  $ josh-filter :/ --revspec 'refs/heads/missing:refs/josh/bulk/missing'
+  ERROR: revspec did not match any refs
+  [1]
+  $ git show-ref --verify --quiet refs/josh/bulk/missing
+  [1]
+
   $ git branch -a
   * master
     remotes/libs/HEAD -> libs/foo
@@ -69,6 +89,9 @@
   |-- heads
   |   `-- master
   |-- josh
+  |   |-- bulk
+  |   |   |-- foo
+  |   |   `-- master
   |   `-- filter
   |       `-- libs
   |           |-- foo
@@ -80,7 +103,7 @@
   |       `-- master
   `-- tags
   
-  8 directories, 6 files
+  9 directories, 8 files
 
   $ git read-tree HEAD josh/filter/libs/master josh/filter/libs/foo
   $ git commit -m "sync"


### PR DESCRIPTION
Filter multiple refs with revspec mappings

Change: filter-multiple-refs

Assisted-By: openai-codex/gpt-5.6-sol